### PR TITLE
Disable mlocate (autoreconf fails)

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -115,6 +115,7 @@
 /^memcached-java$/d
 /^mercurial$/d
 #/^meta-packages\/history$/d
+/^mlocate$/d
 /^mpc$/d
 /^mpfr$/d
 /^mutt$/d


### PR DESCRIPTION
I guess an older version is installed on the build server then
the tested local version 2.68
