### PR TITLE
Force PRESCOTT architecture in OpenBLAS

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -55,9 +55,6 @@
 /^visual-panels\/zconsole$/d
 /^gcc44/d
 
-# openblas can't be build on the build server
-/^scientific\/openblas$/d
-
 # Below is a list of components, which are known to build, but are 
 # disabled for a particular reason. The format is:
 # # <reason why is package disabled>

--- a/components/scientific/openblas/Makefile
+++ b/components/scientific/openblas/Makefile
@@ -45,15 +45,20 @@ include $(WS_MAKE_RULES)/ips.mk
 
 PATH=/usr/gnu/bin:/usr/bin
 
+# In a virtualized environment getarch cannot detect the architecture.
+# It falls back to INTEL_UKNOWN which causes failure of the build.
+# The option TARGET=GENERIC has to be passed to force detection.
 # Do not define NO_STATIC nor NO_SHARED to build both libraries
 COMPONENT_BUILD_GMAKE_ARGS= PREFIX=$(USRDIR) \
                             DYNAMIC_ARCH=1 \
+                            TARGET=PRESCOTT \
                             BINARY=$(BITS) \
                             FC=$(FC) CC=$(CC) \
                             COMMON_OPT="$(CFLAGS) -Wa,--divide" \
+                            NO_LAPACKE=1 \
                             USE_OPENMP=0 \
                             USE_THREAD=1 \
-                            NUM_THREADS=32
+                            NUM_THREADS=64
 
 MACHDIR.32=
 MACHDIR.64=$(MACH64)


### PR DESCRIPTION
Force PRESCOTT architecture as least common denominator as GENERIC is broken and up number of threads to 64 as Debian does.

The developer suggests using a least common denominator architecture until the issue is fixed:
https://github.com/xianyi/OpenBLAS/issues/502
