### PR TITLE
Enable components

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -9,7 +9,6 @@
 /^beanshell$/d
 /^berkeleydb$/d
 /^bzip2$/d
-/^cdrtools$/d
 /^clisp$/d
 /^common$/d
 #/^coreutils$/d

--- a/components/components.ignore
+++ b/components/components.ignore
@@ -127,7 +127,6 @@
 /^socat$/d
 /^tcltls$/d
 /^tidy$/d
-/^timezone$/d
 /^tomcat$/d
 /^trousers$/d
 /^vim$/d

--- a/components/components.ignore
+++ b/components/components.ignore
@@ -70,7 +70,6 @@
 /^openssl\/openssl-0.9.8-fips-140$/d
 /^openssl\/openssl-1.0.1$/d
 /^openusb$/d
-/^p7zip$/d
 /^pam_pkcs11$/d
 /^pbzip2$/d
 /^pconsole$/d

--- a/components/components.ignore
+++ b/components/components.ignore
@@ -118,7 +118,6 @@
 /^samba\/samba30$/d
 /^sane-backends$/d
 /^sane-frontends$/d
-/^slang$/d
 /^snort$/d
 /^stdcxx$/d
 /^stunnel$/d


### PR DESCRIPTION
These components were built successfully while doing CONFIGURE_ENV and CONFIGURE_OPTIONS cleanup. There is no reason why not have them enabled.
