### PR TITLE
openjdk-8: fix PKCS11 (7227) https://www.illumos.org/issues/7227

### DIFF
--- a/components/runtime/openjdk-8/Makefile
+++ b/components/runtime/openjdk-8/Makefile
@@ -16,6 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= oppenjdk-8
+COMPONENT_REVISION= 1
 
 OPENJDK_BUILD_NUMBER=92
 COMPONENT_VERSION=1.8.$(OPENJDK_BUILD_NUMBER)

--- a/components/runtime/openjdk-8/patches/patch-pkcs11.patch
+++ b/components/runtime/openjdk-8/patches/patch-pkcs11.patch
@@ -1,0 +1,22 @@
+$OpenIndiana: Fix https://www.illumos.org/issues/7227 - Franklin Ronald <franklin@wiselabs.com.br>$
+
+--- jdk/src/share/classes/sun/security/jca/ProviderConfig.java.1	2016-05-06 09:11:17.000000000 -0300
++++ jdk/src/share/classes/sun/security/jca/ProviderConfig.java		2016-09-02 15:32:30.826383860 -0300
+@@ -105,5 +105 @@
+-                File file = new File("/usr/lib/libpkcs11.so");
+-                if (file.exists() == false) {
+-                    return Boolean.FALSE;
+-                }
+-                if ("false".equalsIgnoreCase(System.getProperty
++                if ("true".equalsIgnoreCase(System.getProperty
+@@ -111 +107,4 @@
+-                    return Boolean.FALSE;
++                    File file = new File("/usr/lib/libpkcs11.so");
++                    if (file.exists()) {
++                        return Boolean.TRUE;
++                    }
+@@ -113 +112 @@
+-                return Boolean.TRUE;
++                return Boolean.FALSE;
+@@ -284,0 +284 @@
++


### PR DESCRIPTION
Following the correction of bug # 7227. OpenJDK 8 only has this behavior in Solaris and Illumos, why the Solaris Cryptographic Framework does not support SHA-256 hash. This Solaris Cryptographic Framework interface in Java in OpenIndiana was enabled by default, but the right is the opposite. Applications tested on other operating systems, by default use the PKCS11 interface Java itself, not native.

Please give me access to remove the bug triage status or enter me in the group "OI-userland" in Redmine. I will select another task to contribute.

This repository belongs to the company that I am co-founder. We will officially help develop OpenIndiana. The idea is to deploy on all servers of our new customers.

Please visit our website: http://www.wiselabs.com.br
