### PR TITLE
We want to use illumos-gate-provided libm.

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -9,6 +9,9 @@
 # illumos-gate now
 /^perl_modules\/sun_solaris$/d
 
+# skip libm, it should be delivered by illumos-gate now
+/^osol\/math$/d
+
 /^areca$/d
 /^beanshell$/d
 /^clisp$/d


### PR DESCRIPTION
Avoid delivering OpenSolaris-derived libm.
