### PR TITLE
Initial add of harfbuzz 0.9.38

### DIFF
--- a/components/harfbuzz/Makefile
+++ b/components/harfbuzz/Makefile
@@ -1,0 +1,59 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.illumos.org/license/CDDL.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2015, Aurelien Larcher. All rights reserved.
+#
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		harfbuzz
+COMPONENT_VERSION=	0.9.38
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=     	library/c++/harfbuzz
+COMPONENT_CLASSIFICATION=System/Libraries
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=	http://www.freedesktop.org/wiki/Software/HarfBuzz/
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH=	sha256:6736f383b4edfcaaeb6f3292302ca382d617d8c79948bb2dd2e8f86cdccfd514
+COMPONENT_ARCHIVE_URL=	http://www.freedesktop.org/software/harfbuzz/release/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=      MIT
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+COMPONENT_SUMMARY=      HarfBuzz - an OpenType text shaping engine. 
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+CONFIGURE_OPTIONS+=	--enable-shared
+CONFIGURE_OPTIONS+=	--disable-static
+# OI's glib is too ancient, at least 2.36 is required.
+CONFIGURE_OPTIONS+=	--with-glib=no
+CONFIGURE_OPTIONS+=	--with-graphite2=yes
+CONFIGURE_OPTIONS+=	--with-freetype=yes
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+test: $(NO_TESTS)
+
+BUILD_PKG_DEPENDENCIES =    $(BUILD_TOOLS)
+
+include $(WS_TOP)/make-rules/depend.mk
+

--- a/components/harfbuzz/harfbuzz.license
+++ b/components/harfbuzz/harfbuzz.license
@@ -1,0 +1,36 @@
+HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.
+For parts of HarfBuzz that are licensed under different licenses see individual
+files names COPYING in subdirectories where applicable.
+
+Copyright © 2010,2011,2012  Google, Inc.
+Copyright © 2012  Mozilla Foundation
+Copyright © 2011  Codethink Limited
+Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)
+Copyright © 2009  Keith Stribley
+Copyright © 2009  Martin Hosken and SIL International
+Copyright © 2007  Chris Wilson
+Copyright © 2006  Behdad Esfahbod
+Copyright © 2005  David Turner
+Copyright © 2004,2007,2008,2009,2010  Red Hat, Inc.
+Copyright © 1998-2004  David Turner and Werner Lemberg
+
+For full copyright notices consult the individual files in the package.
+
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/components/harfbuzz/harfbuzz.p5m
+++ b/components/harfbuzz/harfbuzz.p5m
@@ -1,0 +1,51 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/harfbuzz/hb-blob.h
+file path=usr/include/harfbuzz/hb-buffer.h
+file path=usr/include/harfbuzz/hb-common.h
+file path=usr/include/harfbuzz/hb-deprecated.h
+file path=usr/include/harfbuzz/hb-face.h
+file path=usr/include/harfbuzz/hb-font.h
+file path=usr/include/harfbuzz/hb-ft.h
+file path=usr/include/harfbuzz/hb-graphite2.h
+file path=usr/include/harfbuzz/hb-ot-font.h
+file path=usr/include/harfbuzz/hb-ot-layout.h
+file path=usr/include/harfbuzz/hb-ot-shape.h
+file path=usr/include/harfbuzz/hb-ot-tag.h
+file path=usr/include/harfbuzz/hb-ot.h
+file path=usr/include/harfbuzz/hb-set.h
+file path=usr/include/harfbuzz/hb-shape-plan.h
+file path=usr/include/harfbuzz/hb-shape.h
+file path=usr/include/harfbuzz/hb-unicode.h
+file path=usr/include/harfbuzz/hb-version.h
+file path=usr/include/harfbuzz/hb.h
+link path=usr/lib/$(MACH64)/libharfbuzz.so target=libharfbuzz.so.0.938.0
+link path=usr/lib/$(MACH64)/libharfbuzz.so.0 target=libharfbuzz.so.0.938.0
+file path=usr/lib/$(MACH64)/libharfbuzz.so.0.938.0
+file path=usr/lib/$(MACH64)/pkgconfig/harfbuzz.pc
+link path=usr/lib/libharfbuzz.so target=libharfbuzz.so.0.938.0
+link path=usr/lib/libharfbuzz.so.0 target=libharfbuzz.so.0.938.0
+file path=usr/lib/libharfbuzz.so.0.938.0
+file path=usr/lib/pkgconfig/harfbuzz.pc


### PR DESCRIPTION
GLib support is not activated as requirement seems >= 2.36 while we have 2.28.
