### PR TITLE
Add netperf 2.7.0

### DIFF
--- a/components/sysutils/netperf/Makefile
+++ b/components/sysutils/netperf/Makefile
@@ -1,0 +1,55 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Adam Stevko
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		netperf
+COMPONENT_VERSION=	2.7.0
+COMPONENT_SUMMARY=	Netperf is a benchmark that can be used to measure the performance of many different types of networking.
+COMPONENT_PROJECT_URL=	http://www.netperf.org/netperf/
+COMPONENT_FMRI=		benchmark/netperf
+COMPONENT_CLASSIFICATION= Applications/System Utilities
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=	ftp://ftp.netperf.org/netperf/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= sha256:9170c4758463bc5342dcdbfc88a40b586fcc9d7ccca048ecbb3b2d49387a28b9
+COMPONENT_LICENSE=	HP
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CONFIGURE_OPTIONS+= --enable-histogram
+CONFIGURE_OPTIONS+= --enable-dirty
+CONFIGURE_OPTIONS+= --enable-demo
+CONFIGURE_OPTIONS+= --enable-unixdomain
+CONFIGURE_OPTIONS+= --enable-dlpi
+CONFIGURE_OPTIONS+= --enable-omni
+CONFIGURE_OPTIONS+= --enable-xti
+CONFIGURE_OPTIONS+= --enable-exs
+CONFIGURE_OPTIONS+= --enable-sctp
+CONFIGURE_OPTIONS+= --enable-intervals
+CONFIGURE_OPTIONS+= --enable-spin
+CONFIGURE_OPTIONS+= --enable-burst
+CONFIGURE_OPTIONS+= --enable-cpuutil=kstat
+
+build:		$(BUILD_32)
+
+install:	$(INSTALL_32)
+
+test:		$(TEST_32)
+
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/sysutils/netperf/files/auth_netserver
+++ b/components/sysutils/netperf/files/auth_netserver
@@ -1,0 +1,2 @@
+solaris.smf.value.netserver:::Change netperf netserver value properties::
+solaris.smf.manage.netserver:::Manage netperf netserver service states::

--- a/components/sysutils/netperf/files/netserver.xml
+++ b/components/sysutils/netperf/files/netserver.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" ?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="netserver">
+    <service name="network/netserver" type="service" version="0">
+	<create_default_instance enabled="false"/>
+
+        <dependency name="network" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/milestone/network:default"/>
+        </dependency>
+
+        <dependency name="filesystem" grouping="require_all" restart_on="error" type="service">
+            <service_fmri value="svc:/system/filesystem/local"/>
+        </dependency>
+
+        <method_context>
+            <method_environment>
+                <envvar name="PATH" value="/usr/bin:/usr/sbin"/>
+            </method_environment>
+        </method_context>
+
+        <exec_method type="method" name="start" exec="/usr/bin/netserver %{config/options}" timeout_seconds="60"/>
+
+        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
+
+	<property_group name='general' type='framework'>
+            <propval name='action_authorization' type='astring' value='solaris.smf.manage.netserver'/>
+      	    <propval name='value_authorization' type='astring' value='solaris.smf.value.netserver'/>
+	</property_group>
+
+        <property_group name="startd" type="framework">
+            <propval name="duration" type="astring" value="contract"/>
+            <propval name="ignore_error" type="astring" value="core,signal"/>
+        </property_group>
+
+	<property_group name='config' type='application'>
+	    <propval name='options' type='astring' value=''/>
+	    <propval name='value_authorization' type='astring' value='solaris.smf.value.netserver'/>
+	</property_group>
+
+        <stability value="Evolving"/>
+
+        <template>
+            <common_name>
+                <loctext xml:lang="C">netperf benchmarking network server</loctext>
+            </common_name>
+            <documentation>
+                <manpage title="netserver" section="8" manpath="/usr/share/man"/>
+                <doc_link name="netperf.org" uri="http://www.netperf.org/netperf/"/>
+            </documentation>
+        </template>
+    </service>
+</service_bundle>

--- a/components/sysutils/netperf/files/prof_netserver
+++ b/components/sysutils/netperf/files/prof_netserver
@@ -1,0 +1,1 @@
+Netperf Administration:RO:::auths=solaris.smf.manage.netserver,solaris.smf.value.netserver

--- a/components/sysutils/netperf/netperf.license
+++ b/components/sysutils/netperf/netperf.license
@@ -1,0 +1,43 @@
+
+ 
+              Copyright (C) 1993 Hewlett-Packard Company
+                         ALL RIGHTS RESERVED.
+ 
+  The enclosed software and documentation includes copyrighted works
+  of Hewlett-Packard Co. For as long as you comply with the following
+  limitations, you are hereby authorized to (i) use, reproduce, and
+  modify the software and documentation, and to (ii) distribute the
+  software and documentation, including modifications, for
+  non-commercial purposes only.
+      
+  1.  The enclosed software and documentation is made available at no
+      charge in order to advance the general development of
+      high-performance networking products.
+ 
+  2.  You may not delete any copyright notices contained in the
+      software or documentation. All hard copies, and copies in
+      source code or object code form, of the software or
+      documentation (including modifications) must contain at least
+      one of the copyright notices.
+ 
+  3.  The enclosed software and documentation has not been subjected
+      to testing and quality control and is not a Hewlett-Packard Co.
+      product. At a future time, Hewlett-Packard Co. may or may not
+      offer a version of the software and documentation as a product.
+  
+  4.  THE SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS".
+      HEWLETT-PACKARD COMPANY DOES NOT WARRANT THAT THE USE,
+      REPRODUCTION, MODIFICATION OR DISTRIBUTION OF THE SOFTWARE OR
+      DOCUMENTATION WILL NOT INFRINGE A THIRD PARTY'S INTELLECTUAL
+      PROPERTY RIGHTS. HP DOES NOT WARRANT THAT THE SOFTWARE OR
+      DOCUMENTATION IS ERROR FREE. HP DISCLAIMS ALL WARRANTIES,
+      EXPRESS AND IMPLIED, WITH REGARD TO THE SOFTWARE AND THE
+      DOCUMENTATION. HP SPECIFICALLY DISCLAIMS ALL WARRANTIES OF
+      MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+  
+  5.  HEWLETT-PACKARD COMPANY WILL NOT IN ANY EVENT BE LIABLE FOR ANY
+      DIRECT, INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES
+      (INCLUDING LOST PROFITS) RELATED TO ANY USE, REPRODUCTION,
+      MODIFICATION, OR DISTRIBUTION OF THE SOFTWARE OR DOCUMENTATION.
+ 
+

--- a/components/sysutils/netperf/netperf.p5m
+++ b/components/sysutils/netperf/netperf.p5m
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Adam Stevko
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file files/auth_netserver path=etc/security/auth_attr.d/netserver
+file files/prof_netserver path=etc/security/prof_attr.d/netserver
+file files/netserver.xml path=lib/svc/manifest/network/netserver.xml restart_fmri=svc:/system/manifest-import:default
+
+file path=usr/bin/netperf
+file path=usr/bin/netserver
+file path=usr/share/info/netperf.info
+file path=usr/share/man/man1/netperf.1
+file path=usr/share/man/man1/netserver.1

--- a/components/sysutils/netperf/patches/sendfile.patch
+++ b/components/sysutils/netperf/patches/sendfile.patch
@@ -1,0 +1,12 @@
+--- netperf-2.7.0-orig/src/netlib.c	Fri Apr 24 18:08:33 2015
++++ netperf-2.7.0/src/netlib.c	Mon Oct  5 15:20:25 2015
+@@ -143,6 +143,9 @@
+ #endif /* __sgi */
+ #endif /* _AIX */
+ 
++#if defined (__sun)
++#include <sys/sendfile.h>
++#endif /* __sun */
+ 
+ #ifdef HAVE_MPCTL
+ #include <sys/mpctl.h>

--- a/components/sysutils/netperf/patches/sys-types-h.patch
+++ b/components/sysutils/netperf/patches/sys-types-h.patch
@@ -1,0 +1,10 @@
+--- netperf-2.6.0/src/dscp.c.orig	Fri Apr 10 11:01:03 2015
++++ netperf-2.6.0/src/dscp.c	Fri Apr 10 11:01:26 2015
+@@ -29,6 +29,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <sys/types.h>
+ #include <stdio.h>
+ #if HAVE_STRING_H
+ #include <string.h>

--- a/components/sysutils/netperf/patches/xopen-sendmsg.patch
+++ b/components/sysutils/netperf/patches/xopen-sendmsg.patch
@@ -1,0 +1,13 @@
+--- netperf-2.7.0-orig/src/nettest_omni.c	Thu May 21 17:32:44 2015
++++ netperf-2.7.0/src/nettest_omni.c	Mon Oct  5 15:36:53 2015
+@@ -73,6 +73,10 @@
+ #include <assert.h>
+ 
+ #ifndef WIN32
++#ifdef __sun
++#define _XPG4_2
++#define __EXTENSIONS__
++#endif /* __sun */
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ 


### PR DESCRIPTION
Should we split netperf and netserver into two different packages? netserver could also use SMF manifest. What do you think?
