### PR TITLE
Add lua.hpp in lua

### DIFF
--- a/components/runtime/lua/Makefile
+++ b/components/runtime/lua/Makefile
@@ -25,7 +25,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		lua
 COMPONENT_VERSION=	5.2.4
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	http://www.lua.org/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -82,7 +82,5 @@ test: 		install
 		$(ENV) LD_LIBRARY_PATH=$(PROTOUSRLIBDIR64) \
 		$(PROTOUSRBINDIR64)/$(COMPONENT_NAME) -e"_U=true" all.lua)
 
-BUILD_PKG_DEPENDENCIES =        $(BUILD_TOOLS)
-
-include $(WS_MAKE_RULES)/depend.mk
-
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/runtime/lua/lua.p5m
+++ b/components/runtime/lua/lua.p5m
@@ -25,25 +25,17 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license lua.license license=MIT
 
-dir  path=usr
-dir  path=usr/bin
-dir  path=usr/bin/$(MACH64)
 file path=usr/bin/$(MACH64)/lua
 file path=usr/bin/$(MACH64)/luac
 file path=usr/bin/lua
 file path=usr/bin/luac
-dir  path=usr/include
 file path=usr/include/lauxlib.h
 file path=usr/include/lua.h
+file path=usr/include/lua.hpp
 file path=usr/include/luaconf.h
 file path=usr/include/lualib.h
-dir  path=usr/lib
-dir  path=usr/lib/$(MACH64)
 file path=usr/lib/$(MACH64)/liblua.so
 file path=usr/lib/liblua.so
-dir  path=usr/share
-dir  path=usr/share/doc
-dir  path=usr/share/doc/lua
 file path=usr/share/doc/lua/contents.html
 file path=usr/share/doc/lua/logo.gif
 file path=usr/share/doc/lua/lua.css
@@ -51,8 +43,6 @@ file path=usr/share/doc/lua/manual.css
 file path=usr/share/doc/lua/manual.html
 file path=usr/share/doc/lua/osi-certified-72x60.png
 file path=usr/share/doc/lua/readme.html
-dir  path=usr/share/man
-dir  path=usr/share/man/man1
 file path=usr/share/man/man1/lua.1
 file path=usr/share/man/man1/luac.1
 file lua-64.pc path=usr/lib/$(MACH64)/pkgconfig/lua.pc

--- a/components/runtime/lua/manifests/sample-manifest.p5m
+++ b/components/runtime/lua/manifests/sample-manifest.p5m
@@ -28,6 +28,7 @@ file path=usr/bin/lua
 file path=usr/bin/luac
 file path=usr/include/lauxlib.h
 file path=usr/include/lua.h
+file path=usr/include/lua.hpp
 file path=usr/include/luaconf.h
 file path=usr/include/lualib.h
 file path=usr/lib/$(MACH64)/liblua.so

--- a/components/runtime/lua/patches/1.Makefile.patch
+++ b/components/runtime/lua/patches/1.Makefile.patch
@@ -44,7 +44,7 @@
  TO_BIN= lua luac
 -TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
 -TO_LIB= liblua.a
-+TO_INC= lua.h luaconf.h lualib.h lauxlib.h
++TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
 +TO_LIB= liblua.so
  TO_MAN= lua.1 luac.1
 +TO_DOC= contents.html osi-certified-72x60.png logo.gif lua.css manual.css manual.html readme.html


### PR DESCRIPTION
Header lua.hpp was removed from distribution but is used by several projects (e.g. ptlib).
