### PR TITLE
Initial commit of libcidr version 1.2.3

### DIFF
--- a/components/library/libcidr/Makefile
+++ b/components/library/libcidr/Makefile
@@ -1,0 +1,86 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=	libcidr
+COMPONENT_VERSION=	1.2.3
+COMPONENT_SUMMARY=	LibCIDR is a library to manipulate CIDR IP addresses
+COMPONENT_SRC=	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH=	\
+  sha256:afbe266a9839775a21091b0e44daaf890a46ea4c2d3f5126b3048d82b9bfbbc4
+COMPONENT_ARCHIVE_URL=	\
+  https://www.over-yonder.net/~fullermd/projects/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://www.over-yonder.net/~fullermd/projects/$(COMPONENT_NAME)
+COMPONENT_FMRI=	library/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION=	System/Libraries
+COMPONENT_LICENSE=	BSD
+COMPONENT_LICENSE_FILE=	LICENSE
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/justmake.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+CXXFLAGS.32=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+CFLAGS.32=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+
+CXXFLAGS+= $(CXXFLAGS.$(BITS))
+CFLAGS+= $(CFLAGS.$(BITS))
+CFLAGS+= -I$(SOURCE_DIR)/include
+CFLAGS+= -I$(SOURCE_DIR)/src/include
+
+COMPONENT_CUSTOM_ARGS += BITS="$(BITS)"
+COMPONENT_CUSTOM_ARGS += CC="$(CC)"
+COMPONENT_CUSTOM_ARGS += CXX="$(CXX)"
+COMPONENT_CUSTOM_ARGS += CPP="$(CPP)"
+COMPONENT_CUSTOM_ARGS += LD="$(LD)"
+COMPONENT_CUSTOM_ARGS += LN="$(LN)"
+COMPONENT_CUSTOM_ARGS += RM="$(RM)"
+COMPONENT_CUSTOM_ARGS += MV="$(MV)"
+COMPONENT_CUSTOM_ARGS += MKDIR="$(MKDIR)"
+COMPONENT_CUSTOM_ARGS += SED="$(GSED)"
+COMPONENT_CUSTOM_ARGS += INSTALL="$(INSTALL)"
+COMPONENT_CUSTOM_ARGS += CFLAGS="$(CFLAGS)"
+COMPONENT_CUSTOM_ARGS += CPPFLAGS="$(CPPFLAGS)"
+COMPONENT_CUSTOM_ARGS += CXXFLAGS="$(CXXFLAGS)"
+COMPONENT_CUSTOM_ARGS += LDFLAGS="$(LDFLAGS)"
+
+USRLIBDIR.32 = $(USRLIBDIR)
+USRLIBDIR.64 = $(USRLIBDIR64)
+USRBINDIR.32 = $(USRBINDIR)
+USRBINDIR.64 = $(USRBINDIR64)
+
+COMPONENT_CUSTOM_ARGS += PREFIX="$(USRDIR)"
+COMPONENT_CUSTOM_ARGS += CIDR_LIBDIR="$(USRLIBDIR.$(BITS))"
+COMPONENT_CUSTOM_ARGS += CIDR_BINDIR="$(USRBINDIR.$(BITS))"
+COMPONENT_CUSTOM_ARGS += CIDR_INCDIR="$(USRINCDIR)"
+COMPONENT_CUSTOM_ARGS += CIDR_MANDIR="$(USRSHAREMANDIR)"
+COMPONENT_CUSTOM_ARGS += CIDR_DOCDIR="$(USRSHAREDIR)/$(COMPONENT_NAME)/docs"
+COMPONENT_CUSTOM_ARGS += CIDR_EXDIR="$(USRSHAREDIR)/$(COMPONENT_NAME)/examples"
+
+COMPONENT_BUILD_ARGS += $(COMPONENT_CUSTOM_ARGS)
+COMPONENT_INSTALL_ARGS += $(COMPONENT_CUSTOM_ARGS)
+
+COMPONENT_PRE_BUILD_ACTION = \
+    ( $(CLONEY) $(SOURCE_DIR) $(@D) && \
+      cd $(@D) && \
+      ./rmgmake.sh && ./mkgmake.sh )
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+test: $(TEST_32_and_64)

--- a/components/library/libcidr/files/libcidr-amd64.pc
+++ b/components/library/libcidr/files/libcidr-amd64.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=/usr/lib/amd64
+includedir=/usr/include
+
+Name: libcidr
+Description: LibCIDR is a library to manipulate CIDR IP addresses
+Version: 1.2.3
+Libs: -L${libdir} -lcidr
+Cflags: -I${includedir}

--- a/components/library/libcidr/files/libcidr-sparcv9.pc
+++ b/components/library/libcidr/files/libcidr-sparcv9.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=/usr/lib/sparcv9
+includedir=/usr/include
+
+Name: libcidr
+Description: LibCIDR is a library to manipulate CIDR IP addresses
+Version: 1.2.3
+Libs: -L${libdir} -lcidr
+Cflags: -I${includedir}

--- a/components/library/libcidr/files/libcidr.pc
+++ b/components/library/libcidr/files/libcidr.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=/usr/lib
+includedir=/usr/include
+
+Name: libcidr
+Description: LibCIDR is a library to manipulate CIDR IP addresses
+Version: 1.2.3
+Libs: -L${libdir} -lcidr
+Cflags: -I${includedir}

--- a/components/library/libcidr/libcidr.p5m
+++ b/components/library/libcidr/libcidr.p5m
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/cidrcalc
+file usr/lib/$(MACH64)/libcidr.so.0 path=usr/lib/$(MACH64)/libcidr.so.0.0.0
+link path=usr/lib/$(MACH64)/libcidr.so.0 target=libcidr.so.0.0.0
+link path=usr/lib/$(MACH64)/libcidr.so target=libcidr.so.0.0.0
+
+file path=usr/bin/cidrcalc
+file usr/lib/libcidr.so.0 path=usr/lib/libcidr.so.0.0.0
+link path=usr/lib/libcidr.so.0 target=libcidr.so.0.0.0
+link path=usr/lib/libcidr.so target=libcidr.so.0.0.0
+
+file files/libcidr-$(MACH64).pc path=usr/lib/$(MACH64)/pkgconfig/libcidr.pc
+file files/libcidr.pc path=usr/lib/pkgconfig/libcidr.pc
+
+file path=usr/include/libcidr.h
+
+file path=usr/share/man/man3/libcidr.3
+
+file path=usr/share/libcidr/docs/codelibrary-html.css
+file path=usr/share/libcidr/docs/libcidr-big.html
+file path=usr/share/libcidr/docs/libcidr.dvi
+file path=usr/share/libcidr/docs/libcidr.pdf
+file path=usr/share/libcidr/docs/libcidr.ps
+file path=usr/share/libcidr/docs/libcidr.rtf
+file path=usr/share/libcidr/docs/libcidr.txt
+file path=usr/share/libcidr/examples/README
+file path=usr/share/libcidr/examples/acl/GNUmakefile
+file path=usr/share/libcidr/examples/acl/acl.c
+file path=usr/share/libcidr/examples/acl/acl.example
+file path=usr/share/libcidr/examples/cidrcalc/GNUmakefile
+file path=usr/share/libcidr/examples/cidrcalc/cidrcalc.c

--- a/components/library/libcidr/patches/01-build.patch
+++ b/components/library/libcidr/patches/01-build.patch
@@ -1,0 +1,49 @@
+This patch should fix up libcidr manually-built makefiles and scripts
+to be protable into oi-userland. The conversion recipe is below:
+
+COMPONENT_PREP_ACTION = \
+    ( cd $(@D) && \
+      $(GSED) -e 's|\-Wl\,\-x|-m\$$\{BITS\}|' \
+        -e 's|^\([ \t]*L_FLAGS.*=[ \t]*\)|\1\$$\{LDFLAGS\} |' \
+        -i src/Makefile.inc && \
+      $(GSED) -e 's|\(^[ \t]*\)awk |\1\$(NAWK) |g' \
+        -e 's|echo -n \(\".*\"\)|/bin/echo \1"\\c"|' \
+        -i mkgmake.sh )
+
+//Jim Klimov
+
+diff -Naur libcidr-1.2.3-orig/mkgmake.sh libcidr-1.2.3/mkgmake.sh
+--- libcidr-1.2.3-orig/mkgmake.sh	2014-02-01 12:34:45.000000000 +0100
++++ libcidr-1.2.3/mkgmake.sh	2016-03-30 15:27:52.000000000 +0200
+@@ -25,8 +25,8 @@
+ 	*)
+ 		for i in ${MAKEFILES}; do
+ 			GMFILE=`echo ${i} | sed "s/Makefile/GNUmakefile/"`
+-			echo -n "Building ${GMFILE} from ${i}...   "
+-			awk -f tools/mkgmake.awk ${i} > ${GMFILE}
++			/bin/echo "Building ${GMFILE} from ${i}...   ""\c"
++			/usr/bin/nawk -f tools/mkgmake.awk ${i} > ${GMFILE}
+ 			echo done.
+ 		done
+ 		;;
+diff -Naur libcidr-1.2.3-orig/src/Makefile.inc libcidr-1.2.3/src/Makefile.inc
+--- libcidr-1.2.3-orig/src/Makefile.inc	2014-02-01 12:34:45.000000000 +0100
++++ libcidr-1.2.3/src/Makefile.inc	2016-03-30 15:27:52.000000000 +0200
+@@ -45,7 +45,7 @@
+ 
+ ${SHLIB_NAME}: ${SO_FILES}
+ 	@echo Linking ${SHLIB_NAME}...
+-	${CC} -shared -Wl,-x -o ${@} -Wl,-soname,${SHLIB_NAME} \
++	${CC} -shared -m${BITS} -o ${@} -Wl,-soname,${SHLIB_NAME} \
+ 			`${LORDER} ${SO_FILES} | ${TSORT}`
+ 	${LN} -sf ${SHLIB_NAME} ${SHLIB_LINK}
+ 
+@@ -69,7 +69,7 @@
+ .ifdef PROGNAME
+ # These paths wind up relative to src/{test,examples}/*
+ CFLAGS += -I../../../include
+-L_FLAGS += -g -pipe -L../..
++L_FLAGS += ${LDFLAGS} -g -pipe -L../..
+ LCIDR = ../../libcidr.so
+ 
+ CLEAN_FILES = ${O_FILES} ${PROGNAME} *core .depend


### PR DESCRIPTION
LibCIDR is a library to manipulate CIDR IP addresses
