### PR TITLE
OpenTTD : fix missed dependencies after renaming of core package

### DIFF
--- a/components/games/openttd/opengfx/opengfx.p5m
+++ b/components/games/openttd/opengfx/opengfx.p5m
@@ -22,7 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license license.txt license='GPLv2'
 
-depend fmri=games/openttd/game type=require
+depend fmri=games/openttd/openttd-core type=require
 
 ### According to docs, it suffices to provide the tarball which is in the ZIP
 file $(COMPONENT_SRC).tar path=$(OPENTTD_SHARE_DIR)/baseset/$(COMPONENT_SRC).tar

--- a/components/games/openttd/openmsx/openmsx.p5m
+++ b/components/games/openttd/openmsx/openmsx.p5m
@@ -22,7 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license license.txt license='GPLv2'
 
-depend fmri=games/openttd/game type=require
+depend fmri=games/openttd/openttd-core type=require
 
 dir  path=$(OPENTTD_SHARE_DIR)/gm/$(COMPONENT_SRC)
 ### List built with (cd SRCDIR):

--- a/components/games/openttd/opensfx/opensfx.p5m
+++ b/components/games/openttd/opensfx/opensfx.p5m
@@ -22,7 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license license.txt license='GPLv2'
 
-depend fmri=games/openttd/game type=require
+depend fmri=games/openttd/openttd-core type=require
 
 ### List built with (cd SRCDIR):
 ###  while read F ; do echo "file $F "'path=$(OPENTTD_SHARE_DIR)/baseset/$(COMPONENT_SRC)/'"$F" ; done


### PR DESCRIPTION
When renaming of core game package was done, myself and reviewers missed the media packages that referred to a now nonexistent package name... Rectifying that now :)
