### PR TITLE
Fixed 64-bit compilation with Sun Studio

### DIFF
--- a/components/python/python26/files/pyconfig.h
+++ b/components/python/python26/files/pyconfig.h
@@ -1,3 +1,5 @@
+#include <sys/types.h>
+
 #ifdef _LP64
 #include <python2.6/pyconfig-64.h>
 #else


### PR DESCRIPTION
This is to make the following compilable:

$ cat a.c
# include &lt;Python.h&gt;

$ /opt/SUNWspro/bin/cc -m64 -I/usr/include/python2.6 -c a.c 
$
