### PR TITLE
Add templates for various component types

### DIFF
--- a/templates/ant.mk
+++ b/templates/ant.mk
@@ -1,0 +1,37 @@
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor name>
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=
+COMPONENT_VERSION=
+COMPONENT_SUMMARY=
+COMPONENT_PROJECT_URL=
+COMPONENT_FMRI=
+COMPONENT_CLASSIFICATION=
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=
+COMPONENT_ARCHIVE_HASH=
+COMPONENT_LICENSE=
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/ant.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+build: $(BUILD_32)
+
+install: $(INSTALL_32)
+
+test: $(NO_TESTS)

--- a/templates/cmake.mk
+++ b/templates/cmake.mk
@@ -1,0 +1,37 @@
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor name>
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=
+COMPONENT_VERSION=
+COMPONENT_SUMMARY=
+COMPONENT_PROJECT_URL=
+COMPONENT_FMRI=
+COMPONENT_CLASSIFICATION=
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=
+COMPONENT_ARCHIVE_HASH=
+COMPONENT_LICENSE=
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/cmake.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+build: $(BUILD_32)
+
+install: $(INSTALL_32)
+
+test: $(NO_TESTS)

--- a/templates/configure.mk
+++ b/templates/configure.mk
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor name>
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=
+COMPONENT_VERSION=
+COMPONENT_SUMMARY=
+COMPONENT_PROJECT_URL=
+COMPONENT_FMRI=
+COMPONENT_CLASSIFICATION=
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=
+COMPONENT_ARCHIVE_HASH=
+COMPONENT_LICENSE=
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+build:		$(BUILD_32)
+
+install:	$(INSTALL_32)
+
+test:		$(TEST_32)

--- a/templates/justmake.mk
+++ b/templates/justmake.mk
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor name>
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=
+COMPONENT_VERSION=
+COMPONENT_SUMMARY=
+COMPONENT_PROJECT_URL=
+COMPONENT_FMRI=
+COMPONENT_CLASSIFICATION=
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=
+COMPONENT_ARCHIVE_HASH=
+COMPONENT_LICENSE=
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/justmake.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+build:		$(BUILD_32)
+
+install:	$(INSTALL_32)
+
+test:		$(TEST_32)

--- a/templates/python.mk
+++ b/templates/python.mk
@@ -1,0 +1,37 @@
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor name>
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=
+COMPONENT_VERSION=
+COMPONENT_SUMMARY=
+COMPONENT_PROJECT_URL=
+COMPONENT_FMRI=
+COMPONENT_CLASSIFICATION=
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=
+COMPONENT_ARCHIVE_HASH=
+COMPONENT_LICENSE=
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/setup.py.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+build:          $(BUILD_NO_ARCH)
+
+install:        $(INSTALL_NO_ARCH)
+
+test:           $(NO_TESTS)

--- a/templates/ruby.mk
+++ b/templates/ruby.mk
@@ -1,0 +1,38 @@
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor name>
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=
+COMPONENT_VERSION=
+COMPONENT_SUMMARY=
+COMPONENT_PROJECT_URL=
+COMPONENT_FMRI=
+COMPONENT_CLASSIFICATION=
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=
+COMPONENT_ARCHIVE_HASH=
+COMPONENT_LICENSE=
+COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/gem.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+
+build:          $(BUILD_32)
+
+install:        $(INSTALL_32)
+
+test:           $(NO_TESTS)


### PR DESCRIPTION
These files serve as a template for creating new components. One should do something like:

<pre>
cd components
mkdir <category>/<component>
cd <category>/<component>
cp ../../../templates/<template> Makefile
</pre>
