### PR TITLE
Initial commit of distcc (at latest Git commit from 20160712)

### DIFF
--- a/components/developer/distcc/Makefile
+++ b/components/developer/distcc/Makefile
@@ -20,8 +20,8 @@ COMPONENT_VERSION=	3.1
 # Versioning is complicated: samba.org/ftp has 2.x versions as newest,
 # while newest github release is 3.1 from 2008, and there is recent HEAD
 # So we take a randomly newest Git snapshot as of package review:
-COMPONENT_GIT_DATE=	20160427
-COMPONENT_GIT_REV=	544904c
+COMPONENT_GIT_DATE=	20160712
+COMPONENT_GIT_REV=	c8eac97
 IPS_COMPONENT_VERSION=	$(COMPONENT_VERSION).0.$(COMPONENT_GIT_DATE)
 COMPONENT_PROJECT_URL=	http://distcc.samba.org/
 
@@ -31,7 +31,7 @@ COMPONENT_SRC= distcc-distcc-$(COMPONENT_GIT_REV)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:6f0ae295e2652b44af91086125ca6df254c72bf5283dc5a10a5bf273c45ed05e
+  sha256:13268ca2f6fee14647610e137c68eef14b2686aad251b3c89da81a0593b2698d
 COMPONENT_ARCHIVE_URL= \
   https://codeload.github.com/distcc/distcc/legacy.tar.gz/$(COMPONENT_GIT_REV)
 

--- a/components/developer/distcc/Makefile
+++ b/components/developer/distcc/Makefile
@@ -97,9 +97,8 @@ CFLAGS += -Wno-error=unused-but-set-variable
 CONFIGURE_OPTIONS +=	--with-auth
 
 # Support mDNS "zeroconf" peer discovery/announcement
-# NOTE: May require some source chizeling, skip in first recipe iterations
-#CONFIGURE_OPTIONS +=	--with-avahi
-CONFIGURE_OPTIONS +=	--without-avahi
+REQUIRED_PACKAGES +=	system/network/avahi
+CONFIGURE_OPTIONS +=	--with-avahi
 
 # GUIs for monitoring
 CONFIGURE_OPTIONS +=	--with-gnome

--- a/components/developer/distcc/Makefile
+++ b/components/developer/distcc/Makefile
@@ -86,10 +86,11 @@ CONFIGURE_OPTIONS +=	--sysconfdir=$(ETCDIR)
 CONFIGURE_OPTIONS +=	--enable-rfc2553
 
 # GSS-API mutual auth
-# NOTE: May require some source chizeling, skip in first recipe iterations
-#REQUIRED_PACKAGES +=	system/kernel/security/gss system/library/security/gss service/security/gss system/header
-#CONFIGURE_OPTIONS +=	--with-auth
-CONFIGURE_OPTIONS +=	--without-auth
+### Are these needed? Or just seemed relevant because they are *gss*?
+###REQUIRED_PACKAGES +=	system/kernel/security/gss service/security/gss
+REQUIRED_PACKAGES +=	system/library/security/gss
+CFLAGS += -Wno-error=unused-but-set-variable
+CONFIGURE_OPTIONS +=	--with-auth
 
 # Support mDNS "zeroconf" peer discovery/announcement
 # NOTE: May require some source chizeling, skip in first recipe iterations

--- a/components/developer/distcc/Makefile
+++ b/components/developer/distcc/Makefile
@@ -53,7 +53,11 @@ COMPONENT_PREP_ACTION = \
 
 COMPONENT_PRE_CONFIGURE_ACTION =	($(CLONEY) $(SOURCE_DIR) $(@D))
 
-COMPONENT_POST_INSTALL_ACTION =	( cd $(PROTOUSRSHAREMAN1DIR) && for F in *.gz ; do [ -s "$$F" ] && gzip -cd < "$$F" > `basename "$$F" .gz` ; done )
+COMPONENT_POST_INSTALL_ACTION =	( \
+    cd $(PROTOUSRSHAREMAN1DIR) && \
+    for F in *.gz ; do \
+        [ -s "$$F" ] && gzip -cd < "$$F" > `basename "$$F" .gz` ; \
+    done )
 
 # Find the <config.h> as included by some sources - must be before GCC plugin dir
 CFLAGS += -I$(BUILD_DIR_$(BITS))/src
@@ -107,16 +111,21 @@ CONFIGURE_OPTIONS +=	--with-gtk
 build:          $(BUILD_32)
 
 install:        $(INSTALL_32)
+	$(GSED) -e 's:\#!/usr/bin/env python:\#!/usr/bin/python$(PYTHON_VERSION):' \
+	    < $(COMPONENT_DIR)/files/distcc-top.py \
+	    > $(PROTOUSRBINDIR)/distcc-top && $(CHMOD) +x $(PROTOUSRBINDIR)/distcc-top
 
 test:           $(NO_TESTS)
 
-# Auto-generated contents below.  Please manually verify and remove this comment
+# The python version required for distcc-top.py seems to be "any 2.x"
+# so we do not add one to REQUIRED_PACKAGES (a system with IPS will
+# likely have a suitable Python anyway) and so we just specify the
+# special one needed for distcc-pump.
 REQUIRED_PACKAGES += library/desktop/gtk2
 REQUIRED_PACKAGES += library/desktop/libgnome
 REQUIRED_PACKAGES += library/desktop/libgnomeui
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/popt
-REQUIRED_PACKAGES += runtime/python-26
 REQUIRED_PACKAGES += runtime/python-34
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/developer/distcc/Makefile
+++ b/components/developer/distcc/Makefile
@@ -1,0 +1,121 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Jim Klimov
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		distcc
+COMPONENT_VERSION=	3.1
+# Versioning is complicated: samba.org/ftp has 2.x versions as newest,
+# while newest github release is 3.1 from 2008, and there is recent HEAD
+# So we take a randomly newest Git snapshot as of package review:
+COMPONENT_GIT_DATE=	20160427
+COMPONENT_GIT_REV=	544904c
+IPS_COMPONENT_VERSION=	$(COMPONENT_VERSION).0.$(COMPONENT_GIT_DATE)
+COMPONENT_PROJECT_URL=	http://distcc.samba.org/
+
+COMPONENT_DOCUMENTATION_URL =	https://github.com/distcc/distcc/blob/master/INSTALL
+
+COMPONENT_SRC= distcc-distcc-$(COMPONENT_GIT_REV)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
+
+COMPONENT_ARCHIVE_HASH=	\
+  sha256:6f0ae295e2652b44af91086125ca6df254c72bf5283dc5a10a5bf273c45ed05e
+COMPONENT_ARCHIVE_URL= \
+  https://codeload.github.com/distcc/distcc/legacy.tar.gz/$(COMPONENT_GIT_REV)
+
+COMPONENT_SUMMARY=	distcc - distributor of preprocessed C/C++/ObjC files across nodes to crowd-build code (bleeding edge, Git $(COMPONENT_GIT_REV) at $(COMPONENT_GIT_DATE))
+COMPONENT_FMRI=		developer/distcc
+COMPONENT_CLASSIFICATION=	Development/C
+COMPONENT_LICENSE=	"GPLv2"
+COMPONENT_LICENSE_FILE=	COPYING
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+# distcc (pump) requires python3...
+PYTHON_VERSION=3.4
+
+COMPONENT_PREP_ACTION = \
+    ( cd $(@D) && ./autogen.sh )
+
+COMPONENT_PRE_CONFIGURE_ACTION =	($(CLONEY) $(SOURCE_DIR) $(@D))
+
+COMPONENT_POST_INSTALL_ACTION =	( cd $(PROTOUSRSHAREMAN1DIR) && for F in *.gz ; do [ -s "$$F" ] && gzip -cd < "$$F" > `basename "$$F" .gz` ; done )
+
+# Find the <config.h> as included by some sources - must be before GCC plugin dir
+CFLAGS += -I$(BUILD_DIR_$(BITS))/src
+CXXFLAGS += -I$(BUILD_DIR_$(BITS))/src
+CPPFLAGS += -I$(BUILD_DIR_$(BITS))/src
+
+# Where to look for libiberty header and .a file: the GCC p5m manifest
+# is explicit about the paths - down to i386'iness of them. Cool :\
+# NOTE: Match this with GCC_ROOT, currently referring to "4.9"
+CFLAGS += -I$(GCC_ROOT)/lib/gcc/i386-pc-solaris2.11/4.9.3/plugin/include -L$(GCC_ROOT)/lib
+
+CXXFLAGS+=	$(CPP_LARGEFILE)
+CFLAGS +=	$(CPP_LARGEFILE)
+
+CFLAGS +=	-D_GNU_SOURCE -D__EXTENSIONS__
+CXXFLAGS +=	-D_GNU_SOURCE -D__EXTENSIONS__
+
+CXXFLAGS +=	-D_POSIX_PTHREAD_SEMANTICS
+CFLAGS +=	-D_POSIX_PTHREAD_SEMANTICS
+
+COMPONENT_INSTALL_ARGS +=	DESTDIR="$(PROTO_DIR)"
+COMPONENT_INSTALL_ARGS +=	PYTHON="$(PYTHON)"
+
+CONFIGURE_ENV +=	PYTHON="$(PYTHON)"
+INSTALL_ENV   +=	PYTHON="$(PYTHON)"
+
+CONFIGURE_OPTIONS +=	--sysconfdir=$(ETCDIR)
+
+# use getaddrinfo, getnameinfo, etc :
+CONFIGURE_OPTIONS +=	--enable-rfc2553
+
+# GSS-API mutual auth
+# NOTE: May require some source chizeling, skip in first recipe iterations
+#REQUIRED_PACKAGES +=	system/kernel/security/gss system/library/security/gss service/security/gss system/header
+#CONFIGURE_OPTIONS +=	--with-auth
+CONFIGURE_OPTIONS +=	--without-auth
+
+# Support mDNS "zeroconf" peer discovery/announcement
+# NOTE: May require some source chizeling, skip in first recipe iterations
+#CONFIGURE_OPTIONS +=	--with-avahi
+CONFIGURE_OPTIONS +=	--without-avahi
+
+# GUIs for monitoring
+CONFIGURE_OPTIONS +=	--with-gnome
+CONFIGURE_OPTIONS +=	--with-gtk
+
+# common targets
+# NOTE: Currently GCC libiberty is only published as a 32-bit .a file
+# so we can only build a 32-bit distcc
+build:          $(BUILD_32)
+
+install:        $(INSTALL_32)
+
+test:           $(NO_TESTS)
+
+# Auto-generated contents below.  Please manually verify and remove this comment
+REQUIRED_PACKAGES += library/desktop/gtk2
+REQUIRED_PACKAGES += library/desktop/libgnome
+REQUIRED_PACKAGES += library/desktop/libgnomeui
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/popt
+REQUIRED_PACKAGES += runtime/python-26
+REQUIRED_PACKAGES += runtime/python-34
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library

--- a/components/developer/distcc/distcc-core.p5m
+++ b/components/developer/distcc/distcc-core.p5m
@@ -1,0 +1,67 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+<transform file hardlink path=usr/lib/.*\.py$ -> default pkg.tmp.pyversion 2.X>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-core@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - the core programs and resource files"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/default/distcc
+file path=etc/distcc/clients.allow
+file path=etc/distcc/commands.allow.sh
+file path=etc/distcc/hosts
+
+file path=usr/bin/distcc
+file path=usr/bin/distccd
+file path=usr/bin/distccmon-text
+file path=usr/bin/lsdistcc
+
+# This only needs a system Python, and we have one for PKG anyway
+file files/distcc-top.py path=usr/bin/distcc-top
+
+file path=usr/share/doc/distcc/AUTHORS
+file path=usr/share/doc/distcc/COPYING
+file path=usr/share/doc/distcc/INSTALL
+file path=usr/share/doc/distcc/NEWS
+file path=usr/share/doc/distcc/README
+file path=usr/share/doc/distcc/TODO
+file path=usr/share/doc/distcc/example/README
+file path=usr/share/doc/distcc/example/default
+file path=usr/share/doc/distcc/example/hosts.allow
+file path=usr/share/doc/distcc/example/init
+file path=usr/share/doc/distcc/example/init-suse
+file path=usr/share/doc/distcc/example/logrotate
+file path=usr/share/doc/distcc/example/services
+file path=usr/share/doc/distcc/example/xinetd
+file path=usr/share/doc/distcc/protocol-1.txt
+file path=usr/share/doc/distcc/protocol-2.txt
+file path=usr/share/doc/distcc/protocol-3-impl.txt
+file path=usr/share/doc/distcc/protocol-3.txt
+file path=usr/share/doc/distcc/protocol-gssapi.txt
+file path=usr/share/doc/distcc/reporting-bugs.txt
+file path=usr/share/doc/distcc/status-1.txt
+file path=usr/share/doc/distcc/survey.txt
+
+file path=usr/share/man/man1/distcc.1
+file path=usr/share/man/man1/distccd.1
+file path=usr/share/man/man1/distccmon-text.1
+file path=usr/share/man/man1/lsdistcc.1

--- a/components/developer/distcc/distcc-core.p5m
+++ b/components/developer/distcc/distcc-core.p5m
@@ -36,7 +36,7 @@ file path=usr/bin/distccmon-text
 file path=usr/bin/lsdistcc
 
 # This only needs a system Python, and we have one for PKG anyway
-file files/distcc-top.py path=usr/bin/distcc-top
+file path=usr/bin/distcc-top
 
 file path=usr/share/doc/distcc/AUTHORS
 file path=usr/share/doc/distcc/COPYING

--- a/components/developer/distcc/distcc-mon.p5m
+++ b/components/developer/distcc/distcc-mon.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+<transform file hardlink path=usr/lib/.*\.py$ -> default pkg.tmp.pyversion 2.X>
+<transform file path=usr/share/applications/.* ->  default restart_fmri svc:/application/desktop-cache/desktop-mime-cache:default>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-mon@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - an X11 monitor"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=$(COMPONENT_FMRI)-core@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
+file path=usr/bin/distccmon-gnome
+
+file path=usr/share/distcc/distccmon-gnome-icon.png
+file path=usr/share/distcc/distccmon-gnome.desktop
+

--- a/components/developer/distcc/distcc-pump.p5m
+++ b/components/developer/distcc/distcc-pump.p5m
@@ -28,6 +28,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 depend type=require fmri=$(COMPONENT_FMRI)-core@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/bin/pump
+link target=pump path=usr/bin/distcc-pump
 
 file path=usr/lib/python3.4/site-packages/include_server-3.2rc1-py3.4.egg-info
 file path=usr/lib/python3.4/site-packages/include_server/__pycache__/basics.cpython-34.pyc

--- a/components/developer/distcc/distcc-pump.p5m
+++ b/components/developer/distcc/distcc-pump.p5m
@@ -1,0 +1,84 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+<transform file hardlink path=usr/lib/.*\.py$ -> default pkg.tmp.pyversion 3.X>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-pump@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - pump and include_server (needs Python3)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=$(COMPONENT_FMRI)-core@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
+file path=usr/bin/pump
+
+file path=usr/lib/python3.4/site-packages/include_server-3.2rc1-py3.4.egg-info
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/basics.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/basics_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/c_extensions_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/cache_basics.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/compiler_defaults.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/compress_files.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/include_analyzer.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/include_analyzer_memoizing_node.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/include_analyzer_memoizing_node_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/include_analyzer_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/include_server.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/include_server_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/macro_eval.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/macro_eval_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/mirror_path.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/mirror_path_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/parse_command.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/parse_command_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/parse_file.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/parse_file_test.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/run.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/setup.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/__pycache__/statistics.cpython-34.pyc
+file path=usr/lib/python3.4/site-packages/include_server/basics.py
+file path=usr/lib/python3.4/site-packages/include_server/basics_test.py
+file path=usr/lib/python3.4/site-packages/include_server/c_extensions_test.py
+file path=usr/lib/python3.4/site-packages/include_server/cache_basics.py
+file path=usr/lib/python3.4/site-packages/include_server/compiler_defaults.py
+file path=usr/lib/python3.4/site-packages/include_server/compress_files.py
+file path=usr/lib/python3.4/site-packages/include_server/distcc_pump_c_extensions.cpython-34m.so
+file path=usr/lib/python3.4/site-packages/include_server/include_analyzer.py
+file path=usr/lib/python3.4/site-packages/include_server/include_analyzer_memoizing_node.py
+file path=usr/lib/python3.4/site-packages/include_server/include_analyzer_memoizing_node_test.py
+file path=usr/lib/python3.4/site-packages/include_server/include_analyzer_test.py
+file path=usr/lib/python3.4/site-packages/include_server/include_server.py
+file path=usr/lib/python3.4/site-packages/include_server/include_server_test.py
+file path=usr/lib/python3.4/site-packages/include_server/macro_eval.py
+file path=usr/lib/python3.4/site-packages/include_server/macro_eval_test.py
+file path=usr/lib/python3.4/site-packages/include_server/mirror_path.py
+file path=usr/lib/python3.4/site-packages/include_server/mirror_path_test.py
+file path=usr/lib/python3.4/site-packages/include_server/parse_command.py
+file path=usr/lib/python3.4/site-packages/include_server/parse_command_test.py
+file path=usr/lib/python3.4/site-packages/include_server/parse_file.py
+file path=usr/lib/python3.4/site-packages/include_server/parse_file_test.py
+file path=usr/lib/python3.4/site-packages/include_server/run.py
+file path=usr/lib/python3.4/site-packages/include_server/setup.py
+file path=usr/lib/python3.4/site-packages/include_server/statistics.py
+
+file path=usr/share/doc/distcc/README.pump
+
+file path=usr/share/man/man1/include_server.1
+file path=usr/share/man/man1/pump.1

--- a/components/developer/distcc/distcc.p5m
+++ b/components/developer/distcc/distcc.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=$(COMPONENT_FMRI)-core@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+depend type=optional fmri=$(COMPONENT_FMRI)-pump@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+depend type=optional fmri=$(COMPONENT_FMRI)-mon@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/developer/distcc/files/distcc-top.py
+++ b/components/developer/distcc/files/distcc-top.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python2.6
+# NOTE: For OI-Userland packaging, we specify a specific version of Python
+
+# http://code.activestate.com/recipes/577933-distcc-top/
+# Created by Mike 'Fuzzy' Partin on Mon, 31 Oct 2011 (BSD)
+#
+# A small recipe for a curses based, 'top'-like monitor for DistCC. I know
+# there is already distccmon-text, but I don't like it, and much prefer this
+# sytle of monitoring. Note that I don't keep hosts around in the list like
+# distccmon-gui/gnome. The screen is drawn for exactly what is currently in
+# state. The terminal size is respected at initialization time, however resize
+# events aren't handled. There is color designation of job types.
+#
+# There are lots of simple things that can be done to improve upon this,
+# however, for a simple monitor, it's feature complete. I say this as I don't
+# care about keyboard input, there are no help screens, there is simply the
+# current state on a snapshot-by-snapshot basis at a 0.75s interval.
+# You simply CTRL+C to exit. Nothing more, nothing less.
+#
+
+import os, sys, time
+import curses,struct
+
+states = ['STARTUP', 'BLOCKED', 'CONNECT', 'PREPROCESS', 'SEND', 'COMPILE', 'RECEIVE', 'DONE']
+DISTCC_DIR = os.getenv('DISTCC_DIR') or '%s/.distcc' % os.getenv('HOME')
+
+def write(win=None, line=None, col=None, txt=None, attrs=None):
+    if win != None:
+        win.move(line, col)
+        win.clrtoeol()
+        win.addstr(line, col, txt, attrs)
+
+def display_time(scr):
+    t = time.ctime().split()
+    write(scr, 0, 0,  t[0], curses.color_pair(9))
+    write(scr, 0, 4,  t[1], curses.color_pair(9))
+    write(scr, 0, 8,  t[2], curses.color_pair(9))
+    write(scr, 0, 11, t[3], curses.color_pair(9))
+    write(scr, 0, 20, t[4], curses.color_pair(9))
+
+def display_loadavg(scr):
+    lavg = os.getloadavg()
+    write(scr, 1, 0, 'System',             curses.color_pair(9))
+    write(scr, 1, 7, 'Load:',              curses.color_pair(9))
+    write(scr, 1, 13, '%.02f' % lavg[0],   curses.color_pair(9))
+    write(scr, 1, 20, '%.02f' % lavg[1],   curses.color_pair(9))
+    write(scr, 1, 27, '%.02f' % lavg[2],   curses.color_pair(9))
+
+def display_header(scr):
+    write(scr, 3, 0,  'Slot',  curses.A_BOLD)
+    write(scr, 3, 5,  'Host',  curses.A_BOLD)
+    write(scr, 3, 25, 'State', curses.A_BOLD)
+    write(scr, 3, 45, 'Filename', curses.A_BOLD)
+    #'%-4s %-20s %-15s %-40s%s' % ('Slot', 'Remote Host', 'State', 'Filename', ' '*(maxX-83)), curses.A_BOLD)
+
+def getStats(scr):
+    curses.init_pair(9,  curses.COLOR_WHITE,  curses.COLOR_BLACK)
+    curses.init_pair(10, curses.COLOR_YELLOW, curses.COLOR_BLACK)
+    curses.init_pair(11, curses.COLOR_RED,    curses.COLOR_BLACK)
+    curses.init_pair(12, curses.COLOR_GREEN,  curses.COLOR_BLACK)
+    (maxY, maxX) = scr.getmaxyx()
+    while 1:
+        try:
+            display_time(scr)
+            display_loadavg(scr)
+            display_header(scr)
+            #write(scr, 3, 0, '%-4s %-20s %-15s %-40s%s' % ('Slot', 'Remote Host', 'State', 'Filename', ' '*(maxX-83)), curses.A_BOLD)
+            cnt = 5
+            try:
+                for i in os.listdir(DISTCC_DIR+'/state'):
+                    data = struct.unpack('@iLL128s128siiP', open(DISTCC_DIR+'/state/'+i).readline().strip())
+                    file = data[3].split('\x00')[0] or 'None'
+                    host = data[4].split('\x00')[0] or 'None'
+                    slot = int(data[5])
+                    stte = states[int(data[6])]
+                    scr.move(cnt,0)
+                    scr.clrtoeol()
+                    if 'None' not in (file, host):
+                        write(scr, cnt, 0, '%s' % slot, curses.color_pair(9))
+                        write(scr, cnt, 5, '%s' % host, curses.color_pair(9))
+                        if int(data[6]) in (2,3):
+                            write(scr, cnt, 25, '%s ' % (stte), curses.color_pair(10))
+                        elif int(data[6]) in (0,1):
+                            write(scr, cnt, 25, '%s ' % (stte), curses.color_pair(11))
+                        elif int(data[6]) in (4,5):
+                            write(scr, cnt, 25, '%s ' % (stte), curses.color_pair(12))
+                        elif int(data[6]) in (6,7):
+                            write(scr, cnt, 25, '%s ' % (stte), curses.color_pair(12)|curses.A_BOLD)
+                        else: write(scr, cnt, 25, '%s ' % (stte))
+                        write(scr, cnt, 45, '%s' % file, curses.color_pair(9))
+                        cnt += 1
+            except struct.error: pass
+            except IOError: pass
+            scr.refresh()
+            time.sleep(0.75)
+            scr.erase()
+            scr.move(0,0)
+        except KeyboardInterrupt:
+            sys.exit(-1)
+
+if __name__ == '__main__':
+    curses.wrapper(getStats)
+

--- a/components/developer/distcc/files/distcc-top.py
+++ b/components/developer/distcc/files/distcc-top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.6
+#!/usr/bin/env python
 # NOTE: For OI-Userland packaging, we specify a specific version of Python
 
 # http://code.activestate.com/recipes/577933-distcc-top/

--- a/components/developer/distcc/patches/01-gssapi-configure.patch
+++ b/components/developer/distcc/patches/01-gssapi-configure.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2016-04-27 23:31:19.000000000 +0200
++++ b/configure.ac	2016-05-09 18:52:56.501124694 +0200
+@@ -502,7 +502,7 @@
+ 
+ if test x"$with_auth" = xyes; then
+         AC_SEARCH_LIBS([gss_init_sec_context],
+-                        [gssapi gssapi_krb5],
++                        [gssapi gssapi_krb5 gss],
+ 	                AC_DEFINE(HAVE_GSSAPI, 1, [Define if the GSS_API is available])
+ 	                AUTH_COMMON_OBJS="src/auth_common.o"
+ 	                AUTH_DISTCC_OBJS="src/auth_distcc.o"

--- a/components/developer/distcc/patches/02-getpeername_type-configure.patch
+++ b/components/developer/distcc/patches/02-getpeername_type-configure.patch
@@ -1,0 +1,15 @@
+--- a/configure.ac	2016-05-09 18:58:41.470160047 +0200
++++ b/configure.ac	2016-05-09 19:00:52.709784163 +0200
+@@ -48,10 +48,10 @@
+ 	AC_MSG_CHECKING([for socklen_t equivalent])
+ 	AC_CACHE_VAL([dcc_cv_socklen_t_equiv],
+ 	[
+-	# Systems have either "struct sockaddr *" or
++	# Systems have either "struct sockaddr{,_in} *" or
+ 	# "void *" as the second argument to getpeername
+ 	dcc_cv_socklen_t_equiv=
+-	for arg2 in "struct sockaddr" void; do
++	for arg2 in "struct sockaddr_in" "struct sockaddr" void; do
+ 		for t in int size_t unsigned long "unsigned long"; do
+ 			AC_TRY_COMPILE([
+ #include <sys/types.h>

--- a/components/developer/distcc/patches/03-src-zeroconf-fcntl.patch
+++ b/components/developer/distcc/patches/03-src-zeroconf-fcntl.patch
@@ -1,0 +1,10 @@
+--- a/src/zeroconf.c	2016-05-09 19:31:42.422415007 +0200
++++ b/src/zeroconf.c	2016-05-09 19:31:22.506310990 +0200
+@@ -25,6 +25,7 @@
+ #include <sys/select.h>
+ #include <signal.h>
+ #include <sys/file.h>
++#include <fcntl.h>
+ #include <sys/time.h>
+ #include <time.h>
+ #include <sys/stat.h>

--- a/components/developer/distcc/patches/04-avahi-sentinel.patch
+++ b/components/developer/distcc/patches/04-avahi-sentinel.patch
@@ -1,0 +1,11 @@
+--- a/src/zeroconf-reg.c	2016-04-27 23:31:19.000000000 +0200
++++ b/src/zeroconf-reg.c	2016-05-10 16:12:16.868101958 +0200
+@@ -97,7 +97,7 @@
+                     "gnuhost="GNU_HOST,
+                     v ? version : NULL,
+                     m ? machine : NULL,
+-                    NULL) < 0) {
++                    NULL, NULL) < 0) {
+             rs_log_crit("Failed to add service: %s\n", avahi_strerror(avahi_client_errno(ctx->client)));
+             goto fail;
+         }

--- a/components/developer/distcc/patches/04-avahi-sentinel.patch
+++ b/components/developer/distcc/patches/04-avahi-sentinel.patch
@@ -1,3 +1,7 @@
+Thanks to answers at
+http://stackoverflow.com/questions/2407605/c-warning-missing-sentinel-in-function-call
+for the hints on properly ensuring the sentinel argument.
+
 --- a/src/zeroconf-reg.c	2016-04-27 23:31:19.000000000 +0200
 +++ b/src/zeroconf-reg.c	2016-05-10 16:12:16.868101958 +0200
 @@ -97,7 +97,7 @@
@@ -5,7 +9,7 @@
                      v ? version : NULL,
                      m ? machine : NULL,
 -                    NULL) < 0) {
-+                    NULL, NULL) < 0) {
++                    (void*)NULL) < 0) {
              rs_log_crit("Failed to add service: %s\n", avahi_strerror(avahi_client_errno(ctx->client)));
              goto fail;
          }

--- a/components/developer/distcc/patches/05-src-auth-casting.patch
+++ b/components/developer/distcc/patches/05-src-auth-casting.patch
@@ -1,0 +1,11 @@
+--- a/src/auth_distcc.c	2016-04-27 23:31:19.000000000 +0200
++++ b/src/auth_distcc.c	2016-06-27 13:46:18.303925757 +0200
+@@ -128,7 +128,7 @@
+ 
+     addr_len = sizeof(addr);
+ 
+-    if ((ret = getpeername(to_net_sd, &addr, &addr_len)) != 0) {
++    if ((ret = getpeername(to_net_sd, (struct sockaddr *)&addr, &addr_len)) != 0) {
+         rs_log_error("Failed to look up peer address using socket \"%d\": %s.",
+                      to_net_sd,
+                      hstrerror(h_errno));

--- a/components/developer/distcc/patches/06-pump-libs.patch
+++ b/components/developer/distcc/patches/06-pump-libs.patch
@@ -1,0 +1,11 @@
+--- a/include_server/setup.py	2016-07-12 11:43:52.000000000 +0200
++++ b/include_server/setup.py	2016-07-22 19:50:27.785243803 +0200
+@@ -157,7 +157,7 @@
+     include_dirs=cpp_flags_includes,
+     define_macros=[('_GNU_SOURCE', 1)],
+     library_dirs=[],
+-    libraries=[],
++    libraries=['xnet', 'resolv'],
+     runtime_library_dirs=[],
+     extra_objects=[],
+     extra_compile_args=[]


### PR DESCRIPTION
NOTES:

1) Currently, the package does not include an init or SMF script like https://github.com/distcc/distcc/blob/master/packaging/RedHat/init.d/distcc since it is questionable with what credentials a host should slave away for compilations from remote clients, and because it is not the only way to get it started (there is also SSH invokation and inetd-style). A service would be nice for e.g. zeroconf (avahi) usecase; the default port is non-privileged so a user may run it. Subsequent PRs to add a service is possible when/if someone has a firmer opinion on what it should be.

2) It is recommended to use same compiler versions (native or cross) on all systems for a distributed build for a particular target platform, so we should have some PR (or manual setup) to expose full compiler names, maybe even with versions (missing now in common cases), into some path that would be usable by distcc. Might be symlinks into /usr/bin, e.g. `i386-pc-solaris2.11-gcc***-4.9.0***`.

3) Integration with CCACHE is a common usecase. Generally the client holds the `.ccache` directory of his build products (can be shared among builders https://ccache.samba.org/manual.html#_sharing_a_cache and buildhosts https://ccache.samba.org/manual.html#_sharing_a_cache_on_nfs), and with an `export CCACHE_PREFIX="distcc"` it spreads the compilation load (if deemed needed) to workers listed in `DISTCC_HOSTS` - e.g. `export DISTCC_HOSTS='--randomize localhost red,cpp,lzo green,cpp,lzo blue,cpp,lzo'`. Not sure how/if this works with pump mode. So far not specially handled nor tested for oi-userland builds in particular (e.g. what level of builds do we want to parallelize - objects inside recipes? many packages with each recipe as a singular-host target?).

4) Did not really get if we can use alien systems to compile for each other (e.g. solarish <-> linux, oi ,-> omnios, etc.) if out-of-the-box compiler versions and system headers are different.

Frankly speaking, the resulting `distcc*` programs are not yet tested in practice (@xen0l - you're welcome ;) )

Some projects and blogs have nice overviews of practical distcc usage:
- https://wiki.gentoo.org/wiki/Distcc
- https://wiki.archlinux.org/index.php/Distcc
- http://blog.kfish.org/2010/06/speeding-up-cross-compiling-with-ccache.html
- http://linux.die.net/man/1/distcc
- http://linux.die.net/man/1/distccd

Also of interest seems to be the DMUCS frontend to list distcc-servers : http://dmucs.sourceforge.net/ which despite a decade-long gap in development seems to be happily used by various internet mailing list members.
