### PR TITLE
Bug #4859 Add refresh and stop methods to rsyslog manifest

### DIFF
--- a/components/rsyslog/files/rsyslog.xml
+++ b/components/rsyslog/files/rsyslog.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-
+<!--
     CDDL HEADER START
 
-    The contents of this file are subject to the terms of the 
-    Common Development and Distribution License (the "License"). 
+    The contents of this file are subject to the terms of the
+    Common Development and Distribution License (the "License").
     You may not use this file except in compliance with the License.
 
     You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
@@ -20,7 +20,7 @@
     information: Portions Copyright [yyyy] [name of copyright owner]
 
     CDDL HEADER END
-
+   
     Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
 
     NOTE:  This service manifest is not editable; its contents will

--- a/components/rsyslog/files/rsyslog.xml
+++ b/components/rsyslog/files/rsyslog.xml
@@ -1,24 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-    CDDL HEADER START
 
-    The contents of this file are subject to the terms of the
-    Common Development and Distribution License (the "License").
-    You may not use this file except in compliance with the License.
-
-    You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-    or http://www.opensolaris.org/os/licensing.
-    See the License for the specific language governing permissions
-    and limitations under the License.
-
-    When distributing Covered Code, include this CDDL HEADER in each
-    file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-    If applicable, add the following below this CDDL HEADER, with the
-    fields enclosed by brackets "[]" replaced with your own identifying
-    information: Portions Copyright [yyyy] [name of copyright owner]
-
-    CDDL HEADER END
    
     Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
 
@@ -42,6 +25,18 @@
 			name='start'
 			exec='/lib/svc/method/rsyslog'
 			timeout_seconds='600' />
+
+		<exec_method
+			type='method'
+			name='stop'
+			exec=':kill'
+			timeout_seconds='60' />
+
+		<exec_method
+			type='method'
+			name='refresh'
+			exec=':kill -HUP'
+			timeout_seconds='60' />
 
 		<template>
 			<common_name>

--- a/components/rsyslog/files/rsyslog.xml
+++ b/components/rsyslog/files/rsyslog.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
-<!--
     CDDL HEADER START
 
     The contents of this file are subject to the terms of the

--- a/components/rsyslog/files/rsyslog.xml
+++ b/components/rsyslog/files/rsyslog.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 
-CDDL HEADER START
+    CDDL HEADER START
 
     The contents of this file are subject to the terms of the 
     Common Development and Distribution License (the "License"). 

--- a/components/rsyslog/files/rsyslog.xml
+++ b/components/rsyslog/files/rsyslog.xml
@@ -2,7 +2,25 @@
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <!--
 
-   
+CDDL HEADER START
+
+    The contents of this file are subject to the terms of the 
+    Common Development and Distribution License (the "License"). 
+    You may not use this file except in compliance with the License.
+
+    You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+    or http://www.opensolaris.org/os/licensing.
+    See the License for the specific language governing permissions
+    and limitations under the License.
+
+    When distributing Covered Code, include this CDDL HEADER in each
+    file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+    If applicable, add the following below this CDDL HEADER, with the
+    fields enclosed by brackets "[]" replaced with your own identifying
+    information: Portions Copyright [yyyy] [name of copyright owner]
+
+    CDDL HEADER END
+
     Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
 
     NOTE:  This service manifest is not editable; its contents will


### PR DESCRIPTION
Please review changes to rsyslog.xml.  Somehow I lost the CDDL license header in the original commit.  The subsequent commits put it back.
