### PR TITLE
Add libjpeg-turbo 1.4.2 with support for API 6,7,8

### DIFF
--- a/components/libjpeg-turbo/Makefile
+++ b/components/libjpeg-turbo/Makefile
@@ -1,0 +1,101 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= libjpeg-turbo
+COMPONENT_VERSION= 1.4.2
+COMPONENT_FMRI= image/library/libjpeg-turbo
+COMPONENT_PROJECT_URL= http://www.libjpeg-turbo.org/
+COMPONENT_SUMMARY= libjpeg -JPEG Turbo libraries
+COMPONENT_SRC= libjpeg-turbo-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+  sha256:521bb5d3043e7ac063ce3026d9a59cc2ab2e9636c655a2515af5f4706122233e
+COMPONENT_ARCHIVE_URL= http://sourceforge.net/projects/libjpeg-turbo/files/$(COMPONENT_VERSION)/$(COMPONENT_SRC).tar.gz/download
+COMPONENT_LICENSE= IJG,BSD,zlib
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+COMPONENT_CLASSIFICATION= System/Multimedia Libraries
+
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+CONFIGURE_DEFAULT_DIRS=no
+
+# Warnings are normal: libtool:   error: ignoring unknown tag NASM
+
+CONFIGURE_OPTIONS.JPEG6= 
+CONFIGURE_OPTIONS.JPEG7= --with-jpeg7
+CONFIGURE_OPTIONS.JPEG8= --with-jpeg8
+
+CONFIGURE_OPTIONS+=	--enable-shared
+CONFIGURE_OPTIONS+=	--disable-static
+# Allow for build with different API compliance
+CONFIGURE_OPTIONS+=	$(CONFIGURE_OPTIONS.JPEG$(JPEG_API_VERSION))
+CONFIGURE_OPTIONS+= --mandir=$(CONFIGURE_MANDIR)
+CONFIGURE_OPTIONS+= --includedir=$(CONFIGURE_INCLUDEDIR)/libjpeg$(JPEG_API_VERSION)-turbo
+CONFIGURE_OPTIONS.32+= --bindir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/bin
+CONFIGURE_OPTIONS.32+= --libdir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/lib
+# Autoconf infers the build type incorrectly from the host triplet
+CONFIGURE_OPTIONS.64+= --build=x86_64-solaris2.11
+CONFIGURE_OPTIONS.64+= --bindir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/bin/$(MACH64)
+CONFIGURE_OPTIONS.64+= --libdir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/lib/$(MACH64)
+
+# Define rules for each API build
+BUILD_DIR_32_6 =		$(BUILD_DIR)/$(MACH32)/6
+BUILD_DIR_32_7 =		$(BUILD_DIR)/$(MACH32)/7
+BUILD_DIR_32_8 =		$(BUILD_DIR)/$(MACH32)/8
+BUILD_DIR_64_6 =		$(BUILD_DIR)/$(MACH64)/6
+BUILD_DIR_64_7 =		$(BUILD_DIR)/$(MACH64)/7
+BUILD_DIR_64_8 =		$(BUILD_DIR)/$(MACH64)/8
+$(BUILD_DIR_32)/%/.configured:	BITS=32
+$(BUILD_DIR_64)/%/.configured:	BITS=64
+$(BUILD_DIR)/%/6/.configured:	JPEG_API_VERSION=6
+$(BUILD_DIR)/%/7/.configured:	JPEG_API_VERSION=7
+$(BUILD_DIR)/%/8/.configured:	JPEG_API_VERSION=8
+
+BUILD_32 =		$(BUILD_DIR_32_6)/.built $(BUILD_DIR_32_7)/.built $(BUILD_DIR_32_8)/.built
+BUILD_64 =		$(BUILD_DIR_64_6)/.built $(BUILD_DIR_64_7)/.built $(BUILD_DIR_64_8)/.built
+BUILD_32_and_64 =	$(BUILD_32) $(BUILD_64)
+$(BUILD_DIR_32)/%/.built:	BITS=32
+$(BUILD_DIR_64)/%/.built:	BITS=64
+$(BUILD_DIR)/%/6/.built:	JPEG_API_VERSION=6
+$(BUILD_DIR)/%/7/.built:	JPEG_API_VERSION=7
+$(BUILD_DIR)/%/8/.built:	JPEG_API_VERSION=8
+
+INSTALL_32 =		$(BUILD_DIR_32_6)/.installed $(BUILD_DIR_32_7)/.installed $(BUILD_DIR_32_8)/.installed
+INSTALL_64 =		$(BUILD_DIR_64_6)/.installed $(BUILD_DIR_64_7)/.installed $(BUILD_DIR_64_8)/.installed
+INSTALL_32_and_64 =	$(INSTALL_32) $(INSTALL_64)
+$(BUILD_DIR_32)/%/.installed: BITS=32
+$(BUILD_DIR_64)/%/.installed: BITS=64
+$(BUILD_DIR)/%/6/.installed: JPEG_API_VERSION=6
+$(BUILD_DIR)/%/7/.installed: JPEG_API_VERSION=7
+$(BUILD_DIR)/%/8/.installed: JPEG_API_VERSION=8
+
+TEST_32 =		$(BUILD_DIR_32_6)/.tested $(BUILD_DIR_32_7)/.tested $(BUILD_DIR_32_8)/.tested
+TEST_64 =		$(BUILD_DIR_64_6)/.tested $(BUILD_DIR_64_7)/.tested $(BUILD_DIR_64_8)/.tested
+TEST_32_and_64 =	$(TEST_32) $(TEST_64)
+$(BUILD_DIR_32)/%/.tested:		BITS=32
+$(BUILD_DIR_64)/%/.tested:		BITS=64
+$(BUILD_DIR)/%/6/.tested: JPEG_API_VERSION=6
+$(BUILD_DIR)/%/7/.tested: JPEG_API_VERSION=7
+$(BUILD_DIR)/%/8/.tested: JPEG_API_VERSION=8
+
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)

--- a/components/libjpeg-turbo/libjpeg-turbo.license
+++ b/components/libjpeg-turbo/libjpeg-turbo.license
@@ -1,0 +1,79 @@
+libjpeg-turbo Licenses
+----------------------
+
+libjpeg-turbo is covered by three compatible BSD-style open source licenses:
+
+-- The IJG (Independent JPEG Group) License, which is listed in README
+
+   This license applies to the libjpeg API library and associated programs
+   (any code inherited from libjpeg, and any modifications to that code.)
+
+-- The Modified (3-clause) BSD License, which is listed in turbojpeg.c
+
+   This license covers the TurboJPEG API library and associated programs.
+
+-- The zlib License, which is listed in simd/jsimdext.inc
+
+   This license is a subset of the other two, and it covers the libjpeg-turbo
+   SIMD extensions.
+
+
+Complying with the libjpeg-turbo Licenses
+-----------------------------------------
+
+This section provides a roll-up of the libjpeg-turbo licensing terms, to the
+best of our understanding.
+
+1.  If you are distributing a modified version of the libjpeg-turbo source,
+    then:
+
+    a.  You cannot alter or remove any existing copyright or license notices
+        from the source.
+
+        Origin:  Clause 1 of the IJG License
+                 Clause 1 of the Modified BSD License
+                 Clauses 1 and 3 of the zlib License
+
+    b.  You must add your own copyright notice to the header of each source
+        file you modified, so others can tell that you modified that file (if
+        there is not an existing copyright header in that file, then you can
+        simply add a notice stating that you modified the file.)
+
+        Origin:  Clause 1 of the IJG License
+                 Clause 2 of the zlib License
+
+    c.  You must include the IJG README file, and you must not alter any of the
+        copyright or license text in that file.
+
+        Origin:  Clause 1 of the IJG License
+
+2.  If you are distributing only libjpeg-turbo binaries without the source, or
+    if you are distributing an application that statically links with
+    libjpeg-turbo, then:
+
+    a.  Your product documentation must include a message stating:
+
+        This software is based in part on the work of the Independent JPEG
+        Group.
+
+        Origin:  Clause 2 of the IJG license
+
+    b.  If your binary distribution includes or uses the TurboJPEG API, then
+        your product documentation must include the text of the Modified BSD
+        License.
+
+        Origin:  Clause 2 of the Modified BSD License
+
+3.  You cannot use the name of the IJG or The libjpeg-turbo Project or the
+    contributors thereof in advertising, publicity, etc.
+
+    Origin:  IJG License
+             Clause 3 of the Modified BSD License
+
+4.  The IJG and The libjpeg-turbo Project do not warrant libjpeg-turbo to be
+    free of defects, nor do we accept any liability for undesirable
+    consequences resulting from your use of the software.
+
+    Origin:  IJG License
+             Modified BSD License
+             zlib License

--- a/components/libjpeg-turbo/libjpeg-turbo.p5m
+++ b/components/libjpeg-turbo/libjpeg-turbo.p5m
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# Require package with default JPEG API
+depend fmri=image/library/libjpeg6-turbo type=require
+
+# Only shipped by libjpeg-turbo
+file path=usr/share/doc/libjpeg-turbo/README
+file path=usr/share/doc/libjpeg-turbo/README-turbo.txt
+file path=usr/share/doc/libjpeg-turbo/example.c
+file path=usr/share/doc/libjpeg-turbo/libjpeg.txt
+file path=usr/share/doc/libjpeg-turbo/structure.txt
+file path=usr/share/doc/libjpeg-turbo/usage.txt
+file path=usr/share/doc/libjpeg-turbo/wizard.txt
+
+# Already shipped by libjpeg6-ijg
+#file path=usr/share/man/man1/cjpeg.1
+#file path=usr/share/man/man1/djpeg.1
+#file path=usr/share/man/man1/jpegtran.1
+#file path=usr/share/man/man1/rdjpgcom.1
+#file path=usr/share/man/man1/wrjpgcom.1
+

--- a/components/libjpeg-turbo/libjpeg6-turbo.p5m
+++ b/components/libjpeg-turbo/libjpeg6-turbo.p5m
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/image/library/libjpeg6-turbo@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend fmri=image/library/libjpeg-turbo type=require
+
+file path=usr/include/libjpeg6-turbo/jconfig.h
+file path=usr/include/libjpeg6-turbo/jerror.h
+file path=usr/include/libjpeg6-turbo/jmorecfg.h
+file path=usr/include/libjpeg6-turbo/jpeglib.h
+file path=usr/include/libjpeg6-turbo/turbojpeg.h
+
+file path=usr/lib/libjpeg6-turbo/bin/$(MACH64)/cjpeg
+file path=usr/lib/libjpeg6-turbo/bin/$(MACH64)/djpeg
+file path=usr/lib/libjpeg6-turbo/bin/$(MACH64)/jpegtran
+file path=usr/lib/libjpeg6-turbo/bin/$(MACH64)/rdjpgcom
+file path=usr/lib/libjpeg6-turbo/bin/$(MACH64)/tjbench
+file path=usr/lib/libjpeg6-turbo/bin/$(MACH64)/wrjpgcom
+file path=usr/lib/libjpeg6-turbo/bin/cjpeg
+file path=usr/lib/libjpeg6-turbo/bin/djpeg
+file path=usr/lib/libjpeg6-turbo/bin/jpegtran
+file path=usr/lib/libjpeg6-turbo/bin/rdjpgcom
+file path=usr/lib/libjpeg6-turbo/bin/tjbench
+file path=usr/lib/libjpeg6-turbo/bin/wrjpgcom
+link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.62.1.0
+link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62 target=libjpeg.so.62.1.0
+file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62.1.0
+link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0 target=libturbojpeg.so.0.1.0
+file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so target=libjpeg.so.62.1.0
+link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62 target=libjpeg.so.62.1.0
+file path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62.1.0
+link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0 target=libturbojpeg.so.0.1.0
+file path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0.1.0

--- a/components/libjpeg-turbo/libjpeg7-turbo.p5m
+++ b/components/libjpeg-turbo/libjpeg7-turbo.p5m
@@ -1,0 +1,57 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/image/library/libjpeg7-turbo@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend fmri=image/library/libjpeg-turbo type=require
+
+file path=usr/include/libjpeg7-turbo/jconfig.h
+file path=usr/include/libjpeg7-turbo/jerror.h
+file path=usr/include/libjpeg7-turbo/jmorecfg.h
+file path=usr/include/libjpeg7-turbo/jpeglib.h
+file path=usr/include/libjpeg7-turbo/turbojpeg.h
+
+file path=usr/lib/libjpeg7-turbo/bin/$(MACH64)/cjpeg
+file path=usr/lib/libjpeg7-turbo/bin/$(MACH64)/djpeg
+file path=usr/lib/libjpeg7-turbo/bin/$(MACH64)/jpegtran
+file path=usr/lib/libjpeg7-turbo/bin/$(MACH64)/rdjpgcom
+file path=usr/lib/libjpeg7-turbo/bin/$(MACH64)/tjbench
+file path=usr/lib/libjpeg7-turbo/bin/$(MACH64)/wrjpgcom
+file path=usr/lib/libjpeg7-turbo/bin/cjpeg
+file path=usr/lib/libjpeg7-turbo/bin/djpeg
+file path=usr/lib/libjpeg7-turbo/bin/jpegtran
+file path=usr/lib/libjpeg7-turbo/bin/rdjpgcom
+file path=usr/lib/libjpeg7-turbo/bin/tjbench
+file path=usr/lib/libjpeg7-turbo/bin/wrjpgcom
+link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.7.1.0
+link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7 target=libjpeg.so.7.1.0
+file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7.1.0
+link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0 target=libturbojpeg.so.0.1.0
+file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so target=libjpeg.so.7.1.0
+link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7 target=libjpeg.so.7.1.0
+file path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7.1.0
+link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0 target=libturbojpeg.so.0.1.0
+file path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0.1.0
+

--- a/components/libjpeg-turbo/libjpeg8-turbo.p5m
+++ b/components/libjpeg-turbo/libjpeg8-turbo.p5m
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/image/library/libjpeg8-turbo@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend fmri=image/library/libjpeg-turbo type=require
+
+file path=usr/include/libjpeg8-turbo/jconfig.h
+file path=usr/include/libjpeg8-turbo/jerror.h
+file path=usr/include/libjpeg8-turbo/jmorecfg.h
+file path=usr/include/libjpeg8-turbo/jpeglib.h
+file path=usr/include/libjpeg8-turbo/turbojpeg.h
+
+file path=usr/lib/libjpeg8-turbo/bin/$(MACH64)/cjpeg
+file path=usr/lib/libjpeg8-turbo/bin/$(MACH64)/djpeg
+file path=usr/lib/libjpeg8-turbo/bin/$(MACH64)/jpegtran
+file path=usr/lib/libjpeg8-turbo/bin/$(MACH64)/rdjpgcom
+file path=usr/lib/libjpeg8-turbo/bin/$(MACH64)/tjbench
+file path=usr/lib/libjpeg8-turbo/bin/$(MACH64)/wrjpgcom
+file path=usr/lib/libjpeg8-turbo/bin/cjpeg
+file path=usr/lib/libjpeg8-turbo/bin/djpeg
+file path=usr/lib/libjpeg8-turbo/bin/jpegtran
+file path=usr/lib/libjpeg8-turbo/bin/rdjpgcom
+file path=usr/lib/libjpeg8-turbo/bin/tjbench
+file path=usr/lib/libjpeg8-turbo/bin/wrjpgcom
+link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.8.0.2
+link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8 target=libjpeg.so.8.0.2
+file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.0.2
+link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0 target=libturbojpeg.so.0.1.0
+file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so target=libjpeg.so.8.0.2
+link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8 target=libjpeg.so.8.0.2
+file path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8.0.2
+link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0 target=libturbojpeg.so.0.1.0
+file path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0.1.0


### PR DESCRIPTION
Each API is installed in a different prefix.
