### PR TITLE
Doc and makefile update for CCACHE_(NO)DISABLE ambiguity

### DIFF
--- a/README
+++ b/README
@@ -74,6 +74,10 @@ Building the Bits
        ENABLE_CCACHE=true
        export ENABLE_CCACHE
 
+    Note: be wary of ccache's own CCACHE_DISABLE environment variable: any
+    value (empty, "false" etc.) is considered a "true" setting for ccache
+    booleans (and so disables the program, falling through to real compiler).
+
   Keeping all sources in one place
 
     The Userland consolidation tools automate download of required source

--- a/doc/makefile-variables.txt
+++ b/doc/makefile-variables.txt
@@ -135,6 +135,13 @@ disabled by default. See below for hints how to enable and optionally configure 
   and/or use `export CCACHE_LOGFILE=/tmp/ccache.log` to trace its activities.
 * You can dedicate a cache directory different from the default `$HOME/.ccache`
   for example with `export CCACHE_DIR=/tmp/ccache-dir; mkdir -p $CCACHE_DIR`.
+* Note: be wary of ccache's own CCACHE_DISABLE environment variable: any
+  value (empty, "false" etc.) is considered a "true" setting for ccache
+  booleans (and so CCACHE_DISABLE=false still disables the program, falling
+  through to real compiler). This is according to the project's documentation
+  and legacy (backwards compatibility), thus not accepted by upstream as a bug.
+  To negate ccache boolean environment variable settings you can use their
+  CCACHE_NO* counterparts, e.g. `export CCACHE_NODISABLE=anything`.
 * Troubleshooting: If no files appear in the cache, verify permissions and disk
   space. Also enable the log file and/or inspect configuration with `ccache -p`
   (see above) to see details about wrapped compilations. In particular,
@@ -145,6 +152,8 @@ disabled by default. See below for hints how to enable and optionally configure 
   running `gcc -o binprog *.c`).
 * You can inspect caching statistics with `ccache -s` and wipe the cache with
   `ccache -C -z`.
+* For debugging or development of the ccache component itself, you can use a
+  custom build for oi-userland compilation with `export CCACHE=/path/to/ccache`
 * The cache directory can contain a configuration file for "ccache" program,
   which is the recommended way to provide tweaks to your setup. While exported
   environment variables (e.g. from shell profile) may work, our Makefiles do

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -348,6 +348,7 @@ export PARFAIT_NATIVESUNCXX=$(SPRO_VROOT)/bin/CC
 export PARFAIT_NATIVEGCC=$(GCC_ROOT)/bin/gcc
 export PARFAIT_NATIVEGXX=$(GCC_ROOT)/bin/g++
 
+#
 # The CCACHE makefile variable should evaluate to empty string or a pathname
 # like /usr/bin/ccache depending on your PATH value and "which" implementation.
 # The assignment via ":=" is important, to only do this once in a Makefile,
@@ -359,23 +360,25 @@ export PARFAIT_NATIVEGXX=$(GCC_ROOT)/bin/g++
 # is currently the default) to not even define the usage of wrapper in the
 # userland-building makefile system.
 # If you want to speed up your re-builds, you must set ENABLE_CCACHE=true.
-# For legacy reasons, the inverted CCACHE_DISABLE variable (configuration of
-# "ccache" program itself) is also supported, but direct use is discouraged.
+# For legacy reasons, the CCACHE_DISABLE and CCACHE_NODISABLE variables (from
+# configuration of the "ccache" program itself) are also supported, but direct
+# use is discouraged, since their syntax and usage are counter-intuitive.
 #
 # Still, absence of ccache in PATH is not considered a fatal error since the
 # build would just proceed well with original compiler.
 # Note: In code below we fast-track if the makefile CCACHE variable is defined
 # but fall back to shell executability tests if just envvar CCACHE is passed.
+#
 export CCACHE := $(shell \
     if test -n "$(CCACHE)" ; then \
         echo "$(CCACHE)"; \
     else \
-        if test x"$${CCACHE_DISABLE-}" = xtrue -o x"$(CCACHE_DISABLE)" = xtrue \
+        if test x"$${CCACHE_DISABLE-}" != x -o x"$(CCACHE_DISABLE)" != x \
              -o x"$${ENABLE_CCACHE-}" = xfalse -o x"$(ENABLE_CCACHE)" = xfalse \
         ; then \
                 echo "NOT USING CCACHE FOR OI-USERLAND because explicitly disabled" >&2 ; \
         else \
-            if test x"$${CCACHE_DISABLE-}" = xfalse -o x"$(CCACHE_DISABLE)" = xfalse \
+            if test x"$${CCACHE_NODISABLE-}" != x -o x"$(CCACHE_NODISABLE)" != x \
                  -o x"$${ENABLE_CCACHE-}" = xtrue -o x"$(ENABLE_CCACHE)" = xtrue \
             ; then \
                 for F in \
@@ -385,6 +388,9 @@ export CCACHE := $(shell \
                 ; do if test -n "$$F" && test -x "$$F" ; then \
                         echo "$$F" ; \
                         echo "USING CCACHE FOR OI-USERLAND: $$F" >&2 ; \
+                        if test x"$${CCACHE_DISABLE-}" != x ; then \
+                            echo "WARNING: envvar CCACHE_DISABLE is set, so effectively ccache will not act!" >&2 ; \
+                        fi; \
                         exit 0; \
                     fi; \
                 done; \


### PR DESCRIPTION
README, makefile-variables.txt and shared-macros.mk : Stress not-using native CCACHE_(NO)DISABLE envvars (do prefer our ENABLE_CCACHE=true|false instead), yet fix support for them according to ccache's non-intuitive conventions
