### PR TITLE
Not very pleasant fixes for apxs and apr always pass "-m64" to gcc while...

### DIFF
--- a/components/apache2/Makefile
+++ b/components/apache2/Makefile
@@ -94,6 +94,7 @@ CONFIGURE_OPTIONS +=	CFLAGS="$(CFLAGS) -DSSL_EXPERIMENTAL -DSSL_ENGINE"
 CONFIGURE_OPTIONS +=	LTFLAGS="--silent --tag=CC"
 CONFIGURE_OPTIONS.32 +=	--enable-layout=Solaris-Apache2
 CONFIGURE_OPTIONS.64 +=	--enable-layout=Solaris-Apache2-$(MACH64)
+CONFIGURE_OPTIONS.64 +=	CC="$(CC) -m64"
 CONFIGURE_OPTIONS.32 +=	--with-apr=/usr/apr/bin/apr-1-config
 CONFIGURE_OPTIONS.64 +=	--with-apr=/usr/apr/bin/$(MACH64)/apr-1-config
 CONFIGURE_OPTIONS.32 +=	--with-apr-util=/usr/apr-util/bin/apu-1-config

--- a/components/apr/Makefile
+++ b/components/apr/Makefile
@@ -65,7 +65,8 @@ COMPONENT_PRE_CONFIGURE_ACTION += (cd $(@D); autoconf);
 APRH=include/apr.h
 $(BUILD_DIR_64)/.installed: COMPONENT_POST_INSTALL_ACTION = \
 	/usr/bin/diff -D __$(MACH64) $(BUILD_DIR_32)/$(APRH) \
-	  $(BUILD_DIR_64)/$(APRH) > $(PROTO_DIR)/$(CONFIGURE_PREFIX)/$(APRH); true
+	  $(BUILD_DIR_64)/$(APRH) > $(PROTO_DIR)/$(CONFIGURE_PREFIX)/$(APRH); \
+	$(GSED) -i -e '/^CFLAGS=""/s:CFLAGS="":CFLAGS="-m64":' $(PROTO_DIR)$(CONFIGURE_PREFIX)/bin/$(MACH64)/apr-1-config ;  true
 
 # Documentation is generated in and directly packaged from 32 bit build
 # directory using doxygen.


### PR DESCRIPTION
... building in amd64-mode
