### PR TITLE
Fix permissions on powerdns-recursor config file

### DIFF
--- a/components/network/pdns-recursor/Makefile
+++ b/components/network/pdns-recursor/Makefile
@@ -16,6 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pdns-recursor
 COMPONENT_VERSION=	3.7.3
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	https://www.powerdns.com/downloads.html
 COMPONENT_FMRI=		service/network/dns/powerdns-recursor
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -28,9 +29,9 @@ COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 COMPONENT_SUMMARY=	a DNS server
 COMPONENT_CLASSIFICATION="System/Services"
 
-include ../../../make-rules/prep.mk
-include ../../../make-rules/configure.mk
-include ../../../make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 CXXFLAGS=-g
 
@@ -55,5 +56,3 @@ REQUIRED_PACKAGES += system/library
 
 # build-time only dependencies
 REQUIRED_PACKAGES += system/library/boost
-
-include ../../../make-rules/depend.mk

--- a/components/network/pdns-recursor/pdns-recursor.p5m
+++ b/components/network/pdns-recursor/pdns-recursor.p5m
@@ -22,7 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file files/recursor.conf path=etc/powerdns/recursor.conf owner=powerdns group=powerdns preserve=true
+file files/recursor.conf path=etc/powerdns/recursor.conf mode=0555 preserve=true
 file files/pdns-recursor.xml path=lib/svc/manifest/network/dns/pdns-recursor.xml
 file files/pdns-recursor path=lib/svc/method/pdns-recursor
 


### PR DESCRIPTION
When I installed pdns-recursor, I was not able to modify config file (had to chmod +w it). @pyhalov review when you have time.