### PR TITLE
Unbreak bash. Remove studio-specific options and patch.

### DIFF
--- a/components/bash/Makefile
+++ b/components/bash/Makefile
@@ -42,7 +42,7 @@ PATCH_LEVEL = 0
 PKG_PROTO_DIRS += $(COMPONENT_DIR)/Solaris
 
 # Enable C99 mode + -Xc for it's additional warnings.
-studio_C99MODE = -Xc $(studio_C99_ENABLE)
+#studio_C99MODE = -Xc $(studio_C99_ENABLE)
 
 # Use the maximum number of registers on sparc since we have no libraries
 studio_XREGS.sparc = -xregs=appl
@@ -52,14 +52,14 @@ studio_ALIGN.sparc.32 = -xmemalign=8i
 studio_ALIGN.sparc.64 = -xmemalign=16i
 
 # -xinline=%auto -- we like inlining where appropriate
-CFLAGS += -xinline=%auto
+# CFLAGS += -xinline=%auto
 
 # -xbuiltin=%none -- builtins have been known to be buggy
-CFLAGS += -xbuiltin=%none
+# CFLAGS += -xbuiltin=%none
 
-CFLAGS += $(XPG6MODE)
-CFLAGS += $(CPP_POSIX)
-CFLAGS += $(CPP_C99_EXTENDED_MATH)
+#CFLAGS += $(XPG6MODE)
+#CFLAGS += $(CPP_POSIX)
+#CFLAGS += $(CPP_C99_EXTENDED_MATH)
 
 # configure checks for some functions, but doesn't seem to want to link in
 # the required libraries for them. We avoid linking with libthread.so.1
@@ -112,7 +112,7 @@ CONFIGURE_OPTIONS  += 		--enable-usg-echo-default=yes
 CONFIGURE_OPTIONS  += 		--enable-xpg-echo-default=yes
 CONFIGURE_OPTIONS  += 		--enable-mem-scramble	
 CONFIGURE_OPTIONS  += 		--disable-profiling	
-CONFIGURE_OPTIONS  += 		--enable-static-link	
+#CONFIGURE_OPTIONS  += 		--enable-static-link	
 CONFIGURE_OPTIONS  += 		--enable-largefile
 CONFIGURE_OPTIONS  += 		--enable-nls	
 CONFIGURE_OPTIONS  += 		--with-bash-malloc=yes

--- a/components/bash/patches/solaris-002.Makefile.in.3.patch
+++ b/components/bash/patches/solaris-002.Makefile.in.3.patch
@@ -9,15 +9,6 @@
  
  BASE_CCFLAGS = $(PROFILE_FLAGS) $(SYSTEM_FLAGS) $(LOCAL_DEFS) \
  	  $(DEFS) $(LOCAL_CFLAGS) $(INCLUDES)
-@@ -538,7 +538,7 @@
- 
- $(Program):  .build $(OBJECTS) $(BUILTINS_DEP) $(LIBDEP)
- 	$(RM) $@
--	$(PURIFY) $(CC) $(BUILTINS_LDFLAGS) $(LIBRARY_LDFLAGS) $(LDFLAGS) -o $(Program) $(OBJECTS) $(LIBS)
-+	$(PURIFY) $(CC) $(CFLAGS) $(BUILTINS_LDFLAGS) $(LIBRARY_LDFLAGS) $(LDFLAGS) -o $(Program) $(OBJECTS) $(LIBS) $(LD_OPTIONS) -s
- 	ls -l $(Program)
- 	-$(SIZE) $(Program)
- 
 @@ -552,10 +552,10 @@
  	@echo
  

--- a/components/components.ignore
+++ b/components/components.ignore
@@ -16,7 +16,6 @@
 /^apr-util$/d
 /^areca$/d
 /^autogen$/d
-/^bash$/d
 /^bcc$/d
 /^beanshell$/d
 /^berkeleydb$/d


### PR DESCRIPTION
New bash builds and it seems to work fine. However, I couldn't test it fully - it conflicted with bash from oi-hipster repository so I tested only uninstalled binary.
