### PR TITLE
configure.mk : extend support for common autoconf "configure" script args

### DIFF
--- a/make-rules/configure.mk
+++ b/make-rules/configure.mk
@@ -114,10 +114,11 @@ CONFIGURE_SHAREDSTATEDIR =	$(VARDIR)
 
 # These optional variables enable certain blocks in this makefile
 # that additionally (re-)define some values and options
-CONFIGURE_PROTO_DIRS?=yes
+# Note: The initial PR adds but does not enable by default some new features
+CONFIGURE_PROTO_DIRS?=no
 CONFIGURE_DEFAULT_DIRS?=yes
-CONFIGURE_DEFAULT_EXTRA_DIRS?=yes
-CONFIGURE_DEFAULT_STATE_DIRS?=yes
+CONFIGURE_DEFAULT_EXTRA_DIRS?=no
+CONFIGURE_DEFAULT_STATE_DIRS?=no
 
 ifeq ($(CONFIGURE_PROTO_DIRS),yes)
 # Redefine the relevant pieces of PROTO*DIR trees to match possible

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -115,6 +115,10 @@ ARCHLIBSUBDIR32	=
 ARCHLIBSUBDIR64	= $(MACH64)
 ARCHLIBSUBDIR	= $(ARCHLIBSUBDIR$(BITS))
 
+# Note: the "configure.mk" file defines a similar structure independently,
+# although referring to some of the definitions from this "shared-macros.mk"
+# file. In case of large reorganizations, make sure to be consistent in all
+# locations ;)
 ETCDIR =	/etc
 USRDIR =	/usr
 BINDIR =	/bin


### PR DESCRIPTION
- optionally update PROTO*DIR definitions where applicable
- shared-macros.mk : added comment about relation to configure.mk

This PR is splintered from #1846 as a smaller, better digestible, piece ;)

Note that after this one is merged, the optimizations from https://github.com/OpenIndiana/oi-userland/pull/1846/commits/a31693a70c88165ca825898469c3a3b83d9a8151 and https://github.com/OpenIndiana/oi-userland/pull/1846/commits/06bcc2c82b53dae6d4c1d7e23038dda85418b8f3 should be next on the line
