### PR TITLE
Update ggrep to 2.22, make GNU egrep/fgrep always call GNU grep

### DIFF
--- a/components/ggrep/Makefile
+++ b/components/ggrep/Makefile
@@ -23,15 +23,13 @@
 include ../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		grep
-COMPONENT_VERSION=	2.20
+COMPONENT_VERSION=	2.22
 COMPONENT_PROJECT_URL=	http://gnu.org/software/grep/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:f0af452bc0d09464b6d089b6d56a0a3c16672e9ed9118fbe37b0b6aeaf069a65
+    sha256:ca91d22f017bfcb503d4bc3b44295491c89a33a3df0c3d8b8614f2d3831836eb
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/grep/$(COMPONENT_ARCHIVE)
-
 COMPONENT_BUGDB=	utility/ggrep
 
 include ../../make-rules/prep.mk

--- a/components/ggrep/files/efgrep
+++ b/components/ggrep/files/efgrep
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+REALPATH=`realpath $0`
+DIRNAME=`dirname $REALPATH`
+BASENAME=`basename $0`
+
+case $BASENAME in
+  egrep)
+    SWITCH="-E";;
+  fgrep)
+    SWITCH="-F";;
+  *)
+    printf "Should be called egrep or fgrep!\n" 1>&2
+    exit 1
+    ;;
+esac
+
+case $DIRNAME in
+  */amd64)
+    GREP=/usr/gnu/bin/amd64/grep;;
+  *)
+    GREP=/usr/gnu/bin/grep;;
+esac
+exec $GREP $SWITCH "$@"

--- a/components/ggrep/gnu-grep.p5m
+++ b/components/ggrep/gnu-grep.p5m
@@ -38,11 +38,12 @@ set name=org.opensolaris.arc-caseid \
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 
-file usr/bin/egrep path=usr/gnu/bin/egrep
-file usr/bin/fgrep path=usr/gnu/bin/fgrep
+file files/efgrep path=usr/gnu/bin/egrep
+hardlink path=usr/gnu/bin/fgrep target=./egrep
+hardlink path=usr/gnu/bin/$(MACH64)/egrep target=../egrep
+hardlink path=usr/gnu/bin/$(MACH64)/fgrep target=../egrep
+
 file usr/bin/grep path=usr/gnu/bin/grep
-file usr/bin/$(MACH64)/egrep path=usr/gnu/bin/$(MACH64)/egrep
-file usr/bin/$(MACH64)/fgrep path=usr/gnu/bin/$(MACH64)/fgrep
 file usr/bin/$(MACH64)/grep path=usr/gnu/bin/$(MACH64)/grep
 file path=usr/share/info/grep.info
 file path=usr/share/locale/af/LC_MESSAGES/grep.mo


### PR DESCRIPTION
Reviewed by: Hans Rosenfeld hans.rosenfeld@nexenta.com
