### PR TITLE
Disable openblas for now.

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -55,6 +55,9 @@
 /^visual-panels\/zconsole$/d
 /^gcc44/d
 
+# openblas can't be build on the build server
+/^scientific\/openblas$/d
+
 # Below is a list of components, which are known to build, but are 
 # disabled for a particular reason. The format is:
 # # <reason why is package disabled>


### PR DESCRIPTION
Build server can't build it:
getarch_2nd.c:12:35: error: ‘SGEMM_DEFAULT_UNROLL_M’ undeclared (first use in this function)
