### PR TITLE
Additional X11 proto from x-S12

### DIFF
--- a/components/meta-packages/x11-protocols/x11-protocols.p5m
+++ b/components/meta-packages/x11-protocols/x11-protocols.p5m
@@ -23,6 +23,7 @@ depend fmri=x11/header/compositeproto type=require
 depend fmri=x11/header/damageproto type=require
 depend fmri=x11/header/dmxproto type=require
 depend fmri=x11/header/dri2proto type=require
+depend fmri=x11/header/dri3proto type=require
 depend fmri=x11/header/evieext type=require
 depend fmri=x11/header/fixesproto type=require
 depend fmri=x11/header/fontcacheproto type=require
@@ -31,6 +32,7 @@ depend fmri=x11/header/glproto type=require
 depend fmri=x11/header/inputproto type=require
 depend fmri=x11/header/kbproto type=require
 depend fmri=x11/header/printproto type=require
+depend fmri=x11/header/presentproto type=require
 depend fmri=x11/header/randrproto type=require
 depend fmri=x11/header/recordproto type=require
 depend fmri=x11/header/renderproto type=require

--- a/components/x11/dri3proto/Makefile
+++ b/components/x11/dri3proto/Makefile
@@ -1,0 +1,52 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           dri3proto
+COMPONENT_VERSION=        1.0
+COMPONENT_FMRI=           x11/header/dri3proto
+COMPONENT_CLASSIFICATION= Development/X11
+COMPONENT_SUMMARY=  headers for DRI3 extension to the X11 protocol
+COMPONENT_SRC=      $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=  $(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH= \
+  sha256:01be49d70200518b9a6b297131f6cc71f4ea2de17436896af153226a774fc074
+COMPONENT_ARCHIVE_URL= \
+  http://www.x.org/releases/individual/proto/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL = http://www.x.org/
+COMPONENT_LICENSE=      MIT License
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+PATH=/usr/gnu/bin:/usr/bin
+
+CONFIGURE_OPTIONS+= --sysconfdir=/etc
+CONFIGURE_OPTIONS+= --without-xmlto
+CONFIGURE_OPTIONS+= --with-asciidoc
+CONFIGURE_OPTIONS+= --without-fop
+CONFIGURE_OPTIONS+= --localstatedir=/var
+
+COMPONENT_INSTALL_ARGS += pkgconfigdir=/usr/share/pkgconfig
+
+build: $(BUILD_32)
+
+install: $(INSTALL_32)
+
+test: $(NO_TESTS)
+

--- a/components/x11/dri3proto/dri3proto.license
+++ b/components/x11/dri3proto/dri3proto.license
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2013 Keith Packard
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and its
+ * documentation for any purpose is hereby granted without fee, provided that
+ * the above copyright notice appear in all copies and that both that copyright
+ * notice and this permission notice appear in supporting documentation, and
+ * that the name of the copyright holders not be used in advertising or
+ * publicity pertaining to distribution of the software without specific,
+ * written prior permission.  The copyright holders make no representations
+ * about the suitability of this software for any purpose.  It is provided "as
+ * is" without express or implied warranty.
+ *
+ * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THIS SOFTWARE.
+ */

--- a/components/x11/dri3proto/dri3proto.p5m
+++ b/components/x11/dri3proto/dri3proto.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/X11/extensions/dri3proto.h
+file path=usr/share/doc/dri3proto/dri3proto.txt
+file path=usr/share/pkgconfig/dri3proto.pc

--- a/components/x11/presentproto/Makefile
+++ b/components/x11/presentproto/Makefile
@@ -1,0 +1,49 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           presentproto
+COMPONENT_VERSION=        1.0
+COMPONENT_FMRI=           x11/header/presentproto
+COMPONENT_CLASSIFICATION= Development/X11
+COMPONENT_SUMMARY=  headers for the Present extension to the X11 protocol
+COMPONENT_SRC=      $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=  $(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH= \
+  sha256:812c7d48721f909a0f7a2cb1e91f6eead76159a36c4712f4579ca587552839ce
+COMPONENT_ARCHIVE_URL= \
+  http://www.x.org/releases/individual/proto/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL = http://www.x.org/
+COMPONENT_LICENSE=      MIT License
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+PATH=/usr/gnu/bin:/usr/bin
+
+CONFIGURE_OPTIONS+= --sysconfdir=/etc
+CONFIGURE_OPTIONS+= --localstatedir=/var
+
+COMPONENT_INSTALL_ARGS += pkgconfigdir=/usr/share/pkgconfig
+
+build: $(BUILD_32)
+
+install: $(INSTALL_32)
+
+test: $(NO_TESTS)
+

--- a/components/x11/presentproto/presentproto.license
+++ b/components/x11/presentproto/presentproto.license
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2013 Keith Packard
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and its
+ * documentation for any purpose is hereby granted without fee, provided that
+ * the above copyright notice appear in all copies and that both that copyright
+ * notice and this permission notice appear in supporting documentation, and
+ * that the name of the copyright holders not be used in advertising or
+ * publicity pertaining to distribution of the software without specific,
+ * written prior permission.  The copyright holders make no representations
+ * about the suitability of this software for any purpose.  It is provided "as
+ * is" without express or implied warranty.
+ *
+ * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+ * EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THIS SOFTWARE.
+ */
+

--- a/components/x11/presentproto/presentproto.p5m
+++ b/components/x11/presentproto/presentproto.p5m
@@ -1,0 +1,28 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/X11/extensions/presentproto.h
+file path=usr/include/X11/extensions/presenttokens.h
+file path=usr/share/doc/presentproto/presentproto.txt
+file path=usr/share/pkgconfig/presentproto.pc


### PR DESCRIPTION
No license file provided in dri3proto tarball.
