### PR TITLE
X 201610 Part 5: libvdpau

### DIFF
--- a/components/openindiana/nvidia/driver-graphics-nvidia.p5m
+++ b/components/openindiana/nvidia/driver-graphics-nvidia.p5m
@@ -243,7 +243,6 @@ link path=usr/X11/lib/modules/NVIDIA/libnvidia-wfb.so \
 link path=usr/X11/lib/modules/extensions/NVIDIA/$(MACH64)/libglx.so \
     target=libglx.so.1
 link path=usr/X11/lib/modules/extensions/NVIDIA/libglx.so target=libglx.so.1
-link path=usr/include/vdpau target=../X11/include/NVIDIA/vdpau
 link path=usr/lib/$(MACH64)/libnvidia-glcore.so.1 \
     target=../../X11/lib/NVIDIA/$(MACH64)/libnvidia-glcore.so.1
 link path=usr/lib/$(MACH64)/libnvidia-tls.so target=libnvidia-tls.so.1

--- a/components/x11/libvdpau/Makefile
+++ b/components/x11/libvdpau/Makefile
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 Aurelien Larcher
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		libvdpau
+COMPONENT_VERSION=	1.1.1
+COMPONENT_SUMMARY=	VDPAU libaries and headers
+COMPONENT_PROJECT_URL=	http://freedesktop.org/wiki/Software/VDPAU/
+COMPONENT_FMRI=		library/graphics/libvdpau
+COMPONENT_CLASSIFICATION=	System/Libraries
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:857a01932609225b9a3a5bf222b85e39b55c08787d0ad427dbd9ec033d58d736
+COMPONENT_ARCHIVE_URL= \
+    http://people.freedesktop.org/~aplattner/vdpau/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	MIT
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/configure.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+PATH=/usr/gnu/bin:/usr/bin
+
+CONFIGURE_LIBDIR.32 = /usr/lib/xorg
+CONFIGURE_LIBDIR.64 = /usr/lib/xorg/$(MACH64)
+
+CONFIGURE_OPTIONS+= --sysconfdir=$(ETCDIR)
+
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(NO_TESTS)
+

--- a/components/x11/libvdpau/libvdpau.license
+++ b/components/x11/libvdpau/libvdpau.license
@@ -1,0 +1,20 @@
+Copyright © 2008-2010 NVIDIA Corporation
+Copyright © 2008 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/components/x11/libvdpau/libvdpau.p5m
+++ b/components/x11/libvdpau/libvdpau.p5m
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file path=usr/lib(.*)/pkgconfig/(.+).pc$ \
+	-> set action.hash usr/lib/xorg%<\1>/pkgconfig/%<\2>.pc >
+
+file path=usr/lib/$(MACH64)/pkgconfig/vdpau.pc
+file path=usr/lib/pkgconfig/vdpau.pc
+
+file path=etc/vdpau_wrapper.cfg preserve=true
+file path=usr/include/vdpau/vdpau.h
+file path=usr/include/vdpau/vdpau_x11.h
+link path=usr/lib/xorg/$(MACH64)/libvdpau.so target=libvdpau.so.1.0.0
+link path=usr/lib/xorg/$(MACH64)/libvdpau.so.1 target=libvdpau.so.1.0.0
+file path=usr/lib/xorg/$(MACH64)/libvdpau.so.1.0.0
+link path=usr/lib/xorg/$(MACH64)/vdpau/libvdpau_trace.so \
+    target=libvdpau_trace.so.1.0.0
+link path=usr/lib/xorg/$(MACH64)/vdpau/libvdpau_trace.so.1 \
+    target=libvdpau_trace.so.1.0.0
+file path=usr/lib/xorg/$(MACH64)/vdpau/libvdpau_trace.so.1.0.0
+link path=usr/lib/xorg/libvdpau.so target=libvdpau.so.1.0.0
+link path=usr/lib/xorg/libvdpau.so.1 target=libvdpau.so.1.0.0
+file path=usr/lib/xorg/libvdpau.so.1.0.0
+link path=usr/lib/xorg/vdpau/libvdpau_trace.so target=libvdpau_trace.so.1.0.0
+link path=usr/lib/xorg/vdpau/libvdpau_trace.so.1 target=libvdpau_trace.so.1.0.0
+file path=usr/lib/xorg/vdpau/libvdpau_trace.so.1.0.0

--- a/components/x11/libvdpau/manifests/sample-manifest.p5m
+++ b/components/x11/libvdpau/manifests/sample-manifest.p5m
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/vdpau_wrapper.cfg
+file path=usr/etc/vdpau_wrapper.cfg
+file path=usr/include/vdpau/vdpau.h
+file path=usr/include/vdpau/vdpau_x11.h
+link path=usr/lib/xorg/$(MACH64)/libvdpau.so target=libvdpau.so.1.0.0
+link path=usr/lib/xorg/$(MACH64)/libvdpau.so.1 target=libvdpau.so.1.0.0
+file path=usr/lib/xorg/$(MACH64)/libvdpau.so.1.0.0
+file path=usr/lib/xorg/$(MACH64)/pkgconfig/vdpau.pc
+link path=usr/lib/xorg/$(MACH64)/vdpau/libvdpau_trace.so \
+    target=libvdpau_trace.so.1.0.0
+link path=usr/lib/xorg/$(MACH64)/vdpau/libvdpau_trace.so.1 \
+    target=libvdpau_trace.so.1.0.0
+file path=usr/lib/xorg/$(MACH64)/vdpau/libvdpau_trace.so.1.0.0
+link path=usr/lib/xorg/libvdpau.so target=libvdpau.so.1.0.0
+link path=usr/lib/xorg/libvdpau.so.1 target=libvdpau.so.1.0.0
+file path=usr/lib/xorg/libvdpau.so.1.0.0
+file path=usr/lib/xorg/pkgconfig/vdpau.pc
+link path=usr/lib/xorg/vdpau/libvdpau_trace.so target=libvdpau_trace.so.1.0.0
+link path=usr/lib/xorg/vdpau/libvdpau_trace.so.1 target=libvdpau_trace.so.1.0.0
+file path=usr/lib/xorg/vdpau/libvdpau_trace.so.1.0.0


### PR DESCRIPTION
- Adding libvdpau in /usr/lib/xorg to avoid clash with Nvidia driver.
- Nvidia driver's symlinks in /usr/include are removed as libvdpau has priority over it.
- Removed glamor 0.6.0 from the PR.