### PR TITLE
Revert "Revert "python26: don't link objects to readline and ncurses sim...

### DIFF
--- a/components/python/python26/patches/Python26-18-readline.patch
+++ b/components/python/python26/patches/Python26-18-readline.patch
@@ -7,12 +7,12 @@ diff --git Python-2.6.4/setup.py Python-2.6.4/setup.py
                  readline_extra_link_args = ('-Wl,-search_paths_first',)
 +            elif sys.platform == 'sunos5':
 +                if sys.maxint != 9223372036854775807L:
-+                    readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib,-R/usr/gnu/lib,-lreadline,-lncurses',)
++                    readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib,-R/usr/gnu/lib,-lreadline',)
 +                else:
 +                    if os.path.exists('/usr/gnu/lib/sparcv9'):
-+                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/sparcv9,-R/usr/gnu/lib/sparcv9,-lreadline,-lncurses',)
++                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/sparcv9,-R/usr/gnu/lib/sparcv9,-lreadline',)
 +                    else:
-+                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/amd64,-R/usr/gnu/lib/amd64,-lreadline,-lncurses',)
++                        readline_extra_link_args = ('-Wl,-zrecord,-L/usr/gnu/lib/amd64,-R/usr/gnu/lib/amd64,-lreadline',)
              else:
                  readline_extra_link_args = ()
  


### PR DESCRIPTION
...ultaneously""

This reverts commit d2a06f482ac60ac85479eb67dfb300f13a2de2bc.
