### PR TITLE
Add libjpeg6 and provide libjpeg as meta-package

### DIFF
--- a/components/libjpeg6-ijg/Makefile
+++ b/components/libjpeg6-ijg/Makefile
@@ -1,0 +1,53 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		libjpeg6-ijg
+COMPONENT_VERSION=	6.0.2
+LIBJPEG_API_VERSION= 6b
+COMPONENT_FMRI= 	image/library/libjpeg6-ijg
+COMPONENT_PROJECT_URL=	http://www.ijg.org/
+COMPONENT_SUMMARY=	libjpeg - Independent JPEG Group library version 6b
+COMPONENT_SRC=		jpeg-$(LIBJPEG_API_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+ sha256:75c3ec241e9996504fe02a9ed4d12f16b74ade713972f3db9e65ce95cd27e35d
+COMPONENT_ARCHIVE_URL=	http://www.ijg.org/files/jpegsrc.v$(LIBJPEG_API_VERSION).tar.gz
+COMPONENT_LICENSE=	IJG,GPLv2.0
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+COMPONENT_CLASSIFICATION=	System/Multimedia Libraries
+
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+CONFIGURE_DEFAULT_DIRS=no
+
+CONFIGURE_OPTIONS+=	--enable-shared
+CONFIGURE_OPTIONS+=	--disable-static
+CONFIGURE_OPTIONS+= --mandir=$(CONFIGURE_MANDIR)
+CONFIGURE_OPTIONS+= --includedir=$(CONFIGURE_INCLUDEDIR)/$(COMPONENT_NAME)
+CONFIGURE_OPTIONS.32+= --bindir=$(USRLIBDIR)/$(COMPONENT_NAME)/bin
+CONFIGURE_OPTIONS.32+= --libdir=$(USRLIBDIR)/$(COMPONENT_NAME)/lib
+CONFIGURE_OPTIONS.64+= --bindir=$(USRLIBDIR)/$(COMPONENT_NAME)/bin/$(MACH64)
+CONFIGURE_OPTIONS.64+= --libdir=$(USRLIBDIR)/$(COMPONENT_NAME)/lib/$(MACH64)
+
+
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)

--- a/components/libjpeg6-ijg/libjpeg6-ijg.license
+++ b/components/libjpeg6-ijg/libjpeg6-ijg.license
@@ -1,0 +1,87 @@
+
+LEGAL ISSUES
+============
+
+In plain English:
+
+1. We don't promise that this software works.  (But if you find any bugs,
+   please let us know!)
+2. You can use this software for whatever you want.  You don't have to pay us.
+3. You may not pretend that you wrote this software.  If you use it in a
+   program, you must acknowledge somewhere in your documentation that
+   you've used the IJG code.
+
+In legalese:
+
+The authors make NO WARRANTY or representation, either express or implied,
+with respect to this software, its quality, accuracy, merchantability, or
+fitness for a particular purpose.  This software is provided "AS IS", and you,
+its user, assume the entire risk as to its quality and accuracy.
+
+This software is copyright (C) 1991-1998, Thomas G. Lane.
+All Rights Reserved except as specified below.
+
+Permission is hereby granted to use, copy, modify, and distribute this
+software (or portions thereof) for any purpose, without fee, subject to these
+conditions:
+(1) If any part of the source code for this software is distributed, then this
+README file must be included, with this copyright and no-warranty notice
+unaltered; and any additions, deletions, or changes to the original files
+must be clearly indicated in accompanying documentation.
+(2) If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the work of
+the Independent JPEG Group".
+(3) Permission for use of this software is granted only if the user accepts
+full responsibility for any undesirable consequences; the authors accept
+NO LIABILITY for damages of any kind.
+
+These conditions apply to any software derived from or based on the IJG code,
+not just to the unmodified library.  If you use our work, you ought to
+acknowledge us.
+
+Permission is NOT granted for the use of any IJG author's name or company name
+in advertising or publicity relating to this software or products derived from
+it.  This software may be referred to only as "the Independent JPEG Group's
+software".
+
+We specifically permit and encourage the use of this software as the basis of
+commercial products, provided that all warranty or liability claims are
+assumed by the product vendor.
+
+
+ansi2knr.c is included in this distribution by permission of L. Peter Deutsch,
+sole proprietor of its copyright holder, Aladdin Enterprises of Menlo Park, CA.
+ansi2knr.c is NOT covered by the above copyright and conditions, but instead
+by the usual distribution terms of the Free Software Foundation; principally,
+that you must include source code if you redistribute it.  (See the file
+ansi2knr.c for full details.)  However, since ansi2knr.c is not needed as part
+of any program generated from the IJG code, this does not limit you more than
+the foregoing paragraphs do.
+
+The Unix configuration script "configure" was produced with GNU Autoconf.
+It is copyright by the Free Software Foundation but is freely distributable.
+The same holds for its supporting scripts (config.guess, config.sub,
+ltconfig, ltmain.sh).  Another support script, install-sh, is copyright
+by M.I.T. but is also freely distributable.
+
+It appears that the arithmetic coding option of the JPEG spec is covered by
+patents owned by IBM, AT&T, and Mitsubishi.  Hence arithmetic coding cannot
+legally be used without obtaining one or more licenses.  For this reason,
+support for arithmetic coding has been removed from the free JPEG software.
+(Since arithmetic coding provides only a marginal gain over the unpatented
+Huffman mode, it is unlikely that very many implementations will support it.)
+So far as we are aware, there are no patent restrictions on the remaining
+code.
+
+The IJG distribution formerly included code to read and write GIF files.
+To avoid entanglement with the Unisys LZW patent, GIF reading support has
+been removed altogether, and the GIF writer has been simplified to produce
+"uncompressed GIFs".  This technique does not use the LZW algorithm; the
+resulting GIF files are larger than usual, but are readable by all standard
+GIF decoders.
+
+We are required to state that
+    "The Graphics Interchange Format(c) is the Copyright property of
+    CompuServe Incorporated.  GIF(sm) is a Service Mark property of
+    CompuServe Incorporated."
+

--- a/components/libjpeg6-ijg/libjpeg6-ijg.p5m
+++ b/components/libjpeg6-ijg/libjpeg6-ijg.p5m
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+
+file path=usr/include/$(COMPONENT_NAME)/jconfig.h
+file path=usr/include/$(COMPONENT_NAME)/jerror.h
+file path=usr/include/$(COMPONENT_NAME)/jmorecfg.h
+file path=usr/include/$(COMPONENT_NAME)/jpeglib.h
+
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/cjpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/djpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/jpegtran
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/rdjpgcom
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/wrjpgcom
+file path=usr/lib/$(COMPONENT_NAME)/bin/cjpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/djpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/jpegtran
+file path=usr/lib/$(COMPONENT_NAME)/bin/rdjpgcom
+file path=usr/lib/$(COMPONENT_NAME)/bin/wrjpgcom
+link path=usr/lib/$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so target=libjpeg.so.62.0.0
+link path=usr/lib/$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62 target=libjpeg.so.62.0.0
+file path=usr/lib/$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62.0.0
+link path=usr/lib/$(COMPONENT_NAME)/lib/libjpeg.so target=libjpeg.so.62.0.0
+link path=usr/lib/$(COMPONENT_NAME)/lib/libjpeg.so.62 target=libjpeg.so.62.0.0
+file path=usr/lib/$(COMPONENT_NAME)/lib/libjpeg.so.62.0.0
+

--- a/components/libjpeg6-ijg/libjpeg6.p5m
+++ b/components/libjpeg6-ijg/libjpeg6.p5m
@@ -1,0 +1,54 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/image/library/libjpeg6@6.0.2,$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend fmri=image/library/libjpeg6-ijg type=require
+
+# Documentation provided by default implementation
+file path=usr/share/man/man1/cjpeg.1
+file path=usr/share/man/man1/djpeg.1
+file path=usr/share/man/man1/jpegtran.1
+file path=usr/share/man/man1/rdjpgcom.1
+file path=usr/share/man/man1/wrjpgcom.1
+
+# Set this version as default implementation for backward compatibility
+link path=usr/bin/cjpeg              target=../lib/$(COMPONENT_NAME)/bin/cjpeg
+link path=usr/bin/djpeg              target=../lib/$(COMPONENT_NAME)/bin/djpeg
+link path=usr/bin/jpegtran           target=../lib/$(COMPONENT_NAME)/bin/jpegtran
+link path=usr/bin/rdjpgcom           target=../lib/$(COMPONENT_NAME)/bin/rdjpgcom
+link path=usr/bin/wrjpgcom           target=../lib/$(COMPONENT_NAME)/bin/wrjpgcom
+link path=usr/bin/$(MACH64)/cjpeg    target=../../lib/$(COMPONENT_NAME)/bin/$(MACH64)/cjpeg
+link path=usr/bin/$(MACH64)/djpeg    target=../../lib/$(COMPONENT_NAME)/bin/$(MACH64)/djpeg
+link path=usr/bin/$(MACH64)/jpegtran target=../../lib/$(COMPONENT_NAME)/bin/$(MACH64)/jpegtran
+link path=usr/bin/$(MACH64)/rdjpgcom target=../../lib/$(COMPONENT_NAME)/bin/$(MACH64)/rdjpgcom
+link path=usr/bin/$(MACH64)/wrjpgcom target=../../lib/$(COMPONENT_NAME)/bin/$(MACH64)/wrjpgcom
+link path=usr/include/jconfig.h      target=$(COMPONENT_NAME)/jconfig.h
+link path=usr/include/jerror.h       target=$(COMPONENT_NAME)/jerror.h
+link path=usr/include/jmorecfg.h     target=$(COMPONENT_NAME)/jmorecfg.h
+link path=usr/include/jpeglib.h      target=$(COMPONENT_NAME)/jpeglib.h
+link path=usr/lib/libjpeg.so         target=$(COMPONENT_NAME)/lib/libjpeg.so.62.0.0
+link path=usr/lib/libjpeg.so.62      target=$(COMPONENT_NAME)/lib/libjpeg.so.62.0.0
+link path=usr/lib/libjpeg.so.62.0.0  target=$(COMPONENT_NAME)/lib/libjpeg.so.62.0.0
+link path=usr/lib/$(MACH64)/libjpeg.so        target=../$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62.0.0
+link path=usr/lib/$(MACH64)/libjpeg.so.62     target=../$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62.0.0
+link path=usr/lib/$(MACH64)/libjpeg.so.62.0.0 target=../$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62.0.0

--- a/components/libjpeg6-ijg/patches/01-makefile-dirs.patch
+++ b/components/libjpeg6-ijg/patches/01-makefile-dirs.patch
@@ -1,0 +1,52 @@
+--- ./makefile.cfg.orig	2015-12-11 22:50:28.338047305 +0100
++++ ./makefile.cfg	2015-12-11 23:14:55.224553592 +0100
+@@ -9,15 +9,15 @@
+ VPATH = @srcdir@
+ 
+ # Where to install the programs and man pages.
+-prefix = @prefix@
+-exec_prefix = @exec_prefix@
+-bindir = $(exec_prefix)/bin
+-libdir = $(exec_prefix)/lib
+-includedir = $(prefix)/include
++prefix = $(DESTDIR)@prefix@
++exec_prefix = $(DESTDIR)@exec_prefix@
++bindir = $(DESTDIR)@bindir@
++libdir = $(DESTDIR)@libdir@
++includedir = $(DESTDIR)@includedir@
+ binprefix =
+ manprefix =
+ manext = 1
+-mandir = $(prefix)/man/man$(manext)
++mandir = $(DESTDIR)@mandir@/man$(manext)
+ 
+ # The name of your C compiler:
+ CC= @CC@
+--- ./makefile.cfg.orig	2015-12-11 23:56:14.674198344 +0100
++++ ./makefile.cfg	2015-12-12 00:06:46.902684026 +0100
+@@ -191,11 +191,13 @@
+ # Installation rules:
+ 
+ install: cjpeg djpeg jpegtran rdjpgcom wrjpgcom @FORCE_INSTALL_LIB@
++	$(MKDIR) -p $(bindir)
+ 	$(INSTALL_PROGRAM) cjpeg $(bindir)/$(binprefix)cjpeg
+ 	$(INSTALL_PROGRAM) djpeg $(bindir)/$(binprefix)djpeg
+ 	$(INSTALL_PROGRAM) jpegtran $(bindir)/$(binprefix)jpegtran
+ 	$(INSTALL_PROGRAM) rdjpgcom $(bindir)/$(binprefix)rdjpgcom
+ 	$(INSTALL_PROGRAM) wrjpgcom $(bindir)/$(binprefix)wrjpgcom
++	$(MKDIR) -p $(mandir)
+ 	$(INSTALL_DATA) $(srcdir)/cjpeg.1 $(mandir)/$(manprefix)cjpeg.$(manext)
+ 	$(INSTALL_DATA) $(srcdir)/djpeg.1 $(mandir)/$(manprefix)djpeg.$(manext)
+ 	$(INSTALL_DATA) $(srcdir)/jpegtran.1 $(mandir)/$(manprefix)jpegtran.$(manext)
+@@ -203,9 +205,11 @@
+ 	$(INSTALL_DATA) $(srcdir)/wrjpgcom.1 $(mandir)/$(manprefix)wrjpgcom.$(manext)
+ 
+ install-lib: libjpeg.$(A) install-headers
++	$(MKDIR) -p $(libdir)
+ 	$(INSTALL_LIB) libjpeg.$(A) $(libdir)/$(binprefix)libjpeg.$(A)
+ 
+ install-headers: jconfig.h
++	$(MKDIR) -p $(includedir)
+ 	$(INSTALL_DATA) jconfig.h $(includedir)/jconfig.h
+ 	$(INSTALL_DATA) $(srcdir)/jpeglib.h $(includedir)/jpeglib.h
+ 	$(INSTALL_DATA) $(srcdir)/jmorecfg.h $(includedir)/jmorecfg.h

--- a/components/libjpeg6-ijg/patches/02-extern-c-jpeglib.patch
+++ b/components/libjpeg6-ijg/patches/02-extern-c-jpeglib.patch
@@ -1,0 +1,31 @@
+Description: Wrap jpeglib.h with extern "C" {} if __cplusplus is defined.
+ Wrap jpeglib.h inside extern "C" { ... } if the compiler
+ defines __cplusplus.
+Author: Bill Allombert <ballombe@debian.org>
+Origin: Debian
+Forwarded: not-needed
+Last-Update: 2010-06-03
+Index: libjpeg6b-6b1/jpeglib.h
+===================================================================
+--- libjpeg6b-6b1.orig/jpeglib.h	2010-06-03 19:02:32.000000000 +0200
++++ libjpeg6b-6b1/jpeglib.h	2010-06-03 19:02:37.000000000 +0200
+@@ -13,6 +13,10 @@
+ #ifndef JPEGLIB_H
+ #define JPEGLIB_H
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ /*
+  * First we include the configuration files that record how this
+  * installation of the JPEG library is set up.  jconfig.h can be
+@@ -1093,4 +1097,8 @@
+ #include "jerror.h"		/* fetch error codes too */
+ #endif
+ 
++#ifdef __cplusplus
++}
++#endif
++
+ #endif /* JPEGLIB_H */

--- a/components/libjpeg6-ijg/patches/CVE-2013-6629.patch
+++ b/components/libjpeg6-ijg/patches/CVE-2013-6629.patch
@@ -1,0 +1,72 @@
+References:
+http://ghostscript.com/pipermail/gs-code-review/2004-June/004580.html
+http://www.hackerfactor.com/blog/index.php?/archives/2014/01/11.html
+*** /tmp/jpeg-6b/jdmarker.c	1998-02-21 12:24:50.000000000 -0800
+--- jpeg/jdmarker.c	2004-06-18 09:05:55.000000000 -0700
+***************
+*** 279,284 ****
+    for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
+         ci++, compptr++) {
+      compptr->component_index = ci;
+!     INPUT_BYTE(cinfo, compptr->component_id, return FALSE);
+      INPUT_BYTE(cinfo, c, return FALSE);
+      compptr->h_samp_factor = (c >> 4) & 15;
+--- 279,303 ----
+    for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
+         ci++, compptr++) {
++     int component_id;
++     int j;
+      compptr->component_index = ci;
+!     INPUT_BYTE(cinfo, component_id, return FALSE);
+!     for (j = 0; j < ci; j++) {
+!       /* Check to see whether component id has already been seen
+! 	 (in violation of the spec, but unfortunately seen in some
+! 	 files). If so, create "fake" component id equal to the
+! 	 max id seen so far + 1. */
+!       if (cinfo->comp_info[j].component_id == component_id) {
+! 	int max_id = cinfo->comp_info[0].component_id;
+! 	int k;
+! 	for (k = 1; k < ci; k++) {
+! 	  int k_id = cinfo->comp_info[k].component_id;
+! 	  if (k_id > max_id) max_id = k_id;
+! 	}
+! 	component_id = max_id + 1;
+! 	break;
+!       }
+!     }
+!     compptr->component_id = component_id;
+      INPUT_BYTE(cinfo, c, return FALSE);
+      compptr->h_samp_factor = (c >> 4) & 15;
+***************
+*** 324,330 ****
+  
+    for (i = 0; i < n; i++) {
+      INPUT_BYTE(cinfo, cc, return FALSE);
+      INPUT_BYTE(cinfo, c, return FALSE);
+!     
+      for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
+  	 ci++, compptr++) {
+--- 343,365 ----
+  
+    for (i = 0; i < n; i++) {
++     int j;
+      INPUT_BYTE(cinfo, cc, return FALSE);
+      INPUT_BYTE(cinfo, c, return FALSE);
+! 
+!     /* Detect the case where component id's are not unique, and, if so,
+!        create a fake component id using the same logic as in get_sof. */
+!     for (j = 0; j < i; j++) {
+!       if (cc == cinfo->cur_comp_info[j]->component_id) {
+! 	int k;
+! 	int max_id = cinfo->cur_comp_info[0]->component_id;
+! 	for (k = 1; k < i; k++) {
+! 	  int k_id = cinfo->cur_comp_info[k]->component_id;
+! 	  if (k_id > max_id) max_id = k_id;
+! 	}
+! 	cc = max_id + 1;
+! 	break;
+!       }
+!     }
+! 
+      for (ci = 0, compptr = cinfo->comp_info; ci < cinfo->num_components;
+  	 ci++, compptr++) {

--- a/components/meta-packages/libjpeg/Makefile
+++ b/components/meta-packages/libjpeg/Makefile
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		libjpeg
+COMPONENT_VERSION=	6.0.2
+COMPONENT_SUMMARY=	Joint Photographic Experts Group library
+
+include ../../../make-rules/ips.mk
+
+download:
+
+prep:
+
+build:
+
+install:
+	[ -d $(PROTO_DIR) ] || mkdir -p $(PROTO_DIR)
+
+clean:
+	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)

--- a/components/meta-packages/libjpeg/libjpeg.p5m
+++ b/components/meta-packages/libjpeg/libjpeg.p5m
@@ -1,0 +1,22 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/image/library/libjpeg@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=description value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="org.opensolaris.category.2008:Meta Packages/Group Packages"
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+depend fmri=image/library/libjpeg6 type=require


### PR DESCRIPTION
First shot, I am still not sure what is the best approach as Debian, Ubuntu, Fedora seem to have dropped IJG's libraries:

https://lists.debian.org/debian-devel-announce/2014/08/msg00000.html

I decided to keep them in subdirectories to minimize the probability of mixing and provided symlinks to provide compatbility with the former package from JDS.

So please consider this PR as a feedback request first.
