### PR TITLE
Missing fix to mapfile-vers in libXi (from x-s12)

### DIFF
--- a/components/x11/libXi/Makefile
+++ b/components/x11/libXi/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libXi
 COMPONENT_VERSION= 1.7.6
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= libXi - X Input extension client library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2

--- a/components/x11/libXi/mapfile-vers
+++ b/components/x11/libXi/mapfile-vers
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,19 +21,18 @@
 # DEALINGS IN THE SOFTWARE.
 #
 
-# Added in libXi 1.7
 SUNW_1.4 {
     global:
+# Added in libXi 1.7.0
 	XIBarrierReleasePointer;
 	XIBarrierReleasePointers;
+
+# Added in libXi 1.6.0
+	XIAllowTouchEvents;
 	XIGrabTouchBegin;
 	XIUngrabTouchBegin;
-} SUNW_1.3;
-
 
 # Added in libXi 1.3.0 / <X11/extensions/XInput2.h>:
-SUNW_1.4 {
-    global:
         XIQueryPointer;
         XIWarpPointer;
         XIDefineCursor;


### PR DESCRIPTION
Reference: https://hg.openindiana.org/upstream/oracle/x-cons/x-s12-clone/rev/5961283983f5
