### PR TITLE
(POC-RFC) SDL2_mixer dual-natured

### DIFF
--- a/components/encumbered/SDL2_mixer/Makefile
+++ b/components/encumbered/SDL2_mixer/Makefile
@@ -13,12 +13,14 @@
 #
 
 # NOTE: This recipe supports both "encumbered" and "license-clean"
-# builds (with or without MP3 support). See Makefile.not-encumbered
-# which includes this one as an example that could be delivered as
-# $(WS_TOP)/library/SDL2_mixer/Makefile in some other reality.
+# builds (with or without MP3 support).
+# A not-encumbered Makefile which includes this one could be delivered
+# as $(WS_TOP)/library/SDL2_mixer/Makefile in some other reality.
 # That file's contents would be just two lines like these:
 ### USE_ENCUMBERED=no
 ### include ../../encumbered/SDL2_mixer/Makefile
+# Also the other version of the component should deliver a symlink to
+# the P5M manifest.
 
 # This file (by default) provides the package with encumbered code
 # or inseparable run-time dependencies:
@@ -42,13 +44,15 @@ COMPONENT_CLASSIFICATION =	System/Multimedia Libraries
 
 ifeq ($(strip $(USE_ENCUMBERED)),yes)
 COMPONENT_SUMMARY:=$(COMPONENT_SUMMARY) (encumbered version)
-include $(WS_TOP)/make-rules/encumbered.mk
+include $(WS_MAKE_RULES)/encumbered.mk
 endif
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH.32=/usr/gnu/bin:/usr/bin
+PATH.64=/usr/gnu/bin:/usr/gnu/bin/$(MACH64):/usr/bin/$(MACH64):/usr/bin
+PATH=$(PATH.$(BITS))
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && ./autogen.sh )
 
@@ -61,11 +65,12 @@ CONFIGURE_OPTIONS +=	--enable-music-mod-mikmod --enable-music-mod-mikmod-shared
 CONFIGURE_OPTIONS +=	--enable-music-ogg-shared
 CONFIGURE_OPTIONS +=	--enable-music-flac-shared
 
+ifeq ($(strip $(USE_ENCUMBERED)),yes)
 ### Note: currently we do not serve libmad in the fully open components,
 ### it and MPEG support is reserved for encumbered components
 #CONFIGURE_OPTIONS +=	--enable-music-mp3-smpeg --enable-music-mp3-smpeg-shared
-ifeq ($(strip $(USE_ENCUMBERED)),yes)
 CONFIGURE_OPTIONS +=	--enable-music-mp3-mad-gpl
+REQUIRED_PACKAGES += library/audio/libmad
 else
 CONFIGURE_OPTIONS +=	--disable-music-mp3
 endif
@@ -76,3 +81,7 @@ build:		$(BUILD_32_and_64)
 install:	$(INSTALL_32_and_64)
 
 test:		$(NO_TESTS)
+
+REQUIRED_PACKAGES += library/sdl2
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/encumbered/SDL2_mixer/Makefile
+++ b/components/encumbered/SDL2_mixer/Makefile
@@ -30,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		SDL2_mixer
 COMPONENT_VERSION=	2.0.1
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	http://www.libsdl.org/projects/SDL_mixer/
 COMPONENT_SUMMARY=	SDL_mixer is a sample multi-channel audio mixer library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -50,6 +51,31 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
+# Prepare mediation for the two variants of the build
+### Alphanumerics only... conjure up a GMake conversion with patsubst?
+###MEDIATOR_NAME=		$(COMPONENT_NAME)
+MEDIATOR_NAME=		SDL2mixer
+MEDIATOR_VERSION=	$(COMPONENT_VERSION)
+ifeq ($(strip $(USE_ENCUMBERED)),yes)
+# Unencumbered version has lower default priority (none) if both are available
+MEDIATOR_PRIO=		vendor
+MEDIATOR_IMPLEM=	encumbered
+MEDIATOR_SUBDIR=	encumbered
+else
+MEDIATOR_PRIO=
+MEDIATOR_IMPLEM=	unencumbered
+MEDIATOR_SUBDIR=	unencumbered
+endif
+
+MEDIATOR_STRING=	mediator=$(MEDIATOR_NAME) mediator-version=$(MEDIATOR_VERSION) \
+	mediator-implementation=$(MEDIATOR_IMPLEM)
+ifneq ($(strip $(MEDIATOR_PRIO)),)
+MEDIATOR_STRING+=	mediator-priority=$(MEDIATOR_PRIO)
+endif
+
+PKG_OPTIONS +=  -D MEDIATOR_STRING="$(MEDIATOR_STRING)"
+PKG_OPTIONS +=  -D MEDIATOR_SUBDIR="$(MEDIATOR_SUBDIR)"
+
 PATH.32=/usr/gnu/bin:/usr/bin
 PATH.64=/usr/gnu/bin:/usr/gnu/bin/$(MACH64):/usr/bin/$(MACH64):/usr/bin
 PATH=$(PATH.$(BITS))
@@ -57,6 +83,9 @@ PATH=$(PATH.$(BITS))
 COMPONENT_PREP_ACTION = ( cd $(@D) && ./autogen.sh )
 
 CONFIGURE_OPTIONS +=	--sysconfdir=/etc
+CONFIGURE_OPTIONS +=	--disable-rpath
+CONFIGURE_OPTIONS +=	--disable-static
+CONFIGURE_OPTIONS +=	--enable-shared
 CONFIGURE_OPTIONS +=	--libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
 CONFIGURE_OPTIONS +=	--enable-music-cmd
 CONFIGURE_OPTIONS +=	--enable-music-wave

--- a/components/encumbered/SDL2_mixer/sdl2-mixer.p5m
+++ b/components/encumbered/SDL2_mixer/sdl2-mixer.p5m
@@ -22,14 +22,43 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/include/SDL2/SDL_mixer.h
+# Original object stuffed into subdirs
+file usr/include/SDL2/SDL_mixer.h path=usr/include/SDL2/$(MEDIATOR_SUBDIR)/SDL_mixer.h
 
-file path=usr/lib/$(MACH64)/libSDL2_mixer-2.0.so.0.0.1
-link path=usr/lib/$(MACH64)/libSDL2_mixer-2.0.so.0 target=libSDL2_mixer-2.0.so.0.0.1
-link path=usr/lib/$(MACH64)/libSDL2_mixer.so target=libSDL2_mixer-2.0.so.0.0.1
-file path=usr/lib/$(MACH64)/pkgconfig/SDL2_mixer.pc
+file usr/lib/$(MACH64)/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/$(MACH64)/$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/$(MACH64)/$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0 \
+     target=libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/$(MACH64)/$(MEDIATOR_SUBDIR)/libSDL2_mixer.so \
+     target=libSDL2_mixer-2.0.so.0.0.1
+file usr/lib/$(MACH64)/pkgconfig/SDL2_mixer.pc \
+     path=usr/lib/$(MACH64)/pkgconfig/$(MEDIATOR_SUBDIR)/SDL2_mixer.pc
 
-file path=usr/lib/libSDL2_mixer-2.0.so.0.0.1
-link path=usr/lib/libSDL2_mixer-2.0.so.0 target=libSDL2_mixer-2.0.so.0.0.1
-link path=usr/lib/libSDL2_mixer.so target=libSDL2_mixer-2.0.so.0.0.1
-file path=usr/lib/pkgconfig/SDL2_mixer.pc
+file usr/lib/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0 target=libSDL2_mixer-2.0.so.0.0.1
+link path=usr/lib/$(MEDIATOR_SUBDIR)/libSDL2_mixer.so target=libSDL2_mixer-2.0.so.0.0.1
+file usr/lib/pkgconfig/SDL2_mixer.pc \
+     path=usr/lib/pkgconfig/$(MEDIATOR_SUBDIR)/SDL2_mixer.pc
+
+# Mediation links
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/SDL_mixer.h \
+     path=usr/include/SDL2/SDL_mixer.h
+
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/$(MACH64)/libSDL2_mixer-2.0.so.0.0.1
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/$(MACH64)/libSDL2_mixer-2.0.so.0
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/$(MACH64)/libSDL2_mixer.so
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/SDL2_mixer.pc \
+     path=usr/lib/$(MACH64)/pkgconfig/SDL2_mixer.pc
+
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/libSDL2_mixer-2.0.so.0.0.1
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/libSDL2_mixer-2.0.so.0
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/libSDL2_mixer-2.0.so.0.0.1 \
+     path=usr/lib/libSDL2_mixer.so
+link $(MEDIATOR_STRING) target=$(MEDIATOR_SUBDIR)/SDL2_mixer.pc \
+     path=usr/lib/pkgconfig/SDL2_mixer.pc

--- a/components/library/SDL2_mixer/Makefile
+++ b/components/library/SDL2_mixer/Makefile
@@ -1,0 +1,3 @@
+USE_ENCUMBERED=no
+include ../../encumbered/SDL2_mixer/Makefile
+

--- a/components/library/SDL2_mixer/sdl2-mixer.p5m
+++ b/components/library/SDL2_mixer/sdl2-mixer.p5m
@@ -1,0 +1,1 @@
+../../encumbered/SDL2_mixer/sdl2-mixer.p5m


### PR DESCRIPTION
As mentioned on IRC, I wonder if it is feasible to provide both a more feature-rich but encumbered package vs. a less featured but license-safe package. Ultimate consumers (in this case multimedia or games packages) would simply declare `pkg depend fmri=taxonomypath/packagename` and either variant of the package would satisfy such requirement (so if user has set up encumbered repo, he'd likely get this build of the package installed and enabled, as it has a higher priority).

In this PoC both packages use the same Makefile and P5M packaging manifest, variations done with conditionals and appropriately exported PKG variables that control mediated-link delivery and enablement of the two builds.

Quoting from the IRC (http://echelog.com/logs/browse/oi-dev/1463695200): 

> (23:09:19) jimklimov: Hi all, got a policy sort of question
> as I recently tackled some media libraries, trying to lay foundations for builds of multimedia apps such as games, I tried to produce recipes that offer as much as a library can - usually by aggregating as many third-party projects as we can reasonably produce in oi-userland. So these are big snowballs ;)
> one area where this goes sour is stepping on encumbered packages, and it is even "sadder" when this is an optional dependency that is nice-to-have but not a life-critical one, usually
> for example, many games allow a user to play his own playlist, so if he has MP3 support - he can play those tracks to; if not - no really big deal
> most recent precedents in PRs led to piling such cover-all libraries into encumbered, since they do link against LAME or somesuch uncertain software
> however I keep thinking that it would not be technically difficult to pkg-mediate safe vs. encumbered versions, including configuration by essentially one makefile (PR for sdl_mixer PoC'ed that aspect of a single recipe for both encumbered and safe builds, although without mediation at that moment, but in the end the feature was cut from the PR)
> so... is there a big reason not to do such double-recipes whose results are independent, mediated and mutually exclusive safe and encumbered packages (latter having more features, usually)
