### PR TITLE
Initial commit of czmq (zeromq C binding) version 3.0.2

### DIFF
--- a/components/library/zeromq/czmq/Makefile
+++ b/components/library/zeromq/czmq/Makefile
@@ -1,0 +1,72 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+include ../../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= czmq
+
+# See configure.ac for ABI version mapping to software version
+COMPONENT_VERSION_ABI= 3
+COMPONENT_VERSION= 3.0.2
+COMPONENT_SUMMARY= C bindings for 0MQ
+COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+  sha256:8bca39ab69375fa4e981daf87b3feae85384d5b40cef6adbe9d5eb063357699a
+COMPONENT_ARCHIVE_URL= \
+  http://download.zeromq.org/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL= http://zeromq.org/
+# Two licenses in tarball, LGPLv3+ is referenced in their spec-file
+COMPONENT_LICENSE_FILE= LICENSE
+COMPONENT_LICENSE= MPLv2
+COMPONENT_CLASSIFICATION= System/Libraries
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+PKG_OPTIONS +=	-D COMPONENT_VERSION_ABI="$(COMPONENT_VERSION_ABI)"
+
+COMPONENT_PREP_ACTION =	\
+	( cd $(@D) && \
+	  libtoolize --copy --force && \
+	  aclocal -I m4 && \
+	  autoheader && \
+	  automake -c -f -a && \
+	  autoconf )
+
+COMPONENT_PRE_CONFIGURE_ACTION =	($(CLONEY) $(SOURCE_DIR) $(@D))
+
+CXXFLAGS.32=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+CFLAGS.32=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+
+CXXFLAGS+=$(CXXFLAGS.$(BITS))
+CFLAGS += $(CFLAGS.$(BITS))
+
+CXXFLAGS += -D_POSIX_PTHREAD_SEMANTICS
+CFLAGS += -D_POSIX_PTHREAD_SEMANTICS
+
+CONFIGURE_OPTIONS +=	--enable-static=no
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+# test_shutdown_stress fails
+test: $(TEST_32_and_64)
+
+BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
+
+include $(WS_TOP)/make-rules/depend.mk

--- a/components/library/zeromq/czmq/czmq.p5m
+++ b/components/library/zeromq/czmq/czmq.p5m
@@ -1,0 +1,125 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/library/c++/czmq@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+file path=usr/bin/$(MACH64)/makecert
+file path=usr/bin/makecert
+
+file path=usr/include/czmq.h
+file path=usr/include/czmq_library.h
+file path=usr/include/czmq_prelude.h
+file path=usr/include/zactor.h
+file path=usr/include/zarmour.h
+file path=usr/include/zauth.h
+file path=usr/include/zauth_v2.h
+file path=usr/include/zbeacon.h
+file path=usr/include/zbeacon_v2.h
+file path=usr/include/zcert.h
+file path=usr/include/zcertstore.h
+file path=usr/include/zchunk.h
+file path=usr/include/zclock.h
+file path=usr/include/zconfig.h
+file path=usr/include/zctx.h
+file path=usr/include/zdigest.h
+file path=usr/include/zdir.h
+file path=usr/include/zdir_patch.h
+file path=usr/include/zfile.h
+file path=usr/include/zframe.h
+file path=usr/include/zgossip.h
+file path=usr/include/zhash.h
+file path=usr/include/zhashx.h
+file path=usr/include/ziflist.h
+file path=usr/include/zlist.h
+file path=usr/include/zlistx.h
+file path=usr/include/zloop.h
+file path=usr/include/zmonitor.h
+file path=usr/include/zmonitor_v2.h
+file path=usr/include/zmsg.h
+file path=usr/include/zmutex.h
+file path=usr/include/zpoller.h
+file path=usr/include/zproxy.h
+file path=usr/include/zproxy_v2.h
+file path=usr/include/zrex.h
+file path=usr/include/zsock.h
+file path=usr/include/zsock_option.h
+file path=usr/include/zsocket.h
+file path=usr/include/zsockopt.h
+file path=usr/include/zstr.h
+file path=usr/include/zsys.h
+file path=usr/include/zthread.h
+file path=usr/include/zuuid.h
+
+link path=usr/lib/$(MACH64)/libczmq.so target=libczmq.so.$(COMPONENT_VERSION_ABI).0.0
+link path=usr/lib/$(MACH64)/libczmq.so.$(COMPONENT_VERSION_ABI) target=libczmq.so.$(COMPONENT_VERSION_ABI).0.0
+file path=usr/lib/$(MACH64)/libczmq.so.$(COMPONENT_VERSION_ABI).0.0
+file path=usr/lib/$(MACH64)/pkgconfig/libczmq.pc
+
+link path=usr/lib/libczmq.so target=libczmq.so.$(COMPONENT_VERSION_ABI).0.0
+link path=usr/lib/libczmq.so.$(COMPONENT_VERSION_ABI) target=libczmq.so.$(COMPONENT_VERSION_ABI).0.0
+file path=usr/lib/libczmq.so.$(COMPONENT_VERSION_ABI).0.0
+file path=usr/lib/pkgconfig/libczmq.pc
+
+file path=usr/share/man/man1/makecert.1
+file path=usr/share/man/man3/zactor.3
+file path=usr/share/man/man3/zarmour.3
+file path=usr/share/man/man3/zauth.3
+file path=usr/share/man/man3/zauth_v2.3
+file path=usr/share/man/man3/zbeacon.3
+file path=usr/share/man/man3/zbeacon_v2.3
+file path=usr/share/man/man3/zcert.3
+file path=usr/share/man/man3/zcertstore.3
+file path=usr/share/man/man3/zchunk.3
+file path=usr/share/man/man3/zclock.3
+file path=usr/share/man/man3/zconfig.3
+file path=usr/share/man/man3/zctx.3
+file path=usr/share/man/man3/zdigest.3
+file path=usr/share/man/man3/zdir.3
+file path=usr/share/man/man3/zdir_patch.3
+file path=usr/share/man/man3/zfile.3
+file path=usr/share/man/man3/zframe.3
+file path=usr/share/man/man3/zgossip.3
+file path=usr/share/man/man3/zhash.3
+file path=usr/share/man/man3/zhashx.3
+file path=usr/share/man/man3/ziflist.3
+file path=usr/share/man/man3/zlist.3
+file path=usr/share/man/man3/zlistx.3
+file path=usr/share/man/man3/zloop.3
+file path=usr/share/man/man3/zmonitor.3
+file path=usr/share/man/man3/zmonitor_v2.3
+file path=usr/share/man/man3/zmsg.3
+file path=usr/share/man/man3/zmutex.3
+file path=usr/share/man/man3/zpoller.3
+file path=usr/share/man/man3/zproxy.3
+file path=usr/share/man/man3/zproxy_v2.3
+file path=usr/share/man/man3/zrex.3
+file path=usr/share/man/man3/zsock.3
+file path=usr/share/man/man3/zsock_option.3
+file path=usr/share/man/man3/zsocket.3
+file path=usr/share/man/man3/zsockopt.3
+file path=usr/share/man/man3/zstr.3
+file path=usr/share/man/man3/zsys.3
+file path=usr/share/man/man3/zthread.3
+file path=usr/share/man/man3/zuuid.3
+file path=usr/share/man/man7/czmq.7

--- a/components/library/zeromq/czmq/patches/01-src-zsys_c.patch
+++ b/components/library/zeromq/czmq/patches/01-src-zsys_c.patch
@@ -1,0 +1,13 @@
+This patch should not be needed in czmq releases after 3.0.2 (merged to upstream)
+
+--- czmq-3.0.2/src/zsys.c.orig	2015-05-26 16:25:43.000000000 +0200
++++ czmq-3.0.2/src/zsys.c	2016-03-30 02:35:49.821499607 +0200
+@@ -1072,7 +1072,7 @@
+         }
+         //   We record the current process id in the lock file
+         char pid_buffer [10];
+-        snprintf (pid_buffer, sizeof (pid_buffer), "%6d\n", getpid ());
++        snprintf (pid_buffer, sizeof (pid_buffer), "%6" PRIi64 "\n", (int64_t)getpid ());
+         if (write (handle, pid_buffer, strlen (pid_buffer)) != strlen (pid_buffer)) {
+             zsys_error ("cannot write to lockfile: %s", strerror (errno));
+             close (handle);


### PR DESCRIPTION
From the README:

> CZMQ has these goals:
> - To wrap the 0MQ core API in semantics that lead to shorter, more readable applications.
> - To hide as far as possible the differences between different versions of 0MQ (2.x, 3.x, 4.x).
> - To provide a space for development of more sophisticated API semantics.
> - To wrap the 0MQ security features with high-level tools and APIs.
> - To become the basis for other language bindings built on top of CZMQ.

From me: As such, this project recipe currently does not constrain a specific libzmq revision / component version.
