### PR TITLE
Initial commit of recipe for tntdb libraries version 1.3 with fixed pgsql/mysql references

### DIFF
--- a/components/library/tntdb/Makefile
+++ b/components/library/tntdb/Makefile
@@ -1,0 +1,80 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=	tntdb
+COMPONENT_VERSION=	1.3
+COMPONENT_SUMMARY=	C++ library to access SQL databases, easy and robust
+COMPONENT_SRC=	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+  sha256:093ab2694bc66bc05ae0a5c8a505d75ae84d4c35c2ddc0ff0283c5b9574b474b
+COMPONENT_ARCHIVE_URL= \
+  http://www.tntnet.org/download/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	http://www.tntnet.org/tntdb.html
+COMPONENT_FMRI=	library/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION=	System/Libraries
+COMPONENT_LICENSE=	LGPLv2.1
+COMPONENT_LICENSE_FILE=	COPYING
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CFLAGS +=	$(CPP_LARGEFILES)
+CXXFLAGS +=	$(CPP_LARGEFILES)
+CPPFLAGS +=	$(CPP_LARGEFILES)
+
+# We use a fixed default mysql and postgres implementation+version as defined
+# in `make-rules/*.mk` files included above
+PATH.64=$(USRBINDIR.64):$(USRBINDIR.32):$(GNUBIN.64):$(GNUBIN.32)
+PATH.32=$(USRBINDIR.32):$(GNUBIN.32)
+PATH=$(MYSQL_BINDIR.$(BITS)):$(PG_BINDIR.$(BITS)):$(PATH.$(BITS))
+
+COMPONENT_COMMON_ENV += PATH="$(PATH)"
+COMPONENT_COMMON_ENV += CC="$(CC)"
+COMPONENT_COMMON_ENV += CXX="$(CXX)"
+COMPONENT_COMMON_ENV += CXXFLAGS="$(CXXFLAGS)"
+COMPONENT_COMMON_ENV += LDFLAGS="$(LDFLAGS)"
+
+CONFIGURE_ENV += $(COMPONENT_COMMON_ENV)
+COMPONENT_BUILD_ENV += $(COMPONENT_COMMON_ENV)
+COMPONENT_INSTALL_ENV += $(COMPONENT_COMMON_ENV)
+
+CONFIGURE_OPTIONS += --sysconfdir=/etc
+CONFIGURE_OPTIONS += --with-mysql=yes
+CONFIGURE_OPTIONS += --with-postgresql=yes
+CONFIGURE_OPTIONS += --with-replicate=yes
+CONFIGURE_OPTIONS += --with-oracle=no
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+test: $(TEST_32_and_64)
+
+REQUIRED_PACKAGES += $(MYSQL_BASEPKG)/library
+# We need mysql_config delivered by (mariadb-55|mysql|percona)/client :
+REQUIRED_PACKAGES += $(MYSQL_BASEPKG)/client
+REQUIRED_PACKAGES += $(PG_BASEPKG)/library
+# We need pg_config :
+REQUIRED_PACKAGES += $(PG_BASEPKG)/developer
+REQUIRED_PACKAGES += database/sqlite-3
+REQUIRED_PACKAGES += library/cxxtools
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/g++-4-runtime
+REQUIRED_PACKAGES += system/library/gcc-4-runtime
+REQUIRED_PACKAGES += system/library/math

--- a/components/library/tntdb/tntdb-common.p5m
+++ b/components/library/tntdb/tntdb-common.p5m
@@ -1,0 +1,82 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/common@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - common libraries and headers"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/tntdb.h
+file path=usr/include/tntdb/connectionpool.h
+file path=usr/include/tntdb/error.h
+file path=usr/include/tntdb/decimal.h
+file path=usr/include/tntdb/connection.h
+file path=usr/include/tntdb/bits/rowreader.h
+file path=usr/include/tntdb/bits/statement.h
+file path=usr/include/tntdb/bits/blobstream.h
+file path=usr/include/tntdb/bits/value.h
+file path=usr/include/tntdb/bits/row_iterator.h
+file path=usr/include/tntdb/bits/row.h
+file path=usr/include/tntdb/bits/blob.h
+file path=usr/include/tntdb/bits/result_iterator.h
+file path=usr/include/tntdb/bits/statement_iterator.h
+file path=usr/include/tntdb/bits/connection.h
+file path=usr/include/tntdb/bits/result.h
+file path=usr/include/tntdb/value.h
+file path=usr/include/tntdb/cxxtools/datetime.h
+file path=usr/include/tntdb/cxxtools/time.h
+file path=usr/include/tntdb/cxxtools/date.h
+file path=usr/include/tntdb/iface/iconnection.h
+file path=usr/include/tntdb/iface/irow.h
+file path=usr/include/tntdb/iface/istatement.h
+file path=usr/include/tntdb/iface/icursor.h
+file path=usr/include/tntdb/iface/iconnectionmanager.h
+file path=usr/include/tntdb/iface/iresult.h
+file path=usr/include/tntdb/iface/iblob.h
+file path=usr/include/tntdb/iface/ivalue.h
+file path=usr/include/tntdb/time.h
+file path=usr/include/tntdb/config.h
+file path=usr/include/tntdb/result.h
+file path=usr/include/tntdb/connect.h
+file path=usr/include/tntdb/impl/blob.h
+file path=usr/include/tntdb/datetime.h
+file path=usr/include/tntdb/transaction.h
+file path=usr/include/tntdb/row.h
+file path=usr/include/tntdb/date.h
+file path=usr/include/tntdb/blob.h
+file path=usr/include/tntdb/statement.h
+file path=usr/include/tntdb/librarymanager.h
+file path=usr/include/tntdb/sqlbuilder.h
+
+file path=usr/lib/libtntdb.so.4.0.0
+file path=usr/lib/tntdb/tntdb4-replicate.so.4.0.0
+file path=usr/lib/$(MACH64)/libtntdb.so.4.0.0
+file path=usr/lib/$(MACH64)/tntdb/tntdb4-replicate.so.4.0.0
+
+link path=usr/lib/libtntdb.so.4 target=libtntdb.so.4.0.0
+link path=usr/lib/libtntdb.so target=libtntdb.so.4.0.0
+link path=usr/lib/tntdb/tntdb4-replicate.so.4 target=tntdb4-replicate.so.4.0.0
+link path=usr/lib/tntdb/tntdb4-replicate.so target=tntdb4-replicate.so.4.0.0
+
+link path=usr/lib/$(MACH64)/libtntdb.so.4 target=libtntdb.so.4.0.0
+link path=usr/lib/$(MACH64)/libtntdb.so target=libtntdb.so.4.0.0
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-replicate.so.4 target=tntdb4-replicate.so.4.0.0
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-replicate.so target=tntdb4-replicate.so.4.0.0

--- a/components/library/tntdb/tntdb-mysql.p5m
+++ b/components/library/tntdb/tntdb-mysql.p5m
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/mysql@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - connector library for Mysql"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# Do not force a dependency on specific DB package variant for
+# the DB libraries that any one of variant packages may provide
+file path=usr/lib/tntdb/tntdb4-mysql.so.4.0.0
+file path=usr/lib/$(MACH64)/tntdb/tntdb4-mysql.so.4.0.0
+
+link path=usr/lib/tntdb/tntdb4-mysql.so target=tntdb4-mysql.so.4.0.0
+link path=usr/lib/tntdb/tntdb4-mysql.so.4 target=tntdb4-mysql.so.4.0.0
+
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-mysql.so.4 target=tntdb4-mysql.so.4.0.0
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-mysql.so target=tntdb4-mysql.so.4.0.0

--- a/components/library/tntdb/tntdb-pgsql.p5m
+++ b/components/library/tntdb/tntdb-pgsql.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/pgsql@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - connector library for Postgresql"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# Do not force a dependency on specific DB package variant for
+# the DB libraries that any one of variant packages may provide
+# TODO: Even with these depend's, usage of libpq.so.5 does not
+# pass pkg(5) checks unless bypasses are also in place :(
+depend fmri=__TBD pkg.debug.depend.file=usr/lib/libpq.so.5 type=require
+depend fmri=__TBD pkg.debug.depend.file=usr/lib/64/libpq.so.5 type=require
+file path=usr/lib/tntdb/tntdb4-postgresql.so.4.0.0 pkg.depend.bypass-generate=.*
+file path=usr/lib/$(MACH64)/tntdb/tntdb4-postgresql.so.4.0.0 pkg.depend.bypass-generate=.*
+
+link path=usr/lib/tntdb/tntdb4-postgresql.so target=tntdb4-postgresql.so.4.0.0
+link path=usr/lib/tntdb/tntdb4-postgresql.so.4 target=tntdb4-postgresql.so.4.0.0
+
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-postgresql.so target=tntdb4-postgresql.so.4.0.0
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-postgresql.so.4 target=tntdb4-postgresql.so.4.0.0

--- a/components/library/tntdb/tntdb-sqlite.p5m
+++ b/components/library/tntdb/tntdb-sqlite.p5m
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/sqlite@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - connector library for sqlite"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# Do not force a dependency on specific DB package variant for
+# the DB libraries that any one of variant packages may provide
+file path=usr/lib/tntdb/tntdb4-sqlite.so.4.0.0
+file path=usr/lib/$(MACH64)/tntdb/tntdb4-sqlite.so.4.0.0
+
+link path=usr/lib/tntdb/tntdb4-sqlite.so.4 target=tntdb4-sqlite.so.4.0.0
+link path=usr/lib/tntdb/tntdb4-sqlite.so target=tntdb4-sqlite.so.4.0.0
+
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-sqlite.so target=tntdb4-sqlite.so.4.0.0
+link path=usr/lib/$(MACH64)/tntdb/tntdb4-sqlite.so.4 target=tntdb4-sqlite.so.4.0.0

--- a/components/library/tntdb/tntdb.p5m
+++ b/components/library/tntdb/tntdb.p5m
@@ -1,0 +1,31 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# Wrap up the known sub-components that can otherwise be installed separately
+depend fmri=$(COMPONENT_FMRI)/common@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) type=require
+depend fmri=$(COMPONENT_FMRI)/pgsql@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)  type=require
+depend fmri=$(COMPONENT_FMRI)/mysql@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)  type=require
+depend fmri=$(COMPONENT_FMRI)/sqlite@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) type=require


### PR DESCRIPTION
Alternate version of https://github.com/OpenIndiana/oi-userland/pull/1776 - here we have fixed dependencies on the mariadb5.5 and whatever postgres version is current in the common makefiles.
