### PR TITLE
Initial recipe for FreeIPMI version 1.5.1

### DIFF
--- a/components/sysutils/freeipmi/Makefile
+++ b/components/sysutils/freeipmi/Makefile
@@ -1,0 +1,82 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+#   via checkout freeipmi_sfw-gate_oi151a~0.7.7~9c2a4ac793f0
+# Copyright 2016 Jim Klimov
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		freeipmi
+COMPONENT_VERSION=	1.5.1
+COMPONENT_SUMMARY=	GNU FreeIPMI - in-band and out-of-band IPMI
+COMPONENT_DESCRIPTION=	GNU FreeIPMI - in-band and out-of-band IPMI software based on the \
+IPMI v1.5/2.0 specification ($(COMPONENT_VERSION))
+COMPONENT_FMRI=	system/management/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION=	System/Hardware
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:47985ab902a62e23aba60e30a9fba5190599eecbc107d442e8b948a220ed1252
+COMPONENT_PROJECT_URL=	http://www.gnu.org/software/freeipmi/
+COMPONENT_ARCHIVE_URL=	\
+	http://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE_FILE=	COPYING
+COMPONENT_LICENSE=	GPLv2
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CFLAGS += $(CPP_LARGEFILES) -DMAXHOSTNAMELEN=256
+CPPFLAGS += $(CPP_LARGEFILES) -DMAXHOSTNAMELEN=256
+
+USRLIBDIR.32=$(USRLIBDIR)
+USRLIBDIR.64=$(USRLIBDIR64)
+
+COMPONENT_PREP_ACTION = \
+    (cd $(@D) &&\
+        aclocal -I . &&\
+        autoheader &&\
+        automake -a -f -c --gnu &&\
+        autoconf &&\
+        $(RM) config.h )
+
+# Missing files in build dir for configure without this
+COMPONENT_PRE_CONFIGURE_ACTION =	($(CLONEY) $(SOURCE_DIR) $(@D))
+
+#       configure(1) options to use
+# a default --prefix and --mandir are set in make-rules
+CONFIGURE_OPTIONS += --with-dont-check-for-root
+CONFIGURE_OPTIONS += --sysconfdir=/etc
+CONFIGURE_OPTIONS += --localstatedir=/var
+CONFIGURE_OPTIONS += --infodir=/usr/share/doc/freeipmi/info
+CONFIGURE_OPTIONS += --enable-static=no
+CONFIGURE_OPTIONS += --libdir=$(USRLIBDIR.$(BITS))
+
+# This is needed to avoid using CCACHE for CPP in this recipe:
+# they use CPP to build manpages! Go figure...
+CONFIGURE_ENV += CPP=$(GCC_ROOT)/bin/cpp
+
+build:		$(BUILD_32_and_64)
+
+# Ensure 32-bit configs are installed last
+$(INSTALL_32): $(INSTALL_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(NO_TESTS)
+
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += system/library/security/libgcrypt

--- a/components/sysutils/freeipmi/Solaris/bmc-watchdog.xml
+++ b/components/sysutils/freeipmi/Solaris/bmc-watchdog.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0"?>
+<!--
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+or http://www.opensolaris.org/os/licensing.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+	Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+	Use is subject to license terms.
+	# Copyright 2016 Jim Klimov
+
+#	ident	"@(#)bmc-watchdog.xml	1.1	09/08/14 SMI"
+-->
+
+<service_bundle type='manifest' name='SUNWfreeipmir:bmc-watchdog'>
+
+	<service name='system/freeipmi/bmc-watchdog' type='service' version='1'>
+
+	<!--
+	  Configure a default instance for the service since it doesn't
+	  require additional configuration intervention before it starts.
+	-->
+		<create_default_instance enabled='false' />
+
+	<!--
+	  Wait for all usr filesystem to be mounted. bmc-watchdog is
+	  located in /usr/sbin.
+	-->
+		<dependency
+		name='filesystem-usr'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri
+		value='svc:/system/filesystem/usr:default'/>
+		</dependency>
+
+	<!--
+	  Wait for syslog to be started in order to write system
+	  messages from the kernel.
+	-->
+		<dependency
+		name='syslog'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri
+		value='svc:/system/system-log:default'/>
+		</dependency>
+
+	<!--
+	  The bmc-watchdog start/stop methods.
+	-->
+
+		<exec_method
+		type='method'
+		name='start'
+		exec='/lib/svc/method/svc-bmc-watchdog %m'
+		timeout_seconds='60'/>
+
+		<exec_method
+		type='method'
+		name='stop'
+		exec=':kill'
+		timeout_seconds='60' />
+
+		<property_group name='startd' type='framework'>
+		<!--
+		  Sub-process core dumps and external kill signals are not
+		  considered errors, so the service should be restarted.
+			-->
+			<propval name='ignore_error' type='astring'
+			 value='core,signal' />
+		</property_group>
+
+		<property_group name='config' type='application' >
+			<propval name='options' type='astring' value='-u 4 -p 0 -a 1 -F -P -L -S -O -i 900 -e 60'/>
+<!-- Enable scripted looping if the BMC daemon fails while the BMC Watchdog is
+  in fact started (errata applied to at least some Sun Fire X4*** models)? -->
+			<propval name='force-looping' type='boolean' value='false'/>
+			<propval name='bmcdev-required' type='boolean' value='true'/>
+			<propval name='bmcdev' type='astring' value='/dev/ipmi0'/>
+<!-- Legacy default (with proprietary driver): -->
+<!--
+			<propval name='bmcdev' type='astring' value='/dev/bmc'/>
+-->
+		</property_group>
+
+		<stability value='Unstable' />
+
+		<template>
+			<common_name>
+				<loctext xml:lang='C'>
+				Baseboard Management Controller (BMC) watchdog timer daemon
+				</loctext>
+			</common_name>
+			<documentation>
+				<manpage title='bmc-watchdog' section='8'
+				manpath='/usr/share/man' />
+			</documentation>
+		</template>
+	</service>
+
+</service_bundle>

--- a/components/sysutils/freeipmi/Solaris/ipmidetectd.xml
+++ b/components/sysutils/freeipmi/Solaris/ipmidetectd.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<!--
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+or http://www.opensolaris.org/os/licensing.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+	Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+	Use is subject to license terms.
+	# Copyright 2016 Jim Klimov
+
+#	ident	"@(#)ipmidetectd.xml	1.1	09/08/14 SMI"
+-->
+
+<service_bundle type='manifest' name='SUNWfreeipmir:ipmidetectd'>
+
+	<service name='system/freeipmi/ipmidetectd' type='service' version='1'>
+
+	<!--
+	  Configure a default instance for the service since it doesn't
+	  require additional configuration intervention before it starts.
+	-->
+		<create_default_instance enabled='false' />
+			
+	<!--
+	  Wait for all local and usr filesystem to be mounted. ipmidetectd is
+	  located in /usr/sbin.
+	-->
+		<dependency
+		name='fs-local'
+		type='service'
+		grouping='require_all'
+		restart_on='none'>
+			<service_fmri value='svc:/system/filesystem/local' />
+		</dependency>
+		
+		<dependency
+		name='filesystem-usr'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri
+		value='svc:/system/filesystem/usr:default'/>
+		</dependency>
+
+	<!--
+	  Wait for syslog to be started in order to write system
+	  messages from the kernel.
+	-->
+		<dependency
+		name='syslog'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri
+		value='svc:/system/system-log:default'/>
+		</dependency>
+
+	<!--
+	  Wait for network to be started in order to reach remote hosts.
+	-->
+		<dependency
+		name='network-service'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri value='svc:/network/service' />
+		</dependency>
+
+	<!--
+	  The ipmidetectd start/stop methods.
+	-->
+
+		<exec_method
+		type='method'
+		name='start'
+		exec='/lib/svc/method/svc-ipmidetectd %m'
+		timeout_seconds='60'/>
+
+		<exec_method
+		type='method'
+		name='stop'
+		exec=':kill'
+		timeout_seconds='60' />
+
+		<property_group name='startd' type='framework'>
+		<!--
+		  Sub-process core dumps and external kill signals are not
+		  considered errors, so the service should be restarted.
+			-->
+			<propval name='ignore_error' type='astring'
+			 value='core,signal' />
+		</property_group>
+
+		<property_group name='config' type='application' >
+			<propval name='options' type='astring' value='-c /etc/freeipmi/ipmidetectd.conf'/>
+			<propval name='bmcdev-required' type='boolean' value='false'/>
+			<propval name='bmcdev' type='astring' value='/dev/ipmi0'/>
+<!-- Legacy default (with proprietary driver): -->
+<!--
+			<propval name='bmcdev' type='astring' value='/dev/bmc'/>
+-->
+		</property_group>
+
+		<stability value='Unstable' />
+
+		<template>
+			<common_name>
+				<loctext xml:lang='C'>
+				IPMI node detection monitoring daemon
+				</loctext>
+			</common_name>
+			<documentation>
+				<manpage title='ipmidetectd' section='8'
+				manpath='/usr/share/man' />
+				<manpage title='ipmidetectd.conf' section='5'
+				manpath='/usr/share/man' />
+			</documentation>
+		</template>
+	</service>
+
+</service_bundle>

--- a/components/sysutils/freeipmi/Solaris/ipmiseld.xml
+++ b/components/sysutils/freeipmi/Solaris/ipmiseld.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<!--
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+or http://www.opensolaris.org/os/licensing.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+	Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+	Use is subject to license terms.
+	Copyright 2016 Jim Klimov
+
+#	ident	"@(#)ipmidetectd.xml	1.1	09/08/14 SMI"
+-->
+
+<service_bundle type='manifest' name='SUNWfreeipmir:ipmiseld'>
+
+	<service name='system/freeipmi/ipmiseld' type='service' version='1'>
+
+	<!--
+	  Configure a default instance for the service since it doesn't
+	  require additional configuration intervention before it starts.
+	-->
+		<create_default_instance enabled='false' />
+
+	<!--
+	  Wait for all local and usr filesystem to be mounted. ipmiseld is
+	  located in /usr/sbin.
+	-->
+		<dependency
+		name='fs-local'
+		type='service'
+		grouping='require_all'
+		restart_on='none'>
+			<service_fmri value='svc:/system/filesystem/local' />
+		</dependency>
+		
+		<dependency
+		name='filesystem-usr'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri
+		value='svc:/system/filesystem/usr:default'/>
+		</dependency>
+
+	<!--
+	  Wait for syslog to be started in order to write system
+	  messages from the kernel.
+	-->
+		<dependency
+		name='syslog'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri
+		value='svc:/system/system-log:default'/>
+		</dependency>
+
+	<!--
+	  Wait for network to be started in order to reach remote hosts.
+	-->
+		<dependency
+		name='network-service'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+			<service_fmri value='svc:/network/service' />
+		</dependency>
+
+	<!--
+	  The ipmiseld start/stop methods.
+	-->
+
+		<exec_method
+		type='method'
+		name='start'
+		exec='/lib/svc/method/svc-ipmiseld %m'
+		timeout_seconds='60'/>
+
+		<exec_method
+		type='method'
+		name='stop'
+		exec=':kill'
+		timeout_seconds='60' />
+
+		<property_group name='startd' type='framework'>
+		<!--
+		  Sub-process core dumps and external kill signals are not
+		  considered errors, so the service should be restarted.
+			-->
+			<propval name='ignore_error' type='astring'
+			 value='core,signal' />
+		</property_group>
+
+		<property_group name='config' type='application' >
+			<propval name='options' type='astring' value='-c /etc/freeipmi/ipmiseld.conf'/>
+			<propval name='bmcdev-required' type='boolean' value='false'/>
+			<propval name='bmcdev' type='astring' value='/dev/ipmi0'/>
+<!-- Legacy default (with proprietary driver): -->
+<!--
+			<propval name='bmcdev' type='astring' value='/dev/bmc'/>
+-->
+		</property_group>
+
+		<stability value='Unstable' />
+
+		<template>
+			<common_name>
+				<loctext xml:lang='C'>
+				IPMI SEL syslog logging daemon
+				</loctext>
+			</common_name>
+			<documentation>
+				<manpage title='ipmiseld' section='8'
+				manpath='/usr/share/man' />
+				<manpage title='ipmiseld.conf' section='5'
+				manpath='/usr/share/man' />
+			</documentation>
+		</template>
+	</service>
+
+</service_bundle>

--- a/components/sysutils/freeipmi/Solaris/svc-bmc-watchdog
+++ b/components/sysutils/freeipmi/Solaris/svc-bmc-watchdog
@@ -1,0 +1,123 @@
+#!/bin/sh
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+# Copyright 2016 Jim Klimov
+#
+#	ident	"@(#)svc-bmc-watchdog	1.1	09/08/14 SMI"
+
+# These are the SMF start/stop/restart methods for bmc-watchdog.
+
+# smf(5)
+. /lib/svc/share/smf_include.sh
+
+[ -n "${SMF_FMRI-}" ] || \
+SMF_FMRI="svc:/system/freeipmi/bmc-watchdog"
+
+if [ $# -eq 0 ]; then
+	# No arguments provided - report current status (use "-c" option to
+	# svcprop to get the current properties, otherwise false will result)
+	if [ "`/usr/bin/svcs -Ho STATE $SMF_FMRI`" = "enabled" ]
+	then
+		echo "svc-bmc-watchdog: bmc-watchdog is enabled"
+	else
+		echo "svc-bmc-watchdog: bmc-watchdog is disabled"
+	fi
+else
+	case "$1" in
+	'start')
+		# bmc-watchdog requires the presence of a BMC character device
+		# to run.  If one is not detected, then disable the service
+		# and exit.
+
+		[ -n "$SMF_FMRI" ] && \
+			BMCDEV="`/usr/bin/svcprop -p config/bmcdev "$SMF_FMRI"`" \
+			&& [ -n "$BMCDEV" ] \
+		|| BMCDEV="/dev/ipmi0"
+		# NOTE: OpenSolaris legacy (proprietary driver) used and required /dev/bmc
+		[ -n "$SMF_FMRI" ] && \
+			BMCDEVREQ="`/usr/bin/svcprop -p config/bmcdev-required "$SMF_FMRI"`" \
+			&& [ -n "$BMCDEVREQ" ] \
+		|| BMCDEVREQ="true"
+
+		# Enable workaround for bad BMCs?
+		[ -n "$SMF_FMRI" ] && \
+			FORCELOOPING="`/usr/bin/svcprop -p config/force-looping "$SMF_FMRI"`" \
+			&& [ -n "$FORCELOOPING" ] \
+		|| FORCELOOPING="false"
+
+		if [ ! -c "$BMCDEV" ]; then
+			if [ "$BMCDEVREQ" = true ]; then
+				echo "$0:  No BMC device found at \"$BMCDEV\": disabling $SMF_FMRI as the device is required in config."
+				/usr/sbin/svcadm disable $SMF_FMRI
+				exit $SMF_EXIT_OK
+			else
+				echo "$0:  No BMC device found at \"$BMCDEV\"; config of $SMF_FMRI says we do not require one."
+			fi
+		fi
+
+		props="`/usr/sbin/svccfg -s $SMF_FMRI listprop config/options | \
+			/usr/bin/nawk '{  for (i = 3; i <= NF; i++) printf $i" " }'`"
+		props="`echo "$props" | sed -e 's/.\(.*\)/\1/' -e 's/\(.*\)./\1/'`"
+
+		if [ -z "$props" ]; then
+			echo "bmc-watchdog needs to be configured. Set options as \
+				svccfg -s $SMF_FMRI setprop \
+					config/options '\"-p 0 -a 1 -F -P -S -O -i 900 -e 60 -u 4\"'"
+			exit $SMF_EXIT_ERR_CONFIG
+		fi
+
+		echo "bmc-watchdog is configured with options \"$props\""
+
+		/usr/sbin/bmc-watchdog -y  > /dev/null 2>&1
+		/usr/sbin/bmc-watchdog -d $props > /dev/null 2>&1
+		RES=$?
+
+		if [ "$FORCELOOPING" = true ]; then
+			### Daemon fails on X4500 without error, because the timer
+			### flag remains "Stopped" even though the clock is ticking.
+			### This simple loop should reset the timer every minute.
+			while true ; do
+				sleep 60
+				/usr/sbin/bmc-watchdog -t
+				STATE="`/usr/bin/svcs -H -o state $SMF_FMRI`"
+				[ x"$STATE" != xonline ] && \
+					echo "`date`: SMF stop requested (STATE='$STATE'), aborting loop" && \
+					exit $SMF_EXIT_OK
+			done &
+
+			[ $? -ne 0 ] && exit $SMF_EXIT_ERR_FATAL
+		else
+			[ $RES -ne 0 ] && exit $SMF_EXIT_ERR_FATAL
+		fi
+		;;
+
+	*)
+		echo "Usage: $0 start"
+		exit $SMF_EXIT_ERR_FATAL
+		;;
+	esac
+fi
+
+exit $SMF_EXIT_OK

--- a/components/sysutils/freeipmi/Solaris/svc-ipmidetectd
+++ b/components/sysutils/freeipmi/Solaris/svc-ipmidetectd
@@ -1,0 +1,100 @@
+#!/bin/sh
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+# Copyright 2016 Jim Klimov
+#
+#	ident	"@(#)svc-ipmidetectd	1.1	09/08/14 SMI"
+
+# These are the SMF start/stop/restart methods for ipmidetectd.
+
+# smf(5)
+. /lib/svc/share/smf_include.sh
+
+[ -n "${SMF_FMRI-}" ] || \
+SMF_FMRI="svc:/system/freeipmi/ipmidetectd"
+
+if [ $# -eq 0 ]; then
+	# No arguments provided - report current status (use "-c" option to
+	# svcprop to get the current properties, otherwise false will result)
+	if [ "`/usr/bin/svcs -Ho STATE $SMF_FMRI`" = "enabled" ]
+	then
+		echo "svc-ipmidetectd: ipmidetectd is enabled"
+	else
+		echo "svc-ipmidetectd: ipmidetectd is disabled"
+	fi
+else
+	case "$1" in
+	'start')
+		# ipmidetectd requires the presence of a BMC character device
+		# to run.  If one is not detected, then disable the service
+		# and exit.
+		# UPDATE: Actually it can also work over network, so our SMF
+		# manifest default (in XML) is BMCDEVREQ="false".
+
+		[ -n "$SMF_FMRI" ] && \
+			BMCDEV="`/usr/bin/svcprop -p config/bmcdev "$SMF_FMRI"`" \
+			&& [ -n "$BMCDEV" ] \
+		|| BMCDEV="/dev/ipmi0"
+		# NOTE: OpenSolaris legacy (proprietary driver) used and required /dev/bmc
+		[ -n "$SMF_FMRI" ] && \
+			BMCDEVREQ="`/usr/bin/svcprop -p config/bmcdev-required "$SMF_FMRI"`" \
+			&& [ -n "$BMCDEVREQ" ] \
+		|| BMCDEVREQ="true"
+
+		if [ ! -c "$BMCDEV" ]; then
+			if [ "$BMCDEVREQ" = true ]; then
+				echo "$0:  No BMC device found at \"$BMCDEV\": disabling $SMF_FMRI as the device is required in config."
+				/usr/sbin/svcadm disable $SMF_FMRI
+				exit $SMF_EXIT_OK
+			else
+				echo "$0:  No BMC device found at \"$BMCDEV\"; config of $SMF_FMRI says we do not require one."
+			fi
+		fi
+
+		props="`/usr/sbin/svccfg -s $SMF_FMRI listprop config/options | \
+			/usr/bin/nawk '{  for (i = 3; i <= NF; i++) printf $i" " }'`"
+		props="`echo "$props" | sed -e 's/.\(.*\)/\1/' -e 's/\(.*\)./\1/'`"
+
+		if [ -z "$props" ]; then
+			echo "ipmidetectd needs to be configured. Set options as \
+			svccfg -s $SMF_FMRI setprop \
+				config/options '\"-c /etc/freeipmi/ipmidetectd.conf\"'"
+			exit $SMF_EXIT_ERR_CONFIG
+		fi
+
+		echo "The ipmidetectd is configured with options \"$props\"."
+		echo "If $SMF_FMRI is in maintenance state, ipmidetectd failed to start - check if configuration file correct."
+
+		/usr/sbin/ipmidetectd $props > /dev/null 2>&1 &
+		;;
+
+	* )
+		echo "Usage: $0 start"
+		exit $SMF_EXIT_ERR_FATAL
+		;;
+	esac
+fi
+
+exit $SMF_EXIT_OK

--- a/components/sysutils/freeipmi/Solaris/svc-ipmiseld
+++ b/components/sysutils/freeipmi/Solaris/svc-ipmiseld
@@ -1,0 +1,100 @@
+#!/bin/sh
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+# Copyright 2016 Jim Klimov
+#
+#	ident	"@(#)svc-ipmidetectd	1.1	09/08/14 SMI"
+
+# These are the SMF start/stop/restart methods for ipmiseld.
+
+# smf(5)
+. /lib/svc/share/smf_include.sh
+
+[ -n "${SMF_FMRI-}" ] || \
+SMF_FMRI="svc:/system/freeipmi/ipmiseld"
+
+if [ $# -eq 0 ]; then
+	# No arguments provided - report current status (use "-c" option to
+	# svcprop to get the current properties, otherwise false will result)
+	if [ "`/usr/bin/svcs -Ho STATE $SMF_FMRI`" = "enabled" ]
+	then
+		echo "svc-ipmiseld: ipmiseld is enabled"
+	else
+		echo "svc-ipmiseld: ipmiseld is disabled"
+	fi
+else
+	case "$1" in
+	'start')
+		# ipmiseld requires the presence of a BMC character device
+		# to run.  If one is not detected, then disable the service
+		# and exit.
+		# UPDATE: Actually it can also work over network, so our SMF
+		# manifest default (in XML) is BMCDEVREQ="false".
+
+		[ -n "$SMF_FMRI" ] && \
+			BMCDEV="`/usr/bin/svcprop -p config/bmcdev "$SMF_FMRI"`" \
+			&& [ -n "$BMCDEV" ] \
+		|| BMCDEV="/dev/ipmi0"
+		# NOTE: OpenSolaris legacy (proprietary driver) used and required /dev/bmc
+		[ -n "$SMF_FMRI" ] && \
+			BMCDEVREQ="`/usr/bin/svcprop -p config/bmcdev-required "$SMF_FMRI"`" \
+			&& [ -n "$BMCDEVREQ" ] \
+		|| BMCDEVREQ="true"
+
+		if [ ! -c "$BMCDEV" ]; then
+			if [ "$BMCDEVREQ" = true ]; then
+				echo "$0:  No BMC device found at \"$BMCDEV\": disabling $SMF_FMRI as the device is required in config."
+				/usr/sbin/svcadm disable $SMF_FMRI
+				exit $SMF_EXIT_OK
+			else
+				echo "$0:  No BMC device found at \"$BMCDEV\"; config of $SMF_FMRI says we do not require one."
+			fi
+		fi
+
+		props="`/usr/sbin/svccfg -s $SMF_FMRI listprop config/options | \
+			/usr/bin/nawk '{  for (i = 3; i <= NF; i++) printf $i" " }'`"
+		props="`echo "$props" | sed -e 's/.\(.*\)/\1/' -e 's/\(.*\)./\1/'`"
+
+		if [ -z "$props" ]; then
+				echo "ipmiseld needs to be configured. Set options as \
+				svccfg -s $SMF_FMRI setprop \
+					config/options '\"-c /etc/freeipmi/ipmiseld.conf\"'"
+				exit $SMF_EXIT_ERR_CONFIG
+		fi
+
+		echo "The ipmiseld is configured with options \"$props\"."
+		echo "If $SMF_FMRI is in maintenance state, ipmiseld failed to start - check if configuration file correct."
+
+		/usr/sbin/ipmiseld $props > /dev/null 2>&1 &
+		;;
+
+	* )
+		echo "Usage: $0 start"
+		exit $SMF_EXIT_ERR_FATAL
+		;;
+	esac
+fi
+
+exit $SMF_EXIT_OK

--- a/components/sysutils/freeipmi/bmc-watchdog.p5m
+++ b/components/sysutils/freeipmi/bmc-watchdog.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/system/management/bmc-watchdog@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="A local BMC-polling watchdog service"
+set name=pkg.description value="A local BMC-polling watchdog service based on freeipmi software and driver/ipmi"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+depend type=require fmri=pkg:/driver/ipmi
+
+#file path=etc/init.d/bmc-watchdog
+#file path=etc/sysconfig/bmc-watchdog preserve=true
+
+file Solaris/bmc-watchdog.xml \
+     path=lib/svc/manifest/application/bmc-watchdog.xml \
+     restart_fmri=svc:/system/manifest-import:default
+
+file Solaris/svc-bmc-watchdog path=lib/svc/method/svc-bmc-watchdog

--- a/components/sysutils/freeipmi/freeipmi.p5m
+++ b/components/sysutils/freeipmi/freeipmi.p5m
@@ -1,0 +1,511 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.description value="$(COMPONENT_DESCRIPTION)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/freeipmi/freeipmi.conf preserve=true
+file path=etc/freeipmi/freeipmi_interpret_sel.conf preserve=true
+file path=etc/freeipmi/freeipmi_interpret_sensor.conf preserve=true
+file path=etc/freeipmi/ipmidetect.conf preserve=true
+file path=etc/freeipmi/ipmidetectd.conf preserve=true
+file path=etc/freeipmi/ipmiseld.conf preserve=true
+file path=etc/freeipmi/libipmiconsole.conf preserve=true
+
+### NOTE: bmc-watchdog programs are delivered by this (freeipmi) package; but
+### the SMF service and binding to driver/ipmi are in bmc-watchdog package.
+### Not all deployments of freeipmi have a desire or (HW) ability to monitor a
+### local BMC, rather than networked remote IPMI cards.
+
+#file path=etc/init.d/ipmidetectd
+#file path=etc/init.d/ipmiseld
+
+file Solaris/ipmidetectd.xml \
+     path=lib/svc/manifest/application/ipmidetectd.xml \
+     restart_fmri=svc:/system/manifest-import:default
+file Solaris/ipmiseld.xml \
+     path=lib/svc/manifest/application/ipmiseld.xml \
+     restart_fmri=svc:/system/manifest-import:default
+
+file Solaris/svc-ipmidetectd  path=lib/svc/method/svc-ipmidetectd
+file Solaris/svc-ipmiseld     path=lib/svc/method/svc-ipmiseld
+
+file path=usr/include/freeipmi/api/ipmi-api.h
+file path=usr/include/freeipmi/api/ipmi-chassis-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-dcmi-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-device-global-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-event-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-firmware-firewall-command-discovery-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-fru-inventory-device-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-lan-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-messaging-support-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-oem-intel-node-manager-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-pef-and-alerting-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-rmcpplus-support-and-payload-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-sdr-repository-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-sel-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-sensor-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-serial-modem-cmds-api.h
+file path=usr/include/freeipmi/api/ipmi-sol-cmds-api.h
+file path=usr/include/freeipmi/cmds/ipmi-bmc-watchdog-timer-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-chassis-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-dcmi-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-dcmi-oem-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-device-global-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-event-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-firmware-firewall-command-discovery-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-fru-inventory-device-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-lan-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-messaging-support-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-oem-intel-node-manager-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-pef-and-alerting-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-rmcpplus-support-and-payload-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-sdr-repository-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-sel-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-sensor-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-serial-modem-cmds.h
+file path=usr/include/freeipmi/cmds/ipmi-sol-cmds.h
+file path=usr/include/freeipmi/cmds/rmcp-cmds.h
+file path=usr/include/freeipmi/debug/ipmi-debug.h
+file path=usr/include/freeipmi/driver/ipmi-inteldcmi-driver.h
+file path=usr/include/freeipmi/driver/ipmi-kcs-driver.h
+file path=usr/include/freeipmi/driver/ipmi-openipmi-driver.h
+file path=usr/include/freeipmi/driver/ipmi-ssif-driver.h
+file path=usr/include/freeipmi/driver/ipmi-sunbmc-driver.h
+file path=usr/include/freeipmi/fiid/fiid.h
+file path=usr/include/freeipmi/freeipmi.h
+file path=usr/include/freeipmi/fru/ipmi-fru.h
+file path=usr/include/freeipmi/interface/ipmi-interface.h
+file path=usr/include/freeipmi/interface/ipmi-ipmb-interface.h
+file path=usr/include/freeipmi/interface/ipmi-kcs-interface.h
+file path=usr/include/freeipmi/interface/ipmi-lan-interface.h
+file path=usr/include/freeipmi/interface/ipmi-rmcpplus-interface.h
+file path=usr/include/freeipmi/interface/rmcp-interface.h
+file path=usr/include/freeipmi/interpret/ipmi-interpret.h
+file path=usr/include/freeipmi/locate/ipmi-locate.h
+file path=usr/include/freeipmi/payload/ipmi-sol-payload.h
+file path=usr/include/freeipmi/record-format/ipmi-cipher-suite-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-fru-dimmspd-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-fru-information-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-fru-oem-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-platform-event-trap-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-sdr-oem-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-sdr-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-sel-oem-record-format.h
+file path=usr/include/freeipmi/record-format/ipmi-sel-record-format.h
+file path=usr/include/freeipmi/record-format/oem/ipmi-fru-wistron-oem-record-format.h
+file path=usr/include/freeipmi/record-format/oem/ipmi-sdr-oem-intel-node-manager-record-format.h
+file path=usr/include/freeipmi/record-format/oem/ipmi-sdr-oem-intel-record-format.h
+file path=usr/include/freeipmi/record-format/oem/ipmi-sel-oem-intel-record-format.h
+file path=usr/include/freeipmi/record-format/oem/ipmi-sel-oem-linux-kernel-record-format.h
+file path=usr/include/freeipmi/sdr/ipmi-sdr-oem.h
+file path=usr/include/freeipmi/sdr/ipmi-sdr.h
+file path=usr/include/freeipmi/sdr/oem/ipmi-sdr-oem-intel-node-manager.h
+file path=usr/include/freeipmi/sel/ipmi-sel.h
+file path=usr/include/freeipmi/sensor-read/ipmi-sensor-read.h
+file path=usr/include/freeipmi/spec/ipmi-authentication-type-spec.h
+file path=usr/include/freeipmi/spec/ipmi-channel-spec.h
+file path=usr/include/freeipmi/spec/ipmi-cmd-dcmi-spec.h
+file path=usr/include/freeipmi/spec/ipmi-cmd-spec.h
+file path=usr/include/freeipmi/spec/ipmi-comp-code-dcmi-spec.h
+file path=usr/include/freeipmi/spec/ipmi-comp-code-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-comp-code-spec.h
+file path=usr/include/freeipmi/spec/ipmi-device-types-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-device-types-spec.h
+file path=usr/include/freeipmi/spec/ipmi-entity-ids-spec.h
+file path=usr/include/freeipmi/spec/ipmi-event-reading-type-code-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-event-reading-type-code-spec.h
+file path=usr/include/freeipmi/spec/ipmi-fru-chassis-types-spec.h
+file path=usr/include/freeipmi/spec/ipmi-fru-language-codes-spec.h
+file path=usr/include/freeipmi/spec/ipmi-iana-enterprise-numbers-spec.h
+file path=usr/include/freeipmi/spec/ipmi-ipmb-lun-spec.h
+file path=usr/include/freeipmi/spec/ipmi-jedec-manufacturer-identification-code-spec.h
+file path=usr/include/freeipmi/spec/ipmi-lan-configuration-parameters-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-lan-configuration-parameters-spec.h
+file path=usr/include/freeipmi/spec/ipmi-netfn-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-netfn-spec.h
+file path=usr/include/freeipmi/spec/ipmi-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-pef-configuration-parameters-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-pef-configuration-parameters-spec.h
+file path=usr/include/freeipmi/spec/ipmi-privilege-level-spec.h
+file path=usr/include/freeipmi/spec/ipmi-product-id-spec.h
+file path=usr/include/freeipmi/spec/ipmi-rmcpplus-status-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sensor-and-event-code-tables-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sensor-and-event-code-tables-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sensor-numbers-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sensor-types-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sensor-types-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sensor-units-spec.h
+file path=usr/include/freeipmi/spec/ipmi-serial-modem-configuration-parameters-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-serial-modem-configuration-parameters-spec.h
+file path=usr/include/freeipmi/spec/ipmi-slave-address-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-slave-address-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sol-configuration-parameters-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-sol-configuration-parameters-spec.h
+file path=usr/include/freeipmi/spec/ipmi-system-boot-option-parameters-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-system-boot-option-parameters-spec.h
+file path=usr/include/freeipmi/spec/ipmi-system-info-parameters-oem-spec.h
+file path=usr/include/freeipmi/spec/ipmi-system-info-parameters-spec.h
+file path=usr/include/freeipmi/spec/ipmi-system-software-id-spec.h
+file path=usr/include/freeipmi/spec/ipmi-timestamp-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-fujitsu-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-ibm-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-intel-node-manager-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-quanta-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-sun-microsystems-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-supermicro-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-cmd-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-comp-code-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-comp-code-oem-fujitsu-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-comp-code-oem-intel-node-manager-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-comp-code-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-comp-code-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-event-reading-type-code-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-event-reading-type-code-oem-hp-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-event-reading-type-code-oem-intel-node-manager-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-event-reading-type-code-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-event-reading-type-code-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-event-reading-type-code-oem-supermicro-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-lan-configuration-parameters-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-lan-configuration-parameters-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-fujitsu-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-ibm-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-quanta-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-supermicro-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-netfn-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-fujitsu-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-ibm-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-quanta-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-sun-microsystems-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-supermicro-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-fujitsu-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-hp-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-intel-node-manager-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-quanta-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-supermicro-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-and-event-code-tables-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-numbers-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-numbers-oem-intel-node-manager-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-numbers-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-numbers-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-numbers-oem-quanta-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-numbers-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-fujitsu-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-hp-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-intel-node-manager-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-supermicro-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sensor-types-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-slave-address-oem-intel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-slave-address-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-slave-address-oem-linux-kernel-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-slave-address-oem-quanta-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-slave-address-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sol-configuration-parameters-oem-inventec-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-sol-configuration-parameters-oem-wistron-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-system-info-parameters-oem-dell-spec.h
+file path=usr/include/freeipmi/spec/oem/ipmi-system-info-parameters-oem-wistron-spec.h
+file path=usr/include/freeipmi/templates/ipmi-bmc-watchdog-timer-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-chassis-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-cipher-suite-record-format-templates.h
+file path=usr/include/freeipmi/templates/ipmi-dcmi-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-device-global-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-event-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-firmware-firewall-command-discovery-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-fru-dimmspd-record-format-templates.h
+file path=usr/include/freeipmi/templates/ipmi-fru-information-record-format-templates.h
+file path=usr/include/freeipmi/templates/ipmi-fru-inventory-device-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-ipmb-interface-templates.h
+file path=usr/include/freeipmi/templates/ipmi-kcs-interface-templates.h
+file path=usr/include/freeipmi/templates/ipmi-lan-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-lan-interface-templates.h
+file path=usr/include/freeipmi/templates/ipmi-messaging-support-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-oem-intel-node-manager-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-pef-and-alerting-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-rmcpplus-interface-templates.h
+file path=usr/include/freeipmi/templates/ipmi-rmcpplus-support-and-payload-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-sdr-record-format-templates.h
+file path=usr/include/freeipmi/templates/ipmi-sdr-repository-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-sel-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-sel-record-format-templates.h
+file path=usr/include/freeipmi/templates/ipmi-sensor-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-serial-modem-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-sol-cmds-templates.h
+file path=usr/include/freeipmi/templates/ipmi-sol-payload-templates.h
+file path=usr/include/freeipmi/templates/oem/ipmi-sdr-oem-intel-node-manager-record-format-templates.h
+file path=usr/include/freeipmi/templates/rmcp-cmds-templates.h
+file path=usr/include/freeipmi/templates/rmcp-interface-templates.h
+file path=usr/include/freeipmi/util/ipmi-channel-util.h
+file path=usr/include/freeipmi/util/ipmi-cipher-suite-util.h
+file path=usr/include/freeipmi/util/ipmi-dcmi-util.h
+file path=usr/include/freeipmi/util/ipmi-device-types-util.h
+file path=usr/include/freeipmi/util/ipmi-entity-ids-util.h
+file path=usr/include/freeipmi/util/ipmi-error-dcmi-util.h
+file path=usr/include/freeipmi/util/ipmi-error-util.h
+file path=usr/include/freeipmi/util/ipmi-iana-enterprise-numbers-util.h
+file path=usr/include/freeipmi/util/ipmi-ipmb-util.h
+file path=usr/include/freeipmi/util/ipmi-jedec-manufacturer-identification-code-util.h
+file path=usr/include/freeipmi/util/ipmi-lan-util.h
+file path=usr/include/freeipmi/util/ipmi-outofband-util.h
+file path=usr/include/freeipmi/util/ipmi-rmcpplus-util.h
+file path=usr/include/freeipmi/util/ipmi-sensor-and-event-code-tables-util.h
+file path=usr/include/freeipmi/util/ipmi-sensor-util.h
+file path=usr/include/freeipmi/util/ipmi-timestamp-util.h
+file path=usr/include/freeipmi/util/ipmi-util.h
+file path=usr/include/freeipmi/util/rmcp-util.h
+file path=usr/include/ipmi_monitoring.h
+file path=usr/include/ipmi_monitoring_bitmasks.h
+file path=usr/include/ipmi_monitoring_offsets.h
+file path=usr/include/ipmiconsole.h
+file path=usr/include/ipmidetect.h
+
+link path=usr/lib/$(MACH64)/libfreeipmi.so target=libfreeipmi.so.17.0.0
+link path=usr/lib/$(MACH64)/libfreeipmi.so.17 target=libfreeipmi.so.17.0.0
+file path=usr/lib/$(MACH64)/libfreeipmi.so.17.0.0
+link path=usr/lib/$(MACH64)/libipmiconsole.so target=libipmiconsole.so.2.3.2
+link path=usr/lib/$(MACH64)/libipmiconsole.so.2 target=libipmiconsole.so.2.3.2
+file path=usr/lib/$(MACH64)/libipmiconsole.so.2.3.2
+link path=usr/lib/$(MACH64)/libipmidetect.so target=libipmidetect.so.0.0.0
+link path=usr/lib/$(MACH64)/libipmidetect.so.0 target=libipmidetect.so.0.0.0
+file path=usr/lib/$(MACH64)/libipmidetect.so.0.0.0
+link path=usr/lib/$(MACH64)/libipmimonitoring.so \
+    target=libipmimonitoring.so.5.0.6
+link path=usr/lib/$(MACH64)/libipmimonitoring.so.5 \
+    target=libipmimonitoring.so.5.0.6
+file path=usr/lib/$(MACH64)/libipmimonitoring.so.5.0.6
+file path=usr/lib/$(MACH64)/pkgconfig/libfreeipmi.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libipmiconsole.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libipmidetect.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libipmimonitoring.pc
+
+link path=usr/lib/libfreeipmi.so target=libfreeipmi.so.17.0.0
+link path=usr/lib/libfreeipmi.so.17 target=libfreeipmi.so.17.0.0
+file path=usr/lib/libfreeipmi.so.17.0.0
+link path=usr/lib/libipmiconsole.so target=libipmiconsole.so.2.3.2
+link path=usr/lib/libipmiconsole.so.2 target=libipmiconsole.so.2.3.2
+file path=usr/lib/libipmiconsole.so.2.3.2
+link path=usr/lib/libipmidetect.so target=libipmidetect.so.0.0.0
+link path=usr/lib/libipmidetect.so.0 target=libipmidetect.so.0.0.0
+file path=usr/lib/libipmidetect.so.0.0.0
+link path=usr/lib/libipmimonitoring.so target=libipmimonitoring.so.5.0.6
+link path=usr/lib/libipmimonitoring.so.5 target=libipmimonitoring.so.5.0.6
+file path=usr/lib/libipmimonitoring.so.5.0.6
+file path=usr/lib/pkgconfig/libfreeipmi.pc
+file path=usr/lib/pkgconfig/libipmiconsole.pc
+file path=usr/lib/pkgconfig/libipmidetect.pc
+file path=usr/lib/pkgconfig/libipmimonitoring.pc
+
+file path=usr/sbin/$(MACH64)/bmc-config
+file path=usr/sbin/$(MACH64)/bmc-device
+file path=usr/sbin/$(MACH64)/bmc-info
+file path=usr/sbin/$(MACH64)/bmc-watchdog
+file path=usr/sbin/$(MACH64)/ipmi-chassis
+file path=usr/sbin/$(MACH64)/ipmi-chassis-config
+file path=usr/sbin/$(MACH64)/ipmi-config
+link path=usr/sbin/$(MACH64)/ipmi-console target=ipmiconsole
+file path=usr/sbin/$(MACH64)/ipmi-dcmi
+link path=usr/sbin/$(MACH64)/ipmi-detect target=ipmidetect
+file path=usr/sbin/$(MACH64)/ipmi-fru
+file path=usr/sbin/$(MACH64)/ipmi-locate
+file path=usr/sbin/$(MACH64)/ipmi-oem
+file path=usr/sbin/$(MACH64)/ipmi-pef-config
+file path=usr/sbin/$(MACH64)/ipmi-pet
+link path=usr/sbin/$(MACH64)/ipmi-ping target=ipmiping
+link path=usr/sbin/$(MACH64)/ipmi-power target=ipmipower
+file path=usr/sbin/$(MACH64)/ipmi-raw
+file path=usr/sbin/$(MACH64)/ipmi-sel
+file path=usr/sbin/$(MACH64)/ipmi-sensors
+file path=usr/sbin/$(MACH64)/ipmi-sensors-config
+file path=usr/sbin/$(MACH64)/ipmiconsole
+file path=usr/sbin/$(MACH64)/ipmidetect
+file path=usr/sbin/$(MACH64)/ipmidetectd
+file path=usr/sbin/$(MACH64)/ipmimonitoring
+file path=usr/sbin/$(MACH64)/ipmiping
+file path=usr/sbin/$(MACH64)/ipmipower
+file path=usr/sbin/$(MACH64)/ipmiseld
+link path=usr/sbin/$(MACH64)/pef-config target=ipmi-pef-config
+link path=usr/sbin/$(MACH64)/rmcp-ping target=rmcpping
+file path=usr/sbin/$(MACH64)/rmcpping
+
+file path=usr/sbin/bmc-config
+file path=usr/sbin/bmc-device
+file path=usr/sbin/bmc-info
+file path=usr/sbin/bmc-watchdog
+file path=usr/sbin/ipmi-chassis
+file path=usr/sbin/ipmi-chassis-config
+file path=usr/sbin/ipmi-config
+link path=usr/sbin/ipmi-console target=ipmiconsole
+file path=usr/sbin/ipmi-dcmi
+link path=usr/sbin/ipmi-detect target=ipmidetect
+file path=usr/sbin/ipmi-fru
+file path=usr/sbin/ipmi-locate
+file path=usr/sbin/ipmi-oem
+file path=usr/sbin/ipmi-pef-config
+file path=usr/sbin/ipmi-pet
+link path=usr/sbin/ipmi-ping target=ipmiping
+link path=usr/sbin/ipmi-power target=ipmipower
+file path=usr/sbin/ipmi-raw
+file path=usr/sbin/ipmi-sel
+file path=usr/sbin/ipmi-sensors
+file path=usr/sbin/ipmi-sensors-config
+file path=usr/sbin/ipmiconsole
+file path=usr/sbin/ipmidetect
+file path=usr/sbin/ipmidetectd
+file path=usr/sbin/ipmimonitoring
+file path=usr/sbin/ipmiping
+file path=usr/sbin/ipmipower
+file path=usr/sbin/ipmiseld
+link path=usr/sbin/pef-config target=ipmi-pef-config
+link path=usr/sbin/rmcp-ping target=rmcpping
+file path=usr/sbin/rmcpping
+
+file path=usr/share/doc/freeipmi/AUTHORS
+file path=usr/share/doc/freeipmi/COPYING
+file path=usr/share/doc/freeipmi/COPYING.ZRESEARCH
+file path=usr/share/doc/freeipmi/COPYING.bmc-watchdog
+file path=usr/share/doc/freeipmi/COPYING.ipmi-dcmi
+file path=usr/share/doc/freeipmi/COPYING.ipmi-fru
+file path=usr/share/doc/freeipmi/COPYING.ipmiconsole
+file path=usr/share/doc/freeipmi/COPYING.ipmidetect
+file path=usr/share/doc/freeipmi/COPYING.ipmimonitoring
+file path=usr/share/doc/freeipmi/COPYING.ipmiping
+file path=usr/share/doc/freeipmi/COPYING.ipmipower
+file path=usr/share/doc/freeipmi/COPYING.ipmiseld
+file path=usr/share/doc/freeipmi/COPYING.pstdout
+file path=usr/share/doc/freeipmi/COPYING.sunbmc
+file path=usr/share/doc/freeipmi/ChangeLog
+file path=usr/share/doc/freeipmi/ChangeLog.0
+file path=usr/share/doc/freeipmi/DISCLAIMER.bmc-watchdog
+file path=usr/share/doc/freeipmi/DISCLAIMER.bmc-watchdog.UC
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmi-dcmi
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmi-fru
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmi-fru.UC
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmiconsole
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmiconsole.UC
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmidetect
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmidetect.UC
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmimonitoring
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmimonitoring.UC
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmiping
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmiping.UC
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmipower
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmipower.UC
+file path=usr/share/doc/freeipmi/DISCLAIMER.ipmiseld
+file path=usr/share/doc/freeipmi/DISCLAIMER.pstdout
+file path=usr/share/doc/freeipmi/DISCLAIMER.pstdout.UC
+file path=usr/share/doc/freeipmi/INSTALL
+file path=usr/share/doc/freeipmi/NEWS
+file path=usr/share/doc/freeipmi/README
+file path=usr/share/doc/freeipmi/README.argp
+file path=usr/share/doc/freeipmi/README.build
+file path=usr/share/doc/freeipmi/README.openipmi
+file path=usr/share/doc/freeipmi/TODO
+file path=usr/share/doc/freeipmi/contrib/ganglia/README
+file path=usr/share/doc/freeipmi/contrib/ganglia/ganglia_ipmi_sensors.pl
+file path=usr/share/doc/freeipmi/contrib/libipmimonitoring/ipmimonitoring-sel.c
+file path=usr/share/doc/freeipmi/contrib/libipmimonitoring/ipmimonitoring-sensors.c
+file path=usr/share/doc/freeipmi/contrib/nagios/README
+file path=usr/share/doc/freeipmi/contrib/nagios/nagios_ipmi_sensors.pl
+file path=usr/share/doc/freeipmi/contrib/pet/README
+file path=usr/share/doc/freeipmi/contrib/pet/check_rmcpping
+file path=usr/share/doc/freeipmi/contrib/pet/ipminodes.cfg
+file path=usr/share/doc/freeipmi/contrib/pet/petalert.pl
+file path=usr/share/doc/freeipmi/freeipmi-bugs-issues-and-workarounds.txt
+file path=usr/share/doc/freeipmi/freeipmi-coding.txt
+file path=usr/share/doc/freeipmi/freeipmi-design.txt
+file path=usr/share/doc/freeipmi/freeipmi-hostrange.txt
+file path=usr/share/doc/freeipmi/freeipmi-libraries.txt
+file path=usr/share/doc/freeipmi/freeipmi-oem-documentation-requirements.txt
+file path=usr/share/doc/freeipmi/freeipmi-testing.txt
+#file path=usr/share/doc/freeipmi/info/dir
+file path=usr/share/doc/freeipmi/info/freeipmi-faq.info
+
+file path=usr/share/man/man3/libfreeipmi.3
+file path=usr/share/man/man3/libipmiconsole.3
+file path=usr/share/man/man3/libipmidetect.3
+file path=usr/share/man/man3/libipmimonitoring.3
+file path=usr/share/man/man5/bmc-config.conf.5
+file path=usr/share/man/man5/freeipmi.conf.5
+file path=usr/share/man/man5/freeipmi_interpret_sel.conf.5
+file path=usr/share/man/man5/freeipmi_interpret_sensor.conf.5
+file path=usr/share/man/man5/ipmi-config.conf.5
+file path=usr/share/man/man5/ipmi_monitoring_sensors.conf.5
+file path=usr/share/man/man5/ipmiconsole.conf.5
+file path=usr/share/man/man5/ipmidetect.conf.5
+file path=usr/share/man/man5/ipmidetectd.conf.5
+file path=usr/share/man/man5/ipmimonitoring.conf.5
+file path=usr/share/man/man5/ipmimonitoring_sensors.conf.5
+file path=usr/share/man/man5/ipmipower.conf.5
+file path=usr/share/man/man5/ipmiseld.conf.5
+file path=usr/share/man/man5/libipmiconsole.conf.5
+file path=usr/share/man/man5/libipmimonitoring.conf.5
+file path=usr/share/man/man7/freeipmi.7
+file path=usr/share/man/man8/bmc-config.8
+file path=usr/share/man/man8/bmc-device.8
+file path=usr/share/man/man8/bmc-info.8
+file path=usr/share/man/man8/bmc-watchdog.8
+file path=usr/share/man/man8/ipmi-chassis-config.8
+file path=usr/share/man/man8/ipmi-chassis.8
+file path=usr/share/man/man8/ipmi-config.8
+file path=usr/share/man/man8/ipmi-console.8
+file path=usr/share/man/man8/ipmi-dcmi.8
+file path=usr/share/man/man8/ipmi-detect.8
+file path=usr/share/man/man8/ipmi-fru.8
+file path=usr/share/man/man8/ipmi-locate.8
+file path=usr/share/man/man8/ipmi-oem.8
+file path=usr/share/man/man8/ipmi-pef-config.8
+file path=usr/share/man/man8/ipmi-pet.8
+file path=usr/share/man/man8/ipmi-ping.8
+file path=usr/share/man/man8/ipmi-power.8
+file path=usr/share/man/man8/ipmi-raw.8
+file path=usr/share/man/man8/ipmi-sel.8
+file path=usr/share/man/man8/ipmi-sensors-config.8
+file path=usr/share/man/man8/ipmi-sensors.8
+file path=usr/share/man/man8/ipmiconsole.8
+file path=usr/share/man/man8/ipmidetect.8
+file path=usr/share/man/man8/ipmidetectd.8
+file path=usr/share/man/man8/ipmimonitoring.8
+file path=usr/share/man/man8/ipmiping.8
+file path=usr/share/man/man8/ipmipower.8
+file path=usr/share/man/man8/ipmiseld.8
+file path=usr/share/man/man8/pef-config.8
+file path=usr/share/man/man8/rmcp-ping.8
+file path=usr/share/man/man8/rmcpping.8
+
+file path=var/lib/freeipmi/ipckey


### PR DESCRIPTION
Essentially a port and update of old freeipmi-0.7.7 integration recipe from OpenSolaris - in the end, they happened to use vanilla freeipmi + manpage fixes (dropped here) and SMF instead of init-scripts. So here that went too. Says it has sunbmc among other devices ;)
