### PR TITLE
Separate IPS validation from publishing

### DIFF
--- a/doc/makefile-targets.txt
+++ b/doc/makefile-targets.txt
@@ -80,13 +80,25 @@ pkglint::
   by the inclusion of $(WS_MAKE_RULES)/prep.mk.  It will run the build steps
   necessary to pkglint the manifests for a component.
 
-publish::
+pre-publish::
   This target is present in all Makefiles.  It can be used at the top level
   to act across all components, or on an individual component basis.  It is
   automatically defined by including $(WS_MAKE_RULES)/ips.mk.  It depends
   on the previously described 'install' target and will perform a series of
   internal, intermediate steps to use the component package manifests to
-  generate and publish packages for that component.
+  generate and validate consistency of packages for that component.
+
+  NOTE: The pre-publish target aims to help a recipe developer to make sure
+  that the recipe can produce a valid package without actually pushing its
+  bits into his or her repository (allows to experiment, saves some time, and
+  avoids polluting the repository with known-bad code during development cycles).
+
+publish::
+  This target is present in all Makefiles.  It can be used at the top level
+  to act across all components, or on an individual component basis.  It is
+  automatically defined by including $(WS_MAKE_RULES)/ips.mk.  It depends
+  on the previously described 'pre-publish' target and will actually publish
+  packages for that component to the repository configured in $(WS_REPO).
 
 clean::
   This target is present in all Makefiles.  It can be used at the top level

--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -426,7 +426,6 @@ $(MANIFEST_BASE)-%.pre-published:	$(MANIFEST_BASE)-%.depend.res $(BUILD_DIR)/.li
 
 # Push to the repo
 $(MANIFEST_BASE)-%.published:	$(MANIFEST_BASE)-%.pre-published
-	@echo "PUSHING NEW PACKAGE CONTENTS TO THE REPO"
 	$(PKGSEND) $(PKGSEND_PUBLISH_OPTIONS) $<
 	$(PKGFMT) <$< >$@
 

--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -174,6 +174,7 @@ MANIFESTS =		$(VERSIONED_MANIFESTS:%=$(MANIFEST_BASE)-%)
 
 DEPENDED=$(VERSIONED_MANIFESTS:%.p5m=$(MANIFEST_BASE)-%.depend)
 RESOLVED=$(VERSIONED_MANIFESTS:%.p5m=$(MANIFEST_BASE)-%.depend.res)
+PRE_PUBLISHED=$(RESOLVED:%.depend.res=%.pre-published)
 PUBLISHED=$(RESOLVED:%.depend.res=%.published)
 
 COPYRIGHT_FILE ?=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).copyright
@@ -185,9 +186,13 @@ IPS_COMPONENT_VERSION ?=	$(COMPONENT_VERSION)
 
 # allow publishing to be overridden, such as when
 # a package is for one architecture only.
+PRE_PUBLISH_STAMP ?= $(BUILD_DIR)/.pre-published-$(MACH)
 PUBLISH_STAMP ?= $(BUILD_DIR)/.published-$(MACH)
 
-publish:		build install $(PUBLISH_STAMP)
+# Do all that is needed to ensure the package is consistent for publishing,
+# except actually pushing to a repo, separately from the push to the repo.
+pre-publish:	build install $(PRE_PUBLISH_STAMP)
+publish:		pre-publish $(PUBLISH_STAMP)
 
 sample-manifest:	$(GENERATED).p5m
 
@@ -412,9 +417,21 @@ FRC:
 PKGSEND_PUBLISH_OPTIONS = -s $(WS_REPO) publish --fmri-in-manifest
 PKGSEND_PUBLISH_OPTIONS += $(PKG_PROTO_DIRS:%=-d %)
 PKGSEND_PUBLISH_OPTIONS += -T \*.py
-$(MANIFEST_BASE)-%.published:	$(MANIFEST_BASE)-%.depend.res $(BUILD_DIR)/.linted-$(MACH)
+
+# Do all the hard work that is needed to ensure the package is consistent
+# and ready for publishing, except actually pushing bits to a repository
+$(MANIFEST_BASE)-%.pre-published:	$(MANIFEST_BASE)-%.depend.res $(BUILD_DIR)/.linted-$(MACH)
+	$(CP) $< $@
+	@echo "NEW PACKAGE CONTENTS ARE LOCALLY VALIDATED AND READY TO GO"
+
+# Push to the repo
+$(MANIFEST_BASE)-%.published:	$(MANIFEST_BASE)-%.pre-published
+	@echo "PUSHING NEW PACKAGE CONTENTS TO THE REPO"
 	$(PKGSEND) $(PKGSEND_PUBLISH_OPTIONS) $<
 	$(PKGFMT) <$< >$@
+
+$(BUILD_DIR)/.pre-published-$(MACH):	$(PRE_PUBLISHED)
+	$(TOUCH) $@
 
 $(BUILD_DIR)/.published-$(MACH):	$(PUBLISHED)
 	$(TOUCH) $@
@@ -422,22 +439,22 @@ $(BUILD_DIR)/.published-$(MACH):	$(PUBLISHED)
 print-package-names:	canonical-manifests
 	@cat $(VERSIONED_MANIFESTS) $(WS_TOP)/transforms/print-pkgs | \
 		$(PKGMOGRIFY) $(PKG_OPTIONS) /dev/fd/0 | \
- 		sed -e '/^$$/d' -e '/^#.*$$/d' | sort -u
+		sed -e '/^$$/d' -e '/^#.*$$/d' | sort -u
 
 print-package-paths:	canonical-manifests
 	@cat $(VERSIONED_MANIFESTS) $(WS_TOP)/transforms/print-paths | \
 		$(PKGMOGRIFY) $(PKG_OPTIONS) /dev/fd/0 | \
- 		sed -e '/^$$/d' -e '/^#.*$$/d' | sort -u
+		sed -e '/^$$/d' -e '/^#.*$$/d' | sort -u
 
 install-packages:	publish
 	@if [ $(IS_GLOBAL_ZONE) = 0 -o x$(ROOT) != x ]; then \
 	    cat $(VERSIONED_MANIFESTS) $(WS_TOP)/transforms/print-paths | \
-		$(PKGMOGRIFY) $(PKG_OPTIONS) /dev/fd/0 | \
- 		sed -e '/^$$/d' -e '/^#.*$$/d' -e 's;/;;' | sort -u | \
-		(cd $(PROTO_DIR) ; pfexec /bin/cpio -dump $(ROOT)) ; \
-	else ; \
+	    $(PKGMOGRIFY) $(PKG_OPTIONS) /dev/fd/0 | \
+	    sed -e '/^$$/d' -e '/^#.*$$/d' -e 's;/;;' | sort -u | \
+	    (cd $(PROTO_DIR) ; pfexec /bin/cpio -dump $(ROOT)) ; \
+	 else ; \
 	    echo "unsafe to install package(s) automatically" ; \
-        fi
+	 fi
 
 $(RESOLVED):	install
 


### PR DESCRIPTION
During my recipe-development and experiments (including point-backports to another OI release), I've found some use for this change:

Separation of IPS validation from publishing, as a usable command-line target. Now a `make pre-publish` allows to make sure that my package formalities are okay, without taking time to pollute my repo wiith e.g. experimental code, and a `make publish` does the pre-publish and then actually transfers the package bits to repo, as before.

Note that sometimes repetitive calls to either old `publish` or new `pre-publish` re-ran for me without changes to sources. I think this is because of dependency on `$(BUILD_DIR)` somewhere in the tree (around line 333), which causes `pkgmogrify` to re-run up till `depend.res` files. And piling IPS temporary files straight into `BUILD_DIR` seems to cause a sort of loop (for re-invokations of `make`), at least if timestamps are far apart enough for `make` to care (or maybe this only hurts on the first run after a `make clean` - afterwards it is the files being updated/touched, but not the directory object). I did not change anything in this regard, it doesn't happen too often to be a problem so far.

As much as I've tested, the hack is convenient and does not break the ordinary use-cases :)

NOTE: Previously this PR was about two separate changes, but due to their different value and potential desirability for upstream, it was split. The other half is PR #2063.
