### PR TITLE
Initial working recipe for cxxtools-2.2.1

### DIFF
--- a/components/library/cxxtools/Makefile
+++ b/components/library/cxxtools/Makefile
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=	cxxtools
+COMPONENT_VERSION=	2.2.1
+COMPONENT_SUMMARY=	Cxxtools is a comprehensive C++ class library for Unix and Linux
+COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+  sha256:8cebb6d6cda7c93cc4f7c0d552a68d50dd5530b699cf87916bb3b708fdc4e342
+COMPONENT_ARCHIVE_URL= \
+  http://www.tntnet.org/download/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	http://www.tntnet.org/cxxtools.html
+COMPONENT_FMRI= library/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_LICENSE = LGPLv2.1
+COMPONENT_LICENSE_FILE = COPYING
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+test: $(TEST_32_and_64)

--- a/components/library/cxxtools/cxxtools.p5m
+++ b/components/library/cxxtools/cxxtools.p5m
@@ -1,0 +1,288 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/cxxtools-config
+file path=usr/bin/cxxtools-config
+
+file path=usr/include/cxxtools/allocator.h
+file path=usr/include/cxxtools/api.h
+file path=usr/include/cxxtools/application.h
+file path=usr/include/cxxtools/arg.h
+file path=usr/include/cxxtools/argin.h
+file path=usr/include/cxxtools/argout.h
+file path=usr/include/cxxtools/atomicity.h
+file path=usr/include/cxxtools/atomicity.sun.h
+file path=usr/include/cxxtools/base64codec.h
+file path=usr/include/cxxtools/base64stream.h
+file path=usr/include/cxxtools/bin/deserializer.h
+file path=usr/include/cxxtools/bin/formatter.h
+file path=usr/include/cxxtools/bin/rpcclient.h
+file path=usr/include/cxxtools/bin/rpcserver.h
+file path=usr/include/cxxtools/bin/serializer.h
+file path=usr/include/cxxtools/bin/valueparser.h
+file path=usr/include/cxxtools/byteorder.h
+file path=usr/include/cxxtools/cache.h
+file path=usr/include/cxxtools/callable.h
+file path=usr/include/cxxtools/callable.tpp
+file path=usr/include/cxxtools/cgi.h
+file path=usr/include/cxxtools/char.h
+file path=usr/include/cxxtools/clock.h
+file path=usr/include/cxxtools/composer.h
+file path=usr/include/cxxtools/condition.h
+file path=usr/include/cxxtools/config.h
+file path=usr/include/cxxtools/connectable.h
+file path=usr/include/cxxtools/connection.h
+file path=usr/include/cxxtools/constmethod.h
+file path=usr/include/cxxtools/constmethod.tpp
+file path=usr/include/cxxtools/conversionerror.h
+file path=usr/include/cxxtools/convert.h
+file path=usr/include/cxxtools/csvdeserializer.h
+file path=usr/include/cxxtools/csvformatter.h
+file path=usr/include/cxxtools/csvparser.h
+file path=usr/include/cxxtools/csvserializer.h
+file path=usr/include/cxxtools/date.h
+file path=usr/include/cxxtools/datetime.h
+file path=usr/include/cxxtools/decomposer.h
+file path=usr/include/cxxtools/delegate.h
+file path=usr/include/cxxtools/delegate.tpp
+file path=usr/include/cxxtools/deserializer.h
+file path=usr/include/cxxtools/deserializerbase.h
+file path=usr/include/cxxtools/dir.h
+file path=usr/include/cxxtools/directory.h
+file path=usr/include/cxxtools/dlloader.h
+file path=usr/include/cxxtools/event.h
+file path=usr/include/cxxtools/eventloop.h
+file path=usr/include/cxxtools/eventsink.h
+file path=usr/include/cxxtools/eventsource.h
+file path=usr/include/cxxtools/facets.h
+file path=usr/include/cxxtools/fdstream.h
+file path=usr/include/cxxtools/file.h
+file path=usr/include/cxxtools/filedevice.h
+file path=usr/include/cxxtools/fileinfo.h
+file path=usr/include/cxxtools/formatter.h
+file path=usr/include/cxxtools/function.h
+file path=usr/include/cxxtools/function.tpp
+file path=usr/include/cxxtools/hdstream.h
+file path=usr/include/cxxtools/hmac.h
+file path=usr/include/cxxtools/http/api.h
+file path=usr/include/cxxtools/http/client.h
+file path=usr/include/cxxtools/http/messageheader.h
+file path=usr/include/cxxtools/http/reply.h
+file path=usr/include/cxxtools/http/replyheader.h
+file path=usr/include/cxxtools/http/request.h
+file path=usr/include/cxxtools/http/requestheader.h
+file path=usr/include/cxxtools/http/responder.h
+file path=usr/include/cxxtools/http/server.h
+file path=usr/include/cxxtools/http/service.h
+file path=usr/include/cxxtools/inifile.h
+file path=usr/include/cxxtools/iniparser.h
+file path=usr/include/cxxtools/invokable.h
+file path=usr/include/cxxtools/invokable.tpp
+file path=usr/include/cxxtools/iodevice.h
+file path=usr/include/cxxtools/ioerror.h
+file path=usr/include/cxxtools/iostream.h
+file path=usr/include/cxxtools/join.h
+file path=usr/include/cxxtools/json/httpclient.h
+file path=usr/include/cxxtools/json/httpservice.h
+file path=usr/include/cxxtools/json/request.h
+file path=usr/include/cxxtools/json/responder.h
+file path=usr/include/cxxtools/json/rpcclient.h
+file path=usr/include/cxxtools/json/rpcserver.h
+file path=usr/include/cxxtools/jsondeserializer.h
+file path=usr/include/cxxtools/jsonformatter.h
+file path=usr/include/cxxtools/jsonparser.h
+file path=usr/include/cxxtools/jsonserializer.h
+file path=usr/include/cxxtools/library.h
+file path=usr/include/cxxtools/log.h
+file path=usr/include/cxxtools/log/cxxtools.h
+file path=usr/include/cxxtools/lrucache.h
+file path=usr/include/cxxtools/main.h
+file path=usr/include/cxxtools/md5.h
+file path=usr/include/cxxtools/md5stream.h
+file path=usr/include/cxxtools/membar.gcc.h
+file path=usr/include/cxxtools/membar.gcc.nosmp.h
+file path=usr/include/cxxtools/membar.h
+file path=usr/include/cxxtools/membar.sun.h
+file path=usr/include/cxxtools/method.h
+file path=usr/include/cxxtools/method.tpp
+file path=usr/include/cxxtools/mime.h
+file path=usr/include/cxxtools/multifstream.h
+file path=usr/include/cxxtools/mutex.h
+file path=usr/include/cxxtools/net/addrinfo.h
+file path=usr/include/cxxtools/net/net.h
+file path=usr/include/cxxtools/net/tcpserver.h
+file path=usr/include/cxxtools/net/tcpsocket.h
+file path=usr/include/cxxtools/net/tcpstream.h
+file path=usr/include/cxxtools/net/udp.h
+file path=usr/include/cxxtools/net/udpstream.h
+file path=usr/include/cxxtools/net/uri.h
+file path=usr/include/cxxtools/noncopyable.h
+file path=usr/include/cxxtools/pipe.h
+file path=usr/include/cxxtools/pool.h
+file path=usr/include/cxxtools/posix/commandinput.h
+file path=usr/include/cxxtools/posix/commandoutput.h
+file path=usr/include/cxxtools/posix/exec.h
+file path=usr/include/cxxtools/posix/fork.h
+file path=usr/include/cxxtools/posix/pipe.h
+file path=usr/include/cxxtools/posix/pipestream.h
+file path=usr/include/cxxtools/properties.h
+file path=usr/include/cxxtools/propertiesdeserializer.h
+file path=usr/include/cxxtools/query_params.h
+file path=usr/include/cxxtools/queue.h
+file path=usr/include/cxxtools/quotedprintablestream.h
+file path=usr/include/cxxtools/refcounted.h
+file path=usr/include/cxxtools/regex.h
+file path=usr/include/cxxtools/remoteclient.h
+file path=usr/include/cxxtools/remoteexception.h
+file path=usr/include/cxxtools/remoteprocedure.h
+file path=usr/include/cxxtools/remoteresult.h
+file path=usr/include/cxxtools/selectable.h
+file path=usr/include/cxxtools/selector.h
+file path=usr/include/cxxtools/semaphore.h
+file path=usr/include/cxxtools/serializationerror.h
+file path=usr/include/cxxtools/serializationinfo.h
+file path=usr/include/cxxtools/serviceprocedure.h
+file path=usr/include/cxxtools/serviceregistry.h
+file path=usr/include/cxxtools/settings.h
+file path=usr/include/cxxtools/signal.h
+file path=usr/include/cxxtools/signal.tpp
+file path=usr/include/cxxtools/singleton.h
+file path=usr/include/cxxtools/slot.h
+file path=usr/include/cxxtools/slot.tpp
+file path=usr/include/cxxtools/smartptr.h
+file path=usr/include/cxxtools/sourceinfo.h
+file path=usr/include/cxxtools/split.h
+file path=usr/include/cxxtools/streambuffer.h
+file path=usr/include/cxxtools/streamcounter.h
+file path=usr/include/cxxtools/string.h
+file path=usr/include/cxxtools/string.tpp
+file path=usr/include/cxxtools/stringstream.h
+file path=usr/include/cxxtools/systemerror.h
+file path=usr/include/cxxtools/tee.h
+file path=usr/include/cxxtools/textbuffer.h
+file path=usr/include/cxxtools/textcodec.h
+file path=usr/include/cxxtools/textstream.h
+file path=usr/include/cxxtools/thread.h
+file path=usr/include/cxxtools/threadpool.h
+file path=usr/include/cxxtools/time.h
+file path=usr/include/cxxtools/timer.h
+file path=usr/include/cxxtools/timespan.h
+file path=usr/include/cxxtools/trim.h
+file path=usr/include/cxxtools/typetraits.h
+file path=usr/include/cxxtools/unit/application.h
+file path=usr/include/cxxtools/unit/assertion.h
+file path=usr/include/cxxtools/unit/registertest.h
+file path=usr/include/cxxtools/unit/reporter.h
+file path=usr/include/cxxtools/unit/test.h
+file path=usr/include/cxxtools/unit/testcase.h
+file path=usr/include/cxxtools/unit/testcontext.h
+file path=usr/include/cxxtools/unit/testfixture.h
+file path=usr/include/cxxtools/unit/testmain.h
+file path=usr/include/cxxtools/unit/testmethod.h
+file path=usr/include/cxxtools/unit/testprotocol.h
+file path=usr/include/cxxtools/unit/testsuite.h
+file path=usr/include/cxxtools/utf8codec.h
+file path=usr/include/cxxtools/uuencode.h
+file path=usr/include/cxxtools/void.h
+file path=usr/include/cxxtools/xml/api.h
+file path=usr/include/cxxtools/xml/characters.h
+file path=usr/include/cxxtools/xml/comment.h
+file path=usr/include/cxxtools/xml/doctypedeclaration.h
+file path=usr/include/cxxtools/xml/enddocument.h
+file path=usr/include/cxxtools/xml/endelement.h
+file path=usr/include/cxxtools/xml/entityresolver.h
+file path=usr/include/cxxtools/xml/namespace.h
+file path=usr/include/cxxtools/xml/namespacecontext.h
+file path=usr/include/cxxtools/xml/node.h
+file path=usr/include/cxxtools/xml/processinginstruction.h
+file path=usr/include/cxxtools/xml/startelement.h
+file path=usr/include/cxxtools/xml/xmldeserializer.h
+file path=usr/include/cxxtools/xml/xmlerror.h
+file path=usr/include/cxxtools/xml/xmlformatter.h
+file path=usr/include/cxxtools/xml/xmlreader.h
+file path=usr/include/cxxtools/xml/xmlserializer.h
+file path=usr/include/cxxtools/xml/xmlwriter.h
+file path=usr/include/cxxtools/xmlrpc/api.h
+file path=usr/include/cxxtools/xmlrpc/client.h
+file path=usr/include/cxxtools/xmlrpc/errorcodes.h
+file path=usr/include/cxxtools/xmlrpc/formatter.h
+file path=usr/include/cxxtools/xmlrpc/httpclient.h
+file path=usr/include/cxxtools/xmlrpc/responder.h
+file path=usr/include/cxxtools/xmlrpc/scanner.h
+file path=usr/include/cxxtools/xmlrpc/service.h
+file path=usr/include/cxxtools/xmltag.h
+
+link path=usr/lib/$(MACH64)/libcxxtools-bin.so target=libcxxtools-bin.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-bin.so.9 target=libcxxtools-bin.so.9.0.0
+file path=usr/lib/$(MACH64)/libcxxtools-bin.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-http.so target=libcxxtools-http.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-http.so.9 target=libcxxtools-http.so.9.0.0
+file path=usr/lib/$(MACH64)/libcxxtools-http.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-json.so target=libcxxtools-json.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-json.so.9 target=libcxxtools-json.so.9.0.0
+file path=usr/lib/$(MACH64)/libcxxtools-json.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-unit.so target=libcxxtools-unit.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-unit.so.9 target=libcxxtools-unit.so.9.0.0
+file path=usr/lib/$(MACH64)/libcxxtools-unit.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-xmlrpc.so target=libcxxtools-xmlrpc.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools-xmlrpc.so.9 target=libcxxtools-xmlrpc.so.9.0.0
+file path=usr/lib/$(MACH64)/libcxxtools-xmlrpc.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools.so target=libcxxtools.so.9.0.0
+link path=usr/lib/$(MACH64)/libcxxtools.so.9 target=libcxxtools.so.9.0.0
+file path=usr/lib/$(MACH64)/libcxxtools.so.9.0.0
+
+link path=usr/lib/libcxxtools-bin.so target=libcxxtools-bin.so.9.0.0
+link path=usr/lib/libcxxtools-bin.so.9 target=libcxxtools-bin.so.9.0.0
+file path=usr/lib/libcxxtools-bin.so.9.0.0
+link path=usr/lib/libcxxtools-http.so target=libcxxtools-http.so.9.0.0
+link path=usr/lib/libcxxtools-http.so.9 target=libcxxtools-http.so.9.0.0
+file path=usr/lib/libcxxtools-http.so.9.0.0
+link path=usr/lib/libcxxtools-json.so target=libcxxtools-json.so.9.0.0
+link path=usr/lib/libcxxtools-json.so.9 target=libcxxtools-json.so.9.0.0
+file path=usr/lib/libcxxtools-json.so.9.0.0
+link path=usr/lib/libcxxtools-unit.so target=libcxxtools-unit.so.9.0.0
+link path=usr/lib/libcxxtools-unit.so.9 target=libcxxtools-unit.so.9.0.0
+file path=usr/lib/libcxxtools-unit.so.9.0.0
+link path=usr/lib/libcxxtools-xmlrpc.so target=libcxxtools-xmlrpc.so.9.0.0
+link path=usr/lib/libcxxtools-xmlrpc.so.9 target=libcxxtools-xmlrpc.so.9.0.0
+file path=usr/lib/libcxxtools-xmlrpc.so.9.0.0
+link path=usr/lib/libcxxtools.so target=libcxxtools.so.9.0.0
+link path=usr/lib/libcxxtools.so.9 target=libcxxtools.so.9.0.0
+file path=usr/lib/libcxxtools.so.9.0.0
+
+file path=usr/lib/$(MACH64)/pkgconfig/cxxtools-bin.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cxxtools-http.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cxxtools-json.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cxxtools-unit.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cxxtools-xmlrpc.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cxxtools.pc
+
+file path=usr/lib/pkgconfig/cxxtools-bin.pc
+file path=usr/lib/pkgconfig/cxxtools-http.pc
+file path=usr/lib/pkgconfig/cxxtools-json.pc
+file path=usr/lib/pkgconfig/cxxtools-unit.pc
+file path=usr/lib/pkgconfig/cxxtools-xmlrpc.pc
+file path=usr/lib/pkgconfig/cxxtools.pc


### PR DESCRIPTION
CXXTOOLS library is part of TNTNet project (to wrap C++ web/db applications development) and a dependency for further components from that project.
