### PR TITLE
Bump freetype-2 to 2.7

### DIFF
--- a/components/library/freetype/Makefile
+++ b/components/library/freetype/Makefile
@@ -17,14 +17,14 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           freetype
-COMPONENT_VERSION=        2.6.3
+COMPONENT_VERSION=        2.7
 COMPONENT_FMRI=           system/library/freetype-2
 COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_SUMMARY=  	FreeType 2 font engine
 COMPONENT_SRC=      	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-  sha256:371e707aa522acf5b15ce93f11183c725b8ed1ee8546d7b3af549863045863a2
+  sha256:d6a451f5b754857d2aa3964fd4473f8bc5c64e879b24516d780fb26bec7f7d48
 COMPONENT_ARCHIVE_URL= \
   http://download.savannah.gnu.org/releases/freetype/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://freetype.org/
@@ -55,3 +55,8 @@ install: $(INSTALL_32_and_64)
 
 test: $(TEST_32_and_64)
 
+REQUIRED_PACKAGES += compress/bzip2
+REQUIRED_PACKAGES += image/library/libpng16
+REQUIRED_PACKAGES += library/c++/harfbuzz
+REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += system/library

--- a/components/library/freetype/freetype-2.p5m
+++ b/components/library/freetype/freetype-2.p5m
@@ -75,13 +75,13 @@ file path=usr/include/freetype2/freetype/tttables.h
 file path=usr/include/freetype2/freetype/tttags.h
 file path=usr/include/freetype2/freetype/ttunpat.h
 file path=usr/include/freetype2/ft2build.h
-link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.12.3
-link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.12.3
-file path=usr/lib/$(MACH64)/libfreetype.so.6.12.3
+link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.12.6
+link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.12.6
+file path=usr/lib/$(MACH64)/libfreetype.so.6.12.6
 file path=usr/lib/$(MACH64)/pkgconfig/freetype2.pc
-link path=usr/lib/libfreetype.so target=libfreetype.so.6.12.3
-link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.12.3
-file path=usr/lib/libfreetype.so.6.12.3
+link path=usr/lib/libfreetype.so target=libfreetype.so.6.12.6
+link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.12.6
+file path=usr/lib/libfreetype.so.6.12.6
 file path=usr/lib/pkgconfig/freetype2.pc
 file path=usr/share/aclocal/freetype2.m4
 file path=usr/share/man/man1/freetype-config.1

--- a/components/library/freetype/manifests/sample-manifest.p5m
+++ b/components/library/freetype/manifests/sample-manifest.p5m
@@ -75,13 +75,13 @@ file path=usr/include/freetype2/freetype/tttables.h
 file path=usr/include/freetype2/freetype/tttags.h
 file path=usr/include/freetype2/freetype/ttunpat.h
 file path=usr/include/freetype2/ft2build.h
-link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.12.3
-link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.12.3
-file path=usr/lib/$(MACH64)/libfreetype.so.6.12.3
+link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.12.6
+link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.12.6
+file path=usr/lib/$(MACH64)/libfreetype.so.6.12.6
 file path=usr/lib/$(MACH64)/pkgconfig/freetype2.pc
-link path=usr/lib/libfreetype.so target=libfreetype.so.6.12.3
-link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.12.3
-file path=usr/lib/libfreetype.so.6.12.3
+link path=usr/lib/libfreetype.so target=libfreetype.so.6.12.6
+link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.12.6
+file path=usr/lib/libfreetype.so.6.12.6
 file path=usr/lib/pkgconfig/freetype2.pc
 file path=usr/share/aclocal/freetype2.m4
 file path=usr/share/man/man1/freetype-config.1


### PR DESCRIPTION
Implementation was changed in 2.6.4 according to
https://sourceforge.net/projects/freetype/files/freetype2/2.6.4/
but compatibility seems to be retained.
