### PR TITLE
Added cxa_finalize binary which is necessary for clang++ and can be

### DIFF
--- a/components/cxa_finalize/LICENSE
+++ b/components/cxa_finalize/LICENSE
@@ -1,0 +1,14 @@
+The BSD License
+
+Copyright 2010-2011 PathScale, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of PathScale, Inc.

--- a/components/cxa_finalize/Makefile
+++ b/components/cxa_finalize/Makefile
@@ -1,0 +1,67 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2013 Andrzej Szeszo.  All rights reserved.
+#
+
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= cxa_finalize
+LIBCXXRT_COMMIT=c88684021db880d3cc9e2bf3da848419fdd41be9
+LIBCXXRT_NAME=libcxxrt
+LIBCXXRT_SRC=$(LIBCXXRT_NAME)-$(LIBCXXRT_COMMIT).zip
+
+COMPONENT_VERSION= 0.1
+COMPONENT_SUMMARY= "PathScale libcxxrt components"
+COMPONENT_SRC= $(LIBCXXRT_NAME)-$(LIBCXXRT_COMMIT)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).zip
+COMPONENT_ARCHIVE_HASH= \
+  sha256:9b33e8d979e6afefb93d74d5d9cda79e492ecca08db8d2e95a529ce233c1cbf1
+COMPONENT_ARCHIVE_URL= \
+  https://github.com/pathscale/libcxxrt/archive/$(LIBCXXRT_COMMIT).zip
+COMPONENT_PROJECT_URL = https://github.com/pathscale/
+
+include ../../make-rules/prep.mk
+include ../../make-rules/ips.mk
+
+CONFIGURE_PREFIX= /usr/llvm/$(COMPONENT_VERSION)
+
+PATH=/usr/sbin:/usr/bin:/usr/perl5/bin
+
+
+build: $(BUILD_32)
+
+$(BUILD_32):$(SOURCE_DIR)/.prep
+	cd $(LIBCXXRT_NAME)-$(LIBCXXRT_COMMIT)/src && \
+	$(CC) -std=c99 -m32 -c cxa_atexit.c -o cxa_atexit.32.o && \
+	$(CC) -std=c99 -m32 -c cxa_finalize.c  -o cxa_finalize.32.o && \
+	/usr/ccs/bin/ld -r cxa_finalize.32.o cxa_atexit.32.o -o cxa_finalize_tg.32.o  && \
+	$(CC) -std=c99 -m64 -c cxa_atexit.c -o cxa_atexit.64.o && \
+	$(CC) -std=c99 -m64 -c cxa_finalize.c  -o cxa_finalize.64.o && \
+	/usr/ccs/bin/ld -r cxa_finalize.64.o cxa_atexit.64.o -o cxa_finalize_tg.64.o && \
+	touch $(BUILD_32)
+		
+
+#  $(COMPONENT_DIR)/../gcc47-libgmp/build/$(MACH32)/.installed \
+#  $(COMPONENT_DIR)/../gcc47-libmpc/build/$(MACH32)/.installed \
+#  $(COMPONENT_DIR)/../gcc47-libmpfr/build/$(MACH32)/.installed \
+#  $(BUILD_32)
+
+install: $(INSTALL_32)
+
+$(INSTALL_32): $(BUILD_32)
+	mkdir -p $(PROTO_DIR)/usr/lib && \
+	mkdir -p $(PROTO_DIR)/usr/lib/amd64 && \
+	cd $(LIBCXXRT_NAME)-$(LIBCXXRT_COMMIT)/src && \
+	cp cxa_finalize_tg.32.o $(PROTO_DIR)/usr/lib/cxa_finalize.o && \
+	cp cxa_finalize_tg.64.o $(PROTO_DIR)/usr/lib/amd64/cxa_finalize.o && \
+	touch $(INSTALL_32)

--- a/components/cxa_finalize/cxa_finalize.p5m
+++ b/components/cxa_finalize/cxa_finalize.p5m
@@ -1,0 +1,40 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+#
+
+set name=pkg.fmri \
+    value=pkg:/developer/cxa_finalize@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(COMPONENT_VERSION)
+set name=pkg.summary \
+    value="Supplementary clang++ binary"
+set name=info.classification \
+    value="org.opensolaris.category.2008:Development/C"
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+file path=usr/lib/cxa_finalize.o
+file path=usr/lib/$(MACH64)/cxa_finalize.o
+
+license LICENSE license=BSD


### PR DESCRIPTION
used by several versions simultaneously (tested on clang/llvm 3.3/3.2).
