### PR TITLE
Initial commit of bash-completion 2.1

### DIFF
--- a/components/bash-completion/Makefile
+++ b/components/bash-completion/Makefile
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2013, Aurelien Larcher. All rights reserved.
+# 
+
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		bash-completion
+COMPONENT_VERSION=	2.1
+COMPONENT_FMRI=		utility/$(COMPONENT_NAME)
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=	http://www.gnu.org/software/bash/
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)_$(COMPONENT_VERSION).orig.tar.bz2
+COMPONENT_ARCHIVE_HASH = \
+    sha256:2b606804a7d5f823380a882e0f7b6c8a37b0e768e72c3d4107c51fbe8a46ae4f
+COMPONENT_ARCHIVE_URL=	http://ftp.de.debian.org/debian/pool/main/b/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+COMPONENT_BUGDB=	$(COMPONENT_FMRI)
+COMPONENT_SUMMARY=	Debian extensions to bash standard completion
+
+COMPONENT_LICENSE=	GPLv2
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CONFIGURE_PREFIX=	/usr
+
+CONFIGURE_OPTIONS += --sysconfdir=/etc
+
+build: $(BUILD_32)
+
+install: $(INSTALL_32)
+
+BUILD_PKG_DEPENDENCIES = $(BUILD_TOOLS)
+
+include $(WS_MAKE_RULES)/depend.mk
+

--- a/components/bash-completion/bash-completion.license
+++ b/components/bash-completion/bash-completion.license
@@ -1,0 +1,339 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/components/bash-completion/bash-completion.p5m
+++ b/components/bash-completion/bash-completion.p5m
@@ -1,0 +1,608 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2013 Aurelien Larcher. All rights reserved.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value=org.opensolaris.category.2008:System/Shells
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file path=.*\.py$ -> default pkg.tmp.autopyc false>
+
+depend type=require fmri=pkg:/shell/bash
+
+dir  path=etc
+dir  path=etc/profile.d
+file path=etc/profile.d/bash_completion.sh mode=0644 preserve=true
+dir  path=usr
+dir  path=usr/share
+dir  path=usr/share/bash-completion
+file path=usr/share/bash-completion/bash_completion
+dir  path=usr/share/bash-completion/completions
+file path=usr/share/bash-completion/completions/a2x
+file path=usr/share/bash-completion/completions/abook
+file path=usr/share/bash-completion/completions/aclocal
+link path=usr/share/bash-completion/completions/aclocal-1.11 target=aclocal
+file path=usr/share/bash-completion/completions/acpi
+file path=usr/share/bash-completion/completions/add_members
+file path=usr/share/bash-completion/completions/alias
+link path=usr/share/bash-completion/completions/alpine target=pine
+link path=usr/share/bash-completion/completions/alternatives \
+    target=update-alternatives
+link path=usr/share/bash-completion/completions/animate target=convert
+file path=usr/share/bash-completion/completions/ant
+file path=usr/share/bash-completion/completions/apache2ctl
+link path=usr/share/bash-completion/completions/apropos target=man
+file path=usr/share/bash-completion/completions/apt-build
+file path=usr/share/bash-completion/completions/apt-cache
+file path=usr/share/bash-completion/completions/apt-get
+file path=usr/share/bash-completion/completions/aptitude
+file path=usr/share/bash-completion/completions/arch
+link path=usr/share/bash-completion/completions/arm-koji target=koji
+file path=usr/share/bash-completion/completions/arping
+file path=usr/share/bash-completion/completions/arpspoof
+file path=usr/share/bash-completion/completions/asciidoc
+link path=usr/share/bash-completion/completions/asciidoc.py target=asciidoc
+file path=usr/share/bash-completion/completions/aspell
+file path=usr/share/bash-completion/completions/autoconf
+link path=usr/share/bash-completion/completions/autoheader target=autoreconf
+file path=usr/share/bash-completion/completions/automake
+link path=usr/share/bash-completion/completions/automake-1.11 target=automake
+file path=usr/share/bash-completion/completions/autoreconf
+file path=usr/share/bash-completion/completions/autorpm
+file path=usr/share/bash-completion/completions/autoscan
+link path=usr/share/bash-completion/completions/autossh target=ssh
+link path=usr/share/bash-completion/completions/autoupdate target=autoscan
+file path=usr/share/bash-completion/completions/avctrl
+file path=usr/share/bash-completion/completions/badblocks
+file path=usr/share/bash-completion/completions/bk
+file path=usr/share/bash-completion/completions/brctl
+link path=usr/share/bash-completion/completions/btdownloadcurses.py \
+    target=btdownloadheadless.py
+link path=usr/share/bash-completion/completions/btdownloadgui.py \
+    target=btdownloadheadless.py
+file path=usr/share/bash-completion/completions/btdownloadheadless.py
+file path=usr/share/bash-completion/completions/bzip2
+link path=usr/share/bash-completion/completions/c++ target=gcc
+file path=usr/share/bash-completion/completions/cal
+file path=usr/share/bash-completion/completions/cancel
+file path=usr/share/bash-completion/completions/cardctl
+link path=usr/share/bash-completion/completions/cc target=gcc
+file path=usr/share/bash-completion/completions/ccache
+link path=usr/share/bash-completion/completions/cdrecord target=wodim
+file path=usr/share/bash-completion/completions/cfagent
+file path=usr/share/bash-completion/completions/cfrun
+file path=usr/share/bash-completion/completions/chage
+file path=usr/share/bash-completion/completions/change_pw
+file path=usr/share/bash-completion/completions/check_db
+file path=usr/share/bash-completion/completions/check_perms
+file path=usr/share/bash-completion/completions/chgrp
+file path=usr/share/bash-completion/completions/chkconfig
+file path=usr/share/bash-completion/completions/chown
+file path=usr/share/bash-completion/completions/chpasswd
+file path=usr/share/bash-completion/completions/chronyc
+file path=usr/share/bash-completion/completions/chrpath
+file path=usr/share/bash-completion/completions/chsh
+link path=usr/share/bash-completion/completions/ci target=rcs
+link path=usr/share/bash-completion/completions/ciptool target=hcitool
+link path=usr/share/bash-completion/completions/civclient target=freeciv-gtk2
+link path=usr/share/bash-completion/completions/civserver target=freeciv-server
+file path=usr/share/bash-completion/completions/cksfv
+file path=usr/share/bash-completion/completions/cleanarch
+file path=usr/share/bash-completion/completions/clisp
+file path=usr/share/bash-completion/completions/clone_member
+link path=usr/share/bash-completion/completions/clzip target=lzip
+link path=usr/share/bash-completion/completions/co target=rcs
+link path=usr/share/bash-completion/completions/colormake target=make
+link path=usr/share/bash-completion/completions/compare target=convert
+link path=usr/share/bash-completion/completions/compgen target=complete
+file path=usr/share/bash-completion/completions/complete
+link path=usr/share/bash-completion/completions/composite target=convert
+file path=usr/share/bash-completion/completions/config_list
+file path=usr/share/bash-completion/completions/configure
+link path=usr/share/bash-completion/completions/conjure target=convert
+file path=usr/share/bash-completion/completions/convert
+file path=usr/share/bash-completion/completions/cowsay
+link path=usr/share/bash-completion/completions/cowthink target=cowsay
+file path=usr/share/bash-completion/completions/cpan2dist
+file path=usr/share/bash-completion/completions/cpio
+file path=usr/share/bash-completion/completions/cppcheck
+link path=usr/share/bash-completion/completions/createdb target=psql
+file path=usr/share/bash-completion/completions/crontab
+file path=usr/share/bash-completion/completions/cryptsetup
+file path=usr/share/bash-completion/completions/curl
+file path=usr/share/bash-completion/completions/cvs
+file path=usr/share/bash-completion/completions/cvsps
+link path=usr/share/bash-completion/completions/dcop target=qdbus
+file path=usr/share/bash-completion/completions/dd
+link path=usr/share/bash-completion/completions/declare target=function
+file path=usr/share/bash-completion/completions/desktop-file-validate
+link path=usr/share/bash-completion/completions/dfutool target=hcitool
+file path=usr/share/bash-completion/completions/dhclient
+file path=usr/share/bash-completion/completions/dict
+link path=usr/share/bash-completion/completions/display target=convert
+file path=usr/share/bash-completion/completions/dmesg
+file path=usr/share/bash-completion/completions/dnsspoof
+file path=usr/share/bash-completion/completions/dot
+file path=usr/share/bash-completion/completions/dpkg
+link path=usr/share/bash-completion/completions/dpkg-deb target=dpkg
+link path=usr/share/bash-completion/completions/dpkg-query target=dpkg
+link path=usr/share/bash-completion/completions/dpkg-reconfigure target=dpkg
+file path=usr/share/bash-completion/completions/dpkg-source
+link path=usr/share/bash-completion/completions/dropdb target=psql
+file path=usr/share/bash-completion/completions/dselect
+file path=usr/share/bash-completion/completions/dsniff
+file path=usr/share/bash-completion/completions/dumpdb
+file path=usr/share/bash-completion/completions/dumpe2fs
+file path=usr/share/bash-completion/completions/e2freefrag
+file path=usr/share/bash-completion/completions/e2label
+link path=usr/share/bash-completion/completions/edquota target=quota
+file path=usr/share/bash-completion/completions/eject
+file path=usr/share/bash-completion/completions/eog
+file path=usr/share/bash-completion/completions/ether-wake
+file path=usr/share/bash-completion/completions/evince
+file path=usr/share/bash-completion/completions/explodepkg
+file path=usr/share/bash-completion/completions/export
+file path=usr/share/bash-completion/completions/faillog
+file path=usr/share/bash-completion/completions/fbgs
+file path=usr/share/bash-completion/completions/fbi
+file path=usr/share/bash-completion/completions/feh
+file path=usr/share/bash-completion/completions/file
+file path=usr/share/bash-completion/completions/file-roller
+link path=usr/share/bash-completion/completions/filebucket target=puppet
+file path=usr/share/bash-completion/completions/filefrag
+file path=usr/share/bash-completion/completions/filesnarf
+file path=usr/share/bash-completion/completions/find
+file path=usr/share/bash-completion/completions/find_member
+file path=usr/share/bash-completion/completions/freeciv-gtk2
+link path=usr/share/bash-completion/completions/freeciv-sdl target=freeciv-gtk2
+file path=usr/share/bash-completion/completions/freeciv-server
+link path=usr/share/bash-completion/completions/freeciv-xaw target=freeciv-gtk2
+file path=usr/share/bash-completion/completions/function
+file path=usr/share/bash-completion/completions/fusermount
+link path=usr/share/bash-completion/completions/g++ target=gcc
+link path=usr/share/bash-completion/completions/g4 target=p4
+link path=usr/share/bash-completion/completions/g77 target=gcc
+file path=usr/share/bash-completion/completions/gcc
+link path=usr/share/bash-completion/completions/gcj target=gcc
+file path=usr/share/bash-completion/completions/gcl
+file path=usr/share/bash-completion/completions/gdb
+file path=usr/share/bash-completion/completions/genaliases
+file path=usr/share/bash-completion/completions/gendiff
+file path=usr/share/bash-completion/completions/genisoimage
+file path=usr/share/bash-completion/completions/getent
+file path=usr/share/bash-completion/completions/gkrellm
+link path=usr/share/bash-completion/completions/gkrellm2 target=gkrellm
+link path=usr/share/bash-completion/completions/gmake target=make
+link path=usr/share/bash-completion/completions/gmplayer target=mplayer
+file path=usr/share/bash-completion/completions/gnatmake
+file path=usr/share/bash-completion/completions/gnome-mplayer
+link path=usr/share/bash-completion/completions/gnumake target=make
+file path=usr/share/bash-completion/completions/gpasswd
+link path=usr/share/bash-completion/completions/gpc target=gcc
+file path=usr/share/bash-completion/completions/gpg
+file path=usr/share/bash-completion/completions/gpg2
+file path=usr/share/bash-completion/completions/gphoto2
+file path=usr/share/bash-completion/completions/gprof
+file path=usr/share/bash-completion/completions/groupadd
+file path=usr/share/bash-completion/completions/groupdel
+file path=usr/share/bash-completion/completions/groupmems
+file path=usr/share/bash-completion/completions/groupmod
+file path=usr/share/bash-completion/completions/growisofs
+file path=usr/share/bash-completion/completions/grpck
+file path=usr/share/bash-completion/completions/gzip
+link path=usr/share/bash-completion/completions/hciattach target=hcitool
+link path=usr/share/bash-completion/completions/hciconfig target=hcitool
+file path=usr/share/bash-completion/completions/hcitool
+link path=usr/share/bash-completion/completions/hd target=hexdump
+file path=usr/share/bash-completion/completions/hddtemp
+file path=usr/share/bash-completion/completions/hexdump
+file path=usr/share/bash-completion/completions/hid2hci
+link path=usr/share/bash-completion/completions/host target=nslookup
+link path=usr/share/bash-completion/completions/hping target=hping2
+file path=usr/share/bash-completion/completions/hping2
+link path=usr/share/bash-completion/completions/hping3 target=hping2
+file path=usr/share/bash-completion/completions/htop
+file path=usr/share/bash-completion/completions/htpasswd
+file path=usr/share/bash-completion/completions/hwclock
+file path=usr/share/bash-completion/completions/iconv
+file path=usr/share/bash-completion/completions/id
+link path=usr/share/bash-completion/completions/identify target=convert
+file path=usr/share/bash-completion/completions/idn
+link path=usr/share/bash-completion/completions/ifdown target=ifup
+link path=usr/share/bash-completion/completions/ifstatus target=ifup
+file path=usr/share/bash-completion/completions/iftop
+file path=usr/share/bash-completion/completions/ifup
+link path=usr/share/bash-completion/completions/import target=convert
+file path=usr/share/bash-completion/completions/info
+file path=usr/share/bash-completion/completions/inject
+file path=usr/share/bash-completion/completions/insmod
+link path=usr/share/bash-completion/completions/insmod.static target=insmod
+file path=usr/share/bash-completion/completions/installpkg
+file path=usr/share/bash-completion/completions/interdiff
+file path=usr/share/bash-completion/completions/invoke-rc.d
+file path=usr/share/bash-completion/completions/ionice
+file path=usr/share/bash-completion/completions/ip
+file path=usr/share/bash-completion/completions/iperf
+file path=usr/share/bash-completion/completions/ipmitool
+file path=usr/share/bash-completion/completions/ipsec
+file path=usr/share/bash-completion/completions/iptables
+file path=usr/share/bash-completion/completions/ipv6calc
+file path=usr/share/bash-completion/completions/iscsiadm
+file path=usr/share/bash-completion/completions/isql
+file path=usr/share/bash-completion/completions/iwconfig
+file path=usr/share/bash-completion/completions/iwlist
+file path=usr/share/bash-completion/completions/iwpriv
+file path=usr/share/bash-completion/completions/iwspy
+file path=usr/share/bash-completion/completions/jar
+file path=usr/share/bash-completion/completions/jarsigner
+file path=usr/share/bash-completion/completions/java
+link path=usr/share/bash-completion/completions/javac target=java
+link path=usr/share/bash-completion/completions/javadoc target=java
+file path=usr/share/bash-completion/completions/javaws
+file path=usr/share/bash-completion/completions/jps
+file path=usr/share/bash-completion/completions/k3b
+file path=usr/share/bash-completion/completions/kcov
+file path=usr/share/bash-completion/completions/kill
+file path=usr/share/bash-completion/completions/killall
+file path=usr/share/bash-completion/completions/kldload
+file path=usr/share/bash-completion/completions/kldunload
+file path=usr/share/bash-completion/completions/koji
+link path=usr/share/bash-completion/completions/kplayer target=mplayer
+file path=usr/share/bash-completion/completions/ktutil
+link path=usr/share/bash-completion/completions/l2ping target=hcitool
+file path=usr/share/bash-completion/completions/larch
+file path=usr/share/bash-completion/completions/lastlog
+link path=usr/share/bash-completion/completions/lbzip2 target=bzip2
+link path=usr/share/bash-completion/completions/ldapadd target=ldapsearch
+link path=usr/share/bash-completion/completions/ldapcompare target=ldapsearch
+link path=usr/share/bash-completion/completions/ldapdelete target=ldapsearch
+link path=usr/share/bash-completion/completions/ldapmodify target=ldapsearch
+link path=usr/share/bash-completion/completions/ldapmodrdn target=ldapsearch
+link path=usr/share/bash-completion/completions/ldappasswd target=ldapsearch
+file path=usr/share/bash-completion/completions/ldapsearch
+file path=usr/share/bash-completion/completions/ldapvi
+link path=usr/share/bash-completion/completions/ldapwhoami target=ldapsearch
+file path=usr/share/bash-completion/completions/lftp
+file path=usr/share/bash-completion/completions/lftpget
+file path=usr/share/bash-completion/completions/lilo
+file path=usr/share/bash-completion/completions/links
+file path=usr/share/bash-completion/completions/lintian
+link path=usr/share/bash-completion/completions/lintian-info target=lintian
+file path=usr/share/bash-completion/completions/lisp
+file path=usr/share/bash-completion/completions/list_admins
+file path=usr/share/bash-completion/completions/list_lists
+file path=usr/share/bash-completion/completions/list_members
+file path=usr/share/bash-completion/completions/list_owners
+file path=usr/share/bash-completion/completions/look
+file path=usr/share/bash-completion/completions/lpq
+file path=usr/share/bash-completion/completions/lpr
+file path=usr/share/bash-completion/completions/lrzip
+file path=usr/share/bash-completion/completions/lsof
+file path=usr/share/bash-completion/completions/lua
+file path=usr/share/bash-completion/completions/luac
+file path=usr/share/bash-completion/completions/luseradd
+file path=usr/share/bash-completion/completions/luserdel
+link path=usr/share/bash-completion/completions/lusermod target=luseradd
+link path=usr/share/bash-completion/completions/lvchange target=lvm
+link path=usr/share/bash-completion/completions/lvcreate target=lvm
+link path=usr/share/bash-completion/completions/lvdisplay target=lvm
+link path=usr/share/bash-completion/completions/lvextend target=lvm
+file path=usr/share/bash-completion/completions/lvm
+link path=usr/share/bash-completion/completions/lvmdiskscan target=lvm
+link path=usr/share/bash-completion/completions/lvreduce target=lvm
+link path=usr/share/bash-completion/completions/lvremove target=lvm
+link path=usr/share/bash-completion/completions/lvrename target=lvm
+link path=usr/share/bash-completion/completions/lvresize target=lvm
+link path=usr/share/bash-completion/completions/lvs target=lvm
+link path=usr/share/bash-completion/completions/lvscan target=lvm
+file path=usr/share/bash-completion/completions/lzip
+file path=usr/share/bash-completion/completions/lzma
+file path=usr/share/bash-completion/completions/lzop
+file path=usr/share/bash-completion/completions/macof
+file path=usr/share/bash-completion/completions/mailmanctl
+link path=usr/share/bash-completion/completions/mailsnarf target=filesnarf
+file path=usr/share/bash-completion/completions/make
+file path=usr/share/bash-completion/completions/makepkg
+file path=usr/share/bash-completion/completions/man
+file path=usr/share/bash-completion/completions/mc
+file path=usr/share/bash-completion/completions/mcrypt
+file path=usr/share/bash-completion/completions/mdadm
+link path=usr/share/bash-completion/completions/mdecrypt target=mcrypt
+file path=usr/share/bash-completion/completions/mdtool
+file path=usr/share/bash-completion/completions/medusa
+link path=usr/share/bash-completion/completions/mencoder target=mplayer
+file path=usr/share/bash-completion/completions/mii-diag
+file path=usr/share/bash-completion/completions/mii-tool
+file path=usr/share/bash-completion/completions/minicom
+file path=usr/share/bash-completion/completions/mkinitrd
+link path=usr/share/bash-completion/completions/mkisofs target=genisoimage
+file path=usr/share/bash-completion/completions/mktemp
+file path=usr/share/bash-completion/completions/mmsitepass
+file path=usr/share/bash-completion/completions/modinfo
+file path=usr/share/bash-completion/completions/modprobe
+link path=usr/share/bash-completion/completions/mogrify target=convert
+file path=usr/share/bash-completion/completions/monodevelop
+link path=usr/share/bash-completion/completions/montage target=convert
+file path=usr/share/bash-completion/completions/mount
+file path=usr/share/bash-completion/completions/mount.linux
+file path=usr/share/bash-completion/completions/mplayer
+link path=usr/share/bash-completion/completions/mplayer2 target=mplayer
+link path=usr/share/bash-completion/completions/msgsnarf target=filesnarf
+file path=usr/share/bash-completion/completions/msynctool
+file path=usr/share/bash-completion/completions/mtx
+file path=usr/share/bash-completion/completions/munin-node-configure
+file path=usr/share/bash-completion/completions/munin-run
+file path=usr/share/bash-completion/completions/munin-update
+file path=usr/share/bash-completion/completions/munindoc
+file path=usr/share/bash-completion/completions/mussh
+file path=usr/share/bash-completion/completions/mutt
+link path=usr/share/bash-completion/completions/muttng target=mutt
+file path=usr/share/bash-completion/completions/mysql
+file path=usr/share/bash-completion/completions/mysqladmin
+file path=usr/share/bash-completion/completions/nc
+link path=usr/share/bash-completion/completions/ncal target=cal
+file path=usr/share/bash-completion/completions/ncftp
+file path=usr/share/bash-completion/completions/nethogs
+file path=usr/share/bash-completion/completions/newgrp
+file path=usr/share/bash-completion/completions/newlist
+file path=usr/share/bash-completion/completions/newusers
+file path=usr/share/bash-completion/completions/ngrep
+file path=usr/share/bash-completion/completions/nmap
+file path=usr/share/bash-completion/completions/nmcli
+file path=usr/share/bash-completion/completions/nslookup
+file path=usr/share/bash-completion/completions/ntpdate
+file path=usr/share/bash-completion/completions/openssl
+file path=usr/share/bash-completion/completions/opera
+file path=usr/share/bash-completion/completions/p4
+file path=usr/share/bash-completion/completions/pack200
+file path=usr/share/bash-completion/completions/passwd
+file path=usr/share/bash-completion/completions/patch
+link path=usr/share/bash-completion/completions/pbzip2 target=bzip2
+link path=usr/share/bash-completion/completions/pccardctl target=cardctl
+link path=usr/share/bash-completion/completions/pdlzip target=lzip
+file path=usr/share/bash-completion/completions/perl
+link path=usr/share/bash-completion/completions/perldoc target=perl
+file path=usr/share/bash-completion/completions/pgrep
+link path=usr/share/bash-completion/completions/phing target=ant
+file path=usr/share/bash-completion/completions/pidof
+link path=usr/share/bash-completion/completions/pigz target=gzip
+file path=usr/share/bash-completion/completions/pine
+link path=usr/share/bash-completion/completions/pinfo target=info
+file path=usr/share/bash-completion/completions/ping
+link path=usr/share/bash-completion/completions/ping6 target=ping
+file path=usr/share/bash-completion/completions/pkg-config
+file path=usr/share/bash-completion/completions/pkg-get
+link path=usr/share/bash-completion/completions/pkg_deinstall target=pkg_delete
+file path=usr/share/bash-completion/completions/pkg_delete
+link path=usr/share/bash-completion/completions/pkg_info target=pkg_delete
+file path=usr/share/bash-completion/completions/pkgadd
+file path=usr/share/bash-completion/completions/pkgrm
+file path=usr/share/bash-completion/completions/pkgtool
+file path=usr/share/bash-completion/completions/pkgutil
+link path=usr/share/bash-completion/completions/pkill target=pgrep
+file path=usr/share/bash-completion/completions/plague-client
+link path=usr/share/bash-completion/completions/plzip target=lzip
+file path=usr/share/bash-completion/completions/pm-hibernate
+file path=usr/share/bash-completion/completions/pm-is-supported
+file path=usr/share/bash-completion/completions/pm-powersave
+link path=usr/share/bash-completion/completions/pm-suspend target=pm-hibernate
+link path=usr/share/bash-completion/completions/pm-suspend-hybrid \
+    target=pm-hibernate
+link path=usr/share/bash-completion/completions/pmake target=make
+file path=usr/share/bash-completion/completions/portinstall
+file path=usr/share/bash-completion/completions/portupgrade
+link path=usr/share/bash-completion/completions/postalias target=postmap
+file path=usr/share/bash-completion/completions/postcat
+file path=usr/share/bash-completion/completions/postconf
+file path=usr/share/bash-completion/completions/postfix
+file path=usr/share/bash-completion/completions/postmap
+file path=usr/share/bash-completion/completions/postsuper
+file path=usr/share/bash-completion/completions/povray
+link path=usr/share/bash-completion/completions/ppc-koji target=koji
+file path=usr/share/bash-completion/completions/prelink
+file path=usr/share/bash-completion/completions/protoc
+file path=usr/share/bash-completion/completions/psql
+file path=usr/share/bash-completion/completions/puppet
+link path=usr/share/bash-completion/completions/puppetca target=puppet
+link path=usr/share/bash-completion/completions/puppetd target=puppet
+link path=usr/share/bash-completion/completions/puppetdoc target=puppet
+link path=usr/share/bash-completion/completions/puppetmasterd target=puppet
+link path=usr/share/bash-completion/completions/puppetqd target=puppet
+link path=usr/share/bash-completion/completions/puppetrun target=puppet
+link path=usr/share/bash-completion/completions/pvchange target=lvm
+link path=usr/share/bash-completion/completions/pvcreate target=lvm
+link path=usr/share/bash-completion/completions/pvdisplay target=lvm
+link path=usr/share/bash-completion/completions/pvmove target=lvm
+link path=usr/share/bash-completion/completions/pvremove target=lvm
+link path=usr/share/bash-completion/completions/pvs target=lvm
+link path=usr/share/bash-completion/completions/pvscan target=lvm
+file path=usr/share/bash-completion/completions/pwck
+file path=usr/share/bash-completion/completions/pwd
+file path=usr/share/bash-completion/completions/pwdx
+file path=usr/share/bash-completion/completions/pwgen
+link path=usr/share/bash-completion/completions/pxz target=xz
+file path=usr/share/bash-completion/completions/pydoc
+link path=usr/share/bash-completion/completions/pydoc3 target=pydoc
+file path=usr/share/bash-completion/completions/pylint
+file path=usr/share/bash-completion/completions/python
+link path=usr/share/bash-completion/completions/python2 target=python
+link path=usr/share/bash-completion/completions/python3 target=python
+file path=usr/share/bash-completion/completions/qdbus
+file path=usr/share/bash-completion/completions/qemu
+file path=usr/share/bash-completion/completions/qrunner
+file path=usr/share/bash-completion/completions/querybts
+file path=usr/share/bash-completion/completions/quota
+link path=usr/share/bash-completion/completions/quotacheck target=quota
+link path=usr/share/bash-completion/completions/quotaoff target=quota
+link path=usr/share/bash-completion/completions/quotaon target=quota
+link path=usr/share/bash-completion/completions/ralsh target=puppet
+file path=usr/share/bash-completion/completions/rcs
+link path=usr/share/bash-completion/completions/rcsdiff target=rcs
+file path=usr/share/bash-completion/completions/rdesktop
+link path=usr/share/bash-completion/completions/rdict target=dict
+file path=usr/share/bash-completion/completions/remove_members
+file path=usr/share/bash-completion/completions/removepkg
+file path=usr/share/bash-completion/completions/renice
+file path=usr/share/bash-completion/completions/reportbug
+link path=usr/share/bash-completion/completions/repquota target=quota
+file path=usr/share/bash-completion/completions/reptyr
+file path=usr/share/bash-completion/completions/resolvconf
+link path=usr/share/bash-completion/completions/rfcomm target=hcitool
+file path=usr/share/bash-completion/completions/rfkill
+file path=usr/share/bash-completion/completions/ri
+link path=usr/share/bash-completion/completions/rlog target=rcs
+file path=usr/share/bash-completion/completions/rmlist
+file path=usr/share/bash-completion/completions/rmmod
+file path=usr/share/bash-completion/completions/route
+file path=usr/share/bash-completion/completions/rpcdebug
+file path=usr/share/bash-completion/completions/rpm
+link path=usr/share/bash-completion/completions/rpm2targz target=rpm2tgz
+file path=usr/share/bash-completion/completions/rpm2tgz
+link path=usr/share/bash-completion/completions/rpm2txz target=rpm2tgz
+link path=usr/share/bash-completion/completions/rpmbuild target=rpm
+link path=usr/share/bash-completion/completions/rpmbuild-md5 target=rpm
+file path=usr/share/bash-completion/completions/rpmcheck
+file path=usr/share/bash-completion/completions/rrdtool
+file path=usr/share/bash-completion/completions/rsync
+file path=usr/share/bash-completion/completions/rtcwake
+link path=usr/share/bash-completion/completions/s390-koji target=koji
+file path=usr/share/bash-completion/completions/sbcl
+link path=usr/share/bash-completion/completions/sbcl-mt target=sbcl
+file path=usr/share/bash-completion/completions/sbopkg
+link path=usr/share/bash-completion/completions/scp target=ssh
+file path=usr/share/bash-completion/completions/screen
+link path=usr/share/bash-completion/completions/sdptool target=hcitool
+link path=usr/share/bash-completion/completions/setquota target=quota
+link path=usr/share/bash-completion/completions/sftp target=ssh
+file path=usr/share/bash-completion/completions/sh
+file path=usr/share/bash-completion/completions/sitecopy
+file path=usr/share/bash-completion/completions/slackpkg
+file path=usr/share/bash-completion/completions/slapt-get
+file path=usr/share/bash-completion/completions/slapt-src
+link path=usr/share/bash-completion/completions/slogin target=ssh
+file path=usr/share/bash-completion/completions/smartctl
+link path=usr/share/bash-completion/completions/smbcacls target=smbclient
+file path=usr/share/bash-completion/completions/smbclient
+link path=usr/share/bash-completion/completions/smbcquotas target=smbclient
+link path=usr/share/bash-completion/completions/smbget target=smbclient
+link path=usr/share/bash-completion/completions/smbpasswd target=smbclient
+link path=usr/share/bash-completion/completions/smbtar target=smbclient
+link path=usr/share/bash-completion/completions/smbtree target=smbclient
+file path=usr/share/bash-completion/completions/snownews
+link path=usr/share/bash-completion/completions/sparc-koji target=koji
+link path=usr/share/bash-completion/completions/spovray target=povray
+file path=usr/share/bash-completion/completions/sqlite3
+file path=usr/share/bash-completion/completions/ss
+file path=usr/share/bash-completion/completions/ssh
+file path=usr/share/bash-completion/completions/ssh-add
+file path=usr/share/bash-completion/completions/ssh-copy-id
+file path=usr/share/bash-completion/completions/sshfs
+file path=usr/share/bash-completion/completions/sshmitm
+file path=usr/share/bash-completion/completions/sshow
+file path=usr/share/bash-completion/completions/strace
+link path=usr/share/bash-completion/completions/stream target=convert
+file path=usr/share/bash-completion/completions/strings
+file path=usr/share/bash-completion/completions/su
+file path=usr/share/bash-completion/completions/sudo
+link path=usr/share/bash-completion/completions/sudoedit target=sudo
+file path=usr/share/bash-completion/completions/svcadm
+file path=usr/share/bash-completion/completions/svk
+file path=usr/share/bash-completion/completions/sync_members
+file path=usr/share/bash-completion/completions/sysbench
+file path=usr/share/bash-completion/completions/sysctl
+file path=usr/share/bash-completion/completions/tar
+file path=usr/share/bash-completion/completions/tcpdump
+file path=usr/share/bash-completion/completions/tcpkill
+file path=usr/share/bash-completion/completions/tcpnice
+link path=usr/share/bash-completion/completions/tightvncviewer target=vncviewer
+file path=usr/share/bash-completion/completions/tracepath
+link path=usr/share/bash-completion/completions/tracepath6 target=tracepath
+file path=usr/share/bash-completion/completions/tshark
+file path=usr/share/bash-completion/completions/tune2fs
+link path=usr/share/bash-completion/completions/typeset target=function
+file path=usr/share/bash-completion/completions/umount
+file path=usr/share/bash-completion/completions/umount.linux
+file path=usr/share/bash-completion/completions/unace
+file path=usr/share/bash-completion/completions/unpack200
+file path=usr/share/bash-completion/completions/unrar
+file path=usr/share/bash-completion/completions/unshunt
+file path=usr/share/bash-completion/completions/update-alternatives
+file path=usr/share/bash-completion/completions/update-rc.d
+file path=usr/share/bash-completion/completions/upgradepkg
+file path=usr/share/bash-completion/completions/urlsnarf
+file path=usr/share/bash-completion/completions/useradd
+file path=usr/share/bash-completion/completions/userdel
+file path=usr/share/bash-completion/completions/usermod
+file path=usr/share/bash-completion/completions/valgrind
+link path=usr/share/bash-completion/completions/vgcfgbackup target=lvm
+link path=usr/share/bash-completion/completions/vgcfgrestore target=lvm
+link path=usr/share/bash-completion/completions/vgchange target=lvm
+link path=usr/share/bash-completion/completions/vgck target=lvm
+link path=usr/share/bash-completion/completions/vgconvert target=lvm
+link path=usr/share/bash-completion/completions/vgcreate target=lvm
+link path=usr/share/bash-completion/completions/vgdisplay target=lvm
+link path=usr/share/bash-completion/completions/vgexport target=lvm
+link path=usr/share/bash-completion/completions/vgextend target=lvm
+link path=usr/share/bash-completion/completions/vgimport target=lvm
+link path=usr/share/bash-completion/completions/vgmerge target=lvm
+link path=usr/share/bash-completion/completions/vgmknodes target=lvm
+link path=usr/share/bash-completion/completions/vgreduce target=lvm
+link path=usr/share/bash-completion/completions/vgremove target=lvm
+link path=usr/share/bash-completion/completions/vgrename target=lvm
+link path=usr/share/bash-completion/completions/vgs target=lvm
+link path=usr/share/bash-completion/completions/vgscan target=lvm
+link path=usr/share/bash-completion/completions/vgsplit target=lvm
+link path=usr/share/bash-completion/completions/vigr target=vipw
+file path=usr/share/bash-completion/completions/vipw
+file path=usr/share/bash-completion/completions/vmstat
+file path=usr/share/bash-completion/completions/vncviewer
+file path=usr/share/bash-completion/completions/vpnc
+file path=usr/share/bash-completion/completions/watch
+file path=usr/share/bash-completion/completions/webmitm
+file path=usr/share/bash-completion/completions/wget
+link path=usr/share/bash-completion/completions/whatis target=man
+file path=usr/share/bash-completion/completions/wine
+file path=usr/share/bash-completion/completions/withlist
+file path=usr/share/bash-completion/completions/wodim
+file path=usr/share/bash-completion/completions/wol
+file path=usr/share/bash-completion/completions/wsimport
+file path=usr/share/bash-completion/completions/wtf
+file path=usr/share/bash-completion/completions/wvdial
+file path=usr/share/bash-completion/completions/xfreerdp
+file path=usr/share/bash-completion/completions/xgamma
+file path=usr/share/bash-completion/completions/xhost
+file path=usr/share/bash-completion/completions/xm
+file path=usr/share/bash-completion/completions/xmllint
+file path=usr/share/bash-completion/completions/xmlwf
+file path=usr/share/bash-completion/completions/xmms
+file path=usr/share/bash-completion/completions/xmodmap
+link path=usr/share/bash-completion/completions/xpovray target=povray
+file path=usr/share/bash-completion/completions/xrandr
+file path=usr/share/bash-completion/completions/xrdb
+file path=usr/share/bash-completion/completions/xsltproc
+link path=usr/share/bash-completion/completions/xvnc4viewer target=vncviewer
+file path=usr/share/bash-completion/completions/xxd
+file path=usr/share/bash-completion/completions/xz
+file path=usr/share/bash-completion/completions/xzdec
+link path=usr/share/bash-completion/completions/ypcat target=ypmatch
+file path=usr/share/bash-completion/completions/ypmatch
+file path=usr/share/bash-completion/completions/yum-arch
+dir  path=usr/share/bash-completion/helpers
+file path=usr/share/bash-completion/helpers/perl
+dir  path=usr/share/pkgconfig
+file path=usr/share/pkgconfig/bash-completion.pc


### PR DESCRIPTION
This is an initial addition of the bash-completion macros maintained by Debian as I need this to handle the environment-modules in a clean way.
- Some macros are not useful on OpenIndiana and other might need modifications but at least this commit would give the possibility for people to get started with.
- A variable BASH_COMPLETIONS_PATH has been added to shared-macros.mk to allow installation of macros by other packages in the same directory.

As it is my first addition to oi-userland I would appreciate your comments and advice on the best practices.
Best regards,

Aurelien
