### PR TITLE
Initial add of openmpi version 1.6.5 and modulefiles

### DIFF
--- a/components/openmpi/Makefile
+++ b/components/openmpi/Makefile
@@ -1,0 +1,90 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2013 Aurelien Larcher.  All rights reserved.
+#
+
+include ../../make-rules/shared-macros.mk
+MPI_IMPLEMENTATION  = openmpi
+include $(WS_MAKE_RULES)/mpi-macros.mk
+
+COMPONENT_NAME =		openmpi/$(COMPILER)
+OPENMPI_VERSION_MAJOR = 	1.6
+COMPONENT_VERSION =	    	$(OPENMPI_VERSION_MAJOR).5
+COMPONENT_FMRI =        	library/$(COMPONENT_NAME)
+COMPONENT_PROJECT_URL =		http://www.open-mpi.org
+COMPONENT_SRC_NAME =		openmpi
+COMPONENT_SRC =		    	$(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE =	    	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH = \
+    sha256:ac308dc38e77c622aedea5f3fd368c800b6636d0500f2124c36a505a65806559
+COMPONENT_ARCHIVE_URL =	http://www.open-mpi.org/software/ompi/v$(OPENMPI_VERSION_MAJOR)/downloads/$(COMPONENT_ARCHIVE)
+COMPONENT_BUGDB =		$(COMPONENT_FMRI)
+
+COMPONENT_SUMMARY =     	OpenMPI - High Performance Message Passing Library
+COMPONENT_LICENSE_FILE = 	$(COMPONENT_SRC_NAME).license
+COMPONENT_LICENSE      = 	BSD 2-Clause
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk  
+
+CONFIGURE_PREFIX   =    $(MPI_PREFIX)
+
+CONFIGURE_OPTIONS+=	--bindir=$(MPI_BINDIR)
+CONFIGURE_OPTIONS+=	--datadir=$(MPI_DATADIR)
+CONFIGURE_OPTIONS+=	--docdir=$(MPI_DOCDIR)
+CONFIGURE_OPTIONS+=	--htmldir=$(MPI_HTMLDIR)
+CONFIGURE_OPTIONS+=	--includedir=$(MPI_INCDIR)
+CONFIGURE_OPTIONS+=	--libdir=$(MPI_LIBDIR)
+CONFIGURE_OPTIONS+=	--mandir=$(MPI_MANDIR)
+CONFIGURE_OPTIONS+=	--sbindir=$(MPI_SBINDIR)
+CONFIGURE_OPTIONS+=	--sysconfdir=$(MPI_ETCDIR)
+CONFIGURE_OPTIONS+=	--enable-ipv6
+CONFIGURE_OPTIONS+=	--enable-mpi-f77
+CONFIGURE_OPTIONS+=	--enable-mpi-f90
+CONFIGURE_OPTIONS+=	--enable-mpi-profile
+CONFIGURE_OPTIONS+=	--enable-mpi-cxx
+CONFIGURE_OPTIONS+=	--enable-mpi-cxx-seek
+CONFIGURE_OPTIONS+=	--with-wrapper-cflags="-L$(MPI_LIBDIR) -R$(MPI_LIBDIR)"
+CONFIGURE_OPTIONS+=	--with-wrapper-cxxflags="-L$(MPI_LIBDIR) -R$(MPI_LIBDIR)"
+CONFIGURE_OPTIONS+=	--with-wrapper-libs="-L$(MPI_LIBDIR) -R$(MPI_LIBDIR)"
+CONFIGURE_OPTIONS+=	--with-wrapper-fflags="-L$(MPI_LIBDIR) -R$(MPI_LIBDIR)"
+CONFIGURE_OPTIONS+=	--with-wrapper-fcflags="-L$(MPI_LIBDIR) -R$(MPI_LIBDIR)"
+
+#COMPONENT_POST_CONFIGURE_ACTION += sed -i -e 's/-export-dynamic//g' $(SOURCE_DIR)/ompi/mpi/cxx/Makefile
+
+build:		$(BUILD_32_and_64)
+
+$(BUILD_DIR)/modulefile.%:		files/modulefile
+	/bin/sed -e "s#%%BITS%%#$*#g" \
+	-e "s#%%COMPONENT_FMRI%%#$(COMPONENT_FMRI)#g" \
+	-e "s#%%COMPONENT_VERSION%%#$(COMPONENT_VERSION)#g" \
+	-e "s#%%MODULE_CONFLICTS%%#$(MPI_IMPLEMENTATIONS_LIST)#g" \
+	-e "s#%%MODULE_INCDIR%%#$(MPI_INCDIR)#g" \
+	-e "s#%%MODULE_PREFIX%%#$(MPI_PREFIX.$*)#g" < $< > $@ ;
+
+PROTO_MODULE_PATH = $(PROTO_DIR)$(MODULE_PATH)/$(COMPONENT_NAME)
+
+install:	$(INSTALL_32_and_64) $(BUILD_DIR)/modulefile.32 $(BUILD_DIR)/modulefile.64
+	$(MKDIR) $(PROTO_MODULE_PATH)/32
+	$(CP) $(BUILD_DIR)/modulefile.32 $(PROTO_MODULE_PATH)/32/$(COMPONENT_VERSION)
+	$(MKDIR) $(PROTO_MODULE_PATH)/64
+	$(CP) $(BUILD_DIR)/modulefile.64 $(PROTO_MODULE_PATH)/64/$(COMPONENT_VERSION)
+
+test:	$(TEST_32)
+
+
+
+BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
+
+include $(WS_MAKE_RULES)/depend.mk

--- a/components/openmpi/files/modulefile
+++ b/components/openmpi/files/modulefile
@@ -1,0 +1,29 @@
+#%Module1.0#####################################################################
+
+proc ModulesHelp { } {
+        global version
+
+        puts stderr "\tpkg:/%%COMPONENT_FMRI%% version %%COMPONENT_VERSION%%"
+}
+
+module-whatis	"%%COMPONENT_FMRI%%/%%BITS%%"
+
+conflict	%%MODULE_CONFLICTS%%
+
+# for Tcl script use only
+set     version      "3.2.10"
+
+set     modroot      %%MODULE_PREFIX%%
+
+prepend-path    PATH            $modroot/bin
+prepend-path    MANPATH         $modroot/man
+prepend-path    LD_LIBRARY_PATH $modroot/lib
+
+## compiler paths
+prepend-path    C_INCLUDE_PATH          %%MODULE_INCDIR%%
+prepend-path    CPP_INCLUDE_PATH        %%MODULE_INCDIR%%
+prepend-path    LIBRARY_PATH            $modroot/lib
+
+## pkgconfig
+prepend-path    PKG_CONFIG_PATH 	$modroot/lib/pkgconfig
+

--- a/components/openmpi/openmpi-modulefiles.p5m
+++ b/components/openmpi/openmpi-modulefiles.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2013 Aurelien Larcher. All rights reserved.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/modulefiles@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) (Modulefiles)"
+set name=info.classification \
+    value="org.opensolaris.category.2008:Development/High Performance Computing"
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/package/environment-modules
+
+dir  path=usr
+dir  path=usr/share
+dir  path=usr/share/Modules
+dir  path=usr/share/Modules/modulefiles
+dir  path=usr/share/Modules/modulefiles/$(COMPONENT_NAME)
+dir  path=usr/share/Modules/modulefiles/$(COMPONENT_NAME)/32
+file path=usr/share/Modules/modulefiles/$(COMPONENT_NAME)/32/$(COMPONENT_VERSION)
+link path=usr/share/Modules/modulefiles/$(COMPONENT_NAME)/32/latest \
+    target=$(COMPONENT_VERSION)
+dir  path=usr/share/Modules/modulefiles/$(COMPONENT_NAME)/64
+file path=usr/share/Modules/modulefiles/$(COMPONENT_NAME)/64/$(COMPONENT_VERSION)
+link path=usr/share/Modules/modulefiles/$(COMPONENT_NAME)/64/latest \
+    target=$(COMPONENT_VERSION)
+

--- a/components/openmpi/openmpi.license
+++ b/components/openmpi/openmpi.license
@@ -1,0 +1,84 @@
+Most files in this release are marked with the copyrights of the
+organizations who have edited them.  The copyrights below are in no
+particular order and generally reflect members of the Open MPI core
+team who have contributed code to this release.  The copyrights for
+code used under license from other parties are included in the
+corresponding files.
+
+Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+                        University Research and Technology
+                        Corporation.  All rights reserved.
+Copyright (c) 2004-2010 The University of Tennessee and The University
+                        of Tennessee Research Foundation.  All rights
+                        reserved.
+Copyright (c) 2004-2010 High Performance Computing Center Stuttgart, 
+                        University of Stuttgart.  All rights reserved.
+Copyright (c) 2004-2008 The Regents of the University of California.
+                        All rights reserved.
+Copyright (c) 2006-2010 Los Alamos National Security, LLC.  All rights
+                        reserved. 
+Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2006-2010 Voltaire, Inc. All rights reserved.
+Copyright (c) 2006-2010 Sandia National Laboratories. All rights reserved.
+Copyright (c) 2006-2010 Sun Microsystems, Inc.  All rights reserved.
+                        Use is subject to license terms.
+Copyright (c) 2006-2010 The University of Houston. All rights reserved.
+Copyright (c) 2006-2009 Myricom, Inc.  All rights reserved.
+Copyright (c) 2007-2008 UT-Battelle, LLC. All rights reserved.
+Copyright (c) 2007-2010 IBM Corporation.  All rights reserved.
+Copyright (c) 1998-2005 Forschungszentrum Juelich, Juelich Supercomputing 
+                        Centre, Federal Republic of Germany
+Copyright (c) 2005-2008 ZIH, TU Dresden, Federal Republic of Germany
+Copyright (c) 2007      Evergrid, Inc. All rights reserved.
+Copyright (c) 2008      Chelsio, Inc.  All rights reserved.
+Copyright (c) 2008-2009 Institut National de Recherche en
+                        Informatique.  All rights reserved.
+Copyright (c) 2007      Lawrence Livermore National Security, LLC.
+                        All rights reserved.
+Copyright (c) 2007-2009 Mellanox Technologies.  All rights reserved.
+Copyright (c) 2006-2010 QLogic Corporation.  All rights reserved.
+Copyright (c) 2008-2010 Oak Ridge National Labs.  All rights reserved.
+Copyright (c) 2006-2010 Oracle and/or its affiliates.  All rights reserved.
+Copyright (c) 2009      Bull SAS.  All rights reserved.
+Copyright (c) 2010      ARM ltd.  All rights reserved.
+
+$COPYRIGHT$
+
+Additional copyrights may follow
+
+$HEADER$
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+- Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer listed
+  in this license in the documentation and/or other materials
+  provided with the distribution.
+
+- Neither the name of the copyright holders nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+The copyright holders provide no reassurances that the source code
+provided does not infringe any patent, copyright, or any other
+intellectual property rights of third parties.  The copyright holders
+disclaim any liability to any recipient for claims brought against
+recipient by any third party for infringement of that parties
+intellectual property rights.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/openmpi/openmpi.p5m
+++ b/components/openmpi/openmpi.p5m
@@ -1,0 +1,1038 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2013 <contributor>. All rights reserved.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification \
+    value="org.opensolaris.category.2008:Development/High Performance Computing"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file path=.* -> default pkg.depend.bypass-generate perl >
+
+dir  path=usr
+dir  path=usr/include
+dir  path=usr/include/openmpi
+file path=usr/include/openmpi/mpi-ext.h
+file path=usr/include/openmpi/mpi.h
+file path=usr/include/openmpi/mpi_portable_platform.h
+file path=usr/include/openmpi/mpif-common.h
+file path=usr/include/openmpi/mpif-config.h
+file path=usr/include/openmpi/mpif-mpi-io.h
+file path=usr/include/openmpi/mpif.h
+dir  path=usr/include/openmpi/openmpi
+dir  path=usr/include/openmpi/openmpi/ompi
+dir  path=usr/include/openmpi/openmpi/ompi/mpi
+dir  path=usr/include/openmpi/openmpi/ompi/mpi/cxx
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/comm.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/comm_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/constants.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/datatype.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/datatype_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/errhandler.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/errhandler_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/exception.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/file.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/file_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/functions.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/functions_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/group.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/group_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/info.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/info_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/intercomm.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/intercomm_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/intracomm.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/intracomm_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/mpicxx.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/op.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/op_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/request.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/request_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/status.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/status_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/topology.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/topology_inln.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/win.h
+file path=usr/include/openmpi/openmpi/ompi/mpi/cxx/win_inln.h
+dir  path=usr/include/openmpi/vampirtrace
+file path=usr/include/openmpi/vampirtrace/opari_omp.h
+dir  path=usr/include/openmpi/vampirtrace/open-trace-format
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTFAUX_MsgMatching.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTFAUX_State.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTFAUX_Thumbnail.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_CopyHandler.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_CopyHandler_stream.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_Definitions.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_Errno.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_File.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_FileManager.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_File_iofsl.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_Filenames.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_HandlerArray.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_KeyValue.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_MasterControl.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_RBuffer.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_RStream.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_Reader.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_Version.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_WBuffer.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_WStream.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_Writer.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_inttypes.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/OTF_inttypes_unix.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/otf.h
+file path=usr/include/openmpi/vampirtrace/open-trace-format/otfaux.h
+file path=usr/include/openmpi/vampirtrace/pomp_lib.h
+file path=usr/include/openmpi/vampirtrace/vt_inttypes.h
+file path=usr/include/openmpi/vampirtrace/vt_libwrap.h
+file path=usr/include/openmpi/vampirtrace/vt_plugin_cntr.h
+file path=usr/include/openmpi/vampirtrace/vt_user.h
+file path=usr/include/openmpi/vampirtrace/vt_user.inc
+file path=usr/include/openmpi/vampirtrace/vt_user_comment.h
+file path=usr/include/openmpi/vampirtrace/vt_user_comment.inc
+file path=usr/include/openmpi/vampirtrace/vt_user_control.h
+file path=usr/include/openmpi/vampirtrace/vt_user_control.inc
+file path=usr/include/openmpi/vampirtrace/vt_user_count.h
+file path=usr/include/openmpi/vampirtrace/vt_user_count.inc
+file path=usr/include/openmpi/vampirtrace/vt_user_marker.h
+file path=usr/include/openmpi/vampirtrace/vt_user_marker.inc
+file path=usr/include/openmpi/vampirtrace/vt_user_message.h
+file path=usr/include/openmpi/vampirtrace/vt_user_message.inc
+file path=usr/include/openmpi/vampirtrace/vt_user_region.h
+file path=usr/include/openmpi/vampirtrace/vt_user_region.inc
+file path=usr/include/openmpi/vampirtrace/vt_wrap_pthread.h
+dir  path=usr/lib
+dir  path=usr/lib/$(MACH64)
+dir  path=usr/lib/$(MACH64)/openmpi
+dir  path=usr/lib/$(MACH64)/openmpi/gcc
+dir  path=usr/lib/$(MACH64)/openmpi/gcc/bin
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpiCC target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpiCC-vt target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpic++ target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpic++-vt target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpicc target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpicc-vt target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpicxx target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpicxx-vt target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpiexec target=orterun
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpif77 target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpif77-vt target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpif90 target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpif90-vt target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/mpirun target=orterun
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi-clean target=orte-clean
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi-iof target=orte-iof
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi-probe
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi-profiler
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi-ps target=orte-ps
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi-server
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi-top target=orte-top
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/ompi_info
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/opal_wrapper
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/opari
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orte-bootproxy.sh
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orte-clean
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orte-iof
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orte-ps
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orte-top
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/orteCC target=opal_wrapper
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orte_wrapper_script
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/ortec++ target=opal_wrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/ortecc target=opal_wrapper
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orted
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/orterun
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfaux
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfcompress
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfconfig
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfdecompress target=otfcompress
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfinfo
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfmerge
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfmerge-mpi
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfprint
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfprofile
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfprofile-mpi
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/otfshrink
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtCC target=vtwrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtc++ target=vtwrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtcc target=vtwrapper
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtcpcavail
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtcxx target=vtwrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtf77 target=vtwrapper
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtf90 target=vtwrapper
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtfilter
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtfilter-mpi
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtfiltergen target=vtfilter
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtfiltergen-mpi target=vtfilter-mpi
+link path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtfort target=vtwrapper
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtrun
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtsetup
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtsetup.jar
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtunify
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtunify-mpi
+file path=usr/lib/$(MACH64)/openmpi/gcc/bin/vtwrapper
+dir  path=usr/lib/$(MACH64)/openmpi/gcc/etc
+file path=usr/lib/$(MACH64)/openmpi/gcc/etc/openmpi-default-hostfile
+file path=usr/lib/$(MACH64)/openmpi/gcc/etc/openmpi-mca-params.conf
+file path=usr/lib/$(MACH64)/openmpi/gcc/etc/openmpi-totalview.tcl
+file path=usr/lib/$(MACH64)/openmpi/gcc/etc/vtsetup-config.dtd
+file path=usr/lib/$(MACH64)/openmpi/gcc/etc/vtsetup-config.xml
+dir  path=usr/lib/$(MACH64)/openmpi/gcc/lib
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmca_common_sm.so \
+    target=libmca_common_sm.so.3.0.1
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmca_common_sm.so.3 \
+    target=libmca_common_sm.so.3.0.1
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmca_common_sm.so.3.0.1
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi.so target=libmpi.so.1.0.8
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi.so.1 target=libmpi.so.1.0.8
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi.so.1.0.8
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_cxx.so \
+    target=libmpi_cxx.so.1.0.2
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_cxx.so.1 \
+    target=libmpi_cxx.so.1.0.2
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_cxx.so.1.0.2
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_f77.so \
+    target=libmpi_f77.so.1.0.7
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_f77.so.1 \
+    target=libmpi_f77.so.1.0.7
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_f77.so.1.0.7
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_f90.so \
+    target=libmpi_f90.so.1.3.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_f90.so.1 \
+    target=libmpi_f90.so.1.3.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libmpi_f90.so.1.3.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libompitrace.so \
+    target=libompitrace.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libompitrace.so.0 \
+    target=libompitrace.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libompitrace.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-pal.so \
+    target=libopen-pal.so.4.0.5
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-pal.so.4 \
+    target=libopen-pal.so.4.0.5
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-pal.so.4.0.5
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-rte.so \
+    target=libopen-rte.so.4.0.3
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-rte.so.4 \
+    target=libopen-rte.so.4.0.3
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-rte.so.4.0.3
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-trace-format.a
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-trace-format.so \
+    target=libopen-trace-format.so.1.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-trace-format.so.1 \
+    target=libopen-trace-format.so.1.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libopen-trace-format.so.1.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libotfaux.a
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libotfaux.so \
+    target=libotfaux.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libotfaux.so.0 \
+    target=libotfaux.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libotfaux.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-hyb.a
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-hyb.so \
+    target=libvt-hyb.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-hyb.so.0 \
+    target=libvt-hyb.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-hyb.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi-unify.a
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi-unify.so \
+    target=libvt-mpi-unify.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi-unify.so.0 \
+    target=libvt-mpi-unify.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi-unify.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi.a
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi.so \
+    target=libvt-mpi.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi.so.0 \
+    target=libvt-mpi.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mpi.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mt.a
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mt.so target=libvt-mt.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mt.so.0 \
+    target=libvt-mt.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-mt.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt-pomp.a
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt.a
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt.so target=libvt.so.0.0.0
+link path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt.so.0 target=libvt.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/libvt.so.0.0.0
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/mpi.mod
+dir  path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/libompi_dbg_msgq.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_allocator_basic.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_allocator_bucket.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_bml_r2.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_btl_sctp.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_btl_self.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_btl_sm.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_btl_tcp.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_carto_auto_detect.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_carto_file.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_coll_basic.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_coll_hierarch.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_coll_inter.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_coll_self.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_coll_sm.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_coll_sync.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_coll_tuned.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_crs_none.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_dpm_orte.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_errmgr_default.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_ess_env.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_ess_hnp.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_ess_singleton.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_ess_slave.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_ess_tool.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_filem_rsh.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_grpcomm_bad.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_grpcomm_basic.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_grpcomm_hier.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_io_romio.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_iof_hnp.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_iof_orted.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_iof_tool.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_maffinity_first_use.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_maffinity_hwloc.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_mpool_fake.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_mpool_rdma.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_mpool_sm.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_notifier_command.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_notifier_syslog.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_odls_default.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_oob_tcp.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_osc_pt2pt.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_osc_rdma.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_paffinity_hwloc.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_plm_rsh.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_pml_bfo.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_pml_cm.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_pml_csum.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_pml_ob1.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_pml_v.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_pubsub_orte.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_ras_cm.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rcache_vma.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rmaps_load_balance.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rmaps_rank_file.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rmaps_resilient.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rmaps_round_robin.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rmaps_seq.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rmaps_topo.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_rml_oob.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_routed_binomial.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_routed_cm.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_routed_direct.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_routed_linear.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_routed_radix.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_routed_slave.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_shmem_mmap.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_shmem_posix.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_shmem_sysv.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_topo_unity.so
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/openmpi/mca_vprotocol_pessimist.so
+dir  path=usr/lib/$(MACH64)/openmpi/gcc/lib/pkgconfig
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/pkgconfig/ompi-c.pc
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/pkgconfig/ompi-cxx.pc
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/pkgconfig/ompi-f77.pc
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/pkgconfig/ompi-f90.pc
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/pkgconfig/ompi.pc
+file path=usr/lib/$(MACH64)/openmpi/gcc/lib/pkgconfig/orte.pc
+dir  path=usr/lib/openmpi
+dir  path=usr/lib/openmpi/gcc
+dir  path=usr/lib/openmpi/gcc/bin
+link path=usr/lib/openmpi/gcc/bin/mpiCC target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpiCC-vt target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpic++ target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpic++-vt target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpicc target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpicc-vt target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpicxx target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpicxx-vt target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpiexec target=orterun
+link path=usr/lib/openmpi/gcc/bin/mpif77 target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpif77-vt target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpif90 target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpif90-vt target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/mpirun target=orterun
+link path=usr/lib/openmpi/gcc/bin/ompi-clean target=orte-clean
+link path=usr/lib/openmpi/gcc/bin/ompi-iof target=orte-iof
+file path=usr/lib/openmpi/gcc/bin/ompi-probe
+file path=usr/lib/openmpi/gcc/bin/ompi-profiler
+link path=usr/lib/openmpi/gcc/bin/ompi-ps target=orte-ps
+file path=usr/lib/openmpi/gcc/bin/ompi-server
+link path=usr/lib/openmpi/gcc/bin/ompi-top target=orte-top
+file path=usr/lib/openmpi/gcc/bin/ompi_info
+file path=usr/lib/openmpi/gcc/bin/opal_wrapper
+file path=usr/lib/openmpi/gcc/bin/opari
+file path=usr/lib/openmpi/gcc/bin/orte-bootproxy.sh
+file path=usr/lib/openmpi/gcc/bin/orte-clean
+file path=usr/lib/openmpi/gcc/bin/orte-iof
+file path=usr/lib/openmpi/gcc/bin/orte-ps
+file path=usr/lib/openmpi/gcc/bin/orte-top
+link path=usr/lib/openmpi/gcc/bin/orteCC target=opal_wrapper
+file path=usr/lib/openmpi/gcc/bin/orte_wrapper_script
+link path=usr/lib/openmpi/gcc/bin/ortec++ target=opal_wrapper
+link path=usr/lib/openmpi/gcc/bin/ortecc target=opal_wrapper
+file path=usr/lib/openmpi/gcc/bin/orted
+file path=usr/lib/openmpi/gcc/bin/orterun
+file path=usr/lib/openmpi/gcc/bin/otfaux
+file path=usr/lib/openmpi/gcc/bin/otfcompress
+file path=usr/lib/openmpi/gcc/bin/otfconfig
+link path=usr/lib/openmpi/gcc/bin/otfdecompress target=otfcompress
+file path=usr/lib/openmpi/gcc/bin/otfinfo
+file path=usr/lib/openmpi/gcc/bin/otfmerge
+file path=usr/lib/openmpi/gcc/bin/otfmerge-mpi
+file path=usr/lib/openmpi/gcc/bin/otfprint
+file path=usr/lib/openmpi/gcc/bin/otfprofile
+file path=usr/lib/openmpi/gcc/bin/otfprofile-mpi
+file path=usr/lib/openmpi/gcc/bin/otfshrink
+link path=usr/lib/openmpi/gcc/bin/vtCC target=vtwrapper
+link path=usr/lib/openmpi/gcc/bin/vtc++ target=vtwrapper
+link path=usr/lib/openmpi/gcc/bin/vtcc target=vtwrapper
+link path=usr/lib/openmpi/gcc/bin/vtcxx target=vtwrapper
+link path=usr/lib/openmpi/gcc/bin/vtf77 target=vtwrapper
+link path=usr/lib/openmpi/gcc/bin/vtf90 target=vtwrapper
+file path=usr/lib/openmpi/gcc/bin/vtfilter
+file path=usr/lib/openmpi/gcc/bin/vtfilter-mpi
+link path=usr/lib/openmpi/gcc/bin/vtfiltergen target=vtfilter
+link path=usr/lib/openmpi/gcc/bin/vtfiltergen-mpi target=vtfilter-mpi
+link path=usr/lib/openmpi/gcc/bin/vtfort target=vtwrapper
+file path=usr/lib/openmpi/gcc/bin/vtrun
+file path=usr/lib/openmpi/gcc/bin/vtsetup
+file path=usr/lib/openmpi/gcc/bin/vtsetup.jar
+file path=usr/lib/openmpi/gcc/bin/vtunify
+file path=usr/lib/openmpi/gcc/bin/vtunify-mpi
+file path=usr/lib/openmpi/gcc/bin/vtwrapper
+dir  path=usr/lib/openmpi/gcc/etc
+file path=usr/lib/openmpi/gcc/etc/openmpi-default-hostfile
+file path=usr/lib/openmpi/gcc/etc/openmpi-mca-params.conf
+file path=usr/lib/openmpi/gcc/etc/openmpi-totalview.tcl
+file path=usr/lib/openmpi/gcc/etc/vtsetup-config.dtd
+file path=usr/lib/openmpi/gcc/etc/vtsetup-config.xml
+dir  path=usr/lib/openmpi/gcc/lib
+link path=usr/lib/openmpi/gcc/lib/libmca_common_sm.so \
+    target=libmca_common_sm.so.3.0.1
+link path=usr/lib/openmpi/gcc/lib/libmca_common_sm.so.3 \
+    target=libmca_common_sm.so.3.0.1
+file path=usr/lib/openmpi/gcc/lib/libmca_common_sm.so.3.0.1
+link path=usr/lib/openmpi/gcc/lib/libmpi.so target=libmpi.so.1.0.8
+link path=usr/lib/openmpi/gcc/lib/libmpi.so.1 target=libmpi.so.1.0.8
+file path=usr/lib/openmpi/gcc/lib/libmpi.so.1.0.8
+link path=usr/lib/openmpi/gcc/lib/libmpi_cxx.so target=libmpi_cxx.so.1.0.2
+link path=usr/lib/openmpi/gcc/lib/libmpi_cxx.so.1 target=libmpi_cxx.so.1.0.2
+file path=usr/lib/openmpi/gcc/lib/libmpi_cxx.so.1.0.2
+link path=usr/lib/openmpi/gcc/lib/libmpi_f77.so target=libmpi_f77.so.1.0.7
+link path=usr/lib/openmpi/gcc/lib/libmpi_f77.so.1 target=libmpi_f77.so.1.0.7
+file path=usr/lib/openmpi/gcc/lib/libmpi_f77.so.1.0.7
+link path=usr/lib/openmpi/gcc/lib/libmpi_f90.so target=libmpi_f90.so.1.3.0
+link path=usr/lib/openmpi/gcc/lib/libmpi_f90.so.1 target=libmpi_f90.so.1.3.0
+file path=usr/lib/openmpi/gcc/lib/libmpi_f90.so.1.3.0
+link path=usr/lib/openmpi/gcc/lib/libompitrace.so target=libompitrace.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libompitrace.so.0 target=libompitrace.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libompitrace.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libopen-pal.so target=libopen-pal.so.4.0.5
+link path=usr/lib/openmpi/gcc/lib/libopen-pal.so.4 target=libopen-pal.so.4.0.5
+file path=usr/lib/openmpi/gcc/lib/libopen-pal.so.4.0.5
+link path=usr/lib/openmpi/gcc/lib/libopen-rte.so target=libopen-rte.so.4.0.3
+link path=usr/lib/openmpi/gcc/lib/libopen-rte.so.4 target=libopen-rte.so.4.0.3
+file path=usr/lib/openmpi/gcc/lib/libopen-rte.so.4.0.3
+file path=usr/lib/openmpi/gcc/lib/libopen-trace-format.a
+link path=usr/lib/openmpi/gcc/lib/libopen-trace-format.so \
+    target=libopen-trace-format.so.1.0.0
+link path=usr/lib/openmpi/gcc/lib/libopen-trace-format.so.1 \
+    target=libopen-trace-format.so.1.0.0
+file path=usr/lib/openmpi/gcc/lib/libopen-trace-format.so.1.0.0
+file path=usr/lib/openmpi/gcc/lib/libotfaux.a
+link path=usr/lib/openmpi/gcc/lib/libotfaux.so target=libotfaux.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libotfaux.so.0 target=libotfaux.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libotfaux.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-hyb.a
+link path=usr/lib/openmpi/gcc/lib/libvt-hyb.so target=libvt-hyb.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libvt-hyb.so.0 target=libvt-hyb.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-hyb.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-mpi-unify.a
+link path=usr/lib/openmpi/gcc/lib/libvt-mpi-unify.so \
+    target=libvt-mpi-unify.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libvt-mpi-unify.so.0 \
+    target=libvt-mpi-unify.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-mpi-unify.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-mpi.a
+link path=usr/lib/openmpi/gcc/lib/libvt-mpi.so target=libvt-mpi.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libvt-mpi.so.0 target=libvt-mpi.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-mpi.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-mt.a
+link path=usr/lib/openmpi/gcc/lib/libvt-mt.so target=libvt-mt.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libvt-mt.so.0 target=libvt-mt.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-mt.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt-pomp.a
+file path=usr/lib/openmpi/gcc/lib/libvt.a
+link path=usr/lib/openmpi/gcc/lib/libvt.so target=libvt.so.0.0.0
+link path=usr/lib/openmpi/gcc/lib/libvt.so.0 target=libvt.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/libvt.so.0.0.0
+file path=usr/lib/openmpi/gcc/lib/mpi.mod
+dir  path=usr/lib/openmpi/gcc/lib/openmpi
+file path=usr/lib/openmpi/gcc/lib/openmpi/libompi_dbg_msgq.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_allocator_basic.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_allocator_bucket.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_bml_r2.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_btl_sctp.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_btl_self.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_btl_sm.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_btl_tcp.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_carto_auto_detect.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_carto_file.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_coll_basic.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_coll_hierarch.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_coll_inter.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_coll_self.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_coll_sm.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_coll_sync.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_coll_tuned.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_crs_none.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_dpm_orte.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_errmgr_default.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_ess_env.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_ess_hnp.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_ess_singleton.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_ess_slave.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_ess_tool.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_filem_rsh.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_grpcomm_bad.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_grpcomm_basic.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_grpcomm_hier.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_io_romio.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_iof_hnp.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_iof_orted.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_iof_tool.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_maffinity_first_use.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_maffinity_hwloc.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_mpool_fake.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_mpool_rdma.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_mpool_sm.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_notifier_command.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_notifier_syslog.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_odls_default.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_oob_tcp.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_osc_pt2pt.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_osc_rdma.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_paffinity_hwloc.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_plm_rsh.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_pml_bfo.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_pml_cm.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_pml_csum.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_pml_ob1.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_pml_v.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_pubsub_orte.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_ras_cm.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rcache_vma.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rmaps_load_balance.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rmaps_rank_file.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rmaps_resilient.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rmaps_round_robin.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rmaps_seq.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rmaps_topo.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_rml_oob.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_routed_binomial.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_routed_cm.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_routed_direct.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_routed_linear.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_routed_radix.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_routed_slave.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_shmem_mmap.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_shmem_posix.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_shmem_sysv.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_topo_unity.so
+file path=usr/lib/openmpi/gcc/lib/openmpi/mca_vprotocol_pessimist.so
+dir  path=usr/lib/openmpi/gcc/lib/pkgconfig
+file path=usr/lib/openmpi/gcc/lib/pkgconfig/ompi-c.pc
+file path=usr/lib/openmpi/gcc/lib/pkgconfig/ompi-cxx.pc
+file path=usr/lib/openmpi/gcc/lib/pkgconfig/ompi-f77.pc
+file path=usr/lib/openmpi/gcc/lib/pkgconfig/ompi-f90.pc
+file path=usr/lib/openmpi/gcc/lib/pkgconfig/ompi.pc
+file path=usr/lib/openmpi/gcc/lib/pkgconfig/orte.pc
+dir  path=usr/share
+dir  path=usr/share/doc
+dir  path=usr/share/doc/openmpi
+file path=usr/share/doc/openmpi/ChangeLog
+file path=usr/share/doc/openmpi/LICENSE
+file path=usr/share/doc/openmpi/UserManual.html
+file path=usr/share/doc/openmpi/UserManual.pdf
+dir  path=usr/share/doc/openmpi/opari
+file path=usr/share/doc/openmpi/opari/ChangeLog
+file path=usr/share/doc/openmpi/opari/LICENSE
+file path=usr/share/doc/openmpi/opari/Readme.html
+file path=usr/share/doc/openmpi/opari/lacsi01.pdf
+file path=usr/share/doc/openmpi/opari/opari-logo-100.gif
+dir  path=usr/share/doc/openmpi/otf
+file path=usr/share/doc/openmpi/otf/ChangeLog
+file path=usr/share/doc/openmpi/otf/LICENSE
+file path=usr/share/doc/openmpi/otf/otfprofile.pdf
+file path=usr/share/doc/openmpi/otf/otfprofile_clustering.pdf
+file path=usr/share/doc/openmpi/otf/otftools.pdf
+file path=usr/share/doc/openmpi/otf/specification.pdf
+dir  path=usr/share/doc/openmpi/vtsetup
+file path=usr/share/doc/openmpi/vtsetup/ChangeLog
+file path=usr/share/doc/openmpi/vtsetup/LICENSE
+dir  path=usr/share/man
+dir  path=usr/share/man/man1
+link path=usr/share/man/man1/mpiCC.1 target=mpic++.1
+file path=usr/share/man/man1/mpic++.1
+file path=usr/share/man/man1/mpicc.1
+file path=usr/share/man/man1/mpicxx.1
+file path=usr/share/man/man1/mpiexec.1
+file path=usr/share/man/man1/mpif77.1
+file path=usr/share/man/man1/mpif90.1
+file path=usr/share/man/man1/mpirun.1
+file path=usr/share/man/man1/ompi-clean.1
+file path=usr/share/man/man1/ompi-iof.1
+file path=usr/share/man/man1/ompi-probe.1
+file path=usr/share/man/man1/ompi-profiler.1
+file path=usr/share/man/man1/ompi-ps.1
+file path=usr/share/man/man1/ompi-server.1
+file path=usr/share/man/man1/ompi-top.1
+file path=usr/share/man/man1/ompi_info.1
+file path=usr/share/man/man1/opal_wrapper.1
+file path=usr/share/man/man1/orte-clean.1
+file path=usr/share/man/man1/orte-iof.1
+file path=usr/share/man/man1/orte-ps.1
+file path=usr/share/man/man1/orte-top.1
+#link path=usr/share/man/man1/orteCC.1 target=ortec++.1
+file path=usr/share/man/man1/orted.1
+file path=usr/share/man/man1/orterun.1
+dir  path=usr/share/man/man3
+file path=usr/share/man/man3/MPI.3
+file path=usr/share/man/man3/MPI_Abort.3
+file path=usr/share/man/man3/MPI_Accumulate.3
+file path=usr/share/man/man3/MPI_Add_error_class.3
+file path=usr/share/man/man3/MPI_Add_error_code.3
+file path=usr/share/man/man3/MPI_Add_error_string.3
+file path=usr/share/man/man3/MPI_Address.3
+file path=usr/share/man/man3/MPI_Allgather.3
+file path=usr/share/man/man3/MPI_Allgatherv.3
+file path=usr/share/man/man3/MPI_Alloc_mem.3
+file path=usr/share/man/man3/MPI_Allreduce.3
+file path=usr/share/man/man3/MPI_Alltoall.3
+file path=usr/share/man/man3/MPI_Alltoallv.3
+file path=usr/share/man/man3/MPI_Alltoallw.3
+file path=usr/share/man/man3/MPI_Attr_delete.3
+file path=usr/share/man/man3/MPI_Attr_get.3
+file path=usr/share/man/man3/MPI_Attr_put.3
+file path=usr/share/man/man3/MPI_Barrier.3
+file path=usr/share/man/man3/MPI_Bcast.3
+file path=usr/share/man/man3/MPI_Bsend.3
+file path=usr/share/man/man3/MPI_Bsend_init.3
+file path=usr/share/man/man3/MPI_Buffer_attach.3
+file path=usr/share/man/man3/MPI_Buffer_detach.3
+file path=usr/share/man/man3/MPI_Cancel.3
+file path=usr/share/man/man3/MPI_Cart_coords.3
+file path=usr/share/man/man3/MPI_Cart_create.3
+file path=usr/share/man/man3/MPI_Cart_get.3
+file path=usr/share/man/man3/MPI_Cart_map.3
+file path=usr/share/man/man3/MPI_Cart_rank.3
+file path=usr/share/man/man3/MPI_Cart_shift.3
+file path=usr/share/man/man3/MPI_Cart_sub.3
+file path=usr/share/man/man3/MPI_Cartdim_get.3
+file path=usr/share/man/man3/MPI_Close_port.3
+file path=usr/share/man/man3/MPI_Comm_accept.3
+file path=usr/share/man/man3/MPI_Comm_c2f.3
+file path=usr/share/man/man3/MPI_Comm_call_errhandler.3
+file path=usr/share/man/man3/MPI_Comm_compare.3
+file path=usr/share/man/man3/MPI_Comm_connect.3
+file path=usr/share/man/man3/MPI_Comm_create.3
+file path=usr/share/man/man3/MPI_Comm_create_errhandler.3
+file path=usr/share/man/man3/MPI_Comm_create_keyval.3
+file path=usr/share/man/man3/MPI_Comm_delete_attr.3
+file path=usr/share/man/man3/MPI_Comm_disconnect.3
+file path=usr/share/man/man3/MPI_Comm_dup.3
+file path=usr/share/man/man3/MPI_Comm_f2c.3
+file path=usr/share/man/man3/MPI_Comm_free.3
+file path=usr/share/man/man3/MPI_Comm_free_keyval.3
+file path=usr/share/man/man3/MPI_Comm_get_attr.3
+file path=usr/share/man/man3/MPI_Comm_get_errhandler.3
+file path=usr/share/man/man3/MPI_Comm_get_name.3
+file path=usr/share/man/man3/MPI_Comm_get_parent.3
+file path=usr/share/man/man3/MPI_Comm_group.3
+file path=usr/share/man/man3/MPI_Comm_join.3
+file path=usr/share/man/man3/MPI_Comm_rank.3
+file path=usr/share/man/man3/MPI_Comm_remote_group.3
+file path=usr/share/man/man3/MPI_Comm_remote_size.3
+file path=usr/share/man/man3/MPI_Comm_set_attr.3
+file path=usr/share/man/man3/MPI_Comm_set_errhandler.3
+file path=usr/share/man/man3/MPI_Comm_set_name.3
+file path=usr/share/man/man3/MPI_Comm_size.3
+file path=usr/share/man/man3/MPI_Comm_spawn.3
+file path=usr/share/man/man3/MPI_Comm_spawn_multiple.3
+file path=usr/share/man/man3/MPI_Comm_split.3
+file path=usr/share/man/man3/MPI_Comm_test_inter.3
+file path=usr/share/man/man3/MPI_Dims_create.3
+file path=usr/share/man/man3/MPI_Errhandler_create.3
+file path=usr/share/man/man3/MPI_Errhandler_free.3
+file path=usr/share/man/man3/MPI_Errhandler_get.3
+file path=usr/share/man/man3/MPI_Errhandler_set.3
+file path=usr/share/man/man3/MPI_Error_class.3
+file path=usr/share/man/man3/MPI_Error_string.3
+file path=usr/share/man/man3/MPI_Exscan.3
+file path=usr/share/man/man3/MPI_File_c2f.3
+file path=usr/share/man/man3/MPI_File_call_errhandler.3
+file path=usr/share/man/man3/MPI_File_close.3
+file path=usr/share/man/man3/MPI_File_create_errhandler.3
+file path=usr/share/man/man3/MPI_File_delete.3
+file path=usr/share/man/man3/MPI_File_f2c.3
+file path=usr/share/man/man3/MPI_File_get_amode.3
+file path=usr/share/man/man3/MPI_File_get_atomicity.3
+file path=usr/share/man/man3/MPI_File_get_byte_offset.3
+file path=usr/share/man/man3/MPI_File_get_errhandler.3
+file path=usr/share/man/man3/MPI_File_get_group.3
+file path=usr/share/man/man3/MPI_File_get_info.3
+file path=usr/share/man/man3/MPI_File_get_position.3
+file path=usr/share/man/man3/MPI_File_get_position_shared.3
+file path=usr/share/man/man3/MPI_File_get_size.3
+file path=usr/share/man/man3/MPI_File_get_type_extent.3
+file path=usr/share/man/man3/MPI_File_get_view.3
+file path=usr/share/man/man3/MPI_File_iread.3
+file path=usr/share/man/man3/MPI_File_iread_at.3
+file path=usr/share/man/man3/MPI_File_iread_shared.3
+file path=usr/share/man/man3/MPI_File_iwrite.3
+file path=usr/share/man/man3/MPI_File_iwrite_at.3
+file path=usr/share/man/man3/MPI_File_iwrite_shared.3
+file path=usr/share/man/man3/MPI_File_open.3
+file path=usr/share/man/man3/MPI_File_preallocate.3
+file path=usr/share/man/man3/MPI_File_read.3
+file path=usr/share/man/man3/MPI_File_read_all.3
+file path=usr/share/man/man3/MPI_File_read_all_begin.3
+file path=usr/share/man/man3/MPI_File_read_all_end.3
+file path=usr/share/man/man3/MPI_File_read_at.3
+file path=usr/share/man/man3/MPI_File_read_at_all.3
+file path=usr/share/man/man3/MPI_File_read_at_all_begin.3
+file path=usr/share/man/man3/MPI_File_read_at_all_end.3
+file path=usr/share/man/man3/MPI_File_read_ordered.3
+file path=usr/share/man/man3/MPI_File_read_ordered_begin.3
+file path=usr/share/man/man3/MPI_File_read_ordered_end.3
+file path=usr/share/man/man3/MPI_File_read_shared.3
+file path=usr/share/man/man3/MPI_File_seek.3
+file path=usr/share/man/man3/MPI_File_seek_shared.3
+file path=usr/share/man/man3/MPI_File_set_atomicity.3
+file path=usr/share/man/man3/MPI_File_set_errhandler.3
+file path=usr/share/man/man3/MPI_File_set_info.3
+file path=usr/share/man/man3/MPI_File_set_size.3
+file path=usr/share/man/man3/MPI_File_set_view.3
+file path=usr/share/man/man3/MPI_File_sync.3
+file path=usr/share/man/man3/MPI_File_write.3
+file path=usr/share/man/man3/MPI_File_write_all.3
+file path=usr/share/man/man3/MPI_File_write_all_begin.3
+file path=usr/share/man/man3/MPI_File_write_all_end.3
+file path=usr/share/man/man3/MPI_File_write_at.3
+file path=usr/share/man/man3/MPI_File_write_at_all.3
+file path=usr/share/man/man3/MPI_File_write_at_all_begin.3
+file path=usr/share/man/man3/MPI_File_write_at_all_end.3
+file path=usr/share/man/man3/MPI_File_write_ordered.3
+file path=usr/share/man/man3/MPI_File_write_ordered_begin.3
+file path=usr/share/man/man3/MPI_File_write_ordered_end.3
+file path=usr/share/man/man3/MPI_File_write_shared.3
+file path=usr/share/man/man3/MPI_Finalize.3
+file path=usr/share/man/man3/MPI_Finalized.3
+file path=usr/share/man/man3/MPI_Free_mem.3
+file path=usr/share/man/man3/MPI_Gather.3
+file path=usr/share/man/man3/MPI_Gatherv.3
+file path=usr/share/man/man3/MPI_Get.3
+file path=usr/share/man/man3/MPI_Get_address.3
+file path=usr/share/man/man3/MPI_Get_count.3
+file path=usr/share/man/man3/MPI_Get_elements.3
+file path=usr/share/man/man3/MPI_Get_processor_name.3
+file path=usr/share/man/man3/MPI_Get_version.3
+file path=usr/share/man/man3/MPI_Graph_create.3
+file path=usr/share/man/man3/MPI_Graph_get.3
+file path=usr/share/man/man3/MPI_Graph_map.3
+file path=usr/share/man/man3/MPI_Graph_neighbors.3
+file path=usr/share/man/man3/MPI_Graph_neighbors_count.3
+file path=usr/share/man/man3/MPI_Graphdims_get.3
+file path=usr/share/man/man3/MPI_Grequest_complete.3
+file path=usr/share/man/man3/MPI_Grequest_start.3
+file path=usr/share/man/man3/MPI_Group_c2f.3
+file path=usr/share/man/man3/MPI_Group_compare.3
+file path=usr/share/man/man3/MPI_Group_difference.3
+file path=usr/share/man/man3/MPI_Group_excl.3
+file path=usr/share/man/man3/MPI_Group_f2c.3
+file path=usr/share/man/man3/MPI_Group_free.3
+file path=usr/share/man/man3/MPI_Group_incl.3
+file path=usr/share/man/man3/MPI_Group_intersection.3
+file path=usr/share/man/man3/MPI_Group_range_excl.3
+file path=usr/share/man/man3/MPI_Group_range_incl.3
+file path=usr/share/man/man3/MPI_Group_rank.3
+file path=usr/share/man/man3/MPI_Group_size.3
+file path=usr/share/man/man3/MPI_Group_translate_ranks.3
+file path=usr/share/man/man3/MPI_Group_union.3
+file path=usr/share/man/man3/MPI_Ibsend.3
+file path=usr/share/man/man3/MPI_Info_c2f.3
+file path=usr/share/man/man3/MPI_Info_create.3
+file path=usr/share/man/man3/MPI_Info_delete.3
+file path=usr/share/man/man3/MPI_Info_dup.3
+file path=usr/share/man/man3/MPI_Info_f2c.3
+file path=usr/share/man/man3/MPI_Info_free.3
+file path=usr/share/man/man3/MPI_Info_get.3
+file path=usr/share/man/man3/MPI_Info_get_nkeys.3
+file path=usr/share/man/man3/MPI_Info_get_nthkey.3
+file path=usr/share/man/man3/MPI_Info_get_valuelen.3
+file path=usr/share/man/man3/MPI_Info_set.3
+file path=usr/share/man/man3/MPI_Init.3
+file path=usr/share/man/man3/MPI_Init_thread.3
+file path=usr/share/man/man3/MPI_Initialized.3
+file path=usr/share/man/man3/MPI_Intercomm_create.3
+file path=usr/share/man/man3/MPI_Intercomm_merge.3
+file path=usr/share/man/man3/MPI_Iprobe.3
+file path=usr/share/man/man3/MPI_Irecv.3
+file path=usr/share/man/man3/MPI_Irsend.3
+file path=usr/share/man/man3/MPI_Is_thread_main.3
+file path=usr/share/man/man3/MPI_Isend.3
+file path=usr/share/man/man3/MPI_Issend.3
+file path=usr/share/man/man3/MPI_Keyval_create.3
+file path=usr/share/man/man3/MPI_Keyval_free.3
+file path=usr/share/man/man3/MPI_Lookup_name.3
+file path=usr/share/man/man3/MPI_Op_c2f.3
+file path=usr/share/man/man3/MPI_Op_create.3
+file path=usr/share/man/man3/MPI_Op_f2c.3
+file path=usr/share/man/man3/MPI_Op_free.3
+file path=usr/share/man/man3/MPI_Open_port.3
+file path=usr/share/man/man3/MPI_Pack.3
+file path=usr/share/man/man3/MPI_Pack_external.3
+file path=usr/share/man/man3/MPI_Pack_external_size.3
+file path=usr/share/man/man3/MPI_Pack_size.3
+file path=usr/share/man/man3/MPI_Pcontrol.3
+file path=usr/share/man/man3/MPI_Probe.3
+file path=usr/share/man/man3/MPI_Publish_name.3
+file path=usr/share/man/man3/MPI_Put.3
+file path=usr/share/man/man3/MPI_Query_thread.3
+file path=usr/share/man/man3/MPI_Recv.3
+file path=usr/share/man/man3/MPI_Recv_init.3
+file path=usr/share/man/man3/MPI_Reduce.3
+file path=usr/share/man/man3/MPI_Reduce_local.3
+file path=usr/share/man/man3/MPI_Reduce_scatter.3
+file path=usr/share/man/man3/MPI_Register_datarep.3
+file path=usr/share/man/man3/MPI_Request_c2f.3
+file path=usr/share/man/man3/MPI_Request_f2c.3
+file path=usr/share/man/man3/MPI_Request_free.3
+file path=usr/share/man/man3/MPI_Request_get_status.3
+file path=usr/share/man/man3/MPI_Rsend.3
+file path=usr/share/man/man3/MPI_Rsend_init.3
+file path=usr/share/man/man3/MPI_Scan.3
+file path=usr/share/man/man3/MPI_Scatter.3
+file path=usr/share/man/man3/MPI_Scatterv.3
+file path=usr/share/man/man3/MPI_Send.3
+file path=usr/share/man/man3/MPI_Send_init.3
+file path=usr/share/man/man3/MPI_Sendrecv.3
+file path=usr/share/man/man3/MPI_Sendrecv_replace.3
+file path=usr/share/man/man3/MPI_Sizeof.3
+file path=usr/share/man/man3/MPI_Ssend.3
+file path=usr/share/man/man3/MPI_Ssend_init.3
+file path=usr/share/man/man3/MPI_Start.3
+file path=usr/share/man/man3/MPI_Startall.3
+file path=usr/share/man/man3/MPI_Status_c2f.3
+file path=usr/share/man/man3/MPI_Status_f2c.3
+file path=usr/share/man/man3/MPI_Status_set_cancelled.3
+file path=usr/share/man/man3/MPI_Status_set_elements.3
+file path=usr/share/man/man3/MPI_Test.3
+file path=usr/share/man/man3/MPI_Test_cancelled.3
+file path=usr/share/man/man3/MPI_Testall.3
+file path=usr/share/man/man3/MPI_Testany.3
+file path=usr/share/man/man3/MPI_Testsome.3
+file path=usr/share/man/man3/MPI_Topo_test.3
+file path=usr/share/man/man3/MPI_Type_c2f.3
+file path=usr/share/man/man3/MPI_Type_commit.3
+file path=usr/share/man/man3/MPI_Type_contiguous.3
+file path=usr/share/man/man3/MPI_Type_create_darray.3
+file path=usr/share/man/man3/MPI_Type_create_f90_complex.3
+file path=usr/share/man/man3/MPI_Type_create_f90_integer.3
+file path=usr/share/man/man3/MPI_Type_create_f90_real.3
+file path=usr/share/man/man3/MPI_Type_create_hindexed.3
+file path=usr/share/man/man3/MPI_Type_create_hvector.3
+file path=usr/share/man/man3/MPI_Type_create_indexed_block.3
+file path=usr/share/man/man3/MPI_Type_create_keyval.3
+file path=usr/share/man/man3/MPI_Type_create_resized.3
+file path=usr/share/man/man3/MPI_Type_create_struct.3
+file path=usr/share/man/man3/MPI_Type_create_subarray.3
+file path=usr/share/man/man3/MPI_Type_delete_attr.3
+file path=usr/share/man/man3/MPI_Type_dup.3
+file path=usr/share/man/man3/MPI_Type_extent.3
+file path=usr/share/man/man3/MPI_Type_f2c.3
+file path=usr/share/man/man3/MPI_Type_free.3
+file path=usr/share/man/man3/MPI_Type_free_keyval.3
+file path=usr/share/man/man3/MPI_Type_get_attr.3
+file path=usr/share/man/man3/MPI_Type_get_contents.3
+file path=usr/share/man/man3/MPI_Type_get_envelope.3
+file path=usr/share/man/man3/MPI_Type_get_extent.3
+file path=usr/share/man/man3/MPI_Type_get_name.3
+file path=usr/share/man/man3/MPI_Type_get_true_extent.3
+file path=usr/share/man/man3/MPI_Type_hindexed.3
+file path=usr/share/man/man3/MPI_Type_hvector.3
+file path=usr/share/man/man3/MPI_Type_indexed.3
+file path=usr/share/man/man3/MPI_Type_lb.3
+file path=usr/share/man/man3/MPI_Type_match_size.3
+file path=usr/share/man/man3/MPI_Type_set_attr.3
+file path=usr/share/man/man3/MPI_Type_set_name.3
+file path=usr/share/man/man3/MPI_Type_size.3
+file path=usr/share/man/man3/MPI_Type_struct.3
+file path=usr/share/man/man3/MPI_Type_ub.3
+file path=usr/share/man/man3/MPI_Type_vector.3
+file path=usr/share/man/man3/MPI_Unpack.3
+file path=usr/share/man/man3/MPI_Unpack_external.3
+file path=usr/share/man/man3/MPI_Unpublish_name.3
+file path=usr/share/man/man3/MPI_Wait.3
+file path=usr/share/man/man3/MPI_Waitall.3
+file path=usr/share/man/man3/MPI_Waitany.3
+file path=usr/share/man/man3/MPI_Waitsome.3
+file path=usr/share/man/man3/MPI_Win_c2f.3
+file path=usr/share/man/man3/MPI_Win_call_errhandler.3
+file path=usr/share/man/man3/MPI_Win_complete.3
+file path=usr/share/man/man3/MPI_Win_create.3
+file path=usr/share/man/man3/MPI_Win_create_errhandler.3
+file path=usr/share/man/man3/MPI_Win_create_keyval.3
+file path=usr/share/man/man3/MPI_Win_delete_attr.3
+file path=usr/share/man/man3/MPI_Win_f2c.3
+file path=usr/share/man/man3/MPI_Win_fence.3
+file path=usr/share/man/man3/MPI_Win_free.3
+file path=usr/share/man/man3/MPI_Win_free_keyval.3
+file path=usr/share/man/man3/MPI_Win_get_attr.3
+file path=usr/share/man/man3/MPI_Win_get_errhandler.3
+file path=usr/share/man/man3/MPI_Win_get_group.3
+file path=usr/share/man/man3/MPI_Win_get_name.3
+file path=usr/share/man/man3/MPI_Win_lock.3
+file path=usr/share/man/man3/MPI_Win_post.3
+file path=usr/share/man/man3/MPI_Win_set_attr.3
+file path=usr/share/man/man3/MPI_Win_set_errhandler.3
+file path=usr/share/man/man3/MPI_Win_set_name.3
+file path=usr/share/man/man3/MPI_Win_start.3
+file path=usr/share/man/man3/MPI_Win_test.3
+file path=usr/share/man/man3/MPI_Win_unlock.3
+file path=usr/share/man/man3/MPI_Win_wait.3
+file path=usr/share/man/man3/MPI_Wtick.3
+file path=usr/share/man/man3/MPI_Wtime.3
+file path=usr/share/man/man3/OpenMPI.3
+dir  path=usr/share/man/man7
+file path=usr/share/man/man7/ompi_crcp.7
+file path=usr/share/man/man7/opal_crs.7
+file path=usr/share/man/man7/orte_filem.7
+file path=usr/share/man/man7/orte_hosts.7
+file path=usr/share/man/man7/orte_snapc.7
+dir  path=usr/share/openmpi
+dir  path=usr/share/openmpi/openmpi
+dir  path=usr/share/openmpi/openmpi/amca-param-sets
+file path=usr/share/openmpi/openmpi/amca-param-sets/example.conf
+file path=usr/share/openmpi/openmpi/help-coll-sync.txt
+file path=usr/share/openmpi/openmpi/help-dash-host.txt
+file path=usr/share/openmpi/openmpi/help-ess-base.txt
+file path=usr/share/openmpi/openmpi/help-hostfile.txt
+file path=usr/share/openmpi/openmpi/help-mca-base.txt
+file path=usr/share/openmpi/openmpi/help-mca-bml-r2.txt
+file path=usr/share/openmpi/openmpi/help-mca-coll-base.txt
+file path=usr/share/openmpi/openmpi/help-mca-op-base.txt
+file path=usr/share/openmpi/openmpi/help-mca-param.txt
+file path=usr/share/openmpi/openmpi/help-mpi-api.txt
+file path=usr/share/openmpi/openmpi/help-mpi-btl-base.txt
+file path=usr/share/openmpi/openmpi/help-mpi-btl-sm.txt
+file path=usr/share/openmpi/openmpi/help-mpi-btl-tcp.txt
+file path=usr/share/openmpi/openmpi/help-mpi-coll-sm.txt
+file path=usr/share/openmpi/openmpi/help-mpi-common-sm.txt
+file path=usr/share/openmpi/openmpi/help-mpi-errors.txt
+file path=usr/share/openmpi/openmpi/help-mpi-pml-bfo.txt
+file path=usr/share/openmpi/openmpi/help-mpi-pml-csum.txt
+file path=usr/share/openmpi/openmpi/help-mpi-pml-ob1.txt
+file path=usr/share/openmpi/openmpi/help-mpi-runtime.txt
+file path=usr/share/openmpi/openmpi/help-mpool-base.txt
+file path=usr/share/openmpi/openmpi/help-odls-default.txt
+file path=usr/share/openmpi/openmpi/help-ompi-crcp-base.txt
+file path=usr/share/openmpi/openmpi/help-ompi-dpm-base.txt
+file path=usr/share/openmpi/openmpi/help-ompi-dpm-orte.txt
+file path=usr/share/openmpi/openmpi/help-ompi-probe.txt
+file path=usr/share/openmpi/openmpi/help-ompi-profiler.txt
+file path=usr/share/openmpi/openmpi/help-ompi-pubsub-orte.txt
+file path=usr/share/openmpi/openmpi/help-ompi-server.txt
+file path=usr/share/openmpi/openmpi/help-ompi_info.txt
+file path=usr/share/openmpi/openmpi/help-oob-tcp.txt
+file path=usr/share/openmpi/openmpi/help-opal-carto-file.txt
+file path=usr/share/openmpi/openmpi/help-opal-crs-base.txt
+file path=usr/share/openmpi/openmpi/help-opal-crs-none.txt
+file path=usr/share/openmpi/openmpi/help-opal-maffinity-hwloc.txt
+file path=usr/share/openmpi/openmpi/help-opal-runtime.txt
+file path=usr/share/openmpi/openmpi/help-opal-shmem-mmap.txt
+file path=usr/share/openmpi/openmpi/help-opal-shmem-posix.txt
+file path=usr/share/openmpi/openmpi/help-opal-shmem-sysv.txt
+file path=usr/share/openmpi/openmpi/help-opal-util.txt
+file path=usr/share/openmpi/openmpi/help-opal-wrapper.txt
+file path=usr/share/openmpi/openmpi/help-orte-clean.txt
+file path=usr/share/openmpi/openmpi/help-orte-filem-base.txt
+file path=usr/share/openmpi/openmpi/help-orte-filem-rsh.txt
+file path=usr/share/openmpi/openmpi/help-orte-iof.txt
+file path=usr/share/openmpi/openmpi/help-orte-notifier-command.txt
+file path=usr/share/openmpi/openmpi/help-orte-odls-base.txt
+file path=usr/share/openmpi/openmpi/help-orte-ps.txt
+file path=usr/share/openmpi/openmpi/help-orte-rmaps-base.txt
+file path=usr/share/openmpi/openmpi/help-orte-rmaps-lb.txt
+file path=usr/share/openmpi/openmpi/help-orte-rmaps-resilient.txt
+file path=usr/share/openmpi/openmpi/help-orte-rmaps-rr.txt
+file path=usr/share/openmpi/openmpi/help-orte-rmaps-seq.txt
+file path=usr/share/openmpi/openmpi/help-orte-rmaps-topo.txt
+file path=usr/share/openmpi/openmpi/help-orte-runtime.txt
+file path=usr/share/openmpi/openmpi/help-orte-snapc-base.txt
+file path=usr/share/openmpi/openmpi/help-orte-top.txt
+file path=usr/share/openmpi/openmpi/help-orted.txt
+file path=usr/share/openmpi/openmpi/help-orterun.txt
+file path=usr/share/openmpi/openmpi/help-plm-base.txt
+file path=usr/share/openmpi/openmpi/help-plm-rsh.txt
+file path=usr/share/openmpi/openmpi/help-ras-base.txt
+file path=usr/share/openmpi/openmpi/help-regex.txt
+file path=usr/share/openmpi/openmpi/help-rmaps_rank_file.txt
+link path=usr/share/openmpi/openmpi/mpiCC-vt-wrapper-data.txt \
+    target=mpic++-vt-wrapper-data.txt
+link path=usr/share/openmpi/openmpi/mpiCC-wrapper-data.txt \
+    target=mpic++-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpic++-vt-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpic++-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpicc-vt-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpicc-wrapper-data.txt
+link path=usr/share/openmpi/openmpi/mpicxx-vt-wrapper-data.txt \
+    target=mpic++-vt-wrapper-data.txt
+link path=usr/share/openmpi/openmpi/mpicxx-wrapper-data.txt \
+    target=mpic++-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpif77-vt-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpif77-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpif90-vt-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/mpif90-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/openmpi-valgrind.supp
+link path=usr/share/openmpi/openmpi/orteCC-wrapper-data.txt \
+    target=ortec++-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/ortec++-wrapper-data.txt
+file path=usr/share/openmpi/openmpi/ortecc-wrapper-data.txt
+dir  path=usr/share/openmpi/vampirtrace
+file path=usr/share/openmpi/vampirtrace/FILTER.SPEC
+file path=usr/share/openmpi/vampirtrace/GROUPS.SPEC
+file path=usr/share/openmpi/vampirtrace/METRICS.SPEC
+file path=usr/share/openmpi/vampirtrace/config.log
+file path=usr/share/openmpi/vampirtrace/libtool
+file path=usr/share/openmpi/vampirtrace/omp.h
+link path=usr/share/openmpi/vampirtrace/vtCC-wrapper-data.txt \
+    target=vtc++-wrapper-data.txt
+file path=usr/share/openmpi/vampirtrace/vtc++-wrapper-data.txt
+file path=usr/share/openmpi/vampirtrace/vtcc-wrapper-data.txt
+link path=usr/share/openmpi/vampirtrace/vtcxx-wrapper-data.txt \
+    target=vtc++-wrapper-data.txt
+link path=usr/share/openmpi/vampirtrace/vtf77-wrapper-data.txt \
+    target=vtfort-wrapper-data.txt
+link path=usr/share/openmpi/vampirtrace/vtf90-wrapper-data.txt \
+    target=vtfort-wrapper-data.txt
+file path=usr/share/openmpi/vampirtrace/vtfort-wrapper-data.txt
+file path=usr/share/openmpi/vampirtrace/vtsetup-data.dtd
+file path=usr/share/openmpi/vampirtrace/vtsetup-data.xml


### PR DESCRIPTION
Hello,
Here is OpenMPI using the same recipe as for MPICH.

One question: should I set group=sys for /usr/lib/openmpi/gcc/etc/\* and /usr/lib/amd64/openmpi/gcc/etc/\* or should I leave group=bin ?

Best regards,

Aurelien
