### PR TITLE
Fixed Component: mate-settings-daemon MACH64 build added to filelist

### DIFF
--- a/components/desktop/mate/mate-settings-daemon/Makefile
+++ b/components/desktop/mate/mate-settings-daemon/Makefile
@@ -35,7 +35,7 @@ include $(WS_TOP)/make-rules/ips.mk
 
 PATH=/usr/gnu/bin:/usr/bin
 
-COMPONENT_PREP_ACTION=	cd $(@D)  && ./autogen.sh --help
+COMPONENT_PREP_ACTION=	cd $(@D)  && NOCONFIGURE=1 ./autogen.sh
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --disable-static

--- a/components/desktop/mate/mate-settings-daemon/mate-settings-daemon.p5m
+++ b/components/desktop/mate/mate-settings-daemon/mate-settings-daemon.p5m
@@ -12,6 +12,9 @@
 #
 # Copyright 2016 Till wegmueller
 #
+<transform file -> add pkg.depend.bypass-generate libplc4\.so>
+<transform file -> add pkg.depend.bypass-generate libnss3\.so>
+<transform file -> add pkg.depend.bypass-generate libnspr4\.so>
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
@@ -21,10 +24,6 @@ set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
-
-<transform file -> add pkg.depend.bypass-generate libplc4\.so>
-<transform file -> add pkg.depend.bypass-generate libnss3\.so>
-<transform file -> add pkg.depend.bypass-generate libnspr4\.so>
 
 depend fmri=library/nspr type=require
 depend fmri=system/library/mozilla-nss type=require
@@ -73,6 +72,39 @@ file path=usr/lib/mate-settings-daemon/xrandr.mate-settings-plugin
 file path=usr/lib/mate-settings-daemon/xrdb.mate-settings-plugin
 file path=usr/lib/mate-settings-daemon/xsettings.mate-settings-plugin
 file path=usr/lib/pkgconfig/mate-settings-daemon.pc
+file path=usr/lib/$(MACH64)/mate-settings-daemon/a11y-keyboard.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/a11y-settings.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/background.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/clipboard.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/housekeeping.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/keybindings.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/keyboard.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/liba11y-keyboard.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/liba11y-settings.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libbackground.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libclipboard.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libhousekeeping.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libkeybindings.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libkeyboard.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libmedia-keys.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libmouse.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libmpris.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libsmartcard.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libsound.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libtyping-break.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libxrandr.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libxrdb.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/libxsettings.so
+file path=usr/lib/$(MACH64)/mate-settings-daemon/media-keys.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/mouse.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/mpris.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/smartcard.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/sound.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/typing-break.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/xrandr.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/xrdb.mate-settings-plugin
+file path=usr/lib/$(MACH64)/mate-settings-daemon/xsettings.mate-settings-plugin
+file path=usr/lib/$(MACH64)/pkgconfig/mate-settings-daemon.pc
 file path=usr/share/dbus-1/services/org.mate.SettingsDaemon.service
 file path=usr/share/glib-2.0/schemas/org.mate.SettingsDaemon.plugins.a11y-keyboard.gschema.xml
 file path=usr/share/glib-2.0/schemas/org.mate.SettingsDaemon.plugins.a11y-settings.gschema.xml


### PR DESCRIPTION
This fixes having no icons on login
