### PR TITLE
Revert "python26: don't link objects to readline and ncurses simultaneou...

### DIFF
--- a/components/python/python26/patches/Python26-18-readline.patch
+++ b/components/python/python26/patches/Python26-18-readline.patch
@@ -7,12 +7,12 @@ diff --git Python-2.6.4/setup.py Python-2.6.4/setup.py
                  readline_extra_link_args = ('-Wl,-search_paths_first',)
 +            elif sys.platform == 'sunos5':
 +                if sys.maxint != 9223372036854775807L:
-+                    readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib,-R/usr/gnu/lib,-lreadline',)
++                    readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib,-R/usr/gnu/lib,-lreadline,-lncurses',)
 +                else:
 +                    if os.path.exists('/usr/gnu/lib/sparcv9'):
-+                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/sparcv9,-R/usr/gnu/lib/sparcv9,-lreadline',)
++                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/sparcv9,-R/usr/gnu/lib/sparcv9,-lreadline,-lncurses',)
 +                    else:
-+                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/amd64,-R/usr/gnu/lib/amd64,-lreadline',)
++                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/amd64,-R/usr/gnu/lib/amd64,-lreadline,-lncurses',)
              else:
                  readline_extra_link_args = ()
  


### PR DESCRIPTION
...sly"

This reverts commit c6dada25110350b140ceaa978cdc230272a87fdb.
