### PR TITLE
glibmm: rework fix for absence of WCHAR_T <=> UTF-8 conversion.

### DIFF
--- a/components/glibmm/Makefile
+++ b/components/glibmm/Makefile
@@ -18,6 +18,7 @@ include ../../make-rules/shared-macros.mk
 COMPONENT_NAME= glibmm
 
 COMPONENT_VERSION= 2.28.2
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= glibmm - C++ Wrapper for the Glib2 Library (g++ - compiled)
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz

--- a/components/glibmm/patches/glib_glibmm_ustring.cc.patch
+++ b/components/glibmm/patches/glib_glibmm_ustring.cc.patch
@@ -1,82 +1,43 @@
 OI (and Solaris) iconv doesn't support WCHAR_T <-> UTF-8 conversions 
-( https://www.illumos.org/issues/5089 ). This patch assumes UTF-8 locale 
-and uses wcsrtombs/mbsrtowcs to convert characters between UTF-8 and 
-WCHAR_T. For non-UTF-8 locales (including C) more work is needed (perhaps,
-using setlocale to detect current locale and iconv for actual conversion could work).
+( https://www.illumos.org/issues/5089 ). But internal encoding used 
+in WCHAR_T is UCS-4LE, so we use it.
 
---- glibmm-2.28.2/glib/glibmm/ustring.cc.~1~	2011-05-11 14:23:15.000000000 +0400
-+++ glibmm-2.28.2/glib/glibmm/ustring.cc	2014-08-19 12:43:48.503811716 +0400
-@@ -1275,7 +1275,24 @@
-   glong n_bytes = 0;
-   const ScopedPtr<char> buf (g_utf16_to_utf8(reinterpret_cast<const gunichar2*>(str.data()),
-                                              str.size(), 0, &n_bytes, &error));
--# else
-+# elif defined(__sun)
-+  gsize n_bytes = 0;
-+  size_t new_sz = (str.size()+1) * MB_LEN_MAX;
-+
-+  gchar *new_str = (gchar *) malloc(new_sz);
-+  if (new_str) {
-+    const wchar_t *ptr=str.data();
-+    n_bytes=wcsrtombs((char*)new_str,(const wchar_t**) &ptr,new_sz,NULL);
-+    if (n_bytes<0){
-+      error=g_error_new(G_CONVERT_ERROR,G_CONVERT_ERROR_FAILED,"Can't convert string to utf-8");
-+    } else {
-+        new_str[n_bytes]='\0';
-+    }
-+  } else{
-+      error=g_error_new(G_CONVERT_ERROR,G_CONVERT_ERROR_FAILED,"Can't convert string to utf-8. Couldn't allocate memory.");
-+  }
-+  const ScopedPtr<char> buf (new_str);
-+# else 
+--- glibmm-2.28.2/glib/glibmm/ustring.cc.~1~	2014-11-28 17:13:54.224573590 +0300
++++ glibmm-2.28.2/glib/glibmm/ustring.cc	2014-11-28 17:20:42.966679418 +0300
+@@ -1279,7 +1279,12 @@
    gsize n_bytes = 0;
    const ScopedPtr<char> buf (g_convert(reinterpret_cast<const char*>(str.data()),
                                         str.size() * sizeof(std::wstring::value_type),
-@@ -1359,6 +1376,23 @@
-   glong n_bytes = 0;
-   const ScopedPtr<char> buf (g_utf16_to_utf8(reinterpret_cast<const gunichar2*>(wstr.data()),
-                                              wstr.size(), 0, &n_bytes, &error));
-+#elif defined(__sun)
-+  gsize n_bytes =0;
-+  size_t new_sz = (wstr.size()+1) * MB_LEN_MAX;
++#if defined(__sun)
++                                       "UTF-8", "UCS-4LE", 0, &n_bytes, &error));
++#else
+                                        "UTF-8", "WCHAR_T", 0, &n_bytes, &error));
++#endif
 +
-+  gchar *new_str =(gchar*) malloc(new_sz);
-+  if (new_str) {
-+    const wchar_t * ptr=wstr.data();
-+    n_bytes=wcsrtombs((char*)new_str,(const wchar_t **)&ptr,new_sz,NULL);
-+    if (n_bytes<0){
-+      error=g_error_new(G_CONVERT_ERROR,G_CONVERT_ERROR_FAILED,"Can't convert string to utf-8");
-+    } else {
-+        new_str[n_bytes]='\0';
-+    }
-+  } else{
-+      error=g_error_new(G_CONVERT_ERROR,G_CONVERT_ERROR_FAILED,"Can't convert string to utf-8. Couldn't allocate memory.");
-+  }
-+  const ScopedPtr<char> buf (new_str);
- #else
+ # endif /* !(__STDC_ISO_10646__ || G_OS_WIN32) */
+ 
+ #else /* !GLIBMM_HAVE_WIDE_STREAM */
+@@ -1363,7 +1368,11 @@
    gsize n_bytes = 0;
    const ScopedPtr<char> buf (g_convert(reinterpret_cast<const char*>(wstr.data()),
-@@ -1388,6 +1422,23 @@
-   // Avoid going through iconv if wchar_t always contains UTF-16.
-   const ScopedPtr<gunichar2> buf (g_utf8_to_utf16(utf8_string.raw().data(),
-                                                   utf8_string.raw().size(), 0, 0, &error));
-+#elif defined(__sun)
-+  size_t new_sz = utf8_string.raw().size() * MB_LEN_MAX;
-+  int n_bytes;
-+
-+  wchar_t *new_str = (wchar_t *) malloc(new_sz);
-+  if (new_str) {
-+    const char* ptr=utf8_string.raw().data();
-+    n_bytes=mbsrtowcs(new_str,(const char**) & ptr,new_sz,NULL);
-+    if (n_bytes<0){
-+      error=g_error_new(G_CONVERT_ERROR,G_CONVERT_ERROR_FAILED,"Can't convert string to utf-8");
-+    } else {
-+        new_str[n_bytes]='\0';
-+    }
-+  } else{
-+      error=g_error_new(G_CONVERT_ERROR,G_CONVERT_ERROR_FAILED,"Can't convert string to utf-8. Couldn't allocate memory.");
-+  }
-+  const ScopedPtr<char> buf ((gchar*)new_str);
- #else
-   // TODO: For some reason the conversion from UTF-8 to WCHAR_T doesn't work
+                                        wstr.size() * sizeof(std::wstring::value_type),
++#if defined(__sun)
++                                       "UTF-8", "UCS-4LE", 0, &n_bytes, &error));
++#else
+                                        "UTF-8", "WCHAR_T", 0, &n_bytes, &error));
++#endif
+ #endif // !(__STDC_ISO_10646__ || G_OS_WIN32)
+ 
+   if (error)
+@@ -1393,7 +1402,11 @@
    // with g_convert(), while iconv on the command line handles it just fine.
+   // Maybe a bug in GLib?
+   const ScopedPtr<char> buf (g_convert(utf8_string.raw().data(), utf8_string.raw().size(),
++#if defined(__sun)
++                                       "UCS-4LE", "UTF-8", 0, 0, &error));
++#else
+                                        "WCHAR_T", "UTF-8", 0, 0, &error));
++#endif
+ #endif // !(__STDC_ISO_10646__ || G_OS_WIN32)
+ 
+   if (error)


### PR DESCRIPTION
The tests are passed. Also this fix works when locale doesn't
correspond to the data we receive.
