### PR TITLE
Add OpenJPEG 2.1.0

### DIFF
--- a/components/openjpeg/Makefile
+++ b/components/openjpeg/Makefile
@@ -1,0 +1,68 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.illumos.org/license/CDDL.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2013, Aurelien Larcher. All rights reserved.
+#
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		openjpeg
+COMPONENT_VERSION=	2.1.0
+COMPONENT_FMRI=     	image/library/openjpeg
+COMPONENT_CLASSIFICATION=System/Libraries
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=	http://www.openjpeg.org/
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:1232bb814fd88d8ed314c94f0bfebb03de8559583a33abbe8c64ef3fc0a8ff03
+COMPONENT_ARCHIVE_URL=	http://sourceforge.net/projects/openjpeg.mirror/files/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)/download
+COMPONENT_LICENSE=      BSD
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+COMPONENT_SUMMARY=      OpenJPEG library : Open source JPEG 2000 codecs
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/cmake.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CMAKE_OPTIONS+= -DCMAKE_EXE_LINKER_FLAGS:STRING="-lnsl -lsocket"
+# Openjpeg does not use CMake's internal variables.
+CMAKE_OPTIONS+=	-DOPENJPEG_INSTALL_BIN_DIR=$(CMAKE_BINDIR.$(BITS))
+CMAKE_OPTIONS+=	-DOPENJPEG_INSTALL_LIB_DIR=$(CMAKE_LIBDIR.$(BITS))
+# For jar files
+CMAKE_OPTIONS+=	-DOPENJPEG_INSTALL_SHARE_DIR=$(USRSHAREDIR)/lib/java
+CMAKE_OPTIONS+= -DBUILD_CODEC:BOOL=ON
+CMAKE_OPTIONS+= -DBUILD_DOC:BOOL=OFF
+CMAKE_OPTIONS+= -DBUILD_JPIP:BOOL=ON
+CMAKE_OPTIONS+= -DBUILD_JPWL:BOOL=ON
+CMAKE_OPTIONS+= -DBUILD_MJ2:BOOL=ON
+CMAKE_OPTIONS+= -DBUILD_PKGCONFIG_FILES:BOOL=ON
+CMAKE_OPTIONS+= -DBUILD_SHARED_LIBS:BOOL=ON
+CMAKE_OPTIONS+= -DBUILD_TESTING:BOOL=OFF
+CMAKE_OPTIONS+= -DBUILD_THIRDPARTY:BOOL=ON   
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+test: $(NO_TESTS)
+
+BUILD_PKG_DEPENDENCIES =    $(BUILD_TOOLS)
+
+include $(WS_MAKE_RULES)/depend.mk
+

--- a/components/openjpeg/openjpeg.license
+++ b/components/openjpeg/openjpeg.license
@@ -1,0 +1,39 @@
+/*
+ * The copyright in this software is being made available under the 2-clauses 
+ * BSD License, included below. This software may be subject to other third 
+ * party and contributor rights, including patent rights, and no such rights
+ * are granted under this license.
+ *
+ * Copyright (c) 2002-2014, Universite catholique de Louvain (UCL), Belgium
+ * Copyright (c) 2002-2014, Professor Benoit Macq
+ * Copyright (c) 2003-2014, Antonin Descampe
+ * Copyright (c) 2003-2009, Francois-Olivier Devaux
+ * Copyright (c) 2005, Herve Drolon, FreeImage Team
+ * Copyright (c) 2002-2003, Yannick Verschueren
+ * Copyright (c) 2001-2003, David Janssens
+ * Copyright (c) 2011-2012, Centre National d'Etudes Spatiales (CNES), France 
+ * Copyright (c) 2012, CS Systemes d'Information, France
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS `AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/components/openjpeg/openjpeg.p5m
+++ b/components/openjpeg/openjpeg.p5m
@@ -1,0 +1,93 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2014 Aurelien Larcher. All rights reserved.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/opj_compress
+file path=usr/bin/$(MACH64)/opj_dec_server
+file path=usr/bin/$(MACH64)/opj_decompress
+file path=usr/bin/$(MACH64)/opj_dump
+file path=usr/bin/$(MACH64)/opj_jpip_addxml
+file path=usr/bin/$(MACH64)/opj_jpip_test
+file path=usr/bin/$(MACH64)/opj_jpip_transcode
+file path=usr/bin/$(MACH64)/opj_jpwl_compress
+file path=usr/bin/$(MACH64)/opj_jpwl_decompress
+file path=usr/bin/$(MACH64)/opj_mj2_compress
+file path=usr/bin/$(MACH64)/opj_mj2_decompress
+file path=usr/bin/$(MACH64)/opj_mj2_extract
+file path=usr/bin/$(MACH64)/opj_mj2_wrap
+file path=usr/bin/opj_compress
+file path=usr/bin/opj_dec_server
+file path=usr/bin/opj_decompress
+file path=usr/bin/opj_dump
+file path=usr/bin/opj_jpip_addxml
+file path=usr/bin/opj_jpip_test
+file path=usr/bin/opj_jpip_transcode
+file path=usr/bin/opj_jpwl_compress
+file path=usr/bin/opj_jpwl_decompress
+file path=usr/bin/opj_mj2_compress
+file path=usr/bin/opj_mj2_decompress
+file path=usr/bin/opj_mj2_extract
+file path=usr/bin/opj_mj2_wrap
+file path=usr/include/openjpeg-2.1/openjpeg.h
+file path=usr/include/openjpeg-2.1/opj_config.h
+file path=usr/include/openjpeg-2.1/opj_stdint.h
+link path=usr/lib/$(MACH64)/libopenjp2.so target=libopenjp2.so.7
+file path=usr/lib/$(MACH64)/libopenjp2.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libopenjp2.so.7 \
+    target=libopenjp2.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libopenjpip.so target=libopenjpip.so.7
+file path=usr/lib/$(MACH64)/libopenjpip.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libopenjpip.so.7 \
+    target=libopenjpip.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libopenjpwl.so target=libopenjpwl.so.7
+file path=usr/lib/$(MACH64)/libopenjpwl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libopenjpwl.so.7 \
+    target=libopenjpwl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libopenmj2.so target=libopenmj2.so.7
+file path=usr/lib/$(MACH64)/libopenmj2.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libopenmj2.so.7 \
+    target=libopenmj2.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/openjpeg-2.1/OpenJPEGConfig.cmake
+file path=usr/lib/$(MACH64)/openjpeg-2.1/OpenJPEGTargets-noconfig.cmake
+file path=usr/lib/$(MACH64)/openjpeg-2.1/OpenJPEGTargets.cmake
+file path=usr/lib/$(MACH64)/pkgconfig/libopenjp2.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libopenjpip.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libopenjpwl.pc
+link path=usr/lib/libopenjp2.so target=libopenjp2.so.7
+file path=usr/lib/libopenjp2.so.$(COMPONENT_VERSION)
+link path=usr/lib/libopenjp2.so.7 target=libopenjp2.so.$(COMPONENT_VERSION)
+link path=usr/lib/libopenjpip.so target=libopenjpip.so.7
+file path=usr/lib/libopenjpip.so.$(COMPONENT_VERSION)
+link path=usr/lib/libopenjpip.so.7 target=libopenjpip.so.$(COMPONENT_VERSION)
+link path=usr/lib/libopenjpwl.so target=libopenjpwl.so.7
+file path=usr/lib/libopenjpwl.so.$(COMPONENT_VERSION)
+link path=usr/lib/libopenjpwl.so.7 target=libopenjpwl.so.$(COMPONENT_VERSION)
+link path=usr/lib/libopenmj2.so target=libopenmj2.so.7
+file path=usr/lib/libopenmj2.so.$(COMPONENT_VERSION)
+link path=usr/lib/libopenmj2.so.7 target=libopenmj2.so.$(COMPONENT_VERSION)
+file path=usr/lib/openjpeg-2.1/OpenJPEGConfig.cmake
+file path=usr/lib/openjpeg-2.1/OpenJPEGTargets-noconfig.cmake
+file path=usr/lib/openjpeg-2.1/OpenJPEGTargets.cmake
+file path=usr/lib/pkgconfig/libopenjp2.pc
+file path=usr/lib/pkgconfig/libopenjpip.pc
+file path=usr/lib/pkgconfig/libopenjpwl.pc
+file path=usr/share/lib/java/opj_jpip_viewer.jar

--- a/components/openjpeg/patches/openjpeg-01-index_t.patch
+++ b/components/openjpeg/patches/openjpeg-01-index_t.patch
@@ -1,0 +1,74 @@
+--- ./src/lib/openjpip/openjpip.h.orig	2015-02-11 06:20:47.740450785 +0000
++++ ./src/lib/openjpip/openjpip.h	2015-02-11 06:24:12.124327493 +0000
+@@ -276,23 +276,20 @@
+  *  test the format of index (cidx) box in JP2 file
+  */
+ 
+-/** Redefinition of index parameters*/
+-typedef index_param_t index_t;
+-
+ /**
+  * Parse JP2 file and get index information from cidx box inside
+  * 
+  * @param[in] fd file descriptor of the JP2 file
+  * @return       pointer to the generated structure of index parameters
+  */
+-OPJ_API index_t * OPJ_CALLCONV get_index_from_JP2file( int fd);
++OPJ_API index_param_t * OPJ_CALLCONV get_index_from_JP2file( int fd);
+ 
+ /**
+  * Destroy index parameters
+  *
+  * @param[in,out] idx addressof the index pointer
+  */
+-OPJ_API void OPJ_CALLCONV destroy_index( index_t **idx);
++OPJ_API void OPJ_CALLCONV destroy_index( index_param_t **idx);
+ 
+ 
+ /**
+@@ -300,7 +297,7 @@
+  *
+  * @param[in] index index parameters
+  */
+-OPJ_API void OPJ_CALLCONV output_index( index_t *index);
++OPJ_API void OPJ_CALLCONV output_index( index_param_t *index);
+ 
+ #endif /*SERVER*/
+ 
+--- ./src/lib/openjpip/openjpip.c.orig	2015-02-11 06:20:19.227751378 +0000
++++ ./src/lib/openjpip/openjpip.c	2015-02-11 06:23:37.274451134 +0000
+@@ -409,7 +409,7 @@
+   opj_free( *dec);
+ }
+ 
+-index_t * OPJ_CALLCONV get_index_from_JP2file( int fd)
++index_param_t * OPJ_CALLCONV get_index_from_JP2file( int fd)
+ {
+   char *data;
+  
+@@ -437,12 +437,12 @@
+   return parse_jp2file( fd);
+ }
+ 
+-void OPJ_CALLCONV destroy_index( index_t **idx)
++void OPJ_CALLCONV destroy_index( index_param_t **idx)
+ {
+   delete_index( idx);
+ }
+ 
+-void OPJ_CALLCONV output_index( index_t *index)
++void OPJ_CALLCONV output_index( index_param_t *index)
+ {
+   print_index( *index);
+ }
+--- ./src/bin/jpip/opj_jpip_test.c.orig	2015-02-11 06:21:44.574812169 +0000
++++ ./src/bin/jpip/opj_jpip_test.c	2015-02-11 06:22:17.156907327 +0000
+@@ -52,7 +52,7 @@
+ main(int argc, char *argv[])
+ {
+   int fd;
+-  index_t *jp2idx;
++  index_param_t *jp2idx;
+   if( argc < 2 ) return 1;
+   
+   if( (fd = open( argv[1], O_RDONLY)) == -1){


### PR DESCRIPTION
The patch is quite ugly, if you have a better idea.
The issue is that index_t is defined in sys/types.h and there is no way to hide it, since POSIX discourages type names with _t suffix, it should be fixed upstream.
