### PR TITLE
ccache 3.2.3: initial commit

### DIFF
--- a/components/ccache/Makefile
+++ b/components/ccache/Makefile
@@ -1,0 +1,51 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2015 Jim Klimov
+#
+
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		ccache
+COMPONENT_VERSION=	3.2.3
+COMPONENT_PROJECT_URL=	http://ccache.samba.org/
+COMPONENT_DOWNLOAD_URL=	http://samba.org/ftp/$(COMPONENT_NAME)/
+COMPONENT_DOCUMENTATION_URL =	http://ccache.samba.org/manual.html
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.bz2
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:b07165d4949d107d17f2f84b90b52953617bf1abbf249d5cc20636f43337c98c
+COMPONENT_ARCHIVE_URL=	$(COMPONENT_DOWNLOAD_URL)/$(COMPONENT_ARCHIVE)
+COMPONENT_SUMMARY=	ccache - cacher of GCC-compiled files to avoid doing the same job twice
+COMPONENT_FMRI=		developer/ccache
+COMPONENT_CLASSIFICATION=	Development/C
+COMPONENT_LICENSE=	"GPLv3,murmurhash,papowell/jhweiss,PostgreSQL,Python,zlib"
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+
+CFLAGS  +=			-D_GNU_SOURCE -D__EXTENSIONS__
+
+include ../../make-rules/prep.mk
+include ../../make-rules/configure.mk
+include ../../make-rules/ips.mk
+
+CONFIGURE_OPTIONS  +=           --sysconfdir=/etc
+
+# common targets
+build:          $(BUILD_32_and_64)
+
+install:        $(INSTALL_32_and_64)
+
+test:           $(NO_TESTS)
+
+BUILD_PKG_DEPENDENCIES =        $(BUILD_TOOLS)
+
+include ../../make-rules/depend.mk

--- a/components/ccache/ccache.license
+++ b/components/ccache/ccache.license
@@ -1,0 +1,475 @@
+ccache copyright and license
+============================
+
+Overall license
+---------------
+
+The license for ccache as a whole is as follows:
+
+-------------------------------------------------------------------------------
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+  Street, Fifth Floor, Boston, MA 02110-1301 USA
+-------------------------------------------------------------------------------
+
+The full license text can be found in GPL-3.0.txt and at
+http://www.gnu.org/licenses/gpl-3.0.html.
+
+
+Copyright and authors
+---------------------
+
+ccache is a collective work with contributions from many people, listed in
+AUTHORS.txt and at http://ccache.samba.org/authors.html. Subsequent additions
+by contributing authors are implicitly licensed to the public under the same
+terms (GNU GPL version 3 or later), but the contributing authors retain
+copyrights on their portions of the work.
+
+The copyright for ccache as a whole is as follows:
+
+-------------------------------------------------------------------------------
+  Copyright (C) 2002-2007 Andrew Tridgell
+  Copyright (C) 2009-2015 Joel Rosdahl
+-------------------------------------------------------------------------------
+
+
+Files derived from other sources
+--------------------------------
+
+The ccache distribution contain some files from other sources and some have
+been modified for use in ccache. These files all carry attribution notices, and
+may qualify as ``separate and independent works in themselves'' for purposes of
+the GPL: that is, if separated from the ccache sources, they may be usable
+under less restrictive terms.
+
+
+getopt_long.[hc]
+~~~~~~~~~~~~~~~~
+
+This implementation of `getopt_long()` was copied from
+http://www.postgresql.org[PostgreSQL] and has the following license text:
+
+-------------------------------------------------------------------------------
+  Portions Copyright (c) 1987, 1993, 1994
+  The Regents of the University of California.  All rights reserved.
+
+  Portions Copyright (c) 2003
+  PostgreSQL Global Development Group
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the University nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+  SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+
+hashtable*.[hc]
+~~~~~~~~~~~~~~~
+
+This code comes from http://www.cl.cam.ac.uk/~cwc22/hashtable/ with the
+following license:
+
+-------------------------------------------------------------------------------
+  Copyright (c) 2002, 2004, Christopher Clark
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of the original author; nor the names of any
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+
+m4/feature_macros.m4
+~~~~~~~~~~~~~~~~~~~~
+
+This Autoconf M4 snippet comes from http://www.python.org[Python] 2.6's
+`configure.in` with the following license:
+
+-------------------------------------------------------------------------------
+  A. HISTORY OF THE SOFTWARE
+  ==========================
+
+  Python was created in the early 1990s by Guido van Rossum at Stichting
+  Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+  as a successor of a language called ABC.  Guido remains Python's
+  principal author, although it includes many contributions from others.
+
+  In 1995, Guido continued his work on Python at the Corporation for
+  National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+  in Reston, Virginia where he released several versions of the
+  software.
+
+  In May 2000, Guido and the Python core development team moved to
+  BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
+  year, the PythonLabs team moved to Digital Creations (now Zope
+  Corporation, see http://www.zope.com).  In 2001, the Python Software
+  Foundation (PSF, see http://www.python.org/psf/) was formed, a
+  non-profit organization created specifically to own Python-related
+  Intellectual Property.  Zope Corporation is a sponsoring member of
+  the PSF.
+
+  All Python releases are Open Source (see http://www.opensource.org for
+  the Open Source Definition).  Historically, most, but not all, Python
+  releases have also been GPL-compatible; the table below summarizes
+  the various releases.
+
+      Release         Derived     Year        Owner       GPL-
+                      from                                compatible? (1)
+
+      0.9.0 thru 1.2              1991-1995   CWI         yes
+      1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes
+      1.6             1.5.2       2000        CNRI        no
+      2.0             1.6         2000        BeOpen.com  no
+      1.6.1           1.6         2001        CNRI        yes (2)
+      2.1             2.0+1.6.1   2001        PSF         no
+      2.0.1           2.0+1.6.1   2001        PSF         yes
+      2.1.1           2.1+2.0.1   2001        PSF         yes
+      2.2             2.1.1       2001        PSF         yes
+      2.1.2           2.1.1       2002        PSF         yes
+      2.1.3           2.1.2       2002        PSF         yes
+      2.2.1           2.2         2002        PSF         yes
+      2.2.2           2.2.1       2002        PSF         yes
+      2.2.3           2.2.2       2003        PSF         yes
+      2.3             2.2.2       2002-2003   PSF         yes
+      2.3.1           2.3         2002-2003   PSF         yes
+      2.3.2           2.3.1       2002-2003   PSF         yes
+      2.3.3           2.3.2       2002-2003   PSF         yes
+      2.3.4           2.3.3       2004        PSF         yes
+      2.3.5           2.3.4       2005        PSF         yes
+      2.4             2.3         2004        PSF         yes
+      2.4.1           2.4         2005        PSF         yes
+      2.4.2           2.4.1       2005        PSF         yes
+      2.4.3           2.4.2       2006        PSF         yes
+      2.4.4           2.4.3       2006        PSF         yes
+      2.5             2.4         2006        PSF         yes
+      2.5.1           2.5         2007        PSF         yes
+      2.5.2           2.5.1       2008        PSF         yes
+      2.5.3           2.5.2       2008        PSF         yes
+      2.6             2.5         2008        PSF         yes
+      2.6.1           2.6         2008        PSF         yes
+
+  Footnotes:
+
+  (1) GPL-compatible doesn't mean that we're distributing Python under
+      the GPL.  All Python licenses, unlike the GPL, let you distribute
+      a modified version without making your changes open source.  The
+      GPL-compatible licenses make it possible to combine Python with
+      other software that is released under the GPL; the others don't.
+
+  (2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+      because its license has a choice of law clause.  According to
+      CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+      is "not incompatible" with the GPL.
+
+  Thanks to the many outside volunteers who have worked under Guido's
+  direction to make these releases possible.
+
+
+  B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+  ===============================================================
+
+  PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+  --------------------------------------------
+
+  1. This LICENSE AGREEMENT is between the Python Software Foundation
+  ("PSF"), and the Individual or Organization ("Licensee") accessing and
+  otherwise using this software ("Python") in source or binary form and
+  its associated documentation.
+
+  2. Subject to the terms and conditions of this License Agreement, PSF hereby
+  grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+  analyze, test, perform and/or display publicly, prepare derivative works,
+  distribute, and otherwise use Python alone or in any derivative version,
+  provided, however, that PSF's License Agreement and PSF's notice of copyright,
+  i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Python
+  Software Foundation; All Rights Reserved" are retained in Python alone or in any
+  derivative version prepared by Licensee.
+
+  3. In the event Licensee prepares a derivative work that is based on
+  or incorporates Python or any part thereof, and wants to make
+  the derivative work available to others as provided herein, then
+  Licensee hereby agrees to include in any such work a brief summary of
+  the changes made to Python.
+
+  4. PSF is making Python available to Licensee on an "AS IS"
+  basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+  IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+  DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+  FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+  INFRINGE ANY THIRD PARTY RIGHTS.
+
+  5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+  FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+  A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+  OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+  6. This License Agreement will automatically terminate upon a material
+  breach of its terms and conditions.
+
+  7. Nothing in this License Agreement shall be deemed to create any
+  relationship of agency, partnership, or joint venture between PSF and
+  Licensee.  This License Agreement does not grant permission to use PSF
+  trademarks or trade name in a trademark sense to endorse or promote
+  products or services of Licensee, or any third party.
+
+  8. By copying, installing or otherwise using Python, Licensee
+  agrees to be bound by the terms and conditions of this License
+  Agreement.
+
+
+  BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+  -------------------------------------------
+
+  BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+  1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+  office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+  Individual or Organization ("Licensee") accessing and otherwise using
+  this software in source or binary form and its associated
+  documentation ("the Software").
+
+  2. Subject to the terms and conditions of this BeOpen Python License
+  Agreement, BeOpen hereby grants Licensee a non-exclusive,
+  royalty-free, world-wide license to reproduce, analyze, test, perform
+  and/or display publicly, prepare derivative works, distribute, and
+  otherwise use the Software alone or in any derivative version,
+  provided, however, that the BeOpen Python License is retained in the
+  Software, alone or in any derivative version prepared by Licensee.
+
+  3. BeOpen is making the Software available to Licensee on an "AS IS"
+  basis.  BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+  IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+  DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+  FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+  INFRINGE ANY THIRD PARTY RIGHTS.
+
+  4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+  SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+  AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+  DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+  5. This License Agreement will automatically terminate upon a material
+  breach of its terms and conditions.
+
+  6. This License Agreement shall be governed by and interpreted in all
+  respects by the law of the State of California, excluding conflict of
+  law provisions.  Nothing in this License Agreement shall be deemed to
+  create any relationship of agency, partnership, or joint venture
+  between BeOpen and Licensee.  This License Agreement does not grant
+  permission to use BeOpen trademarks or trade names in a trademark
+  sense to endorse or promote products or services of Licensee, or any
+  third party.  As an exception, the "BeOpen Python" logos available at
+  http://www.pythonlabs.com/logos.html may be used according to the
+  permissions granted on that web page.
+
+  7. By copying, installing or otherwise using the software, Licensee
+  agrees to be bound by the terms and conditions of this License
+  Agreement.
+
+
+  CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+  ---------------------------------------
+
+  1. This LICENSE AGREEMENT is between the Corporation for National
+  Research Initiatives, having an office at 1895 Preston White Drive,
+  Reston, VA 20191 ("CNRI"), and the Individual or Organization
+  ("Licensee") accessing and otherwise using Python 1.6.1 software in
+  source or binary form and its associated documentation.
+
+  2. Subject to the terms and conditions of this License Agreement, CNRI
+  hereby grants Licensee a nonexclusive, royalty-free, world-wide
+  license to reproduce, analyze, test, perform and/or display publicly,
+  prepare derivative works, distribute, and otherwise use Python 1.6.1
+  alone or in any derivative version, provided, however, that CNRI's
+  License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+  1995-2001 Corporation for National Research Initiatives; All Rights
+  Reserved" are retained in Python 1.6.1 alone or in any derivative
+  version prepared by Licensee.  Alternately, in lieu of CNRI's License
+  Agreement, Licensee may substitute the following text (omitting the
+  quotes): "Python 1.6.1 is made available subject to the terms and
+  conditions in CNRI's License Agreement.  This Agreement together with
+  Python 1.6.1 may be located on the Internet using the following
+  unique, persistent identifier (known as a handle): 1895.22/1013.  This
+  Agreement may also be obtained from a proxy server on the Internet
+  using the following URL: http://hdl.handle.net/1895.22/1013".
+
+  3. In the event Licensee prepares a derivative work that is based on
+  or incorporates Python 1.6.1 or any part thereof, and wants to make
+  the derivative work available to others as provided herein, then
+  Licensee hereby agrees to include in any such work a brief summary of
+  the changes made to Python 1.6.1.
+
+  4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+  basis.  CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+  IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+  DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+  FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+  INFRINGE ANY THIRD PARTY RIGHTS.
+
+  5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+  1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+  A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+  OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+  6. This License Agreement will automatically terminate upon a material
+  breach of its terms and conditions.
+
+  7. This License Agreement shall be governed by the federal
+  intellectual property law of the United States, including without
+  limitation the federal copyright law, and, to the extent such
+  U.S. federal law does not apply, by the law of the Commonwealth of
+  Virginia, excluding Virginia's conflict of law provisions.
+  Notwithstanding the foregoing, with regard to derivative works based
+  on Python 1.6.1 that incorporate non-separable material that was
+  previously distributed under the GNU General Public License (GPL), the
+  law of the Commonwealth of Virginia shall govern this License
+  Agreement only as to issues arising under or with respect to
+  Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in this
+  License Agreement shall be deemed to create any relationship of
+  agency, partnership, or joint venture between CNRI and Licensee.  This
+  License Agreement does not grant permission to use CNRI trademarks or
+  trade name in a trademark sense to endorse or promote products or
+  services of Licensee, or any third party.
+
+  8. By clicking on the "ACCEPT" button where indicated, or by copying,
+  installing or otherwise using Python 1.6.1, Licensee agrees to be
+  bound by the terms and conditions of this License Agreement.
+
+          ACCEPT
+
+
+  CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+  --------------------------------------------------
+
+  Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+  The Netherlands.  All rights reserved.
+
+  Permission to use, copy, modify, and distribute this software and its
+  documentation for any purpose and without fee is hereby granted,
+  provided that the above copyright notice appear in all copies and that
+  both that copyright notice and this permission notice appear in
+  supporting documentation, and that the name of Stichting Mathematisch
+  Centrum or CWI not be used in advertising or publicity pertaining to
+  distribution of the software without specific, written prior
+  permission.
+
+  STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+  THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+  FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+  OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+-------------------------------------------------------------------------------
+
+
+murmurhashneutral2.[hc]
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This fast hash implementation is released to the public domain by Austin
+Appleby. See http://murmurhash.googlepages.com.
+
+
+snprintf.c and m4/snprintf.m4
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This implementation of `snprintf()` and similar functions was downloaded from
+http://www.jhweiss.de/software/snprintf.html and has the following license:
+
+-------------------------------------------------------------------------------
+  Copyright (c) 1995 Patrick Powell.
+
+  This code is based on code written by Patrick Powell <papowell@astart.com>.
+  It may be used for any purpose as long as this notice remains intact on all
+  source code distributions.
+
+  Copyright (c) 2008 Holger Weiss.
+
+  This version of the code is maintained by Holger Weiss <holger@jhweiss.de>.
+  My changes to the code may freely be used, modified and/or redistributed for
+  any purpose. It would be nice if additions and fixes to this file (including
+  trivial code cleanups) would be sent back in order to let me include them in
+  the version available at <http://www.jhweiss.de/software/snprintf.html>.
+  However, this is not a requirement for using or redistributing (possibly
+  modified) versions of this file, nor is leaving this notice intact mandatory.
+-------------------------------------------------------------------------------
+
+
+zlib/*.[hc]
+~~~~~~~~~~~
+
+This is a bundled subset of zlib 1.2.8 from <http://zlib.net> with the
+following license:
+
+-------------------------------------------------------------------------------
+  Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+-------------------------------------------------------------------------------

--- a/components/ccache/ccache.p5m
+++ b/components/ccache/ccache.p5m
@@ -1,0 +1,49 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2015 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+hardlink path=usr/bin/ccache target=../lib/isaexec pkg.linted.userland.action002.0=true
+file usr/bin/ccache path=usr/bin/$(MACH32)/ccache
+file path=usr/bin/$(MACH64)/ccache
+file usr/share/man/man1/ccache.1 path=usr/share/man/man1/ccache.1
+
+# Files from tarball (HTMLs may be rebuilt)
+file MANUAL.txt path=usr/share/ccache/manual.txt
+file MANUAL.html path=usr/share/ccache/manual.html
+file README.txt path=usr/share/ccache/readme.txt
+file README.html path=usr/share/ccache/readme.html
+
+# Softlinks to simplify builds - just prepend /usr/lib/ccache to PATH
+# NOTE: Since these are softlinks, a certain relative directory structure
+# is expected (like rooting at /usr) when the package is installed.
+# You can turn off ccache without  paths by exporting CCACHE_DISABLE=1
+link target=../../bin/ccache path=usr/lib/ccache/gcc
+link target=../../bin/ccache path=usr/lib/ccache/g++
+link target=../../bin/ccache path=usr/lib/ccache/cc
+link target=../../bin/ccache path=usr/lib/ccache/c++
+
+# A few links specifically to support gcc-4.4.4-il
+link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-c++
+link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-g++
+link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-gcc
+link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-gcc-4.4.4
+


### PR DESCRIPTION
Compiles without warnings, package installs OK.

Verified to work: original compilation (of ccache itself) took 25 sec several times; then with Makefile edited to redefine `CC = /usr/bin/ccache /usr/gcc/4.8/bin/gcc` initial recompilation took 33 sec (part of the added overhead could be ccache's acquaintance with the newly encountered compiler - checksum, flag support and other metadata saved into the cache), several subsequent runs took 2-2.5 sec.

Package creates a /usr/lib/ccache directory with symlinks to several GCC filenames in order to simplify usage of the cache (just prepend it into the PATH).

Recommended for build farms, CI systems and similar projects that build same sources more than once. Hopefully will speed up cycles for illumos-gate and oi-userland among others ;)

Can be used with clang/llvm, crosscompilers, etc.
