### PR TITLE
Update tuntap to (the real) 1.3, fix installed locations, etc.

### DIFF
--- a/components/tuntap/Makefile
+++ b/components/tuntap/Makefile
@@ -17,42 +17,34 @@ include ../../make-rules/shared-macros.mk
 COMPONENT_NAME=		tuntap
 COMPONENT_VERSION=	1.3.0
 COMPONENT_LICENSE=	GPLv2
-COMPONENT_GIT_REV=	348e202
+COMPONENT_GIT_REV=	16eed2b
 COMPONENT_SRC=		kaizawa-$(COMPONENT_NAME)-$(COMPONENT_GIT_REV)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:72c9a7dc56cf52297ad163451df46f345a1c6019ba8fa84936e59550ab0f506e
+COMPONENT_ARCHIVE_HASH=	sha256:25e0cfcdd47ffcd814b40b2e6e89670650c85634b566ed615c789ccacd0eca42
 COMPONENT_PROJECT_URL=	http://www.whiteboard.ne.jp/~admin2/tuntap/
-COMPONENT_ARCHIVE_URL= 	https://codeload.github.com/kaizawa/tuntap/legacy.tar.gz/v$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE_URL= 	https://codeload.github.com/kaizawa/tuntap/legacy.tar.gz/$(COMPONENT_GIT_REV)
 
 include ../../make-rules/prep.mk
 include ../../make-rules/configure.mk
 include ../../make-rules/ips.mk
 
-COMPONENT_PRE_CONFIGURE_ACTION = \
-        ($(CLONEY) $(SOURCE_DIR) $(@D))
+PATCH_LEVEL = 0
 
-CONFIGURE_SCRUPT= $(@D)/configure
+CFLAGS +=	$(CPP_LARGEFILES)
+LDFLAGS +=	$(LD_Z_DEFS) $(LD_Z_TEXT) -lpthread
 
-CONFIGURE_OPTIONS.32 = --disable-64bit
+CONFIGURE_OPTIONS += CFLAGS="$(CFLAGS)"
+CONFIGURE_OPTIONS += LDFLAGS="$(LDFLAGS)"
+CONFIGURE_OPTIONS.32 +=  --disable-64bit
+CONFIGURE_OPTIONS.64 +=  --enable-64bit
 
 PKGLINT=true
 
+# common targets
 build:          $(BUILD_32_and_64)
 
-install:       
-	$(INSTALL) -d -m 0755 $(PROTOUSRDIR)/kernel/drv 
-	$(INSTALL) -d -m 0755 $(PROTOUSRDIR)/kernel/$(MACH64)/drv
-	$(INSTALL) -d -m 0755 $(PROTOUSRINCDIR)/net
+install:	$(INSTALL_32_and_64)
 
-	$(INSTALL) -m 644 $(BUILD_DIR_32)/if_tun.h $(PROTOUSRINCDIR)/net
-	$(INSTALL) -m 644 $(BUILD_DIR_32)/tun $(PROTOUSRDIR)/kernel/drv
-	$(INSTALL) -m 644 $(BUILD_DIR_32)/tap $(PROTOUSRDIR)/kernel/drv
-	$(INSTALL) -m 644 $(BUILD_DIR_32)/tun.conf $(PROTOUSRDIR)/kernel/drv 
-	$(INSTALL) -m 644 $(BUILD_DIR_32)/tap.conf $(PROTOUSRDIR)/kernel/drv
+BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
 
-	$(INSTALL) -m 644 $(BUILD_DIR_64)/tun $(PROTOUSRDIR)/kernel/$(MACH64)/drv 
-	$(INSTALL) -m 644 $(BUILD_DIR_64)/tap $(PROTOUSRDIR)/kernel/$(MACH64)/drv
-
-	$(TOUCH) $(BUILD_DIR_32)/.installed
-	$(TOUCH) $(BUILD_DIR_64)/.installed
-
+include ../../make-rules/depend.mk

--- a/components/tuntap/patches/makefile-in.patch
+++ b/components/tuntap/patches/makefile-in.patch
@@ -1,0 +1,44 @@
+Allow build from outside SRCDIR
+
+--- Makefile.in.~1~	Tue Jul 17 11:15:22 2012
++++ Makefile.in	Tue Jan 29 18:15:54 2013
+@@ -36,6 +36,7 @@
+ REM_DRV = /usr/sbin/rem_drv
+ DRV_DIR = @DRV_DIR@
+ DRV_CONF_DIR = /usr/kernel/drv
++SRCDIR = @srcdir@
+ DESTDIR = @prefix@
+ 
+ INSTALL = @INSTALL@
+@@ -47,20 +48,20 @@
+ tap: tap.o
+ 	$(LD) $(LD_FLAGS) -r -o tap tap.o
+ 
+-tun.o: tun.c if_tun.h
+-	$(CC) $(KCFLAGS) -c tun.c -o tun.o -DTUNTAP_TUN
++tun.o: $(SRCDIR)/tun.c $(SRCDIR)/if_tun.h
++	$(CC) $(KCFLAGS) -c $(SRCDIR)/tun.c -o tun.o -DTUNTAP_TUN
+ 
+-tap.o: tun.c if_tun.h
+-	$(CC) $(KCFLAGS) -c tun.c -o tap.o -DTUNTAP_TAP
++tap.o: $(SRCDIR)/tun.c $(SRCDIR)/if_tun.h
++	$(CC) $(KCFLAGS) -c $(SRCDIR)/tun.c -o tap.o -DTUNTAP_TAP
+ 
+ install: tun tap
+-	$(INSTALL) -d -m 0755 -o root -g bin $(DESTDIR)/usr/include/net
+-	$(INSTALL) -d -m 0755 -o root -g sys $(DESTDIR)$(DRV_DIR)
+-	$(INSTALL) -m 644 -o root -g root if_tun.h $(DESTDIR)/usr/include/net 
+-	$(INSTALL) -m 644 -o root -g root tun $(DESTDIR)$(DRV_DIR)
+-	$(INSTALL) -m 644 -o root -g root tap $(DESTDIR)$(DRV_DIR)
+-	$(INSTALL) -m 644 -o root -g root tun.conf $(DESTDIR)$(DRV_CONF_DIR)
+-	$(INSTALL) -m 644 -o root -g root tap.conf $(DESTDIR)$(DRV_CONF_DIR)
++	$(INSTALL) -d -m 0755 $(DESTDIR)/usr/include/net
++	$(INSTALL) -d -m 0755 $(DESTDIR)$(DRV_DIR)
++	$(INSTALL) -m 644 $(SRCDIR)/if_tun.h $(DESTDIR)/usr/include/net 
++	$(INSTALL) -m 644 tun $(DESTDIR)$(DRV_DIR)
++	$(INSTALL) -m 644 tap $(DESTDIR)$(DRV_DIR)
++	$(INSTALL) -m 644 $(SRCDIR)/tun.conf $(DESTDIR)$(DRV_CONF_DIR)
++	$(INSTALL) -m 644 $(SRCDIR)/tap.conf $(DESTDIR)$(DRV_CONF_DIR)
+ 	-[ -z "$(DESTDIR)" ]&& $(REM_DRV) tun >/dev/null 2>&1
+ 	-[ -z "$(DESTDIR)" ]&& $(REM_DRV) tap >/dev/null 2>&1
+ 	-[ -z "$(DESTDIR)" ]&& $(ADD_DRV) tun	

--- a/components/tuntap/patches/tun-c.patch
+++ b/components/tuntap/patches/tun-c.patch
@@ -1,0 +1,14 @@
+Drivers should not spew stuff like this to the console at boot.
+Make this message go only to the log, as most drivers do.
+
+--- tun.c.~1~	Tue Jul 17 11:15:22 2012
++++ tun.c	Thu Feb 21 14:15:37 2013
+@@ -166,7 +166,7 @@
+ 
+ int _init(void)
+ {
+-  cmn_err(CE_CONT, "Universal TUN/TAP device driver ver %s "
++  cmn_err(CE_CONT, "?Universal TUN/TAP device driver ver %s "
+ 		   "(C) 1999-2000 Maxim Krasnyansky\n", TUN_VER);
+ 
+   DBG(CE_CONT,"tun: _init\n");

--- a/components/tuntap/tap.p5m
+++ b/components/tuntap/tap.p5m
@@ -15,7 +15,7 @@
 <transform file dir path=.*kernel.* -> default group sys>
 <transform file path=.*kernel/drv/.+\.conf -> default mode 0644>
 <transform file path=.*kernel/drv/.+ -> default mode 0755>
-<transform file path=.*kernel/$(MACH64)/drv/.+ -> default mode 0755>
+<transform file path=.*kernel/drv/$(MACH64)/.+ -> default mode 0755>
 <transform file path=.*kernel/.+(?<!\.conf)$ -> default reboot-needed true>
 
 <transform file dir link hardlink path=.*kernel/.* -> set variant.opensolaris.zone global>
@@ -37,8 +37,7 @@ driver name=tap
 dir  path=usr
 dir  path=usr/kernel
 dir  path=usr/kernel/drv
-dir  path=usr/kernel/$(MACH64)
-dir  path=usr/kernel/$(MACH64)/drv
+dir  path=usr/kernel/drv/$(MACH64)
 file path=usr/kernel/drv/tap
-file path=usr/kernel/$(MACH64)/drv/tap
+file path=usr/kernel/drv/$(MACH64)/tap
 file path=usr/kernel/drv/tap.conf preserve=true

--- a/components/tuntap/tun.p5m
+++ b/components/tuntap/tun.p5m
@@ -15,7 +15,7 @@
 <transform file dir path=.*kernel.* -> default group sys>
 <transform file path=.*kernel/drv/.+\.conf -> default mode 0644>
 <transform file path=.*kernel/drv/.+ -> default mode 0755>
-<transform file path=.*kernel/$(MACH64)/drv/.+ -> default mode 0755>
+<transform file path=.*kernel/drv/$(MACH64)/.+ -> default mode 0755>
 <transform file path=.*kernel/.+(?<!\.conf)$ -> default reboot-needed true>
 
 <transform file dir link hardlink path=.*kernel/.* -> set variant.opensolaris.zone global>
@@ -37,8 +37,7 @@ driver name=tun
 dir  path=usr
 dir  path=usr/kernel
 dir  path=usr/kernel/drv
-dir  path=usr/kernel/$(MACH64)
-dir  path=usr/kernel/$(MACH64)/drv
+dir  path=usr/kernel/drv/$(MACH64)
 file path=usr/kernel/drv/tun
-file path=usr/kernel/$(MACH64)/drv/tun
+file path=usr/kernel/drv/$(MACH64)/tun
 file path=usr/kernel/drv/tun.conf preserve=true


### PR DESCRIPTION
This is what I've been running for a while to support openvpn.
It's been quite stable for me on OI.

Fixes:
a: locations of 64-bit drivers should be:
       /usr/kernel/drv/amd64/*
 not /usr/kernel/amd64/drv/*

b: Don't spew message to the console when loaded

c: Build correctly with PWD != SRCDIR
   (so that "cloney" is not needed)

d: fix the install rule, and use it.

(Yes, should propose those patches to kaizawa)
