### PR TITLE
Fixed description metadata for tuntap package

### DIFF
--- a/components/tuntap/Makefile
+++ b/components/tuntap/Makefile
@@ -24,9 +24,18 @@ COMPONENT_ARCHIVE_HASH=	sha256:6ed84336b3eaf29aa227bfc0b5a6e7143431862b97113a31c
 COMPONENT_PROJECT_URL=	http://www.whiteboard.ne.jp/~admin2/tuntap/
 COMPONENT_ARCHIVE_URL= 	https://codeload.github.com/kaizawa/tuntap/legacy.tar.gz/$(COMPONENT_GIT_REV)
 
+COMPONENT_DESCRIPTION=	tuntap is a Virtual Point-to-Point network device: \
+a TAP driver for OpenIndiana that can be used for \
+OpenVPN, OpenConnect, and vpnc. The code is based on the \
+Universal TUN/TAP driver. Some changes were made and code added \
+for supporting Ethernet tunneling feature, since the Universal \
+TUN/TAP driver for Solaris only supports IP tunneling known as TUN.
+
 include $(WS_TOP)/make-rules/prep.mk
 include $(WS_TOP)/make-rules/configure.mk
 include $(WS_TOP)/make-rules/ips.mk
+
+PKG_OPTIONS +=		-D COMPONENT_DESCRIPTION="$(COMPONENT_DESCRIPTION)"
 
 PATCH_LEVEL = 0
 

--- a/components/tuntap/tap.p5m
+++ b/components/tuntap/tap.p5m
@@ -24,6 +24,7 @@
 
 set name=pkg.fmri value=pkg:/driver/network/tap@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="TAP driver from tuntap package"
+set name=pkg.description value="$(COMPONENT_DESCRIPTION)"
 set name=info.classification value="org.opensolaris.category.2008:Drivers/Networking"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/tuntap/tun-header.p5m
+++ b/components/tuntap/tun-header.p5m
@@ -13,7 +13,8 @@
 #
 
 set name=pkg.fmri value=pkg:/driver/network/header-tun@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="TUN driver from tuntap package"
+set name=pkg.summary value="Header file for TUN driver from tuntap package"
+set name=pkg.description value="$(COMPONENT_DESCRIPTION)"
 set name=info.classification value="org.opensolaris.category.2008:Drivers/Networking"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/tuntap/tun.p5m
+++ b/components/tuntap/tun.p5m
@@ -24,6 +24,7 @@
 
 set name=pkg.fmri value=pkg:/driver/network/tun@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="TUN driver from tuntap package"
+set name=pkg.description value="$(COMPONENT_DESCRIPTION)"
 set name=info.classification value="org.opensolaris.category.2008:Drivers/Networking"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)


### PR DESCRIPTION
Summary in tun-header was a bit misleading
Ported description text from SFE version of the package, using evaluatable Make-scripting.
