### PR TITLE
Add a way to NOT remove "corrupt" downloads when they are known new

### DIFF
--- a/README
+++ b/README
@@ -51,6 +51,21 @@ Getting the Bits
     directory and use 'gmake download' from that to only get it's source
     archive.
 
+    Also, when you start to work with a new archive file - update the source
+    version in an existing recipe component, or start a new one from scratch -
+    you can use 'gmake fetch' to download the archive(s) defined in the new
+    recipe, calculate the checksums and *NOT* remove the archive because its
+    actual checksum does not match the value recorded in the recipe Makefile
+    (if any) so the download is deemed corrupted while you know it is not.
+    There is also a side-effect: by framework recipe, a file in the download
+    location only depends on the component recipe Makefile. So once an archive
+    is "fetched" (downloaded and not removed), it will not be re-verified -
+    the downloading script is just not called. This is a moderate problem,
+    since the "fetch" ability is a helper for recipe-makers doing initial
+    archive downloads in a certain situation, to save some traffic and time
+    on their workstations. You can still remove files fetched by a recipe
+    using 'gmake clobber'.
+
 Building the Bits
 
     You can build individual components or the contents of the entire gate.

--- a/make-rules/prep-download.mk
+++ b/make-rules/prep-download.mk
@@ -38,6 +38,12 @@ FETCH =		$(WS_TOOLS)/userland-fetch
 URL_SUFFIXES = $(subst COMPONENT_ARCHIVE_URL_,, \
 		$(filter COMPONENT_ARCHIVE_URL_%, $(.VARIABLES)))
 
+# Argument to "userland-fetch" script that causes it to download and verify
+# files, but not to remove mismatches; good to save traffic when initially
+# fetching a new archive just to learn what checksum to expect in Makefile.
+#FETCH_KEEP ?= --keep
+FETCH_KEEP ?= 
+
 # Template for download rules.
 define download-rules
 ifdef COMPONENT_ARCHIVE_URL$(1)
@@ -45,10 +51,13 @@ ifdef COMPONENT_ARCHIVE_URL$(1)
 ARCHIVES += $$(COMPONENT_ARCHIVE$(1))
 CLOBBER_PATHS += $$(COMPONENT_ARCHIVE$(1))
 
+fetch::	FETCH_KEEP=--keep
+fetch::	$$(USERLAND_ARCHIVES)$$(COMPONENT_ARCHIVE$(1))
+
 download::	$$(USERLAND_ARCHIVES)$$(COMPONENT_ARCHIVE$(1))
 
 $$(USERLAND_ARCHIVES)$$(COMPONENT_ARCHIVE$(1)):	$(MAKEFILE_PREREQ)
-	$$(FETCH) --file $$@ \
+	$$(FETCH) $$(FETCH_KEEP) --file $$@ \
 		$$(COMPONENT_ARCHIVE_URL$(1):%=--url %) \
 		$$(COMPONENT_ARCHIVE_HASH$(1):%=--hash %) \
 		$$(COMPONENT_SIG_URL$(1):%=--sigurl %) \

--- a/tools/userland-fetch
+++ b/tools/userland-fetch
@@ -179,13 +179,14 @@ def main():
 	user_agent_arg = None
 	file_arg = None
 	link_arg = False
+	keep_arg = False
 	hash_arg = None
 	url_arg = None
 	search_list = list()
 
 	try:
-		opts, args = getopt.getopt(sys.argv[1:], "a:f:h:ls:u:",
-			["file=", "link", "hash=", "search=", "url=",
+		opts, args = getopt.getopt(sys.argv[1:], "a:f:h:lks:u:",
+			["file=", "link", "keep", "hash=", "search=", "url=",
 			"user-agent="])
 	except getopt.GetoptError, err:
 		print str(err)
@@ -198,6 +199,8 @@ def main():
 			file_arg = arg
 		elif opt in [ "-l", "--link" ]:
 			link_arg = True
+		elif opt in [ "-k", "--keep" ]:
+			keep_arg = True
 		elif opt in [ "-h", "--hash" ]:
 			hash_arg = arg
 		elif opt in [ "-s", "--search" ]:
@@ -255,10 +258,14 @@ def main():
 			print "    actual:   %s" % realhash
 			print "    payload:  %s" % payloadhash
 
-		try:
-			os.remove(name)
-		except OSError:
-			pass
+		if keep_arg == False:
+			try:
+				print "\nWARN: Removing the corrupt downloaded file"
+				os.remove(name)
+			except OSError:
+				pass
+		else:
+			print "\nINFO: Keeping the downloaded file because asked to"
 
 	sys.exit(1)
 


### PR DESCRIPTION
Extend userland-fetch with a --keep option to not delete files, and add a "gmake fetch" action to just download and verify (not remove) files.

Save traffic and gain speed as a result, when initially preparing a userland recipe for an archive with yet-unknown checksum.
