### PR TITLE
Zeromq-3.2.5 recipe updated to match PRs for other ZeroMQ versions

### DIFF
--- a/components/library/zeromq/zeromq3/Makefile
+++ b/components/library/zeromq/zeromq3/Makefile
@@ -20,7 +20,12 @@ COMPONENT_NAME= zeromq
 
 # See configure.ac for ABI version mapping to software version
 COMPONENT_VERSION_ABI= 3
-COMPONENT_VERSION= 3.2.5
+COMPONENT_VERSION_MAJ= 3
+COMPONENT_VERSION_MIN= 2
+COMPONENT_VERSION_PAT= 5
+COMPONENT_VERSION_MAJ_MIN= $(COMPONENT_VERSION_MAJ).$(COMPONENT_VERSION_MIN)
+COMPONENT_VERSION= $(COMPONENT_VERSION_MAJ_MIN).$(COMPONENT_VERSION_PAT)
+
 COMPONENT_SUMMARY= Open source message queue optimised for performance
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
@@ -34,11 +39,19 @@ COMPONENT_LICENSE_FILE= COPYING.LESSER
 COMPONENT_LICENSE= LGPLv3+
 COMPONENT_CLASSIFICATION= System/Libraries
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+# Note: This USR path is used in build prefix and in p5m manifest,
+# except where we mediate the links and the relative SUB path is used
+COMPONENT_SUB_DIR=zeromq-$(COMPONENT_VERSION_MAJ_MIN)
+COMPONENT_USR_DIR=$(USRDIR)/$(COMPONENT_SUB_DIR)
 
 PKG_OPTIONS +=	-D COMPONENT_VERSION_ABI="$(COMPONENT_VERSION_ABI)"
+PKG_OPTIONS +=	-D COMPONENT_VERSION_MAJ_MIN="$(COMPONENT_VERSION_MAJ_MIN)"
+PKG_OPTIONS +=	-D COMPONENT_SUB_DIR="$(COMPONENT_SUB_DIR)"
+PKG_OPTIONS +=	-D COMPONENT_USR_DIR="$(COMPONENT_USR_DIR)"
 
 COMPONENT_PREP_ACTION =	\
 	( cd $(@D) && \
@@ -50,23 +63,24 @@ COMPONENT_PREP_ACTION =	\
 
 COMPONENT_PRE_CONFIGURE_ACTION =	($(CLONEY) $(SOURCE_DIR) $(@D))
 
-CONFIGURE_OPTIONS +=	--with-documentation
-CONFIGURE_OPTIONS +=	--enable-static=no
+# Build docs just once (for one ARCH), parameter varies from version to version
+CONFIGURE_OPTIONS.32 +=	--with-documentation --with-docs
+CONFIGURE_OPTIONS.64 +=	--without-documentation --without-docs
 
-COMPONENT_POST_INSTALL_ACTION=	( cd $(PROTO_DIR)/usr && \
-    for D in lib include share/man/* ; do \
-        $(MKDIR) "./share/zeromq$(COMPONENT_VERSION_ABI)/$$D" && \
-        $(CLONEY) "$(PROTO_DIR)/usr/$$D" "$(PROTO_DIR)/usr/share/zeromq$(COMPONENT_VERSION_ABI)/$$D" || exit ; \
-    done \
-)
+CONFIGURE_OPTIONS +=	--enable-static=no
+CONFIGURE_OPTIONS +=	--with-libsodium
+
+CONFIGURE_PREFIX   =	$(COMPONENT_USR_DIR)
+
+CONFIGURE_OPTIONS +=	--sysconfdir=/etc
+CONFIGURE_OPTIONS +=	--localstatedir=/var
 
 build: $(BUILD_32_and_64)
 
 install: $(INSTALL_32_and_64)
 
-# test_shutdown_stress fails
 test: $(TEST_32_and_64)
 
 BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
 
-include $(WS_TOP)/make-rules/depend.mk
+include $(WS_MAKE_RULES)/depend.mk

--- a/components/library/zeromq/zeromq3/zeromq.p5m
+++ b/components/library/zeromq/zeromq3/zeromq.p5m
@@ -20,11 +20,11 @@
 
 # Set version of the grouper same as newest libzmq (per Makefile)
 set name=pkg.fmri value=pkg:/library/c++/zeromq@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) - dependency for the newest version ($(COMPONENT_VERSION_ABI))"
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - dependency for the newest ABI version ($(COMPONENT_VERSION_ABI))"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value="$(COMPONENT_PROJECT_URL)"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend fmri=library/c++/zeromq$(COMPONENT_VERSION_ABI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) type=require
+depend fmri=library/c++/zeromq-$(COMPONENT_VERSION_MAJ_MIN)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) type=require

--- a/components/library/zeromq/zeromq3/zeromq3.p5m
+++ b/components/library/zeromq/zeromq3/zeromq3.p5m
@@ -25,259 +25,102 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
 
+
 # Generated section:
 
-file path=usr/lib/$(MACH64)/libzmq.so.$(COMPONENT_VERSION_ABI).0.0 mode=0555
-link path=usr/lib/$(MACH64)/libzmq.so.$(COMPONENT_VERSION_ABI) target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0
-file path=usr/lib/libzmq.so.$(COMPONENT_VERSION_ABI).0.0 mode=0555
-link path=usr/lib/libzmq.so.$(COMPONENT_VERSION_ABI) target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0
+file path=$(COMPONENT_USR_DIR)/lib/$(MACH64)/libzmq.so.$(COMPONENT_VERSION_ABI).0.0 mode=0555
+link path=$(COMPONENT_USR_DIR)/lib/$(MACH64)/libzmq.so.$(COMPONENT_VERSION_ABI) \
+    target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0
+link path=$(COMPONENT_USR_DIR)/lib/$(MACH64)/libzmq.so \
+    target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0
+file path=$(COMPONENT_USR_DIR)/lib/libzmq.so.$(COMPONENT_VERSION_ABI).0.0 mode=0555
+link path=$(COMPONENT_USR_DIR)/lib/libzmq.so.$(COMPONENT_VERSION_ABI) \
+    target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0
+link path=$(COMPONENT_USR_DIR)/lib/libzmq.so \
+    target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0
 
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/lib/$(MACH64)/pkgconfig/libzmq.pc
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/lib/pkgconfig/libzmq.pc
+file path=$(COMPONENT_USR_DIR)/lib/$(MACH64)/pkgconfig/libzmq.pc
+file path=$(COMPONENT_USR_DIR)/lib/pkgconfig/libzmq.pc
 
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/include/zmq.h
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/include/zmq_utils.h
-
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_bind.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_close.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_connect.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_destroy.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_get.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_new.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_set.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_disconnect.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_errno.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_getsockopt.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_init.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_close.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_copy.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_data.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_get.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_init.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_init_data.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_init_size.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_more.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_move.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_recv.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_send.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_set.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_size.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_poll.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_proxy.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_recv.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_recvmsg.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_send.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_sendmsg.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_setsockopt.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_socket.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_socket_monitor.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_strerror.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_term.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_unbind.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_version.3
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq.7
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_epgm.7
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_inproc.7
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_ipc.7
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_pgm.7
-file path=usr/share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_tcp.7
-
+file path=$(COMPONENT_USR_DIR)/include/zmq.h
+file path=$(COMPONENT_USR_DIR)/include/zmq_utils.h
 
 # Mediate this:
-link path=usr/lib/$(MACH64)/libzmq.so target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-link path=usr/lib/libzmq.so target=libzmq.so.$(COMPONENT_VERSION_ABI).0.0 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
+link path=usr/lib/$(MACH64)/libzmq.so \
+    target=../../$(COMPONENT_SUB_DIR)/lib/$(MACH64)/libzmq.so.$(COMPONENT_VERSION_ABI).0.0 \
+    mediator=zeromq mediator-version=$(COMPONENT_VERSION_MAJ_MIN)
+link path=usr/lib/libzmq.so \
+    target=../$(COMPONENT_SUB_DIR)/lib/libzmq.so.$(COMPONENT_VERSION_ABI).0.0 \
+    mediator=zeromq mediator-version=$(COMPONENT_VERSION_MAJ_MIN)
 
 
 link path=usr/lib/$(MACH64)/pkgconfig/libzmq.pc \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/lib/$(MACH64)/pkgconfig/libzmq.pc \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
+    target=../../../$(COMPONENT_SUB_DIR)/lib/$(MACH64)/pkgconfig/libzmq.pc \
+    mediator=zeromq mediator-version=$(COMPONENT_VERSION_MAJ_MIN)
 
 link path=usr/lib/pkgconfig/libzmq.pc \
-    target=../../share/zeromq$(COMPONENT_VERSION_ABI)/lib/pkgconfig/libzmq.pc \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
+    target=../../$(COMPONENT_SUB_DIR)/lib/pkgconfig/libzmq.pc \
+    mediator=zeromq mediator-version=$(COMPONENT_VERSION_MAJ_MIN)
 
 
 link path=usr/include/zmq.h \
-    target=../share/zeromq$(COMPONENT_VERSION_ABI)/include/zmq.h \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
+    target=../$(COMPONENT_SUB_DIR)/include/zmq.h \
+    mediator=zeromq mediator-version=$(COMPONENT_VERSION_MAJ_MIN)
 
 link path=usr/include/zmq_utils.h \
-    target=../share/zeromq$(COMPONENT_VERSION_ABI)/include/zmq_utils.h \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
+    target=../$(COMPONENT_SUB_DIR)/include/zmq_utils.h \
+    mediator=zeromq mediator-version=$(COMPONENT_VERSION_MAJ_MIN)
 
 
-link path=usr/share/man/man3/zmq_bind.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_bind.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_close.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_close.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_connect.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_connect.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_ctx_destroy.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_destroy.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_ctx_get.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_get.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_ctx_new.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_new.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_ctx_set.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_ctx_set.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_disconnect.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_disconnect.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_errno.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_errno.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_getsockopt.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_getsockopt.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_init.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_init.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_close.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_close.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_copy.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_copy.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_data.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_data.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_get.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_get.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_init.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_init.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_init_data.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_init_data.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_init_size.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_init_size.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_more.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_more.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_move.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_move.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_recv.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_recv.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_send.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_send.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_set.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_set.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_msg_size.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_msg_size.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_poll.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_poll.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_proxy.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_proxy.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_recv.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_recv.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_recvmsg.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_recvmsg.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_send.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_send.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_sendmsg.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_sendmsg.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_setsockopt.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_setsockopt.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_socket.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_socket.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_socket_monitor.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_socket_monitor.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_strerror.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_strerror.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_term.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_term.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_unbind.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_unbind.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man3/zmq_version.3 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man3/zmq_version.3 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man7/zmq.7 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq.7 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man7/zmq_epgm.7 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_epgm.7 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man7/zmq_inproc.7 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_inproc.7 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man7/zmq_ipc.7 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_ipc.7 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man7/zmq_pgm.7 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_pgm.7 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
-
-link path=usr/share/man/man7/zmq_tcp.7 \
-    target=../../../share/zeromq$(COMPONENT_VERSION_ABI)/share/man/man7/zmq_tcp.7 \
-    mediator=zeromq mediator-version=$(COMPONENT_VERSION_ABI)
+# This link should simplify usage of current (mediated) manpages via simple
+# addition to developer's MANPATH=/usr/zeromq/share/man:$MANPATH :
+link path=usr/zeromq target=./$(COMPONENT_SUB_DIR) \
+    mediator=zeromq mediator-version=$(COMPONENT_VERSION_MAJ_MIN)
 
 
+# Manpages provided only under dedicated project dir, not mediated
+# into common locations for visibility :
+
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_bind.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_close.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_connect.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_ctx_destroy.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_ctx_get.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_ctx_new.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_ctx_set.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_disconnect.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_errno.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_getsockopt.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_init.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_close.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_copy.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_data.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_get.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_init.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_init_data.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_init_size.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_more.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_move.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_recv.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_send.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_set.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_msg_size.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_poll.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_proxy.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_recv.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_recvmsg.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_send.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_sendmsg.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_setsockopt.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_socket.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_socket_monitor.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_strerror.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_term.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_unbind.3
+file path=$(COMPONENT_USR_DIR)/share/man/man3/zmq_version.3
+file path=$(COMPONENT_USR_DIR)/share/man/man7/zmq.7
+file path=$(COMPONENT_USR_DIR)/share/man/man7/zmq_epgm.7
+file path=$(COMPONENT_USR_DIR)/share/man/man7/zmq_inproc.7
+file path=$(COMPONENT_USR_DIR)/share/man/man7/zmq_ipc.7
+file path=$(COMPONENT_USR_DIR)/share/man/man7/zmq_pgm.7
+file path=$(COMPONENT_USR_DIR)/share/man/man7/zmq_tcp.7


### PR DESCRIPTION
This impacts the "real" package version (zeromq-3.2) and the directory for file deliveries (/usr/zeromq-3.2); the reference-package "zeromq" still remains and should pull the right thing (the highest "zeromq-X.Y" available in repo).
