### PR TITLE
Add SPARC support to gcc47 component

### DIFF
--- a/components/gcc47/Makefile
+++ b/components/gcc47/Makefile
@@ -98,10 +98,13 @@ CONFIGURE_OPTIONS+= --enable-plugins
 CONFIGURE_OPTIONS+= --enable-objc-gc
 CONFIGURE_OPTIONS+= --enable-languages=c,c++,fortran,lto,objc
 CONFIGURE_OPTIONS+= --enable-ld=no
-CONFIGURE_OPTIONS+= --with-as=/usr/bin/gas
-CONFIGURE_OPTIONS+= --with-gnu-as
 CONFIGURE_OPTIONS+= --with-build-time-tools=/usr/gnu/$(GNU_ARCH)/bin
 CONFIGURE_OPTIONS+= --disable-libitm
+
+# On SPARC systems, use Sun Assembler
+CONFIGURE_OPTIONS.sparc+= --without-gnu-as --with-as=/usr/bin/as
+CONFIGURE_OPTIONS.i386+= --with-gnu-as --with-as=/usr/bin/gas
+CONFIGURE_OPTIONS+= $(CONFIGURE_OPTIONS.$(MACH))
 
 CONFIGURE_OPTIONS+= LDFLAGS="-R$(CONFIGURE_PREFIX)/lib"
 

--- a/components/gcc47/Makefile
+++ b/components/gcc47/Makefile
@@ -17,6 +17,7 @@ include ../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gcc
 COMPONENT_VERSION= 4.7.3
+COMPONENT_REVISION=1
 MPFR_NAME= mpfr
 MPFR_VERSION=3.1.2
 MPC_NAME=mpc

--- a/components/gcc47/gcc-47.p5m
+++ b/components/gcc47/gcc-47.p5m
@@ -837,11 +837,11 @@ link path=usr/gcc/4.7/lib/$(MACH64)/libgomp.so target=libgomp.so.1.0.0
 link path=usr/gcc/4.7/lib/$(MACH64)/libgomp.so.1 target=libgomp.so.1.0.0
 file path=usr/gcc/4.7/lib/$(MACH64)/libgomp.so.1.0.0
 file path=usr/gcc/4.7/lib/$(MACH64)/libgomp.spec
-file path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.a
-file path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.la
-link path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.so target=libquadmath.so.0.0.0
-link path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.so.0 target=libquadmath.so.0.0.0
-file path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.so.0.0.0
+file path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.a variant.arch=i386
+file path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.la variant.arch=i386
+link path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.so target=libquadmath.so.0.0.0 variant.arch=i386
+link path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.so.0 target=libquadmath.so.0.0.0 variant.arch=i386
+file path=usr/gcc/4.7/lib/$(MACH64)/libquadmath.so.0.0.0 variant.arch=i386
 file path=usr/gcc/4.7/lib/$(MACH64)/libssp.a
 file path=usr/gcc/4.7/lib/$(MACH64)/libssp.la
 link path=usr/gcc/4.7/lib/$(MACH64)/libssp.so target=libssp.so.0.0.0
@@ -861,12 +861,14 @@ dir  path=usr/gcc/4.7/lib/gcc
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crt1.o variant.arch=sparc
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtbegin.o
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtend.o
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtfastmath.o
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtprec32.o
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtprec64.o
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtprec80.o
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtprec32.o variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtprec64.o variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/crtprec80.o variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/gcrt1.o variant.arch=sparc
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/gmon.o
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/libcaf_single.a
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/$(MACH64)/libcaf_single.la
@@ -882,15 +884,17 @@ file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/collect2
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtbegin.o
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtend.o
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtfastmath.o
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtprec32.o
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtprec64.o
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtprec80.o
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crt1.o variant.arch=sparc
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtprec32.o variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtprec64.o variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/crtprec80.o variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/f951
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/finclude
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/finclude/omp_lib.f90
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/finclude/omp_lib.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/finclude/omp_lib.mod
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/finclude/omp_lib_kinds.mod
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/gcrt1.o variant.arch=sparc
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/gmon.o
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/objc
@@ -904,34 +908,34 @@ file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/objc/NXCo
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/objc/objc-sync.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/objc/runtime.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/objc/thr.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/ammintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/avx2intrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/avxintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/bmi2intrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/bmiintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/bmmintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/cpuid.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/cross-stdarg.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/emmintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/f16cintrin.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/ammintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/avx2intrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/avxintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/bmi2intrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/bmiintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/bmmintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/cpuid.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/cross-stdarg.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/emmintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/f16cintrin.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/float.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/fma4intrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/fmaintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/ia32intrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/immintrin.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/fma4intrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/fmaintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/ia32intrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/immintrin.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/iso646.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/lwpintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/lzcntintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/mm3dnow.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/mm_malloc.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/mmintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/nmmintrin.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/lwpintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/lzcntintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/mm3dnow.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/mm_malloc.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/mmintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/nmmintrin.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/omp.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/pmmintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/popcntintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/quadmath.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/quadmath_weak.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/smmintrin.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/pmmintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/popcntintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/quadmath.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/quadmath_weak.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/smmintrin.h variant.arch=i386
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/ssp
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/ssp/ssp.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/ssp/stdio.h
@@ -945,15 +949,15 @@ file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/stdfix.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/stdint-gcc.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/stdint.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/stdnoreturn.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/tbmintrin.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/tbmintrin.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/tgmath.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/tmmintrin.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/tmmintrin.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/unwind.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/varargs.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/wmmintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/x86intrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/xmmintrin.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/xopintrin.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/wmmintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/x86intrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/xmmintrin.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include/xopintrin.h variant.arch=i386
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/install-tools
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/install-tools/fixinc.sh
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/install-tools/fixinc_list
@@ -1014,15 +1018,19 @@ file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/ci
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config.h
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/att.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/i386-opts.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/i386-protos.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/i386.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/sol2-bi.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/att.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/biarch64.h variant.arch=sparc
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/i386-opts.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/i386-protos.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/i386.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/sol2-bi.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/sol2.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/sparc-opts.h variant.arch=sparc
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/sparc.h variant.arch=sparc
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/sysv4.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/unix.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/x86-64.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/tso.h variant.arch=sparc
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/unix.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/$(MACH)/x86-64.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/dbxelf.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/elfos.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/initfini-array.h
@@ -1030,8 +1038,8 @@ file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/co
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/sol2-bi.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/sol2-protos.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/sol2.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/usegas.h
-file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/vxworks-dummy.h
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/usegas.h variant.arch=i386
+file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/config/vxworks-dummy.h variant.arch=i386
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/configargs.h
 file path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/coretypes.h
 dir  path=usr/gcc/4.7/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/plugin/include/cp
@@ -1167,11 +1175,11 @@ link path=usr/gcc/4.7/lib/libgomp.so.1 target=libgomp.so.1.0.0
 file path=usr/gcc/4.7/lib/libgomp.so.1.0.0
 file path=usr/gcc/4.7/lib/libgomp.spec
 file path=usr/gcc/4.7/lib/libiberty.a
-file path=usr/gcc/4.7/lib/libquadmath.a
-file path=usr/gcc/4.7/lib/libquadmath.la
-link path=usr/gcc/4.7/lib/libquadmath.so target=libquadmath.so.0.0.0
-link path=usr/gcc/4.7/lib/libquadmath.so.0 target=libquadmath.so.0.0.0
-file path=usr/gcc/4.7/lib/libquadmath.so.0.0.0
+file path=usr/gcc/4.7/lib/libquadmath.a variant.arch=i386
+file path=usr/gcc/4.7/lib/libquadmath.la variant.arch=i386
+link path=usr/gcc/4.7/lib/libquadmath.so target=libquadmath.so.0.0.0 variant.arch=i386
+link path=usr/gcc/4.7/lib/libquadmath.so.0 target=libquadmath.so.0.0.0 variant.arch=i386
+file path=usr/gcc/4.7/lib/libquadmath.so.0.0.0 variant.arch=i386
 file path=usr/gcc/4.7/lib/libssp.a
 file path=usr/gcc/4.7/lib/libssp.la
 link path=usr/gcc/4.7/lib/libssp.so target=libssp.so.0.0.0

--- a/components/gcc47/gfortran-4-runtime.p5m
+++ b/components/gcc47/gfortran-4-runtime.p5m
@@ -34,9 +34,9 @@ link path=usr/lib/libgfortran.so target=libgfortran.so.3.0.0
 link path=usr/lib/libgfortran.so.3 target=libgfortran.so.3.0.0
 file usr/gcc/4.7/lib/libgfortran.so.3.0.0 path=usr/lib/libgfortran.so.3.0.0 pkg.depend.bypass-generate=.*
 
-link path=usr/lib/$(MACH64)/libquadmath.so target=libquadmath.so.0.0.0
-link path=usr/lib/$(MACH64)/libquadmath.so.0 target=libquadmath.so.0.0.0
-file usr/gcc/4.7/lib/$(MACH64)/libquadmath.so.0.0.0 path=usr/lib/$(MACH64)/libquadmath.so.0.0.0 pkg.depend.bypass-generate=.*
-link path=usr/lib/libquadmath.so target=libquadmath.so.0.0.0
-link path=usr/lib/libquadmath.so.0 target=libquadmath.so.0.0.0
-file usr/gcc/4.7/lib/libquadmath.so.0.0.0 path=usr/lib/libquadmath.so.0.0.0 pkg.depend.bypass-generate=.*
+link path=usr/lib/$(MACH64)/libquadmath.so target=libquadmath.so.0.0.0 variant.arch=i386
+link path=usr/lib/$(MACH64)/libquadmath.so.0 target=libquadmath.so.0.0.0 variant.arch=i386
+file usr/gcc/4.7/lib/$(MACH64)/libquadmath.so.0.0.0 path=usr/lib/$(MACH64)/libquadmath.so.0.0.0 pkg.depend.bypass-generate=.* variant.arch=i386
+link path=usr/lib/libquadmath.so target=libquadmath.so.0.0.0 variant.arch=i386
+link path=usr/lib/libquadmath.so.0 target=libquadmath.so.0.0.0 variant.arch=i386
+file usr/gcc/4.7/lib/libquadmath.so.0.0.0 path=usr/lib/libquadmath.so.0.0.0 pkg.depend.bypass-generate=.* variant.arch=i386


### PR DESCRIPTION
A simple set of changes - it simply sets the Makefile to use Sun Assembler when building with SPARC, and alters the manifests to allow packaging of a SPARC build.
