### PR TITLE
percona-server-57: avoid delivering private copy of libstdc++.so (fix…

### DIFF
--- a/components/database/percona-server-57/Makefile
+++ b/components/database/percona-server-57/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		percona-server
 COMPONENT_VERSION=	5.7.10-3
 IPS_COMPONENT_VERSION=	5.7.10.3
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_PROJECT_URL=	http://www.percona.com/
@@ -75,3 +75,15 @@ COMPONENT_POST_CMAKE_ACTION=$(COMPONENT_POST_CMAKE_ACTION.$(BITS))
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
+
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += database/percona-server-57/client
+REQUIRED_PACKAGES += database/percona-server-57/library
+REQUIRED_PACKAGES += library/readline
+REQUIRED_PACKAGES += library/security/openssl
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += shell/bash
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/g++-4-runtime
+REQUIRED_PACKAGES += system/library/gcc-4-runtime
+REQUIRED_PACKAGES += system/library/math

--- a/components/database/percona-server-57/percona-server-57lib.p5m
+++ b/components/database/percona-server-57/percona-server-57lib.p5m
@@ -140,11 +140,11 @@ link path=usr/percona-server/5.7/lib/$(MACH64)/libperconaserverclient.so \
 link path=usr/percona-server/5.7/lib/$(MACH64)/libperconaserverclient.so.20 \
     target=libperconaserverclient.so.20.1.0
 file path=usr/percona-server/5.7/lib/$(MACH64)/libperconaserverclient.so.20.1.0
-link path=usr/percona-server/5.7/lib/$(MACH64)/libstdc++.so \
-    target=libstdc++.so.6.0.20
-link path=usr/percona-server/5.7/lib/$(MACH64)/libstdc++.so.6 \
-    target=libstdc++.so.6.0.20
-file path=usr/percona-server/5.7/lib/$(MACH64)/libstdc++.so.6.0.20
+#link path=usr/percona-server/5.7/lib/$(MACH64)/libstdc++.so \
+#    target=libstdc++.so.6.0.20
+#link path=usr/percona-server/5.7/lib/$(MACH64)/libstdc++.so.6 \
+#    target=libstdc++.so.6.0.20
+#file path=usr/percona-server/5.7/lib/$(MACH64)/libstdc++.so.6.0.20
 file path=usr/percona-server/5.7/lib/$(MACH64)/pkgconfig/perconaserverclient.pc
 link path=usr/percona-server/5.7/lib/libgcc_s.so target=libgcc_s.so.1
 file path=usr/percona-server/5.7/lib/libgcc_s.so.1
@@ -156,7 +156,7 @@ link path=usr/percona-server/5.7/lib/libperconaserverclient.so \
 link path=usr/percona-server/5.7/lib/libperconaserverclient.so.20 \
     target=libperconaserverclient.so.20.1.0
 file path=usr/percona-server/5.7/lib/libperconaserverclient.so.20.1.0
-link path=usr/percona-server/5.7/lib/libstdc++.so target=libstdc++.so.6.0.20
-link path=usr/percona-server/5.7/lib/libstdc++.so.6 target=libstdc++.so.6.0.20
-file path=usr/percona-server/5.7/lib/libstdc++.so.6.0.20
+#link path=usr/percona-server/5.7/lib/libstdc++.so target=libstdc++.so.6.0.20
+#link path=usr/percona-server/5.7/lib/libstdc++.so.6 target=libstdc++.so.6.0.20
+#file path=usr/percona-server/5.7/lib/libstdc++.so.6.0.20
 file path=usr/percona-server/5.7/lib/pkgconfig/perconaserverclient.pc


### PR DESCRIPTION
…es build with gcc 5.3)
