### PR TITLE
Initial commit of SDL2_mixer version 2.0.1

### DIFF
--- a/components/encumbered/SDL2_mixer/Makefile
+++ b/components/encumbered/SDL2_mixer/Makefile
@@ -1,0 +1,78 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Jim Klimov
+#
+
+# NOTE: This recipe supports both "encumbered" and "license-clean"
+# builds (with or without MP3 support). See Makefile.not-encumbered
+# which includes this one as an example that could be delivered as
+# $(WS_TOP)/library/SDL2_mixer/Makefile in some other reality.
+# That file's contents would be just two lines like these:
+### USE_ENCUMBERED=no
+### include ../../encumbered/SDL2_mixer/Makefile
+
+# This file (by default) provides the package with encumbered code
+# or inseparable run-time dependencies:
+USE_ENCUMBERED?=yes
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		SDL2_mixer
+COMPONENT_VERSION=	2.0.1
+COMPONENT_PROJECT_URL=	http://www.libsdl.org/projects/SDL_mixer/
+COMPONENT_SUMMARY=	SDL_mixer is a sample multi-channel audio mixer library
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:5a24f62a610249d744cbd8d28ee399d8905db7222bf3bdbc8a8b4a76e597695f
+COMPONENT_ARCHIVE_URL=	http://www.libsdl.org/projects/SDL_mixer/release/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=	library/audio/sdl2-mixer
+COMPONENT_LICENSE =	ZLIB
+COMPONENT_LICENSE_FILE =	COPYING.txt
+COMPONENT_CLASSIFICATION =	System/Multimedia Libraries
+
+ifeq ($(strip $(USE_ENCUMBERED)),yes)
+COMPONENT_SUMMARY:=$(COMPONENT_SUMMARY) (encumbered version)
+include $(WS_TOP)/make-rules/encumbered.mk
+endif
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+PATH=/usr/gnu/bin:/usr/bin
+
+COMPONENT_PREP_ACTION = ( cd $(@D) && ./autogen.sh )
+
+CONFIGURE_OPTIONS +=	--sysconfdir=/etc
+CONFIGURE_OPTIONS +=	--libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
+CONFIGURE_OPTIONS +=	--enable-music-cmd
+CONFIGURE_OPTIONS +=	--enable-music-wave
+CONFIGURE_OPTIONS +=	--enable-music-midi
+CONFIGURE_OPTIONS +=	--enable-music-mod-mikmod --enable-music-mod-mikmod-shared
+CONFIGURE_OPTIONS +=	--enable-music-ogg-shared
+CONFIGURE_OPTIONS +=	--enable-music-flac-shared
+
+### Note: currently we do not serve libmad in the fully open components,
+### it and MPEG support is reserved for encumbered components
+#CONFIGURE_OPTIONS +=	--enable-music-mp3-smpeg --enable-music-mp3-smpeg-shared
+ifeq ($(strip $(USE_ENCUMBERED)),yes)
+CONFIGURE_OPTIONS +=	--enable-music-mp3-mad-gpl
+else
+CONFIGURE_OPTIONS +=	--disable-music-mp3
+endif
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(NO_TESTS)

--- a/components/encumbered/SDL2_mixer/sdl2-mixer.p5m
+++ b/components/encumbered/SDL2_mixer/sdl2-mixer.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/SDL2/SDL_mixer.h
+
+file path=usr/lib/$(MACH64)/libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/$(MACH64)/libSDL2_mixer-2.0.so.0 target=libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/$(MACH64)/libSDL2_mixer.so target=libSDL2_mixer-2.0.so.0.0.1
+file path=usr/lib/$(MACH64)/pkgconfig/SDL2_mixer.pc
+
+file path=usr/lib/libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/libSDL2_mixer-2.0.so.0 target=libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/libSDL2_mixer.so target=libSDL2_mixer-2.0.so.0.0.1
+file path=usr/lib/pkgconfig/SDL2_mixer.pc


### PR DESCRIPTION
NOTE: For MOD file support, PR#1921 should be merged first. Note that the build is not failed otherwise, just the support will be missing, despite the "--enable" flags for configure.
