### PR TITLE
Initial commit for libp11 version 0.4.2

### DIFF
--- a/components/library/libp11/Makefile
+++ b/components/library/libp11/Makefile
@@ -1,0 +1,70 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		libp11
+COMPONENT_VERSION=	0.4.2
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+COMPONENT_FMRI=		library/security/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION=	System/Security
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=	https://github.com/OpenSC/$(COMPONENT_NAME)/wiki
+COMPONENT_ARCHIVE_URL=	https://github.com/OpenSC/$(COMPONENT_NAME)/releases/download/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:e2c3614a314b452a9b57e2914252df3ffee59e262dfb75b4fc73a2247f8ddebe
+COMPONENT_LICENSE=		LGPLv2.1+
+COMPONENT_LICENSE_FILE= COPYING
+COMPONENT_DESCRIPTION=	libp11 is a library implementing a thin layer on top of PKCS11 API to make using PKCS11 implementations easier
+COMPONENT_SUMMARY=	libp11 is a library to make using PKCS11 implementations easier
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_PREP_ACTION = \
+        (cd $(@D) &&\
+        autoreconf -fiv &&\
+        $(RM) config.h )
+
+COMPONENT_PRE_CONFIGURE_ACTION = \
+        ($(CLONEY) $(SOURCE_DIR) $(@D))
+
+INDIR.32=/usr/bin
+BINDIR.64=/usr/bin/$(MACH64)
+LIBDIR.32=/usr/lib
+LIBDIR.64=/usr/lib/$(MACH64)
+
+# OpenSSL engine directories; default is for files, engines is for symlinks
+ENGINESDIR_32 = /lib/openssl/engines
+ENGINESDIR_64 = /lib/openssl/engines/$(MACH64)
+DEFENGINESDIR_32 = /lib/openssl/default/engines
+DEFENGINESDIR_64 = /lib/openssl/default/engines/$(MACH64)
+
+# The project install recipe is somehow borked, that it does some actions
+# just assuming the engine directory is present... in the proto area...
+# So we must ensure these dirs for both bitnesses are available before install.
+COMPONENT_PRE_INSTALL_ACTION = (\
+	$(MKDIR) $(PROTO_DIR)$(DEFENGINESDIR_$(BITS)) $(PROTO_DIR)$(ENGINESDIR_$(BITS)) ; \
+	)
+
+CONFIGURE_OPTIONS +=	--with-enginesdir=$(DEFENGINESDIR_$(BITS))
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += library/security/openssl

--- a/components/library/libp11/libp11.p5m
+++ b/components/library/libp11/libp11.p5m
@@ -1,0 +1,52 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# Common library that other programs link to:
+file path=usr/lib/$(MACH64)/libp11.so.2.4.2
+link path=usr/lib/$(MACH64)/libp11.so target=libp11.so.2.4.2
+link path=usr/lib/$(MACH64)/libp11.so.2 target=libp11.so.2.4.2
+
+link path=usr/lib/libp11.so target=libp11.so.2.4.2
+link path=usr/lib/libp11.so.2 target=libp11.so.2.4.2
+file path=usr/lib/libp11.so.2.4.2
+
+file path=usr/include/libp11.h
+
+file path=usr/lib/$(MACH64)/pkgconfig/libp11.pc
+file path=usr/lib/pkgconfig/libp11.pc
+
+# Useful notes on integration of the library into an OpenSSL installation:
+file README.md path=usr/share/doc/libp11/README.libp11
+file path=usr/share/doc/libp11/NEWS
+
+# OpenSSL engine:
+file path=lib/openssl/default/engines/$(MACH64)/pkcs11.so
+link path=lib/openssl/default/engines/$(MACH64)/libpkcs11.so target=pkcs11.so
+link path=lib/openssl/engines/$(MACH64)/pkcs11.so target=../../default/engines/$(MACH64)/pkcs11.so
+link path=lib/openssl/engines/$(MACH64)/libpkcs11.so target=pkcs11.so
+
+file path=lib/openssl/default/engines/pkcs11.so
+link path=lib/openssl/default/engines/libpkcs11.so target=pkcs11.so
+link path=lib/openssl/engines/pkcs11.so target=../default/engines/pkcs11.so
+link path=lib/openssl/engines/libpkcs11.so target=pkcs11.so

--- a/components/library/libp11/manifests/sample-manifest.p5m
+++ b/components/library/libp11/manifests/sample-manifest.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=lib/openssl/default/engines/$(MACH64)/libpkcs11.so target=pkcs11.so
+file path=lib/openssl/default/engines/$(MACH64)/pkcs11.so
+link path=lib/openssl/default/engines/libpkcs11.so target=pkcs11.so
+file path=lib/openssl/default/engines/pkcs11.so
+file path=usr/include/libp11.h
+file path=usr/lib/$(MACH64)/libp11.a
+link path=usr/lib/$(MACH64)/libp11.so target=libp11.so.2.4.2
+link path=usr/lib/$(MACH64)/libp11.so.2 target=libp11.so.2.4.2
+file path=usr/lib/$(MACH64)/libp11.so.2.4.2
+file path=usr/lib/$(MACH64)/pkgconfig/libp11.pc
+file path=usr/lib/libp11.a
+link path=usr/lib/libp11.so target=libp11.so.2.4.2
+link path=usr/lib/libp11.so.2 target=libp11.so.2.4.2
+file path=usr/lib/libp11.so.2.4.2
+file path=usr/lib/pkgconfig/libp11.pc
+file path=usr/share/doc/libp11/NEWS


### PR DESCRIPTION
Helper library to wrap PKCS#11 manipulation via openssl.

Openconnect wants this, along with p11-kit which we have already.