### PR TITLE
Remove dependencies on python-26

### DIFF
--- a/components/developer/dtracetoolkit/Makefile
+++ b/components/developer/dtracetoolkit/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		DTraceToolkit
 COMPONENT_VERSION=	0.99
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4	
 COMPONENT_PROJECT_URL=	http://www.brendangregg.com/dtracetoolkit.html
 COMPONENT_SUMMARY=	A collection of opensource dtrace scripts
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/developer/dtracetoolkit/dtracetoolkit.p5m
+++ b/components/developer/dtracetoolkit/dtracetoolkit.p5m
@@ -28,9 +28,10 @@ license License license='CDDL v1.0'
 <transform file path=opt/DTT/Code/.*\.rb$ -> default mode 0555>
 <transform file path=opt/DTT/Code/.*\.sh$ -> default mode 0555>
 
-# We don't depend on particular python version for examples
+# Depend on python-27 explicitly, so we can disconnect userland from
+# python-26 once and for all.
 <transform file path=opt/DTT/.*\.py$ -> default pkg.depend.bypass-generate .*>
-depend fmri=__TBD pkg.debug.depend.file=usr/bin/python type=require
+depend fmri=runtime/python-27 type=require
 
 file path=opt/DTT/Apps/Readme
 file path=opt/DTT/Apps/httpdstat.d

--- a/components/developer/dtracetoolkit/patches/shebang.patch
+++ b/components/developer/dtracetoolkit/patches/shebang.patch
@@ -87,3 +87,21 @@ diff -ur DTraceToolkit-0.99/Code/Shell/func_waste.sh DTraceToolkit-0.99-1/Code/S
  
  func_c()
  {
+diff -ruN DTraceToolkit-0.99.orig/Code/Python/func_abc.py DTraceToolkit-0.99/Code/Python/func_abc.py
+--- DTraceToolkit-0.99.orig/Code/Python/func_abc.py	2007-09-15 09:48:11.000000000 +0400
++++ DTraceToolkit-0.99/Code/Python/func_abc.py	2016-08-17 15:13:28.470546645 +0300
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python2.7
+ 
+ import time
+ 
+diff -ruN DTraceToolkit-0.99.orig/Code/Python/func_slow.py DTraceToolkit-0.99/Code/Python/func_slow.py
+--- DTraceToolkit-0.99.orig/Code/Python/func_slow.py	2007-09-15 09:48:11.000000000 +0400
++++ DTraceToolkit-0.99/Code/Python/func_slow.py	2016-08-17 15:13:36.355687977 +0300
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python2.7
+ 
+ def func_c():
+ 	print "Function C"

--- a/components/text/texinfo/Makefile
+++ b/components/text/texinfo/Makefile
@@ -65,3 +65,9 @@ build:		$(BUILD_32_and_64)
 install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
+
+REQUIRED_PACKAGES += library/ncurses
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += shell/bash
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library

--- a/components/text/texinfo/svc-texinfo-update
+++ b/components/text/texinfo/svc-texinfo-update
@@ -39,9 +39,9 @@ function readlink() {
 	shift $((OPTIND - 1))
 
 	if (( follow )); then
-		python -ESc "import os; print os.path.realpath('$1')"
+		/usr/bin/python2.7 -ESc "import os; print os.path.realpath('$1')"
 	else    
-		python -ESc "import os; print os.readlink('$1')"
+		/usr/bin/python2.7 -ESc "import os; print os.readlink('$1')"
         fi
 }
 

--- a/components/text/texinfo/texinfo.p5m
+++ b/components/text/texinfo/texinfo.p5m
@@ -514,4 +514,4 @@ legacy pkg=SUNWtexi desc="GNU texinfo (texinfo)" \
     name="GNU texinfo - Texinfo utilities (texinfo)"
 license texinfo.copyright license='GPLv3,FDLv1.3'
 license texi2html.copyright license=texi2html
-depend type=require fmri=__TBD pkg.debug.depend.file=usr/bin/python
+depend type=require fmri=runtime/python-27


### PR DESCRIPTION
This PR fixes remaining components to not depend on python-26.

<pre>


| pkg://openindiana.org/developer/build/onbld@0.5.11-2016.0.0.15794:20160808T133129Z
| pkg://openindiana.org/system/file-system/zfs@0.5.11-2016.0.0.15794:20160808T135540Z
|------(    require)--pkg://openindiana.org/runtime/python-26

| pkg://openindiana.org/library/python-2/argparse-26@1.2.1-2016.0.0.0:20160730T012155Z
| pkg://openindiana.org/library/python/numpy-26@1.11.1-2016.0.0.0:20160730T071113Z
| pkg://openindiana.org/library/python-2/pybonjour-26@1.1.1-2016.0.0.0:20160730T071230Z
| pkg://openindiana.org/library/python-2/cherrypy-26@3.1.2-2016.0.0.0:20160730T012228Z
| pkg://openindiana.org/library/python-2/python-twisted-26@10.1.0-2016.0.0.0:20160730T071916Z
| pkg://openindiana.org/library/python-2/mako-26@1.0.3-2016.0.0.0:20160730T070912Z
| pkg://openindiana.org/library/python-2/libxml2-26@2.9.4-2016.0.0.0:20160730T003842Z
| pkg://openindiana.org/library/python-2/simplejson-26@3.8.2-2016.0.0.0:20160730T071755Z
| pkg://openindiana.org/system/library@0.5.11-2016.0.0.15794:20160808T135756Z
| pkg://openindiana.org/library/python-2/libxsl-26@1.1.28-2016.0.0.2:20160730T004810Z
| pkg://openindiana.org/library/python-2/tkinter-26@2.6.9-2016.0.0.6:20160730T013858Z
| pkg://openindiana.org/library/python-2/lcms-26@1.19-2016.0.0.0:20160730T000921Z
| pkg://openindiana.org/library/python-2/python-xdg-26@0.25-2016.0.0.0:20160730T071659Z
| pkg://openindiana.org/library/python/setuptools-26@19.2-2016.0.0.0:20160730T071727Z
| pkg://openindiana.org/library/python-2/pyopenssl-26@0.13-2016.0.0.2:20160730T071432Z
| pkg://openindiana.org/library/python-2/pyrex-26@0.9.9-2016.0.0.0:20160730T071447Z
| pkg://openindiana.org/install/beadm@0.5.11-2016.0.0.15794:20160808T134158Z
| pkg://openindiana.org/library/python-2/pycurl-26@7.19.0.1-2016.0.0.1:20160730T071324Z
| pkg://openindiana.org/library/python-2/python-zope-interface-26@3.3.0-2016.0.0.0:20160730T072001Z
| pkg://openindiana.org/library/python-2/ply-26@3.1-2016.0.0.0:20160730T071202Z
| pkg://openindiana.org/library/python-2/jsonschema-26@2.4.0-2016.0.0.0:20160730T070828Z
| pkg://openindiana.org/library/python-2/docutils-26@0.12-2016.0.0.0:20160730T070509Z
| pkg://openindiana.org/developer/versioning/mercurial-26@3.8.4-2016.0.0.1:20160730T064340Z
| pkg://openindiana.org/library/python-2/m2crypto-26@0.21.1-2016.0.0.1:20160730T070909Z
|------(    require)--pkg://openindiana.org/runtime/python-26@2.6.9-2016.0.0.6

| pkg://openindiana.org/text/texinfo@6.0-2016.0.0.0:20160730T021723Z
| pkg://openindiana.org/developer/dtrace/toolkit@0.99-2016.0.0.3:20160729T232924Z
|------(require-any)--pkg://openindiana.org/runtime/python-26@2.6.9-2016.0.0.6

| pkg://openindiana.org/runtime/python-27@2.7.12-2016.0.0.1:20160730T013915Z
|------(   optional)--pkg://openindiana.org/runtime/python-26@2.6.9,2014.0.1.2
</pre>


After this is merged, only python modules and illumos-gate should depend on python-26.
