### PR TITLE
Tickle the Makefile to trigger republication.

### DIFF
--- a/components/osol/ddu/Makefile
+++ b/components/osol/ddu/Makefile
@@ -10,13 +10,14 @@
 
 #
 # Copyright 2016 Aurelien Larcher
+# Copyright 2016 William Headrick
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= ddu
 COMPONENT_VERSION= 1.3.1
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_SUMMARY= Device Driver Utility (DDU)
 COMPONENT_PROJECT_URL= http://www.openindiana.org/
 COMPONENT_FMRI= diagnostic/ddu
@@ -24,26 +25,38 @@ COMPONENT_CLASSIFICATION= System/Hardware
 COMPONENT_LICENSE= CDDL,BSD3
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 
+include $(WS_MAKE_RULES)/justmake.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 PCI_IDS_FILE=/usr/share/pci.ids.gz
 
-build:
+$(SOURCE_DIR)/.prep: $(MAKEFILE_PREREQ)
+	$(TOUCH) $@
+
+# Redefine BUILD_32 as there are not Makefiles all the way down
+# for the COMPONENT_BUILD_ACTION to use.
+$(BUILD_32): $(SOURCE_DIR)/.prep
+	$(RM) -r $(@D); $(MKDIR) $(@D)
+	$(TOUCH) $@
 
 # Using gzipped pci.ids at another location than /usr/ddu/data/ is not possible
 # until all_devices is modified. For now just copy the file as expected.
-
-install:
+$(INSTALL_32): $(BUILD_32)
 	$(MKDIR) $(PROTO_DIR)
 	($(CP) -rpf $(SOURCE_DIR)/srcs/usr $(PROTO_DIR))
 	if [ -f $(PCI_IDS_FILE) ]; \
 	then gunzip -c $(PCI_IDS_FILE) > $(PROTO_DIR)/usr/ddu/data/pci.ids; \
 	fi;
+	$(TOUCH) $@
 
-clean:
-	$(RM) -rf	$(BUILD_DIR)
+clean::
+	$(RM) $(SOURCE_DIR)/.prep
 
 clobber: clean
+
+build: $(BUILD_32)
+
+install: $(INSTALL_32)
 
 test:		$(NO_TESTS)
 


### PR DESCRIPTION
The 'ddu' didn't get republished after the change to include
the ddu.desktop action in MATE as well as GNOME.

Requested by alarcher.
