### PR TITLE
Add the abook program to oi-userland

### DIFF
--- a/components/abook/Makefile
+++ b/components/abook/Makefile
@@ -1,0 +1,55 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+
+#
+# Copyright (c) 2015 Matt Samudio
+#
+
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		abook
+COMPONENT_VERSION=	0.5.6
+COMPONENT_PROJECT_URL=	http://abook.sourceforge.net/
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:0646f6311a94ad3341812a4de12a5a940a7a44d5cb6e9da5b0930aae9f44756e
+COMPONENT_ARCHIVE_URL=	http://prdownloads.sourceforge.net/abook/$(COMPONENT_ARCHIVE)
+
+COMPONENT_FMRI=		mail/$(COMPONENT_NAME)
+COMPONENT_SUMMARY=	abook addressbook program
+COMPONENT_LICENSE=	GPLv2
+COMPONENT_LICENSE_FILE=	COPYING
+
+include ../../make-rules/prep.mk
+include ../../make-rules/configure.mk
+include ../../make-rules/ips.mk
+
+COMPONENT_PRE_CONFIGURE_ACTION = (cp -r $(SOURCE_DIR)/* $(BUILD_DIR_$(BITS))/) 
+COMPONENT_BUILD_ARGS=
+COMPONENT_BUILD_ENV += CC=$(CC)
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(NO_TESTS)
+

--- a/components/abook/abook.p5m
+++ b/components/abook/abook.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Matt Samudio
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/abook
+file path=usr/bin/abook
+file path=usr/share/locale/de/LC_MESSAGES/abook.mo
+file path=usr/share/locale/fr/LC_MESSAGES/abook.mo
+file path=usr/share/locale/ja/LC_MESSAGES/abook.mo
+file path=usr/share/locale/sv/LC_MESSAGES/abook.mo
+file path=usr/share/man/man1/abook.1
+file path=usr/share/man/man5/abookrc.5


### PR DESCRIPTION
Adding this program, which is a console-based addressbook program frequenly used with the mutt email client, to oi-userland.
