### PR TITLE
These are patches we make to openvpn 2.2.2 (ported onto 2.3.2)

### DIFF
--- a/components/openvpn/Makefile
+++ b/components/openvpn/Makefile
@@ -26,6 +26,17 @@ include ../../make-rules/prep.mk
 include ../../make-rules/configure.mk
 include ../../make-rules/ips.mk
 
+PATCH_LEVEL = 0
+
+CPPFLAGS +=	-I$(WS_TOP)/components/tuntap/build/prototype/$(MACH)/usr/include
+CFLAGS +=	$(CPP_LARGEFILES)
+LDFLAGS +=	$(LD_Z_DEFS) $(LD_Z_TEXT) -lpthread
+
+CONFIGURE_OPTIONS += CPPFLAGS="$(CPPFLAGS)"
+CONFIGURE_OPTIONS += CFLAGS="$(CFLAGS)"
+CONFIGURE_OPTIONS += LDFLAGS="$(LDFLAGS)"
+CONFIGURE_OPTIONS += GREP=/usr/gnu/bin/grep
+CONFIGURE_OPTIONS += --disable-lzo
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --enable-shared
 

--- a/components/openvpn/openvpn.p5m
+++ b/components/openvpn/openvpn.p5m
@@ -1,6 +1,6 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL)". You may
+# Common Development and Distribution License ("CDDL"). You may
 # only use this file in accordance with the terms of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
@@ -52,9 +52,10 @@ file path=usr/share/doc/openvpn/README.auth-pam
 file path=usr/share/doc/openvpn/README.down-root
 file path=usr/share/doc/openvpn/README.polarssl
 file path=usr/share/doc/openvpn/management-notes.txt
+
 dir  path=usr/share/man
-dir  path=usr/share/man/man8
-file path=usr/share/man/man8/openvpn.8
+dir  path=usr/share/man/man1m
+file usr/share/man/man8/openvpn.8 path=usr/share/man/man1m/openvpn.1m
 
 depend type=require fmri=driver/network/tun variant.opensolaris.zone=global
 depend type=require fmri=driver/network/tap variant.opensolaris.zone=global

--- a/components/openvpn/patches/ipsec-bypass.patch
+++ b/components/openvpn/patches/ipsec-bypass.patch
@@ -1,0 +1,71 @@
+--- src/openvpn/socket.c.~1~	Fri May 31 08:00:25 2013
++++ src/openvpn/socket.c	Thu Nov  7 13:52:41 2013
+@@ -615,7 +615,46 @@
+     }
+ }
+ 
++#ifdef IP_SEC_OPT
+ /*
++ * On Solarish systems (Illumos distros, Oracle Solaris), have the socket
++ * bypass systemwide IPsec policy.  Useful if OpenVPN lives on a server that
++ * is also acting as an IPsec gateway.  (Note the correct capitalization of
++ * IPsec.)
++ */
++static void
++set_ipsec_bypass(int sock)
++{
++  ipsec_req_t ipsr;
++
++  /* Don't bother if the socket is a failure.  Caller never checks... */
++  if (sock == -1)
++    return;
++
++  ipsr.ipsr_ah_req = IPSEC_PREF_NEVER;
++  ipsr.ipsr_esp_req = IPSEC_PREF_NEVER;
++  ipsr.ipsr_self_encap_req = IPSEC_PREF_NEVER;
++  ipsr.ipsr_auth_alg = 0;
++  ipsr.ipsr_esp_alg = 0;
++  ipsr.ipsr_esp_auth_alg = 0;
++
++  if (setsockopt(sock, IPPROTO_IP, IP_SEC_OPT, &ipsr, sizeof (ipsr)) == -1) {
++    switch (errno) {
++    case EPROTONOSUPPORT:
++      dmsg (D_SOCKET_DEBUG, "Not using IPsec.");
++      break;
++    case EPERM:
++      msg (M_ERR, "Need more privilege for IPsec bypass.");
++      break;
++    default:
++      msg (M_ERR|M_ERRNO, "Can't set IPsec bypass.");
++      break;
++    }
++  }
++}	
++#endif /* IP_SEC_OPT */
++
++/*
+  * SOCKET INITALIZATION CODE.
+  * Create a TCP/UDP socket
+  */
+@@ -638,6 +677,10 @@
+   }
+ #endif
+ 
++#ifdef IP_SEC_OPT
++  set_ipsec_bypass(sd);
++#endif
++
+   return sd;
+ }
+ 
+@@ -725,6 +768,10 @@
+     {
+       ASSERT (0);
+     }
++
++#ifdef IP_SEC_OPT
++  set_ipsec_bypass(sock->sd);
++#endif
+ }
+ 
+ /*

--- a/components/openvpn/patches/openvpn-man8.patch
+++ b/components/openvpn/patches/openvpn-man8.patch
@@ -1,0 +1,101 @@
+--- doc/openvpn.8.~1~	Fri May 31 08:00:25 2013
++++ doc/openvpn.8	Thu Nov  7 14:02:40 2013
+@@ -34,7 +34,7 @@
+ .\" .ft -- normal face
+ .\" .in +|-{n} -- indent
+ .\"
+-.TH openvpn 8 "17 November 2008"
++.TH openvpn 1m "17 November 2008"
+ .\"*********************************************************
+ .SH NAME
+ openvpn \- secure IP tunnel daemon.
+@@ -647,7 +647,7 @@
+ .I our
+ IP address changes due to DHCP, we should configure
+ our IP address change script (see man page for
+-.BR dhcpcd (8)
++.BR in.dhcpcd (1m)
+ ) to deliver a
+ .B SIGHUP
+ or
+@@ -776,7 +776,7 @@
+ directive code.  When used on Windows, requires version 8.2 or higher
+ of the TAP-Win32 driver.  When used on *nix, requires that the tun
+ driver supports an
+-.BR ifconfig (8)
++.BR ifconfig (1m)
+ command which sets a subnet instead of a remote endpoint IP address.
+ 
+ This option exists in OpenVPN 2.1 or higher.
+@@ -871,7 +871,7 @@
+ same purpose).
+ 
+ This option, while primarily a proxy for the
+-.BR ifconfig (8)
++.BR ifconfig (1m)
+ command, is designed to simplify TUN/TAP
+ tunnel configuration by providing a
+ standard interface to the different
+@@ -929,7 +929,7 @@
+ 
+ This option is intended as
+ a convenience proxy for the
+-.BR route (8)
++.BR route (1m)
+ shell command,
+ while at the same time providing portable semantics
+ across OpenVPN's platform space.
+@@ -2130,7 +2130,7 @@
+ .TP
+ .B \-\-inetd [wait|nowait] [progname]
+ Use this option when OpenVPN is being run from the inetd or
+-.BR xinetd(8)
++.BR xinetd(1m)
+ server.
+ 
+ The
+@@ -4958,9 +4958,9 @@
+ and
+ .B \-\-down
+ scripts to run the appropriate
+-.BR ifconfig (8)
++.BR ifconfig (1m)
+ and
+-.BR route (8)
++.BR route (1m)
+ commands.  These commands can be placed in the the same shell script
+ which starts or terminates an OpenVPN session.
+ 
+@@ -5294,7 +5294,7 @@
+ Show available TAP-Win32 adapters which can be selected using the
+ .B \-\-dev-node
+ option.  On non-Windows systems, the
+-.BR ifconfig (8)
++.BR ifconfig (1m)
+ command provides similar functionality.
+ .\"*********************************************************
+ .TP
+@@ -6271,7 +6271,7 @@
+ The
+ .B \-\-verb 9
+ option will produce verbose output, similar to the
+-.BR tcpdump (8)
++.BR tcpdump (1m)
+ program.  Omit the
+ .B \-\-verb 9
+ option to have OpenVPN run quietly.
+@@ -6486,10 +6486,10 @@
+ Report all bugs to the OpenVPN team <info@openvpn.net>.
+ .\"*********************************************************
+ .SH "SEE ALSO"
+-.BR dhcpcd (8),
+-.BR ifconfig (8),
+-.BR openssl (1),
+-.BR route (8),
++.BR in.dhcpcd (1m),
++.BR ifconfig (1m),
++.BR openssl (1openssl),
++.BR route (1m),
+ .BR scp (1)
+ .BR ssh (1)
+ .\"*********************************************************


### PR DESCRIPTION
Configure our socket for IPsec bypass, when appropriate.
(You need this when you're on an "edge" machine that's using IPsec.)

Fix up 1m vs. 8 in the man page.

I just tested this (updating my machine from 2.2.2 -> 2.3.2 and it worked fine.

I see that easy-rsa went away between those versions, which we use.
Perhaps I should find a way to package that from somewhere...
