### PR TITLE
Support a custom macros makefile (optional includes from start and end of shared-macros.mk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ tools/python/pkglint/*.pyc
 tools/parfait
 tools/pkglint
 tools/time-*o
+
+make-rules/custom-macros-pre.mk
+make-rules/custom-macros-post.mk

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -57,6 +57,10 @@ WS_LICENSES =   $(WS_TOP)/licenses
 WS_INCORPORATIONS =     $(WS_TOP)/incorporations
 WS_LINT_CACHE = $(WS_MACH)/pkglint-cache
 
+# If you have some customization to apply to common recipes on your build host,
+# you can put then into this file.
+-include $(WS_MAKE_RULES)/custom-macros-pre.mk
+
 # we want our pkg piplines to fail if there is an error
 # (like if pkgdepend fails in the middle of a pipe), but
 # we don't want the builds or ./configure's failing as well.
@@ -1011,3 +1015,7 @@ include $(WS_MAKE_RULES)/environment.mk
 # is not always what you get.
 print-%:
 	@echo '$(subst ','\'',$*=$($*)) (origin: $(origin $*), flavor: $(flavor $*))'
+
+# If you have some customization to apply to common recipes on your build host,
+# you can put then into this file.
+-include $(WS_MAKE_RULES)/custom-macros-post.mk


### PR DESCRIPTION
During my recipe-development and experiments (including point-backports to another OI release), I've found some use for this hack:

While back-porting recipes to an OI-151a8 machine, which generally works for whatever few packages I needed to try there, I needed to override the `GCC_ROOT` and some other stuff. Patching up the `shared-macros.mk` directly is inconvenient (later Git rebases are tricky). So I'd rather optionally include a non-Git-tracked makefile with such customizations.

For example, this snippet allows me to build with gcc-4.4.4 that is available on that box, and happens to work for me:

```
jim@jimoi:~/shared/oi-userland/make-rules$ cat custom-macros-pre.mk 
# Use another GCC
override GCC_ROOT := /opt/gcc/4.4.4
```

As much as I've tested, the hack is convenient for its purpose and does not break the ordinary use-cases :)
