### PR TITLE
Fixed missing "and_64" in build target for mpich

### DIFF
--- a/components/mpich/Makefile
+++ b/components/mpich/Makefile
@@ -62,7 +62,7 @@ CONFIGURE_OPTIONS+=	--enable-mpe
 
 COMPONENT_TEST_TARGETS = test
 
-build:		$(BUILD_32)
+build:		$(BUILD_32_and_64)
 
 $(BUILD_DIR)/modulefile.%:		files/modulefile
 	/bin/sed -e "s#%%BITS%%#$*#g" \


### PR DESCRIPTION
Due to a mix up between commits.
By chance, it is required by install_32_and_64 so it has built so far.
