### PR TITLE
Initial commit of TestDisk, PhotoRec and QPhotoRec 

### DIFF
--- a/components/testdisk/Makefile
+++ b/components/testdisk/Makefile
@@ -1,0 +1,49 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2016 by Jim Klimov. All rights reserved.
+#
+include ../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		testdisk
+COMPONENT_VERSION=	7.0
+COMPONENT_PROJECT_URL=	https://www.cgsecurity.org/wiki/TestDisk
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:00bb3b6b22e6aba88580eeb887037aef026968c21a87b5f906c6652cbee3442d
+COMPONENT_ARCHIVE_URL=	https://www.cgsecurity.org/$(COMPONENT_ARCHIVE)
+
+include ../../make-rules/prep.mk
+include ../../make-rules/configure.mk
+include ../../make-rules/ips.mk
+
+CONFIGURE_OPTIONS  +=		--enable-qt
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)
+
+BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
+
+include ../../make-rules/depend.mk

--- a/components/testdisk/photorec.p5m
+++ b/components/testdisk/photorec.p5m
@@ -1,0 +1,46 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2016 Jim Klimov. All rights reserved.
+#
+
+# pull the manpages out of the component dir
+<transform file path=usr/share/man/(man3/.+$) -> set action.hash %<\1> >
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+set name=pkg.fmri \
+    value=pkg:/system/storage/photorec@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="PhotoRec - toolkit for file un-deletion and other forensics"
+set name=pkg.description value="PhotoRec - toolkit for file un-deletion and other forensics"
+set name=info.classification value="org.opensolaris.category.2008:System/Administration and Configuration"
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=https://www.cgsecurity.org/wiki/PhotoRec
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license COPYING license="GPL2+"
+
+file path=usr/bin/$(MACH64)/fidentify
+file path=usr/bin/$(MACH64)/photorec
+file path=usr/bin/photorec
+file path=usr/bin/fidentify
+file path=usr/share/man/zh_CN/man8/photorec.8
+file path=usr/share/man/zh_CN/man8/fidentify.8
+file path=usr/share/man/man8/photorec.8
+file path=usr/share/man/man8/fidentify.8

--- a/components/testdisk/qphotorec.p5m
+++ b/components/testdisk/qphotorec.p5m
@@ -1,0 +1,53 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2016 Jim Klimov. All rights reserved.
+#
+
+# pull the manpages out of the component dir
+<transform file path=usr/share/man/(man3/.+$) -> set action.hash %<\1> >
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+set name=pkg.fmri \
+    value=pkg:/system/storage/qphotorec@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="QPhotoRec - GUI for toolkit for file un-deletion and other forensics"
+set name=pkg.description value="QPhotoRec - GUI for toolkit for file un-deletion and other forensics"
+set name=info.classification value="org.opensolaris.category.2008:System/Administration and Configuration"
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=https://www.cgsecurity.org/wiki/PhotoRec
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license COPYING license="GPL2+"
+
+<transform file path=usr/share/applications/.* ->  default restart_fmri svc:/application/desktop-cache/desktop-mime-cache:default>
+<transform file path=usr/share/applications/.* ->  default restart_fmri svc:/application/desktop-cache/mime-types-cache:default>
+
+file path=usr/bin/$(MACH64)/qphotorec
+file path=usr/bin/qphotorec
+file path=usr/share/icons/hicolor/scalable/apps/qphotorec.svg
+file path=usr/share/icons/hicolor/48x48/apps/qphotorec.png
+file path=usr/share/man/zh_CN/man8/qphotorec.8
+file path=usr/share/man/man8/qphotorec.8
+
+# The desktop file is available in sources... downside - hardcoded /usr/bin
+file linux/qphotorec.desktop \
+    path=usr/share/applications/photorec.desktop
+file usr/share/icons/hicolor/48x48/apps/qphotorec.png \
+    path=usr/share/pixmaps/qphotorec.png

--- a/components/testdisk/testdisk.p5m
+++ b/components/testdisk/testdisk.p5m
@@ -1,0 +1,48 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2013 David Hoeppner. All rights reserved.
+#
+
+# pull the manpages out of the component dir
+<transform file path=usr/share/man/(man3/.+$) -> set action.hash %<\1> >
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+set name=pkg.fmri \
+    value=pkg:/system/storage/testdisk@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="TestDisk - toolkit for partition recovery"
+set name=pkg.description value="TestDisk - toolkit for partition recovery"
+set name=info.classification value="org.opensolaris.category.2008:System/Administration and Configuration"
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license COPYING license="GPL2+"
+
+file path=usr/bin/$(MACH64)/testdisk
+file path=usr/bin/testdisk
+file path=usr/share/man/zh_CN/man8/testdisk.8
+file path=usr/share/man/man8/testdisk.8
+file path=usr/share/doc/testdisk/documentation.html
+file path=usr/share/doc/testdisk/THANKS
+file path=usr/share/doc/testdisk/ChangeLog
+file path=usr/share/doc/testdisk/AUTHORS
+file path=usr/share/doc/testdisk/README
+file path=usr/share/doc/testdisk/NEWS


### PR DESCRIPTION
(same source, different purposes - three packages)

Toolkits for recovery of deleted/mangled/lost partitions and filesystems, and for recovery of photos and hundreds of other file formats on disks (e.g. broken photo flash). 
Saved me some grief a few times ;)

"gmake publish" and "gmake clean clobber" both pass.
The GUI frontend does get registered with an icon in the GNOME menu.
