### PR TITLE
Unbreak tcl/expect.

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -193,7 +193,6 @@
 /^subversion$/d
 /^sudo$/d
 /^swig$/d
-/^tcl\/expect$/d
 /^tcl\/tk$/d
 /^tcltls$/d
 /^tcpdump$/d

--- a/components/tcl/expect/Makefile
+++ b/components/tcl/expect/Makefile
@@ -54,6 +54,7 @@ CONFIGURE_OPTIONS 	+= --with-tcl="$(COMPONENT_DIR)/../tcl/build/$(MACH$(BITS))"
 CONFIGURE_OPTIONS 	+= --with-tclinclude="$(COMPONENT_DIR)/../tcl/build/$(MACH$(BITS))/generic"
 
 CONFIGURE_OPTIONS.64	+= LDFLAGS="$(LDFLAGS) -m64"
+CONFIGURE_OPTIONS.64	+= LIBS=" -m64"
 
 COMPONENT_TEST_TARGETS = test
 


### PR DESCRIPTION
It seems to be a bug in aucoconf or packet configuration.
This workaround is a bit ugly, but it works.
