### PR TITLE
tuntap grouping and SMF integration

### DIFF
--- a/components/tuntap/files/tuntap.sh
+++ b/components/tuntap/files/tuntap.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+#
+# Make sure TUN/TAP device nodes are present. This may be not needed
+# if clients such as OpenVPN are running in the global zone and so
+# tickle initialization of the drivers, but seems to be needed when
+# clients are only in local zones that use `device match` attribute
+# to get their pipes to `/dev/tun` and `/dev/tap`.
+# This can be used as either init-script or an SMF service method.
+#
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+do_start() {
+    /usr/sbin/add_drv tun
+    /usr/sbin/add_drv tap
+}
+
+do_stop() {
+    /usr/sbin/rem_drv tun
+    /usr/sbin/rem_drv tap
+}
+
+do_status() {
+    modinfo | egrep ' (tun|tap) '
+}
+
+
+case "$1" in
+    stop) do_stop;;
+    #start) do_start;;
+    start|restart) do_stop; sleep 5; do_start; do_status;;
+    status) do_status;;
+esac

--- a/components/tuntap/files/tuntap.xml
+++ b/components/tuntap/files/tuntap.xml
@@ -1,0 +1,64 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+
+<!--
+#
+# Make sure TUN/TAP device nodes are present. This may be not needed
+# if clients such as OpenVPN are running in the global zone and so
+# tickle initialization of the drivers, but seems to be needed when
+# clients are only in local zones that use `device match` attribute
+# to get their pipes to `/dev/tun` and `/dev/tap`.
+#
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+-->
+<service_bundle type='manifest' name='export'>
+  <service name='network/tuntap' type='service' version='0'>
+    <create_default_instance enabled='false'/>
+    <single_instance/>
+    <dependency name='network' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/milestone/network:default'/>
+    </dependency>
+    <dependency name='filesystem-local' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/system/filesystem/local:default'/>
+    </dependency>
+<!-- If this service is at all enabled, it should run before these: -->
+    <dependent name="zones" grouping="optional_all" restart_on="none">
+        <service_fmri value="svc:/system/zones"/>
+        <service_fmri value="svc:/system/zone-group"/>
+        <service_fmri value="svc:/application/openvpn"/>
+    </dependent>
+    <method_context working_directory='/var/tmp'>
+      <method_credential group='root' user='root'/>
+    </method_context>
+    <exec_method name='start' type='method' exec='/lib/svc/method/svc-tuntap %m' timeout_seconds='120'/>
+    <exec_method name='restart' type='method' exec='/lib/svc/method/svc-tuntap %m' timeout_seconds='120'/>
+    <exec_method name='stop' type='method' exec='/lib/svc/method/svc-tuntap %m' timeout_seconds='120'/>
+    <property_group name='startd' type='framework'>
+      <propval name='ignore_error' type='astring' value='core,signal'/>
+      <!-- mark service as transient - so SMF won't monitor its children -->
+      <propval name='duration' type='astring' value='transient' />
+    </property_group>
+    <stability value='Unstable'/>
+    <template>
+      <common_name>
+        <loctext xml:lang='C'>Tickle /dev/tun and /dev/tap nodes</loctext>
+      </common_name>
+      <documentation>
+        <manpage title='TUN/TAP driver for OpenIndiana' section='1'/>
+      </documentation>
+    </template>
+  </service>
+</service_bundle>

--- a/components/tuntap/tuntap.p5m
+++ b/components/tuntap/tuntap.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# 
+# Copyright 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/driver/network/tuntap@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="Grouping for tuntap package and SMF integration"
+set name=pkg.description value="$(COMPONENT_DESCRIPTION)"
+set name=info.classification value="org.opensolaris.category.2008:Drivers/Networking"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+set name=variant.opensolaris.zone value="global"
+
+license $(COMPONENT_NAME).license license="$(COMPONENT_LICENSE)"
+
+depend type=require fmri=pkg:/driver/network/tun@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+depend type=require fmri=pkg:/driver/network/tap@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
+file files/tuntap.sh path=lib/svc/method/svc-tuntap mode=555 owner=root group=sys
+file files/tuntap.xml path=lib/svc/manifest/network/tuntap.xml mode=444 owner=root group=sys \
+     restart_fmri=svc:/system/manifest-import:default


### PR DESCRIPTION
While running OpenVPN in a local zone [1], I found that the GZ does not provide it the device nodes after a reboot. In fact, the drivers are not loaded at all. And simply `modload`ing them did not work for some reason, while `rem_drv`+`add_drv` did.

So I made this service (disabled by default) to do just that - recreate `/dev/{tun,tap}` after booting before local zones are started.

[1]: The local zone with OpenVPN simply has the devices piped, and it works:

```
  <device match="/dev/tun"/>
  <device match="/dev/tap"/>
```
