### PR TITLE
Initial commit of sysstat version 20151012

### DIFF
--- a/components/sysutils/sysstat/Makefile
+++ b/components/sysutils/sysstat/Makefile
@@ -1,0 +1,54 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016, Jim Klimov
+#
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		sysstat
+COMPONENT_VERSION=	20151012
+COMPONENT_FMRI=		diagnostic/sysstat
+COMPONENT_CLASSIFICATION=	Applications/System Utilities
+COMPONENT_SUMMARY=	sysstat - tool for quick overview of various Solaris stats
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tgz
+COMPONENT_ARCHIVE_HASH=	sha256:4ec664956b557f7c3a01eb644f731314f976e6ff6b83afe55c2d6e8f73ae0736
+COMPONENT_ARCHIVE_URL=	http://www.maier-komor.de/sysstat/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	http://www.maier-komor.de/sysstat.html
+COMPONENT_LICENSE=	GPLv3
+COMPONENT_LICENSE_FILE=	LICENSE
+# Note: the website says the project is under GPLv2, but sources provide a
+# copy of GPLv3 explicitly. Probably the page was not updated in this regard.
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/justmake.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+# WARNING: non-autoconf "configure" script here
+COMPONENT_PRE_BUILD_ACTION = \
+	( cd $(@D) && \
+		./configure \
+			-c "$(CC)" \
+			-m "$(BITS)" \
+			-P "$(MACH$(BITS))" \
+			-K "$(MACH$(BITS))" \
+			--prefix "$(PROTOUSRDIR)" \
+	)
+
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+REQUIRED_PACKAGES += library/ncurses
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/sysutils/sysstat/files/auth_sysstatd
+++ b/components/sysutils/sysstat/files/auth_sysstatd
@@ -1,0 +1,2 @@
+solaris.smf.value.sysstatd:::Change sysstatd value properties::
+solaris.smf.manage.sysstatd:::Manage sysstatd service states::

--- a/components/sysutils/sysstat/files/prof_sysstatd
+++ b/components/sysutils/sysstat/files/prof_sysstatd
@@ -1,0 +1,1 @@
+SysStat Daemon Administration:RO:::auths=solaris.smf.manage.sysstatd,solaris.smf.value.sysstatd

--- a/components/sysutils/sysstat/files/sysstatd.xml
+++ b/components/sysutils/sysstat/files/sysstatd.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type='manifest' name='sysstatd'>
+
+<service
+	name='diagnostic/sysstatd'
+	type='service'
+	version='1'>
+
+	<create_default_instance enabled='false' />
+
+	<single_instance />
+
+	<!-- Read/Write access required to /var/run for lockfiles -->
+	<dependency
+		name='filesystem'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri
+			value='svc:/system/filesystem/local'
+		/>
+	</dependency>
+
+	<dependency
+		name='loopback'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri
+			value='svc:/system/filesystem/local'
+		/>
+	</dependency>
+
+	<dependency
+		name='net-physical'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri
+			value='svc:/network/physical'
+		/>
+	</dependency>
+
+	<dependency
+		name='cryptosvc'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri
+			value='svc:/system/cryptosvc'
+		/>
+	</dependency>
+
+	<exec_method
+		type='method'
+		name='start'
+		exec='/usr/sbin/sysstatd %{config/daemon_args}'
+		timeout_seconds='60' />
+
+	<exec_method
+		type='method'
+		name='stop'
+		exec=':kill'
+		timeout_seconds='60' />
+
+	<property_group name='general' type='framework'>
+		<!-- A user with this authorization can:
+
+			svcadm restart sysstatd
+			svcadm disable -t sysstatd
+			svcadm mark <state> sysstatd
+			svcadm clear sysstatd
+
+		see auths(1) and user_attr(4)-->
+
+		<propval
+			name='action_authorization'
+			type='astring'
+			value='solaris.smf.manage.sysstatd'
+		/>
+		<!-- A user with this authorization can:
+		
+			svcadm disable sysstatd
+			svcadm enable sysstatd
+
+		see auths(1) and user_attr(4)-->
+
+		<propval
+			name='value_authorization'
+			type='astring'
+			value='solaris.smf.value.sysstatd'
+		/>
+	</property_group>
+
+	<!-- The properties defined below can be changed by a user
+	with 'solaris.smf.value.sysstatd' authorization using the 
+	svccfg(1M) command.
+
+	e.g.
+
+	svccfg -s sysstatd setprop config/daemon_args = -v
+
+	Now refresh the service:
+
+	svcadm refresh diagnostic/sysstatd
+
+	Note: svcadm disable/enable does not use the new property
+	until after the service has been refreshed.
+
+	***Do not edit this manifest to change these properties! -->
+
+	<property_group name='config' type='application'>
+		<propval
+			name='daemon_args'
+			type='astring'
+			value=''
+		/>
+		<propval
+			name='value_authorization'
+			type='astring'
+			value='solaris.smf.value.sysstatd'
+		/>
+	</property_group>
+
+	<!-- default service model of 'contract' -->
+	<property_group name='startd' type='framework'>
+		<propval
+			name='duration'
+			type='astring'
+			value='contract'
+		/>
+	</property_group>
+
+	<stability value='Unstable' />
+
+	<template>
+		<common_name>
+			<loctext xml:lang='C'>
+			sysstatd daemon, multicasts system state on 224.0.0.75:7536/udp every second so a sysstat client on admin workstation can track the server farm
+			</loctext>
+		</common_name>
+		<documentation>
+			<manpage title='sysstat' section='1m'
+				manpath='/usr/share/man' />
+			<doc_link
+				name='sysstat website'
+				uri='http://www.maier-komor.de/sysstat.html'
+			/>
+		</documentation>
+	</template>
+
+</service>
+</service_bundle>
+

--- a/components/sysutils/sysstat/manifests/sample-manifest.p5m
+++ b/components/sysutils/sysstat/manifests/sample-manifest.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH32)/sysstat
+file path=usr/bin/$(MACH64)/sysstat
+hardlink path=usr/bin/sysstat target=../lib/isaexec
+file path=usr/lib/isaexec
+file path=usr/sbin/$(MACH32)/sysstatd
+file path=usr/sbin/$(MACH64)/sysstatd
+hardlink path=usr/sbin/sysstatd target=../lib/isaexec
+file path=usr/share/man/man1m/sysstat.1m

--- a/components/sysutils/sysstat/patches/01-configure.patch
+++ b/components/sysutils/sysstat/patches/01-configure.patch
@@ -1,0 +1,64 @@
+--- a/configure	2015-10-12 21:30:47.000000000 +0200
++++ b/configure	2016-10-30 14:46:56.143484807 +0100
+@@ -47,6 +47,12 @@
+ -n             : to prevent overwriting of an existing mkrules file
+ --cc <cc>      :
+ -c <cc>        : to set the C compiler
++--BITS <BITS>  :
++-m <BITS>      : to set the built binaries bitness
++--PROC <PROC>  :
++-P <PROC>      : to set the processor name for userland
++--KPROC <KPROC>:
++-K <KPROC>     : to set the processor name for kernelland
+ "
+ env ksh -c builtin 1>&- 2>&-
+ ksh93=$?
+@@ -57,20 +63,26 @@
+ 	[d:debug?enable debugging]
+ 	[p:prefix?set prefix for installation]:[prefix]
+ 	[c:cc:?set C compiler]:[cc]
++	[m:BITS:?set custom bitness]:[BITS]
++	[P:PROC:?set custom PROC name]:[PROC]
++	[K:KPROC:?set custom KPROC name]:[KERNEL]
+ 	'
+ else
+ 	getopts_out=`getopts "h(help)" xx "--help" 2>&1`
+ 	if [ "$getopts_out" == "" ]; then
+-		USAGE=$':c:dp:(prefix)h(help)n'
++		USAGE=$':c:m:P:K:dp:(prefix)h(help)n'
+ 	else
+-		USAGE=$':c:dp:hn'
+-		help="Usage: ./configure [-p <prefix-dir>] [-c <cc>] [-d] [-n] [lib]
++		USAGE=$':c:m:P:K:dp:hn'
++		help="Usage: ./configure [-p <prefix-dir>] [-c <cc>] [-m <BITS>] [-d] [-n] [lib]
+ <lib>    : 'curses' for Sun's libcurses (fallback)
+            'ncurses' for libncurses (default)
+ -p <dir> : to set the installation directory to <dir>
+ -d       : to enable debugging
+ -n       : to prevent overwriting of an existing mkrules file
+ -c <cc>  : to set the C compiler
++-m <BITS>: to set the built binaries bitness
++-P <PROC>      : to set the processor name for userland
++-K <KPROC>     : to set the processor name for kernelland
+ "
+ 	fi
+ fi
+@@ -80,6 +92,9 @@
+ 	x=$(( $OPTIND - 2))
+ 	case $opt in
+ 		c) CC="$OPTARG";;
++		m) BITS="$OPTARG";;
++		P) PROC="$OPTARG";;
++		K) KERNEL="$OPTARG";;
+ 		d) debug=1 ;;
+ 		p) prefix="$OPTARG";;
+ 		n) nooverwrite=1;;
+@@ -251,7 +266,7 @@
+ CC		= $CC
+ DEFS		= $defs -DSOLARIS=$solaris
+ INCDIRS		= $incdirs
+-C_CFLAGS	= $cflags \$(DEFS) \$(INCDIRS) $LFS_CFLAGS
++C_CFLAGS	= $cflags -m$BITS \$(DEFS) \$(INCDIRS) $LFS_CFLAGS
+ D_CFLAGS	= $cflags $d_cflags \$(DEFS) $LFS_CFLAGS
+ PROC		= $PROC
+ KPROC		= $KERNEL

--- a/components/sysutils/sysstat/patches/02-PRIx64-format.patch
+++ b/components/sysutils/sysstat/patches/02-PRIx64-format.patch
@@ -1,0 +1,521 @@
+diff -Naur sysstat-20151012.orig/fsstats.c sysstat-20151012/fsstats.c
+--- sysstat-20151012.orig/fsstats.c	2015-10-12 21:30:47.000000000 +0200
++++ sysstat-20151012/fsstats.c	2016-12-07 17:11:27.194303530 +0100
+@@ -101,7 +101,7 @@
+ 	while (f && (strcmp(dev,f->dev) || strcmp(typ,f->typ)))
+ 		f = f->next;
+ 	if (f == 0) {
+-		dbug("add_fs(%s,%s,%s,%llu,%llu,%lx)\n",dev,mnt,typ,blocks,free,id);
++		dbug("add_fs(%s,%s,%s,%" PRIu64 ",%" PRIu64 ",%lx)\n",dev,mnt,typ,blocks,free,id);
+ 		f = malloc(sizeof(fsstat_t));
+ 		bzero(f,sizeof(fsstat_t));
+ 		f->next = Fs;
+@@ -112,7 +112,7 @@
+ 		f->ops_rate = -1;
+ 		Fs = f;
+ 	} else
+-		dbug("update_fs(%s,%s,%s,%llu,%llu,%lx)\n",dev,mnt,typ,blocks,free,id);
++		dbug("update_fs(%s,%s,%s,%" PRIu64 ",%" PRIu64 ",%lx)\n",dev,mnt,typ,blocks,free,id);
+ 	f->blocks = blocks;
+ 	f->free = free;
+ 	return f;
+@@ -125,7 +125,7 @@
+ {
+ 	fsstat_t *f = Fs;
+ 	while (f) {
+-		printf("%s@%s (%s): %llu\n",f->dev,f->mnt,f->typ,(long long unsigned) f->blocks);
++		printf("%s@%s (%s): %" PRIu64 "\n",f->dev,f->mnt,f->typ,(long long unsigned) f->blocks);
+ 		f = f->next;
+ 	}
+ }
+@@ -262,7 +262,7 @@
+ 		f = Fs;
+ 		dbug("sort_fs(): sorted file systems\n");
+ 		while (f) {
+-			dbug("%s:%lld\n",f->dev,f->free>>20);
++			dbug("%s:%" PRIi64 "\n",f->dev,f->free>>20);
+ 			++n;
+ 			f = f->next;
+ 		}
+@@ -324,7 +324,7 @@
+ 			if (-1 == statvfs(mnt_pnt,&vst))
+ 				continue;
+ 			size = ((uint64_t) vst.f_blocks * vst.f_frsize) >> 10;
+-			dbug("%s @ %s : %llu/%llu\n",
++			dbug("%s @ %s : %" PRIu64 "/%" PRIu64 "\n",
+ 					fstyp,
+ 					mnt_pnt,
+ 					(uint64_t)vst.f_bfree,
+@@ -345,7 +345,7 @@
+ 				continue;
+ 			}
+ 			if (-1 != statvfs(f->mnt,&vst)) {
+-				dbug("updated %s@%s: %llu/%llu\n",
++				dbug("updated %s@%s: %" PRIu64 "/%" PRIu64 "\n",
+ 					f->typ,
+ 					f->mnt,
+ 					(uint64_t)vst.f_bfree,
+diff -Naur sysstat-20151012.orig/localstats.c sysstat-20151012/localstats.c
+--- sysstat-20151012.orig/localstats.c	2015-10-12 21:30:47.000000000 +0200
++++ sysstat-20151012/localstats.c	2016-12-07 17:10:47.538894435 +0100
+@@ -572,7 +572,7 @@
+ 		c->rates.nread = (double) ((data->nread - c->iodata.nread) >> 10) * td;
+ 		c->rates.nwritten = (double)((data->nwritten - c->iodata.nwritten) >> 10) * td;
+ 		c->rates.rbusy = (data->rtime - c->iodata.rtime) / (double)(s->ks_snaptime - c->timestamp) * 100.0;
+-		dbug("rbusy: (%lld - %lld) == %lld / (%lld - %lld ) == %lld = %g\n",data->rtime,c->iodata.rtime,data->rtime-c->iodata.rtime,s->ks_snaptime,c->timestamp,s->ks_snaptime-c->timestamp,c->rates.rbusy);
++		dbug("rbusy: (%" PRIi64 " - %" PRIi64 ") == %" PRIi64 " / (%" PRIi64 " - %" PRIi64 " ) == %" PRIi64 " = %g\n",data->rtime,c->iodata.rtime,data->rtime-c->iodata.rtime,s->ks_snaptime,c->timestamp,s->ks_snaptime-c->timestamp,c->rates.rbusy);
+ 		if (c->rates.rbusy < 0)
+ 			c->rates.wbusy = 0;
+ 		c->rates.wbusy = (data->wtime - c->iodata.wtime) / (double)(s->ks_snaptime - c->timestamp) * 100.0;
+@@ -1417,19 +1417,19 @@
+ 		data = fsks.read_bytes;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		f->read_rate = (float)((data->value.ui64 - f->numread) >> 10) * td;
+-		dbug("read: %llu-%llu/%llu-%llu, %g\n",data->value.ui64,f->numread,s->ks_snaptime,f->rate_ts,f->read_rate);
++		dbug("read: %" PRIu64 "-%" PRIu64 "/%" PRIu64 "-%" PRIu64 ", %g\n",data->value.ui64,f->numread,s->ks_snaptime,f->rate_ts,f->read_rate);
+ 		f->numread = data->value.ui64;
+ 
+ 		data = fsks.readdir_bytes;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		f->read_rate += (float)((data->value.ui64 - f->numreaddir) >> 10) * td; 
+-		//dbug("readdir: %llu-%llu/%llu-%llu, %g\n",data->value.ui64,f->numread,s->ks_snaptime,f->rate_ts,f->read_rate);
++		//dbug("readdir: %" PRIu64 "-%" PRIu64 "/%" PRIu64 "-%" PRIu64 ", %g\n",data->value.ui64,f->numread,s->ks_snaptime,f->rate_ts,f->read_rate);
+ 		f->numreaddir = data->value.ui64;
+ 
+ 		data = fsks.write_bytes;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		f->write_rate = (float)((data->value.ui64 - f->numwrite) >> 10) * td;
+-		dbug("write: %llu-%llu, %g\n",data->value.ui64,f->numwrite,f->write_rate);
++		dbug("write: %" PRIu64 "-%" PRIu64 ", %g\n",data->value.ui64,f->numwrite,f->write_rate);
+ 		f->numwrite = data->value.ui64;
+ 
+ 		data = fsks.naccess;
+@@ -1437,7 +1437,7 @@
+ 		if (data->value.ui64 < f->naccess)
+ 			f->naccess = data->value.ui64;
+ 		ops += data->value.ui64 - f->naccess;
+-		//dbug("naccess = %llu\n",data->value.ui64-f->naccess);
++		//dbug("naccess = %" PRIu64 "\n",data->value.ui64-f->naccess);
+ 		f->naccess = data->value.ui64;
+ 
+ 		data = fsks.naddmap;
+@@ -1445,7 +1445,7 @@
+ 		if (data->value.ui64 < f->naddmap)
+ 			f->naddmap = data->value.ui64;
+ 		ops += data->value.ui64 - f->naddmap;
+-		//dbug("naddmap = %llu\n",data->value.ui64-f->naddmap);
++		//dbug("naddmap = %" PRIu64 "\n",data->value.ui64-f->naddmap);
+ 		f->naddmap = data->value.ui64;
+ 
+ 		data = fsks.nclose;
+@@ -1453,73 +1453,73 @@
+ 		if (data->value.ui64 < f->nclose)
+ 			f->nclose = data->value.ui64;
+ 		ops += data->value.ui64 - f->nclose;
+-		//dbug("nclose = %llu\n",data->value.ui64-f->nclose);
++		//dbug("nclose = %" PRIu64 "\n",data->value.ui64-f->nclose);
+ 		f->nclose = data->value.ui64;
+ 
+ 		data = fsks.ncmp;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ncmp;
+-		//dbug("ncmp = %llu\n",data->value.ui64-f->ncmp);
++		//dbug("ncmp = %" PRIu64 "\n",data->value.ui64-f->ncmp);
+ 		f->ncmp = data->value.ui64;
+ 
+ 		data = fsks.ncreate;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ncreate;
+-		//dbug("ncreate = %llu\n",data->value.ui64-f->ncreate);
++		//dbug("ncreate = %" PRIu64 "\n",data->value.ui64-f->ncreate);
+ 		f->ncreate = data->value.ui64;
+ 
+ 		data = fsks.ndelmap;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ndelmap;
+-		//dbug("ndelmap = %llu\n",data->value.ui64-f->ndelmap);
++		//dbug("ndelmap = %" PRIu64 "\n",data->value.ui64-f->ndelmap);
+ 		f->ndelmap = data->value.ui64;
+ 
+ 		data = fsks.ndispose;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ndispose;
+-		//dbug("ndispose = %llu\n",data->value.ui64-f->ndispose);
++		//dbug("ndispose = %" PRIu64 "\n",data->value.ui64-f->ndispose);
+ 		f->ndispose = data->value.ui64;
+ 		
+ 		data = fsks.ndump;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ndump;
+-		//dbug("ndump = %llu\n",data->value.ui64-f->ndump);
++		//dbug("ndump = %" PRIu64 "\n",data->value.ui64-f->ndump);
+ 		f->ndump = data->value.ui64;
+ 
+ 		data = fsks.ndumpctl;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ndumpctl;
+-		//dbug("ndumpctl = %llu\n",data->value.ui64-f->ndumpctl);
++		//dbug("ndumpctl = %" PRIu64 "\n",data->value.ui64-f->ndumpctl);
+ 		f->ndumpctl = data->value.ui64;
+ 
+ 		data = fsks.nfid;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->nfid;
+-		//dbug("nfid = %llu\n",data->value.ui64-f->nfid);
++		//dbug("nfid = %" PRIu64 "\n",data->value.ui64-f->nfid);
+ 		f->nfid = data->value.ui64;
+ 
+ 		data = fsks.nfrlock;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->nfrlock;
+-		//dbug("nfrlock = %llu\n",data->value.ui64-f->nfrlock);
++		//dbug("nfrlock = %" PRIu64 "\n",data->value.ui64-f->nfrlock);
+ 		f->nfrlock = data->value.ui64;
+ 
+ 		data = fsks.nfsync;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->nfsync;
+-		//dbug("nfsync = %llu\n",data->value.ui64-f->nfsync);
++		//dbug("nfsync = %" PRIu64 "\n",data->value.ui64-f->nfsync);
+ 		f->nfsync = data->value.ui64;
+ 
+ 		data = fsks.ngetattr;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ngetattr;
+-		//dbug("ngetattr = %llu\n",data->value.ui64-f->ngetattr);
++		//dbug("ngetattr = %" PRIu64 "\n",data->value.ui64-f->ngetattr);
+ 		f->ngetattr = data->value.ui64;
+ 
+ 		data = fsks.ngetpage;
+ 		assert(data && (data->data_type == KSTAT_DATA_UINT64));
+ 		ops += data->value.ui64 - f->ngetpage;
+-		//dbug("ngetpage = %llu\n",data->value.ui64-f->ngetpage);
++		//dbug("ngetpage = %" PRIu64 "\n",data->value.ui64-f->ngetpage);
+ 		f->ngetpage = data->value.ui64;
+ 
+ 		data = fsks.ngetsecattr;
+@@ -1527,7 +1527,7 @@
+ 		if (data->value.ui64 < f->ngetsecattr)
+ 			f->ngetsecattr = data->value.ui64;
+ 		ops += data->value.ui64 - f->ngetsecattr;
+-		//dbug("ngetsecattr = %llu\n",data->value.ui64-f->ngetsecattr);
++		//dbug("ngetsecattr = %" PRIu64 "\n",data->value.ui64-f->ngetsecattr);
+ 		f->ngetsecattr = data->value.ui64;
+ 
+ 		data = fsks.ninactive;
+@@ -1535,7 +1535,7 @@
+ 		if (data->value.ui64 < f->ninactive)
+ 			f->ninactive = data->value.ui64;
+ 		ops += data->value.ui64 - f->ninactive;
+-		//dbug("ninactive = %llu\n",data->value.ui64-f->ninactive);
++		//dbug("ninactive = %" PRIu64 "\n",data->value.ui64-f->ninactive);
+ 		f->ninactive = data->value.ui64;
+ 
+ 		data = fsks.nioctl;
+@@ -1543,7 +1543,7 @@
+ 		if (data->value.ui64 < f->nioctl)
+ 			f->nioctl = data->value.ui64;
+ 		ops += data->value.ui64 - f->nioctl;
+-		//dbug("nioctl = %llu\n",data->value.ui64-f->nioctl);
++		//dbug("nioctl = %" PRIu64 "\n",data->value.ui64-f->nioctl);
+ 		f->nioctl = data->value.ui64;
+ 
+ 		data = fsks.nlink;
+@@ -1551,7 +1551,7 @@
+ 		if (data->value.ui64 < f->nlink)
+ 			f->nlink = data->value.ui64;
+ 		ops += data->value.ui64 - f->nlink;
+-		//dbug("nlink = %llu\n",data->value.ui64-f->nlink);
++		//dbug("nlink = %" PRIu64 "\n",data->value.ui64-f->nlink);
+ 		f->nlink = data->value.ui64;
+ 
+ 		data = fsks.nlookup;
+@@ -1559,7 +1559,7 @@
+ 		if (data->value.ui64 < f->nlookup)
+ 			f->nlookup = data->value.ui64;
+ 		ops += data->value.ui64 - f->nlookup;
+-		//dbug("nlookup = %llu\n",data->value.ui64-f->nlookup);
++		//dbug("nlookup = %" PRIu64 "\n",data->value.ui64-f->nlookup);
+ 		f->nlookup = data->value.ui64;
+ 
+ 		data = fsks.nmap;
+@@ -1567,7 +1567,7 @@
+ 		if (data->value.ui64 < f->nmap)
+ 			f->nmap = data->value.ui64;
+ 		ops += data->value.ui64 - f->nmap;
+-		//dbug("nmap = %llu\n",data->value.ui64-f->nmap);
++		//dbug("nmap = %" PRIu64 "\n",data->value.ui64-f->nmap);
+ 		f->nmap = data->value.ui64;
+ 
+ 		data = fsks.nmkdir;
+@@ -1575,7 +1575,7 @@
+ 		if (data->value.ui64 < f->nmkdir)
+ 			f->nmkdir = data->value.ui64;
+ 		ops += data->value.ui64 - f->nmkdir;
+-		//dbug("nmkdir = %llu\n",data->value.ui64-f->nmkdir);
++		//dbug("nmkdir = %" PRIu64 "\n",data->value.ui64-f->nmkdir);
+ 		f->nmkdir = data->value.ui64;
+ 
+ 		data = fsks.nopen;
+@@ -1583,7 +1583,7 @@
+ 		if (data->value.ui64 < f->nopen)
+ 			f->nopen = data->value.ui64;
+ 		ops += data->value.ui64 - f->nopen;
+-		//dbug("nopen = %llu\n",data->value.ui64-f->nopen);
++		//dbug("nopen = %" PRIu64 "\n",data->value.ui64-f->nopen);
+ 		f->nopen = data->value.ui64;
+ 
+ 		data = fsks.npageio;
+@@ -1591,7 +1591,7 @@
+ 		if (data->value.ui64 < f->npageio)
+ 			f->npageio = data->value.ui64;
+ 		ops += data->value.ui64 - f->npageio;
+-		//dbug("npageio = %llu\n",data->value.ui64-f->npageio);
++		//dbug("npageio = %" PRIu64 "\n",data->value.ui64-f->npageio);
+ 		f->npageio = data->value.ui64;
+ 
+ 		data = fsks.npathconf;
+@@ -1599,7 +1599,7 @@
+ 		if (data->value.ui64 < f->npathconf)
+ 			f->npathconf = data->value.ui64;
+ 		ops += data->value.ui64 - f->npathconf;
+-		//dbug("npathconf = %llu\n",data->value.ui64-f->npathconf);
++		//dbug("npathconf = %" PRIu64 "\n",data->value.ui64-f->npathconf);
+ 		f->npathconf = data->value.ui64;
+ 
+ 		data = fsks.npoll;
+@@ -1607,7 +1607,7 @@
+ 		if (data->value.ui64 < f->npoll)
+ 			f->npoll = data->value.ui64;
+ 		ops += data->value.ui64 - f->npoll;
+-		//dbug("npoll = %llu\n",data->value.ui64-f->npoll);
++		//dbug("npoll = %" PRIu64 "\n",data->value.ui64-f->npoll);
+ 		f->npoll = data->value.ui64;
+ 
+ 		data = fsks.nputpage;
+@@ -1615,7 +1615,7 @@
+ 		if (data->value.ui64 < f->nputpage)
+ 			f->nputpage = data->value.ui64;
+ 		ops += data->value.ui64 - f->nputpage;
+-		//dbug("nputpage = %llu\n",data->value.ui64-f->nputpage);
++		//dbug("nputpage = %" PRIu64 "\n",data->value.ui64-f->nputpage);
+ 		f->nputpage = data->value.ui64;
+ 
+ 		data = fsks.nread;
+@@ -1623,7 +1623,7 @@
+ 		if (data->value.ui64 < f->nread)
+ 			f->nread = data->value.ui64;
+ 		ops += data->value.ui64 - f->nread;
+-		//dbug("nread = %llu\n",data->value.ui64-f->nread);
++		//dbug("nread = %" PRIu64 "\n",data->value.ui64-f->nread);
+ 		f->nread = data->value.ui64;
+ 
+ 		data = fsks.nreaddir;
+@@ -1631,7 +1631,7 @@
+ 		if (data->value.ui64 < f->nreaddir)
+ 			f->nreaddir = data->value.ui64;
+ 		ops += data->value.ui64 - f->nreaddir;
+-		//dbug("nreaddir = %llu\n",data->value.ui64-f->nreaddir);
++		//dbug("nreaddir = %" PRIu64 "\n",data->value.ui64-f->nreaddir);
+ 		f->nreaddir = data->value.ui64;
+ 
+ 		data = fsks.nreadlink;
+@@ -1639,7 +1639,7 @@
+ 		if (data->value.ui64 < f->nreadlink)
+ 			f->nreadlink = data->value.ui64;
+ 		ops += data->value.ui64 - f->nreadlink;
+-		//dbug("nreadlink = %llu\n",data->value.ui64-f->nreadlink);
++		//dbug("nreadlink = %" PRIu64 "\n",data->value.ui64-f->nreadlink);
+ 		f->nreadlink = data->value.ui64;
+ 
+ 		data = fsks.nrealvp;
+@@ -1647,7 +1647,7 @@
+ 		if (data->value.ui64 < f->nrealvp)
+ 			f->nrealvp = data->value.ui64;
+ 		ops += data->value.ui64 - f->nrealvp;
+-		//dbug("nrealvp = %llu\n",data->value.ui64-f->nrealvp);
++		//dbug("nrealvp = %" PRIu64 "\n",data->value.ui64-f->nrealvp);
+ 		f->nrealvp = data->value.ui64;
+ 
+ 		data = fsks.nremove;
+@@ -1655,7 +1655,7 @@
+ 		if (data->value.ui64 < f->nremove)
+ 			f->nremove = data->value.ui64;
+ 		ops += data->value.ui64 - f->nremove;
+-		//dbug("nremove = %llu\n",data->value.ui64-f->nremove);
++		//dbug("nremove = %" PRIu64 "\n",data->value.ui64-f->nremove);
+ 		f->nremove = data->value.ui64;
+ 
+ 		data = fsks.nrename;
+@@ -1663,7 +1663,7 @@
+ 		if (data->value.ui64 < f->nrename)
+ 			f->nrename = data->value.ui64;
+ 		ops += data->value.ui64 - f->nrename;
+-		//dbug("nrename = %llu\n",data->value.ui64-f->nrename);
++		//dbug("nrename = %" PRIu64 "\n",data->value.ui64-f->nrename);
+ 		f->nrename = data->value.ui64;
+ 
+ 		data = fsks.nrmdir;
+@@ -1671,7 +1671,7 @@
+ 		if (data->value.ui64 < f->nrmdir)
+ 			f->nrmdir = data->value.ui64;
+ 		ops += data->value.ui64 - f->nrmdir;
+-		//dbug("nrmdir = %llu\n",data->value.ui64-f->nrmdir);
++		//dbug("nrmdir = %" PRIu64 "\n",data->value.ui64-f->nrmdir);
+ 		f->nrmdir = data->value.ui64;
+ 
+ 		data = fsks.nrwlock;
+@@ -1679,7 +1679,7 @@
+ 		if (data->value.ui64 < f->nrwlock)
+ 			f->nrwlock = data->value.ui64;
+ 		ops += data->value.ui64 - f->nrwlock;
+-		//dbug("nrwlock = %llu\n",data->value.ui64-f->nrwlock);
++		//dbug("nrwlock = %" PRIu64 "\n",data->value.ui64-f->nrwlock);
+ 		f->nrwlock = data->value.ui64;
+ 
+ 		data = fsks.nrwunlock;
+@@ -1687,7 +1687,7 @@
+ 		if (data->value.ui64 < f->nrwunlock)
+ 			f->nrwunlock = data->value.ui64;
+ 		ops += data->value.ui64 - f->nrwunlock;
+-		//dbug("nrwunlock = %llu\n",data->value.ui64-f->nrwunlock);
++		//dbug("nrwunlock = %" PRIu64 "\n",data->value.ui64-f->nrwunlock);
+ 		f->nrwunlock = data->value.ui64;
+ 
+ 		data = fsks.nseek;
+@@ -1695,7 +1695,7 @@
+ 		if (data->value.ui64 < f->nseek)
+ 			f->nseek = data->value.ui64;
+ 		ops += data->value.ui64 - f->nseek;
+-		//dbug("nseek = %llu\n",data->value.ui64-f->nseek);
++		//dbug("nseek = %" PRIu64 "\n",data->value.ui64-f->nseek);
+ 		f->nseek = data->value.ui64;
+ 
+ 		data = fsks.nsetattr;
+@@ -1703,7 +1703,7 @@
+ 		if (data->value.ui64 < f->nsetattr)
+ 			f->nsetattr = data->value.ui64;
+ 		ops += data->value.ui64 - f->nsetattr;
+-		//dbug("nsetattr = %llu\n",data->value.ui64-f->nsetattr);
++		//dbug("nsetattr = %" PRIu64 "\n",data->value.ui64-f->nsetattr);
+ 		f->nsetattr = data->value.ui64;
+ 
+ 		data = fsks.nsetfl;
+@@ -1711,7 +1711,7 @@
+ 		if (data->value.ui64 < f->nsetfl)
+ 			f->nsetfl = data->value.ui64;
+ 		ops += data->value.ui64 - f->nsetfl;
+-		//dbug("nsetfl = %llu\n",data->value.ui64-f->nsetfl);
++		//dbug("nsetfl = %" PRIu64 "\n",data->value.ui64-f->nsetfl);
+ 		f->nsetfl = data->value.ui64;
+ 
+ 		data = fsks.nsetsecattr;
+@@ -1719,7 +1719,7 @@
+ 		if (data->value.ui64 < f->nsetsecattr)
+ 			f->nsetsecattr = data->value.ui64;
+ 		ops += data->value.ui64 - f->nsetsecattr;
+-		//dbug("nsetsecattr = %llu\n",data->value.ui64-f->nsetsecattr);
++		//dbug("nsetsecattr = %" PRIu64 "\n",data->value.ui64-f->nsetsecattr);
+ 		f->nsetsecattr = data->value.ui64;
+ 
+ 		data = fsks.nshrlock;
+@@ -1727,7 +1727,7 @@
+ 		if (data->value.ui64 < f->nshrlock)
+ 			f->nshrlock = data->value.ui64;
+ 		ops += data->value.ui64 - f->nshrlock;
+-		//dbug("nshrlock = %llu\n",data->value.ui64-f->nsetsecattr);
++		//dbug("nshrlock = %" PRIu64 "\n",data->value.ui64-f->nsetsecattr);
+ 		f->nshrlock = data->value.ui64;
+ 
+ 		data = fsks.nspace;
+@@ -1735,7 +1735,7 @@
+ 		if (data->value.ui64 < f->nspace)
+ 			f->nspace = data->value.ui64;
+ 		ops += data->value.ui64 - f->nspace;
+-		//dbug("nspace = %llu\n",data->value.ui64-f->nsetsecattr);
++		//dbug("nspace = %" PRIu64 "\n",data->value.ui64-f->nsetsecattr);
+ 		f->nspace = data->value.ui64;
+ 
+ 		data = fsks.nsymlink;
+@@ -1743,7 +1743,7 @@
+ 		if (data->value.ui64 < f->nsymlink)
+ 			f->nsymlink = data->value.ui64;
+ 		ops += data->value.ui64 - f->nsymlink;
+-		//dbug("nsymlink = %llu\n",data->value.ui64-f->nsymlink);
++		//dbug("nsymlink = %" PRIu64 "\n",data->value.ui64-f->nsymlink);
+ 		f->nsymlink = data->value.ui64;
+ 
+ 		data = fsks.nvnevent;
+@@ -1751,7 +1751,7 @@
+ 		if (data->value.ui64 < f->nvnevent)
+ 			f->nvnevent = data->value.ui64;
+ 		ops += data->value.ui64 - f->nvnevent;
+-		//dbug("nvnevent = %llu\n",data->value.ui64-f->nvnevent);
++		//dbug("nvnevent = %" PRIu64 "\n",data->value.ui64-f->nvnevent);
+ 		f->nvnevent = data->value.ui64;
+ 
+ 		data = fsks.nwrite;
+@@ -1759,16 +1759,16 @@
+ 		if (data->value.ui64 < f->nwrite)
+ 			f->nwrite = data->value.ui64;
+ 		ops += data->value.ui64 - f->nwrite;
+-		//dbug("nwrite = %llu\n",data->value.ui64-f->nwrite);
++		//dbug("nwrite = %" PRIu64 "\n",data->value.ui64-f->nwrite);
+ 		f->nwrite = data->value.ui64;
+ 
+ 		f->ops_rate = (float)(ops) * td;
+-		dbug("%s: oprate %g, ntotal %llu, ops %llu, dt %lld\n",f->dev,f->ops_rate,f->ntotal,ops,s->ks_snaptime-f->rate_ts);
++		dbug("%s: oprate %g, ntotal %" PRIu64 ", ops %" PRIu64 ", dt %" PRIi64 "\n",f->dev,f->ops_rate,f->ntotal,ops,s->ks_snaptime-f->rate_ts);
+ 		f->ntotal = ops;
+ 
+ 		f->rate_ts = s->ks_snaptime;
+ 		c->iteration = Iteration;
+-		dbug("%s: I/O(%g/%g), %lld %lld\n",f->dev,f->read_rate,f->write_rate,c->value[0],c->value[1]);
++		dbug("%s: I/O(%g/%g), %" PRIi64 " %" PRIi64 "\n",f->dev,f->read_rate,f->write_rate,c->value[0],c->value[1]);
+ 		c = c->next;
+ 	}
+ 	while (fs) {
+diff -Naur sysstat-20151012.orig/network.c sysstat-20151012/network.c
+--- sysstat-20151012.orig/network.c	2015-10-12 21:30:47.000000000 +0200
++++ sysstat-20151012/network.c	2016-12-07 17:11:38.387770462 +0100
+@@ -126,7 +126,7 @@
+ 	S -= l + 1;
+ 	m += l;
+ 	*m++ = '\t';
+-	/* c1 = snprintf(m,S,"%lld",v); {*/
++	/* c1 = snprintf(m,S,"%" PRIi64 "",v); {*/
+ 	{
+ 		long long d = 10;
+ 		while (d <= v) {
+@@ -143,7 +143,7 @@
+ 		}
+ 	}
+ 	--S;
+-	/* c1 = snprintf(m,S,"%lld",v); } */
++	/* c1 = snprintf(m,S,"%" PRIi64 "",v); } */
+ 	*m++ = c;
+ 	M = m;
+ }
+diff -Naur sysstat-20151012.orig/terminal.c sysstat-20151012/terminal.c
+--- sysstat-20151012.orig/terminal.c	2015-10-12 21:30:47.000000000 +0200
++++ sysstat-20151012/terminal.c	2016-12-07 17:11:54.772223283 +0100
+@@ -758,16 +758,16 @@
+ 		}
+ 		dl = sprintf(l,"%s",fs->dev);
+ 		if (fs->numzfs) {
+-			zl = snprintf(l+dl,Numcol,"(%llu)",fs->numzfs);
++			zl = snprintf(l+dl,Numcol,"(%" PRIu64 ")",fs->numzfs);
+ 			assert(zl >= 0);
+ 			if (dl + zl > 21) {
+ 				if (zl)
+-					(void) sprintf(l+21-3-zl,"...(%llu) ",fs->numzfs);
++					(void) sprintf(l+21-3-zl,"...(%" PRIu64 ") ",fs->numzfs);
+ 				else
+ 					(void) sprintf(l+21-3,"... ");
+ 				dl += zl;
+ 			} else if (zl) {
+-				(void) sprintf(l+dl,"(%llu) ",fs->numzfs);
++				(void) sprintf(l+dl,"(%" PRIu64 ") ",fs->numzfs);
+ 				dl += zl;
+ 			}
+ 		}

--- a/components/sysutils/sysstat/patches/03-retval.patch
+++ b/components/sysutils/sysstat/patches/03-retval.patch
@@ -1,0 +1,11 @@
+--- sysstat-20151012.orig/localstats.c	2015-10-12 21:30:47.000000000 +0200
++++ sysstat-20151012/localstats.c	2016-12-07 17:15:59.523654262 +0100
+@@ -224,6 +224,8 @@
+ 		rewinddir(dskdir);
+ 		(void) sleep(60);
+ 	}
++	/* Should not get here, so keep the compiler happy: */
++	return NULL;
+ }
+ 
+ 

--- a/components/sysutils/sysstat/sysstat.p5m
+++ b/components/sysutils/sysstat/sysstat.p5m
@@ -1,0 +1,46 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016, Jim Klimov
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value="$(COMPONENT_PROJECT_URL)"
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+### Client part
+file path=usr/bin/$(MACH64)/sysstat
+file path=usr/bin/$(MACH32)/sysstat
+file path=usr/share/man/man1m/sysstat.1m
+
+# Should run the binary matching the kernel bitness
+hardlink path=usr/bin/sysstat target=../lib/isaexec pkg.linted=true
+
+### Server part, required for client even locally,
+### even if not networked via the -l CLI switch
+file files/auth_sysstatd path=etc/security/auth_attr.d/sysstatd
+file files/prof_sysstatd path=etc/security/prof_attr.d/sysstatd
+file files/sysstatd.xml path=lib/svc/manifest/system/diagnostic-sysstatd.xml
+
+file path=usr/sbin/$(MACH64)/sysstatd
+file path=usr/sbin/$(MACH32)/sysstatd
+# Note: No manpage for the daemon is provided in the sources
+
+# Should run the binary matching the kernel bitness
+hardlink path=usr/sbin/sysstatd target=../lib/isaexec pkg.linted=true


### PR DESCRIPTION
Another useful tool from the author of mbuffer

Note : `sysstat` includes a daemon mode (`sysstatd`) which is currently provided "as is" but without an SMF manifest - this piece is left for another PR if anyone wants to figure out how and why to run it at all, what permissions are needed, etc. ;)

Assumption from glancing over docs is is that multiple hosts may run their daemons and an admin workstation can collect their data over LAN (broadcasts) - this implies privacy, security, firewall and other concerns that are a lot of research out of scope for initial recipe which just adds the utility.
