### PR TITLE
Initial commit of SDL2 (2.0.4)

### DIFF
--- a/components/library/SDL2/Makefile
+++ b/components/library/SDL2/Makefile
@@ -1,0 +1,51 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Jim Klimov
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		SDL2
+COMPONENT_VERSION=	2.0.4
+COMPONENT_PROJECT_URL=	http://www.libsdl.org/
+COMPONENT_SUMMARY=	libsdl2 - Simple DirectMedia Layer 2.0
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:da55e540bf6331824153805d58b590a29c39d2d506c6d02fa409aedeab21174b
+COMPONENT_ARCHIVE_URL=	http://www.libsdl.org/release/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI =	library/sdl2
+# Note: license change from LGPL was significant in 2.x vs 1.x series, and now
+# static linking is permitted. See e.g. https://wiki.libsdl.org/Installation
+COMPONENT_LICENSE=	ZLIB
+COMPONENT_LICENSE_FILE=	COPYING.txt
+COMPONENT_CLASSIFICATION =	System/Libraries
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+PATH=/usr/gnu/bin:/usr/bin
+
+COMPONENT_PREP_ACTION = \
+			( cd $(@D) && $(CONFIG_SHELL) autogen.sh )
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(NO_TESTS)
+
+BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
+
+include $(WS_TOP)/make-rules/depend.mk

--- a/components/library/SDL2/sdl2.p5m
+++ b/components/library/SDL2/sdl2.p5m
@@ -1,0 +1,125 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/sdl2-config
+file path=usr/bin/sdl2-config
+file path=usr/lib/$(MACH64)/pkgconfig/sdl2.pc
+file path=usr/lib/pkgconfig/sdl2.pc
+file path=usr/lib/$(MACH64)/libSDL2-2.0.so.0.4.0
+link path=usr/lib/$(MACH64)/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.4.0
+link path=usr/lib/$(MACH64)/libSDL2-2.0.so target=libSDL2-2.0.so.0
+link path=usr/lib/$(MACH64)/libSDL2.so target=libSDL2-2.0.so
+file path=usr/lib/$(MACH64)/libSDL2.a
+file path=usr/lib/$(MACH64)/libSDL2_test.a
+file path=usr/lib/$(MACH64)/libSDL2main.a
+file path=usr/lib/libSDL2-2.0.so.0.4.0
+link path=usr/lib/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.4.0
+link path=usr/lib/libSDL2-2.0.so target=libSDL2-2.0.so.0
+link path=usr/lib/libSDL2.so target=libSDL2-2.0.so
+file path=usr/lib/libSDL2.a
+file path=usr/lib/libSDL2_test.a
+file path=usr/lib/libSDL2main.a
+file path=usr/lib/$(MACH64)/cmake/SDL2/sdl2-config.cmake
+file path=usr/lib/cmake/SDL2/sdl2-config.cmake
+file path=usr/share/aclocal/sdl2.m4
+file path=usr/include/SDL2/SDL_power.h
+file path=usr/include/SDL2/SDL_stdinc.h
+file path=usr/include/SDL2/SDL_hints.h
+file path=usr/include/SDL2/SDL_opengles2_gl2ext.h
+file path=usr/include/SDL2/begin_code.h
+file path=usr/include/SDL2/SDL_name.h
+file path=usr/include/SDL2/SDL_quit.h
+file include/SDL_config_macosx.h path=usr/include/SDL2/SDL_config_macosx.h
+file path=usr/include/SDL2/SDL_thread.h
+file path=usr/include/SDL2/SDL_test_assert.h
+file path=usr/include/SDL2/SDL_test_font.h
+file path=usr/include/SDL2/SDL_clipboard.h
+file path=usr/include/SDL2/SDL_timer.h
+file path=usr/include/SDL2/SDL_gamecontroller.h
+file path=usr/include/SDL2/SDL_log.h
+file path=usr/include/SDL2/SDL_test_harness.h
+file path=usr/include/SDL2/close_code.h
+file path=usr/include/SDL2/SDL_video.h
+file path=usr/include/SDL2/SDL_keycode.h
+file path=usr/include/SDL2/SDL_types.h
+file path=usr/include/SDL2/SDL_loadso.h
+file path=usr/include/SDL2/SDL_test_fuzzer.h
+file path=usr/include/SDL2/SDL_render.h
+file include/SDL_config_winrt.h path=usr/include/SDL2/SDL_config_winrt.h
+file path=usr/include/SDL2/SDL_scancode.h
+file include/SDL_config_windows.h path=usr/include/SDL2/SDL_config_windows.h
+file path=usr/include/SDL2/SDL_test.h
+file path=usr/include/SDL2/SDL_version.h
+file path=usr/include/SDL2/SDL_test_common.h
+file path=usr/include/SDL2/SDL_error.h
+file path=usr/include/SDL2/SDL_platform.h
+file path=usr/include/SDL2/SDL_gesture.h
+file path=usr/include/SDL2/SDL_test_crc32.h
+file path=usr/include/SDL2/SDL_surface.h
+file path=usr/include/SDL2/SDL_opengles2.h
+file path=usr/include/SDL2/SDL_opengles2_khrplatform.h
+file include/SDL_config_iphoneos.h path=usr/include/SDL2/SDL_config_iphoneos.h
+file path=usr/include/SDL2/SDL_mouse.h
+file include/SDL_copying.h path=usr/include/SDL2/SDL_copying.h
+file path=usr/include/SDL2/SDL_shape.h
+file include/SDL_config_minimal.h path=usr/include/SDL2/SDL_config_minimal.h
+file path=usr/include/SDL2/SDL_blendmode.h
+file path=usr/include/SDL2/SDL_syswm.h
+file include/SDL_config_psp.h path=usr/include/SDL2/SDL_config_psp.h
+file path=usr/include/SDL2/SDL_pixels.h
+file path=usr/include/SDL2/SDL_test_random.h
+file path=usr/include/SDL2/SDL_test_compare.h
+file path=usr/include/SDL2/SDL_assert.h
+file path=usr/include/SDL2/SDL_endian.h
+file path=usr/include/SDL2/SDL_bits.h
+file path=usr/include/SDL2/SDL_cpuinfo.h
+file path=usr/include/SDL2/SDL_test_md5.h
+file path=usr/include/SDL2/SDL_events.h
+file path=usr/include/SDL2/SDL_system.h
+file path=usr/include/SDL2/SDL_haptic.h
+file path=usr/include/SDL2/SDL_audio.h
+file path=usr/include/SDL2/SDL_atomic.h
+file path=usr/include/SDL2/SDL_opengl.h
+file path=usr/include/SDL2/SDL_opengles.h
+file path=usr/include/SDL2/SDL_touch.h
+file include/SDL_config_pandora.h path=usr/include/SDL2/SDL_config_pandora.h
+file path=usr/include/SDL2/SDL_config.h
+file path=usr/include/SDL2/SDL.h
+file path=usr/include/SDL2/SDL_rect.h
+file path=usr/include/SDL2/SDL_revision.h
+file path=usr/include/SDL2/SDL_keyboard.h
+file path=usr/include/SDL2/SDL_egl.h
+file path=usr/include/SDL2/SDL_test_images.h
+file path=usr/include/SDL2/SDL_opengles2_gl2.h
+file path=usr/include/SDL2/SDL_rwops.h
+file path=usr/include/SDL2/SDL_opengles2_gl2platform.h
+file path=usr/include/SDL2/SDL_joystick.h
+file path=usr/include/SDL2/SDL_test_log.h
+file path=usr/include/SDL2/SDL_opengl_glext.h
+file path=usr/include/SDL2/SDL_main.h
+file include/SDL_config_wiz.h path=usr/include/SDL2/SDL_config_wiz.h
+file path=usr/include/SDL2/SDL_messagebox.h
+file include/SDL_config_android.h path=usr/include/SDL2/SDL_config_android.h
+file path=usr/include/SDL2/SDL_mutex.h
+file path=usr/include/SDL2/SDL_filesystem.h


### PR DESCRIPTION
Added a recipe for libsdl2 and friends, since sdl1.2.x is more or less considered obsolete by the project, and I'm looking at some programs that would need SDL2 to compile.
Package builds and publishes cleanly. Usability for the job - remains to be seen ;)
