### PR TITLE
https://www.illumos.org/issues/4468

### DIFF
--- a/components/libtool/libtool.p5m
+++ b/components/libtool/libtool.p5m
@@ -103,6 +103,6 @@ depend fmri=__TBD pkg.debug.depend.file=usr/bin/ggrep type=require
 depend fmri=__TBD pkg.debug.depend.file=usr/bin/gsed type=require
 depend fmri=__TBD pkg.debug.depend.file=usr/bin/ld type=require
 depend fmri=__TBD pkg.debug.depend.file=usr/bin/nm type=require
-depend fmri=__TBD pkg.debug.depend.file=usr/gnu/bin/echo type=require
+depend fmri=__TBD pkg.debug.depend.file=usr/ucb/echo type=require
 
 license libtool.license license="GPLv2, FDLv1.3"


### PR DESCRIPTION
It seems libtool uses /usr/ucb/echo, but not /usr/gnu/bin/echo
