### PR TITLE
Adding serial build of hdf5 version 1.8.13

### DIFF
--- a/components/scientific/hdf5/Makefile
+++ b/components/scientific/hdf5/Makefile
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2014 (c) Aurelien Larcher. All rights reserved.
+#
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		hdf5
+COMPONENT_VERSION=	1.8.13
+COMPONENT_FMRI=		library/g++/hdf5
+COMPONENT_PROJECT_URL=	http://www.hdfgroup.org
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:82f6b38eec103b4fccfbf14892786e0c27a8135d3252d8601cf5bf20066d38c1
+COMPONENT_ARCHIVE_URL=	http://www.hdfgroup.org/ftp/HDF5/current/src/$(COMPONENT_ARCHIVE)
+COMPONENT_BUGDB=	$(COMPONENT_FMRI)
+COMPONENT_LICENSE=	NCSA
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+COMPONENT_SUMMARY=	Data model, library, and file format for storing and managing data
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CONFIGURE_PREFIX=/usr/g++
+CONFIGURE_OPTIONS  +=		CFLAGS="$(CFLAGS) -D_LARGEFILE_SOURCE -D__EXTENSIONS__"
+CONFIGURE_OPTIONS  +=		--includedir=$(CONFIGURE_PREFIX)/include/hdf5
+CONFIGURE_OPTIONS  +=		--disable-static
+CONFIGURE_OPTIONS  +=		--enable-fortran
+CONFIGURE_OPTIONS  +=		--enable-cxx
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
+
+include $(WS_MAKE_RULES)/depend.mk

--- a/components/scientific/hdf5/hdf5.license
+++ b/components/scientific/hdf5/hdf5.license
@@ -1,0 +1,92 @@
+
+Copyright Notice and License Terms for 
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+-----------------------------------------------------------------------------
+
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 2006-2013 by The HDF Group.
+
+NCSA HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 1998-2006 by the Board of Trustees of the University of Illinois.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted for any purpose (including commercial purposes) 
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, 
+   this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions, and the following disclaimer in the documentation 
+   and/or materials provided with the distribution.
+
+3. In addition, redistributions of modified forms of the source or binary 
+   code must carry prominent notices stating that the original code was 
+   changed and the date of the change.
+
+4. All publications or advertising materials mentioning features or use of 
+   this software are asked, but not required, to acknowledge that it was 
+   developed by The HDF Group and by the National Center for Supercomputing 
+   Applications at the University of Illinois at Urbana-Champaign and 
+   credit the contributors.
+
+5. Neither the name of The HDF Group, the name of the University, nor the 
+   name of any Contributor may be used to endorse or promote products derived 
+   from this software without specific prior written permission from 
+   The HDF Group, the University, or the Contributor, respectively.
+
+DISCLAIMER: 
+THIS SOFTWARE IS PROVIDED BY THE HDF GROUP AND THE CONTRIBUTORS 
+"AS IS" WITH NO WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED.  In no 
+event shall The HDF Group or the Contributors be liable for any damages 
+suffered by the users arising out of the use of this software, even if 
+advised of the possibility of such damage. 
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Contributors:   National Center for Supercomputing Applications (NCSA) at 
+the University of Illinois, Fortner Software, Unidata Program Center (netCDF), 
+The Independent JPEG Group (JPEG), Jean-loup Gailly and Mark Adler (gzip), 
+and Digital Equipment Corporation (DEC).
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the Lawrence Berkeley 
+National Laboratory (LBNL) and the United States Department of Energy 
+under Prime Contract No. DE-AC02-05CH11231.
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the University of 
+California, Lawrence Livermore National Laboratory (UC LLNL).  
+The following statement applies to those portions of the product and must 
+be retained in any redistribution of source code, binaries, documentation, 
+and/or accompanying materials:
+
+   This work was partially produced at the University of California, 
+   Lawrence Livermore National Laboratory (UC LLNL) under contract 
+   no. W-7405-ENG-48 (Contract 48) between the U.S. Department of Energy 
+   (DOE) and The Regents of the University of California (University) 
+   for the operation of UC LLNL.
+
+   DISCLAIMER: 
+   This work was prepared as an account of work sponsored by an agency of 
+   the United States Government. Neither the United States Government nor 
+   the University of California nor any of their employees, makes any 
+   warranty, express or implied, or assumes any liability or responsibility 
+   for the accuracy, completeness, or usefulness of any information, 
+   apparatus, product, or process disclosed, or represents that its use 
+   would not infringe privately- owned rights. Reference herein to any 
+   specific commercial products, process, or service by trade name, 
+   trademark, manufacturer, or otherwise, does not necessarily constitute 
+   or imply its endorsement, recommendation, or favoring by the United 
+   States Government or the University of California. The views and 
+   opinions of authors expressed herein do not necessarily state or reflect 
+   those of the United States Government or the University of California, 
+   and shall not be used for advertising or product endorsement purposes.
+-----------------------------------------------------------------------------
+
+

--- a/components/scientific/hdf5/hdf5.p5m
+++ b/components/scientific/hdf5/hdf5.p5m
@@ -1,0 +1,304 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2014 Aurelien Larcher. All rights reserved.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification \
+    value=org.opensolaris.category.2008:System/Libraries
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/g++/bin/$(MACH64)/gif2h5
+file path=usr/g++/bin/$(MACH64)/h52gif
+file path=usr/g++/bin/$(MACH64)/h5c++
+file path=usr/g++/bin/$(MACH64)/h5cc
+file path=usr/g++/bin/$(MACH64)/h5copy
+file path=usr/g++/bin/$(MACH64)/h5debug
+file path=usr/g++/bin/$(MACH64)/h5diff
+file path=usr/g++/bin/$(MACH64)/h5dump
+file path=usr/g++/bin/$(MACH64)/h5fc
+file path=usr/g++/bin/$(MACH64)/h5import
+file path=usr/g++/bin/$(MACH64)/h5jam
+file path=usr/g++/bin/$(MACH64)/h5ls
+file path=usr/g++/bin/$(MACH64)/h5mkgrp
+file path=usr/g++/bin/$(MACH64)/h5perf_serial
+file path=usr/g++/bin/$(MACH64)/h5redeploy
+file path=usr/g++/bin/$(MACH64)/h5repack
+file path=usr/g++/bin/$(MACH64)/h5repart
+file path=usr/g++/bin/$(MACH64)/h5stat
+file path=usr/g++/bin/$(MACH64)/h5unjam
+file path=usr/g++/bin/gif2h5
+file path=usr/g++/bin/h52gif
+file path=usr/g++/bin/h5c++
+file path=usr/g++/bin/h5cc
+file path=usr/g++/bin/h5copy
+file path=usr/g++/bin/h5debug
+file path=usr/g++/bin/h5diff
+file path=usr/g++/bin/h5dump
+file path=usr/g++/bin/h5fc
+file path=usr/g++/bin/h5import
+file path=usr/g++/bin/h5jam
+file path=usr/g++/bin/h5ls
+file path=usr/g++/bin/h5mkgrp
+file path=usr/g++/bin/h5perf_serial
+file path=usr/g++/bin/h5redeploy
+file path=usr/g++/bin/h5repack
+file path=usr/g++/bin/h5repart
+file path=usr/g++/bin/h5stat
+file path=usr/g++/bin/h5unjam
+file path=usr/g++/include/hdf5/H5ACpublic.h
+file path=usr/g++/include/hdf5/H5AbstractDs.h
+file path=usr/g++/include/hdf5/H5Apublic.h
+file path=usr/g++/include/hdf5/H5ArrayType.h
+file path=usr/g++/include/hdf5/H5AtomType.h
+file path=usr/g++/include/hdf5/H5Attribute.h
+file path=usr/g++/include/hdf5/H5Classes.h
+file path=usr/g++/include/hdf5/H5CommonFG.h
+file path=usr/g++/include/hdf5/H5CompType.h
+file path=usr/g++/include/hdf5/H5Cpp.h
+file path=usr/g++/include/hdf5/H5CppDoc.h
+file path=usr/g++/include/hdf5/H5Cpublic.h
+file path=usr/g++/include/hdf5/H5DOpublic.h
+file path=usr/g++/include/hdf5/H5DSpublic.h
+file path=usr/g++/include/hdf5/H5DataSet.h
+file path=usr/g++/include/hdf5/H5DataSpace.h
+file path=usr/g++/include/hdf5/H5DataType.h
+file path=usr/g++/include/hdf5/H5DcreatProp.h
+file path=usr/g++/include/hdf5/H5Dpublic.h
+file path=usr/g++/include/hdf5/H5DxferProp.h
+file path=usr/g++/include/hdf5/H5EnumType.h
+file path=usr/g++/include/hdf5/H5Epubgen.h
+file path=usr/g++/include/hdf5/H5Epublic.h
+file path=usr/g++/include/hdf5/H5Exception.h
+file path=usr/g++/include/hdf5/H5FDcore.h
+file path=usr/g++/include/hdf5/H5FDdirect.h
+file path=usr/g++/include/hdf5/H5FDfamily.h
+file path=usr/g++/include/hdf5/H5FDlog.h
+file path=usr/g++/include/hdf5/H5FDmpi.h
+file path=usr/g++/include/hdf5/H5FDmpio.h
+file path=usr/g++/include/hdf5/H5FDmulti.h
+file path=usr/g++/include/hdf5/H5FDpublic.h
+file path=usr/g++/include/hdf5/H5FDsec2.h
+file path=usr/g++/include/hdf5/H5FDstdio.h
+file path=usr/g++/include/hdf5/H5FaccProp.h
+file path=usr/g++/include/hdf5/H5FcreatProp.h
+file path=usr/g++/include/hdf5/H5File.h
+file path=usr/g++/include/hdf5/H5FloatType.h
+file path=usr/g++/include/hdf5/H5Fpublic.h
+file path=usr/g++/include/hdf5/H5Gpublic.h
+file path=usr/g++/include/hdf5/H5Group.h
+file path=usr/g++/include/hdf5/H5IMpublic.h
+file path=usr/g++/include/hdf5/H5IdComponent.h
+file path=usr/g++/include/hdf5/H5Include.h
+file path=usr/g++/include/hdf5/H5IntType.h
+file path=usr/g++/include/hdf5/H5Ipublic.h
+file path=usr/g++/include/hdf5/H5LTpublic.h
+file path=usr/g++/include/hdf5/H5Library.h
+file path=usr/g++/include/hdf5/H5Location.h
+file path=usr/g++/include/hdf5/H5Lpublic.h
+file path=usr/g++/include/hdf5/H5MMpublic.h
+file path=usr/g++/include/hdf5/H5Object.h
+file path=usr/g++/include/hdf5/H5Opublic.h
+file path=usr/g++/include/hdf5/H5PLextern.h
+file path=usr/g++/include/hdf5/H5PTpublic.h
+file path=usr/g++/include/hdf5/H5PacketTable.h
+file path=usr/g++/include/hdf5/H5Ppublic.h
+file path=usr/g++/include/hdf5/H5PredType.h
+file path=usr/g++/include/hdf5/H5PropList.h
+file path=usr/g++/include/hdf5/H5Rpublic.h
+file path=usr/g++/include/hdf5/H5Spublic.h
+file path=usr/g++/include/hdf5/H5StrType.h
+file path=usr/g++/include/hdf5/H5TBpublic.h
+file path=usr/g++/include/hdf5/H5Tpublic.h
+file path=usr/g++/include/hdf5/H5VarLenType.h
+file path=usr/g++/include/hdf5/H5Zpublic.h
+file path=usr/g++/include/hdf5/H5api_adpt.h
+file path=usr/g++/include/hdf5/H5f90i.h
+file path=usr/g++/include/hdf5/H5f90i_gen.h
+file path=usr/g++/include/hdf5/H5overflow.h
+file path=usr/g++/include/hdf5/H5pubconf.h
+file path=usr/g++/include/hdf5/H5public.h
+file path=usr/g++/include/hdf5/H5version.h
+file path=usr/g++/include/hdf5/h5_dble_interface.mod
+file path=usr/g++/include/hdf5/h5a.mod
+file path=usr/g++/include/hdf5/h5a_provisional.mod
+file path=usr/g++/include/hdf5/h5d.mod
+file path=usr/g++/include/hdf5/h5d_provisional.mod
+file path=usr/g++/include/hdf5/h5ds.mod
+file path=usr/g++/include/hdf5/h5e.mod
+file path=usr/g++/include/hdf5/h5e_provisional.mod
+file path=usr/g++/include/hdf5/h5f.mod
+file path=usr/g++/include/hdf5/h5f_provisional.mod
+file path=usr/g++/include/hdf5/h5fortran_types.mod
+file path=usr/g++/include/hdf5/h5g.mod
+file path=usr/g++/include/hdf5/h5global.mod
+file path=usr/g++/include/hdf5/h5i.mod
+file path=usr/g++/include/hdf5/h5im.mod
+file path=usr/g++/include/hdf5/h5l.mod
+file path=usr/g++/include/hdf5/h5l_provisional.mod
+file path=usr/g++/include/hdf5/h5lib.mod
+file path=usr/g++/include/hdf5/h5lib_provisional.mod
+file path=usr/g++/include/hdf5/h5lt.mod
+file path=usr/g++/include/hdf5/h5o.mod
+file path=usr/g++/include/hdf5/h5o_provisional.mod
+file path=usr/g++/include/hdf5/h5p.mod
+file path=usr/g++/include/hdf5/h5p_provisional.mod
+file path=usr/g++/include/hdf5/h5r.mod
+file path=usr/g++/include/hdf5/h5r_provisional.mod
+file path=usr/g++/include/hdf5/h5s.mod
+file path=usr/g++/include/hdf5/h5t.mod
+file path=usr/g++/include/hdf5/h5t_provisional.mod
+file path=usr/g++/include/hdf5/h5tb.mod
+file path=usr/g++/include/hdf5/h5test_kind_sizeof_mod.mod
+file path=usr/g++/include/hdf5/h5z.mod
+file path=usr/g++/include/hdf5/hdf5.h
+file path=usr/g++/include/hdf5/hdf5.mod
+file path=usr/g++/include/hdf5/hdf5_hl.h
+file path=usr/g++/lib/$(MACH64)/libhdf5.settings
+link path=usr/g++/lib/$(MACH64)/libhdf5.so target=libhdf5.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5.so.8 target=libhdf5.so.8.0.2
+file path=usr/g++/lib/$(MACH64)/libhdf5.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_cpp.so target=libhdf5_cpp.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_cpp.so.8 target=libhdf5_cpp.so.8.0.2
+file path=usr/g++/lib/$(MACH64)/libhdf5_cpp.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_fortran.so \
+    target=libhdf5_fortran.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_fortran.so.8 \
+    target=libhdf5_fortran.so.8.0.2
+file path=usr/g++/lib/$(MACH64)/libhdf5_fortran.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_hl.so target=libhdf5_hl.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_hl.so.8 target=libhdf5_hl.so.8.0.2
+file path=usr/g++/lib/$(MACH64)/libhdf5_hl.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_hl_cpp.so target=libhdf5_hl_cpp.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5_hl_cpp.so.8 \
+    target=libhdf5_hl_cpp.so.8.0.2
+file path=usr/g++/lib/$(MACH64)/libhdf5_hl_cpp.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5hl_fortran.so \
+    target=libhdf5hl_fortran.so.8.0.2
+link path=usr/g++/lib/$(MACH64)/libhdf5hl_fortran.so.8 \
+    target=libhdf5hl_fortran.so.8.0.2
+file path=usr/g++/lib/$(MACH64)/libhdf5hl_fortran.so.8.0.2
+file path=usr/g++/lib/libhdf5.settings
+link path=usr/g++/lib/libhdf5.so target=libhdf5.so.8.0.2
+link path=usr/g++/lib/libhdf5.so.8 target=libhdf5.so.8.0.2
+file path=usr/g++/lib/libhdf5.so.8.0.2
+link path=usr/g++/lib/libhdf5_cpp.so target=libhdf5_cpp.so.8.0.2
+link path=usr/g++/lib/libhdf5_cpp.so.8 target=libhdf5_cpp.so.8.0.2
+file path=usr/g++/lib/libhdf5_cpp.so.8.0.2
+link path=usr/g++/lib/libhdf5_fortran.so target=libhdf5_fortran.so.8.0.2
+link path=usr/g++/lib/libhdf5_fortran.so.8 target=libhdf5_fortran.so.8.0.2
+file path=usr/g++/lib/libhdf5_fortran.so.8.0.2
+link path=usr/g++/lib/libhdf5_hl.so target=libhdf5_hl.so.8.0.2
+link path=usr/g++/lib/libhdf5_hl.so.8 target=libhdf5_hl.so.8.0.2
+file path=usr/g++/lib/libhdf5_hl.so.8.0.2
+link path=usr/g++/lib/libhdf5_hl_cpp.so target=libhdf5_hl_cpp.so.8.0.2
+link path=usr/g++/lib/libhdf5_hl_cpp.so.8 target=libhdf5_hl_cpp.so.8.0.2
+file path=usr/g++/lib/libhdf5_hl_cpp.so.8.0.2
+link path=usr/g++/lib/libhdf5hl_fortran.so target=libhdf5hl_fortran.so.8.0.2
+link path=usr/g++/lib/libhdf5hl_fortran.so.8 target=libhdf5hl_fortran.so.8.0.2
+file path=usr/g++/lib/libhdf5hl_fortran.so.8.0.2
+file path=usr/g++/share/hdf5/examples/README
+file path=usr/g++/share/hdf5/examples/c++/chunks.cpp
+file path=usr/g++/share/hdf5/examples/c++/compound.cpp
+file path=usr/g++/share/hdf5/examples/c++/create.cpp
+file path=usr/g++/share/hdf5/examples/c++/extend_ds.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5group.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_cmprss.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_crtatt.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_crtdat.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_crtgrp.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_crtgrpar.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_crtgrpd.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_extend.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_rdwt.cpp
+file path=usr/g++/share/hdf5/examples/c++/h5tutr_subset.cpp
+file path=usr/g++/share/hdf5/examples/c++/readdata.cpp
+file path=usr/g++/share/hdf5/examples/c++/run-c++-ex.sh
+file path=usr/g++/share/hdf5/examples/c++/writedata.cpp
+file path=usr/g++/share/hdf5/examples/c/h5_attribute.c
+file path=usr/g++/share/hdf5/examples/c/h5_chunk_read.c
+file path=usr/g++/share/hdf5/examples/c/h5_cmprss.c
+file path=usr/g++/share/hdf5/examples/c/h5_compound.c
+file path=usr/g++/share/hdf5/examples/c/h5_crtatt.c
+file path=usr/g++/share/hdf5/examples/c/h5_crtdat.c
+file path=usr/g++/share/hdf5/examples/c/h5_crtgrp.c
+file path=usr/g++/share/hdf5/examples/c/h5_crtgrpar.c
+file path=usr/g++/share/hdf5/examples/c/h5_crtgrpd.c
+file path=usr/g++/share/hdf5/examples/c/h5_drivers.c
+file path=usr/g++/share/hdf5/examples/c/h5_elink_unix2win.c
+file path=usr/g++/share/hdf5/examples/c/h5_extend.c
+file path=usr/g++/share/hdf5/examples/c/h5_extend_write.c
+file path=usr/g++/share/hdf5/examples/c/h5_extlink.c
+file path=usr/g++/share/hdf5/examples/c/h5_group.c
+file path=usr/g++/share/hdf5/examples/c/h5_mount.c
+file path=usr/g++/share/hdf5/examples/c/h5_rdwt.c
+file path=usr/g++/share/hdf5/examples/c/h5_read.c
+file path=usr/g++/share/hdf5/examples/c/h5_ref2reg.c
+file path=usr/g++/share/hdf5/examples/c/h5_reference.c
+file path=usr/g++/share/hdf5/examples/c/h5_select.c
+file path=usr/g++/share/hdf5/examples/c/h5_shared_mesg.c
+file path=usr/g++/share/hdf5/examples/c/h5_subset.c
+file path=usr/g++/share/hdf5/examples/c/h5_write.c
+file path=usr/g++/share/hdf5/examples/c/ph5example.c
+file path=usr/g++/share/hdf5/examples/c/run-c-ex.sh
+file path=usr/g++/share/hdf5/examples/fortran/compound.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_cmprss.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_crtatt.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_crtdat.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_crtgrp.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_crtgrpar.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_crtgrpd.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_extend.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_rdwt.f90
+file path=usr/g++/share/hdf5/examples/fortran/h5_subset.f90
+file path=usr/g++/share/hdf5/examples/fortran/hyperslab.f90
+file path=usr/g++/share/hdf5/examples/fortran/mountexample.f90
+file path=usr/g++/share/hdf5/examples/fortran/ph5example.f90
+file path=usr/g++/share/hdf5/examples/fortran/refobjexample.f90
+file path=usr/g++/share/hdf5/examples/fortran/refregexample.f90
+file path=usr/g++/share/hdf5/examples/fortran/run-fortran-ex.sh
+file path=usr/g++/share/hdf5/examples/fortran/selectele.f90
+file path=usr/g++/share/hdf5/examples/hl/c++/ptExampleFL.cpp
+file path=usr/g++/share/hdf5/examples/hl/c++/run-hlc++-ex.sh
+file path=usr/g++/share/hdf5/examples/hl/c/ex_ds1.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_image1.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_image2.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_lite1.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_lite2.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_lite3.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_01.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_02.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_03.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_04.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_05.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_06.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_07.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_08.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_09.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_10.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_11.c
+file path=usr/g++/share/hdf5/examples/hl/c/ex_table_12.c
+file path=usr/g++/share/hdf5/examples/hl/c/image24pixel.txt
+file path=usr/g++/share/hdf5/examples/hl/c/image8.txt
+file path=usr/g++/share/hdf5/examples/hl/c/pal_rgb.h
+file path=usr/g++/share/hdf5/examples/hl/c/ptExampleFL.c
+file path=usr/g++/share/hdf5/examples/hl/c/run-hlc-ex.sh
+file path=usr/g++/share/hdf5/examples/hl/fortran/ex_ds1.f90
+file path=usr/g++/share/hdf5/examples/hl/fortran/exlite.f90
+file path=usr/g++/share/hdf5/examples/hl/fortran/run-hlfortran-ex.sh
+file path=usr/g++/share/hdf5/examples/hl/run-hl-ex.sh
+file path=usr/g++/share/hdf5/examples/run-all-ex.sh

--- a/components/scientific/hdf5/patches/hdf5-01-config-solaris2.x.patch
+++ b/components/scientific/hdf5/patches/hdf5-01-config-solaris2.x.patch
@@ -1,0 +1,11 @@
+--- ./config/solaris2.x.orig	2012-11-15 16:22:28.394091724 +0100
++++ ./config/solaris2.x	2012-11-15 16:22:54.408998345 +0100
+@@ -105,7 +105,7 @@
+ 
+ # Try solaris native compiler flags
+ if test -z "$cxx_flags_set"; then
+-  H5_CXXFLAGS="$H5_CXXFLAGS -instances=static"
++  H5_CXXFLAGS="$H5_CXXFLAGS "
+   H5_CPPFLAGS="$H5_CPPFLAGS -LANG:std"
+   # -g produces rather slow code. "-g -O" produces much faster code with some
+   # loss of debugger functions such as not able to print local variables.

--- a/components/scientific/hdf5/patches/hdf5-02-examples-path.patch
+++ b/components/scientific/hdf5/patches/hdf5-02-examples-path.patch
@@ -1,0 +1,228 @@
+--- hdf5-1.8.13/release_docs/RELEASE.txt.orig	2014-09-05 20:38:27.543384208 +0000
++++ hdf5-1.8.13/release_docs/RELEASE.txt	2014-09-05 20:38:27.549808511 +0000
+@@ -206,7 +206,7 @@
+ 
+       An export of LD_LIBRARY_PATH=<szip library location> was
+       removed from configure; make installcheck was revised to run
+-      scripts installed in share/hdf5_examples to use the installed h5cc, etc. 
++      scripts installed in share/hdf5/examples to use the installed h5cc, etc. 
+       to compile and run example source files also installed there. 
+ 
+       Make installcheck will now fail when a shared szip or other external lib 
+--- hdf5-1.8.13/release_docs/HISTORY-1_8.txt.orig	2014-09-05 20:38:27.553817046 +0000
++++ hdf5-1.8.13/release_docs/HISTORY-1_8.txt	2014-09-05 20:38:27.602619079 +0000
+@@ -5133,7 +5133,7 @@
+   (11.0) avoids the issue. MAM - 2010/06/01
+   
+ * On solaris systems, when running the examples with the scripts installed in
+-  .../share/hdf5_examples, two of the c tests, h5_extlink and h5_elink_unix2win 
++  .../share/hdf5/examples, two of the c tests, h5_extlink and h5_elink_unix2win 
+   may fail or generate HDF5 errors because the script commands in c/run-c-ex.sh 
+   fail to create test directories red, blue, and u2w.  Moving the '!' in lines 
+   67, 70, 73 of run-c-ex.sh will fix the problem.  For example the script command 
+--- hdf5-1.8.13/fortran/examples/Makefile.in.orig	2014-09-05 20:38:27.608224856 +0000
++++ hdf5-1.8.13/fortran/examples/Makefile.in	2014-09-05 20:38:27.616955927 +0000
+@@ -649,7 +649,7 @@
+ 
+ # Tell automake how to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples/fortran
++EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples/fortran
+ 
+ # Assume that all tests in this directory are examples, and tell
+ # conclude.am when to build them.
+--- hdf5-1.8.13/fortran/examples/run-fortran-ex.sh.in.orig	2014-09-05 20:38:27.620525849 +0000
++++ hdf5-1.8.13/fortran/examples/run-fortran-ex.sh.in	2014-09-05 20:38:27.622697203 +0000
+@@ -20,7 +20,7 @@
+ # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+ #                                                                               #
+ # This script will compile and run the fortran examples from source files       #
+-# installed in .../share/hdf5_examples/fortran using h5fc or h5pfc.  The        #
++# installed in .../share/hdf5/examples/fortran using h5fc or h5pfc.  The        #
+ # order for running programs with RunTest in the MAIN section below is taken    #
+ # from the Makefile.  The order is important since some of the test programs    #
+ # use data files created by earlier test programs.  Any future additions should #
+--- hdf5-1.8.13/fortran/examples/Makefile.am.orig	2014-09-05 20:38:27.625706614 +0000
++++ hdf5-1.8.13/fortran/examples/Makefile.am	2014-09-05 20:38:27.627733385 +0000
+@@ -78,7 +78,7 @@
+ 
+ # Tell automake how to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples/fortran
++EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples/fortran
+ 
+ # List dependencies for each example.  Normally, automake would take
+ # care of this for us, but if we tell automake about the programs it
+--- hdf5-1.8.13/c++/examples/run-c++-ex.sh.in.orig	2014-09-05 20:38:27.631704147 +0000
++++ hdf5-1.8.13/c++/examples/run-c++-ex.sh.in	2014-09-05 20:38:27.633881715 +0000
+@@ -20,7 +20,7 @@
+ # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+ #                                                                               #
+ # This script will compile and run the c++ examples from source files           #
+-# installed in .../share/hdf5_examples/c++ using h5c++.  The                    #
++# installed in .../share/hdf5/examples/c++ using h5c++.  The                    #
+ # order for running programs with RunTest in the MAIN section below is taken    #
+ # from the Makefile.  The order is important since some of the test programs    #
+ # use data files created by earlier test programs.  Any future additions should #
+--- hdf5-1.8.13/c++/examples/Makefile.in.orig	2014-09-05 20:38:27.636939363 +0000
++++ hdf5-1.8.13/c++/examples/Makefile.in	2014-09-05 20:38:27.645494767 +0000
+@@ -637,7 +637,7 @@
+ 
+ # Where to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples/c++
++EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples/c++
+ 
+ # Assume that all tests in this directory are examples, and tell
+ # conclude.am when to build them.
+--- hdf5-1.8.13/c++/examples/Makefile.am.orig	2014-09-05 20:38:27.648939847 +0000
++++ hdf5-1.8.13/c++/examples/Makefile.am	2014-09-05 20:38:27.650944589 +0000
+@@ -51,7 +51,7 @@
+ 
+ # Where to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples/c++
++EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples/c++
+ 
+ # How to build programs using h5c++
+ $(EXTRA_PROG): $(H5CPP)
+--- hdf5-1.8.13/examples/run-c-ex.sh.in.orig	2014-09-05 20:38:27.654001399 +0000
++++ hdf5-1.8.13/examples/run-c-ex.sh.in	2014-09-05 20:38:27.656136727 +0000
+@@ -20,7 +20,7 @@
+ # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+ #                                                                               #
+ # This script will compile and run the c examples from source files installed   #
+-# in .../share/hdf5_examples/c using h5cc or h5pc.  The order for running       #
++# in .../share/hdf5/examples/c using h5cc or h5pc.  The order for running       #
+ # programs with RunTest in the MAIN section below is taken from the Makefile.   #
+ # The order is important since some of the test programs use data files created #
+ # by earlier test programs.  Any future additions should be placed accordingly. #
+--- hdf5-1.8.13/examples/Makefile.in.orig	2014-09-05 20:38:27.659084329 +0000
++++ hdf5-1.8.13/examples/Makefile.in	2014-09-05 20:38:27.668472492 +0000
+@@ -646,8 +646,8 @@
+ 
+ # Example directory
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples/c
+-EXAMPLETOPDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples
++EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples/c
++EXAMPLETOPDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples
+ @BUILD_SHARED_SZIP_CONDITIONAL_TRUE@LD_LIBRARY_PATH = $(LL_PATH)
+ 
+ # Assume that all tests in this directory are examples, and tell
+--- hdf5-1.8.13/examples/Makefile.am.orig	2014-09-05 20:38:27.672108027 +0000
++++ hdf5-1.8.13/examples/Makefile.am	2014-09-05 20:38:27.674280143 +0000
+@@ -82,8 +82,8 @@
+ 
+ # Example directory
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples/c
+-EXAMPLETOPDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples
++EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples/c
++EXAMPLETOPDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples
+ 
+ # List dependencies for each program.  Normally, automake would take
+ # care of this for us, but if we tell automake about the programs it
+--- hdf5-1.8.13/hl/examples/run-hlc-ex.sh.in.orig	2014-09-05 20:38:27.677341629 +0000
++++ hdf5-1.8.13/hl/examples/run-hlc-ex.sh.in	2014-09-05 20:38:27.679443413 +0000
+@@ -20,7 +20,7 @@
+ # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+ #                                                                               #
+ # This script will compile and run the c examples from source files installed   #
+-# in .../share/hdf5_examples/hl/c using h5cc or h5pc.  The order for running    #
++# in .../share/hdf5/examples/hl/c using h5cc or h5pc.  The order for running    #
+ # programs with RunTest in the MAIN section below is taken from the Makefile.   #
+ # The order is important since some of the test programs use data files created #
+ # by earlier test programs.  Any future additions should be placed accordingly. #
+--- hdf5-1.8.13/hl/examples/Makefile.am.orig	2014-09-05 20:38:27.682551946 +0000
++++ hdf5-1.8.13/hl/examples/Makefile.am	2014-09-05 20:38:27.684635021 +0000
+@@ -27,8 +27,8 @@
+ 
+ # Example directory
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl/c
+-EXAMPLETOPDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl
++EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl/c
++EXAMPLETOPDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl
+ INSTALL_SCRIPT_FILES = run-hlc-ex.sh
+ INSTALL_TOP_SCRIPT_FILES = run-hl-ex.sh
+ 
+--- hdf5-1.8.13/hl/examples/Makefile.in.orig	2014-09-05 20:38:27.687766239 +0000
++++ hdf5-1.8.13/hl/examples/Makefile.in	2014-09-05 20:38:27.696733145 +0000
+@@ -615,8 +615,8 @@
+ 
+ # Example directory
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl/c
+-EXAMPLETOPDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl
++EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl/c
++EXAMPLETOPDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl
+ INSTALL_SCRIPT_FILES = run-hlc-ex.sh
+ INSTALL_TOP_SCRIPT_FILES = run-hl-ex.sh
+ 
+--- hdf5-1.8.13/hl/c++/examples/run-hlc++-ex.sh.in.orig	2014-09-05 20:38:27.700464649 +0000
++++ hdf5-1.8.13/hl/c++/examples/run-hlc++-ex.sh.in	2014-09-05 20:38:27.702407874 +0000
+@@ -20,7 +20,7 @@
+ # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+ #                                                                               #
+ # This script will compile and run the c++ examples from source files           #
+-# installed in .../share/hdf5_examples/hl/c++ using h5c++.  The                 #
++# installed in .../share/hdf5/examples/hl/c++ using h5c++.  The                 #
+ # order for running programs with RunTest in the MAIN section below is taken    #
+ # from the Makefile.  The order is important since some of the test programs    #
+ # use data files created by earlier test programs.  Any future additions should #
+--- hdf5-1.8.13/hl/c++/examples/Makefile.am.orig	2014-09-05 20:38:27.705806508 +0000
++++ hdf5-1.8.13/hl/c++/examples/Makefile.am	2014-09-05 20:38:27.707584704 +0000
+@@ -35,7 +35,7 @@
+ 
+ # Where to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl/c++
++EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl/c++
+ 
+ # How to build programs using h5c++
+ $(EXTRA_PROG): $(H5CPP)
+--- hdf5-1.8.13/hl/c++/examples/Makefile.in.orig	2014-09-05 20:38:27.710691344 +0000
++++ hdf5-1.8.13/hl/c++/examples/Makefile.in	2014-09-05 20:38:27.718575708 +0000
+@@ -626,7 +626,7 @@
+ 
+ # Where to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl/c++
++EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl/c++
+ 
+ # Assume that all tests in this directory are examples, and tell
+ # conclude.am when to build them.
+--- hdf5-1.8.13/hl/fortran/examples/run-hlfortran-ex.sh.in.orig	2014-09-05 20:38:27.722157447 +0000
++++ hdf5-1.8.13/hl/fortran/examples/run-hlfortran-ex.sh.in	2014-09-05 20:38:27.724653879 +0000
+@@ -20,7 +20,7 @@
+ # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+ #                                                                               #
+ # This script will compile and run the fortran examples from source files       #
+-# installed in .../share/hdf5_examples/hl/fortran using h5fc or h5pfc.  The     #
++# installed in .../share/hdf5/examples/hl/fortran using h5fc or h5pfc.  The     #
+ # order for running programs with RunTest in the MAIN section below is taken    #
+ # from the Makefile.  The order is important since some of the test programs    #
+ # use data files created by earlier test programs.  Any future additions should #
+--- hdf5-1.8.13/hl/fortran/examples/Makefile.in.orig	2014-09-05 20:38:27.728236886 +0000
++++ hdf5-1.8.13/hl/fortran/examples/Makefile.in	2014-09-05 20:38:27.736232975 +0000
+@@ -633,7 +633,7 @@
+ 
+ # Tell automake how to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl/fortran
++EXAMPLEDIR = ${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl/fortran
+ 
+ # Assume that all tests in this directory are examples, and tell
+ # conclude.am when to build them.
+--- hdf5-1.8.13/hl/fortran/examples/Makefile.am.orig	2014-09-05 20:38:27.739749225 +0000
++++ hdf5-1.8.13/hl/fortran/examples/Makefile.am	2014-09-05 20:38:27.741715194 +0000
+@@ -53,7 +53,7 @@
+ 
+ # Tell automake how to install examples
+ # Note: no '/' after DESTDIR.  Explanation in commence.am
+-EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5_examples/hl/fortran
++EXAMPLEDIR=${DESTDIR}$(exec_prefix)/share/hdf5/examples/hl/fortran
+ 
+ # List dependencies for each example.  Normally, automake would take
+ # care of this for us, but if we tell automake about the programs it


### PR DESCRIPTION
HDF5 is installed in /usr/g++ prefix as it contains C++ code.
I am not sure what is the policy for software compiled with gcc that provides libraries written with different programming languages.
I will provide a parallel enabled version compiled with mpich/gcc later.
Thank you.
