### PR TITLE
Initial recipe for groovy-2.4.7 language

### DIFF
--- a/components/developer/groovy/Makefile
+++ b/components/developer/groovy/Makefile
@@ -32,9 +32,6 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/justmake.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-LN_S ?= $(LN) -s
-LN_SYM_REL = $(GNUBIN)/ln -s -r
-
 # This is an archive with prebuilt binaries, nothing to build
 $(BUILD_$(BITS)): $(SOURCE_DIR)/.prep
 	$(MKDIR) $(BUILD_DIR_$(BITS))
@@ -42,23 +39,11 @@ $(BUILD_$(BITS)): $(SOURCE_DIR)/.prep
 
 build: $(BUILD_32)
 
-$(INSTALL_32): $(BUILD_32) $(SOURCE_DIR)/.prep
-	$(MKDIR) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION) $(PROTOUSRBINDIR)
-	cd $(SOURCE_DIR) && \
-		$(CP) -pr \
-bin \
-conf \
-embeddable \
-grooid \
-indy \
-lib \
-LICENSE \
-licenses \
-NOTICE \
-		$(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-	$(RM) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/bin/*.bat
-	cd $(PROTOUSRBINDIR) && \
-		$(LN_SYM_REL) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/bin/* .
+# There are many "intimate" variables to pass into the other Makefile,
+# so rather than run a sub-make we include it into our context.
+include $(COMPONENT_DIR)/files/Makefile
+
+$(INSTALL_32): install-groovy
 	$(TOUCH) $@
 
 install: $(INSTALL_32)

--- a/components/developer/groovy/Makefile
+++ b/components/developer/groovy/Makefile
@@ -1,0 +1,69 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		groovy
+# Commit timestamp and previous known release (none here)
+COMPONENT_VERSION=	2.4.7
+COMPONENT_ARCHIVE=	apache-$(COMPONENT_NAME)-binary-$(COMPONENT_VERSION).zip
+COMPONENT_FMRI=		developer/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION=	Development/Java
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=	http://groovy-lang.org/
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:438dd6098252647e88ff12ac5737d0d0f7e16a8e4e42e8be3e05a4c43abefbd5
+COMPONENT_ARCHIVE_URL=	https://bintray.com/artifact/download/groovy/maven/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=		Apache-2.0,BSD,MIT,Eclipse,PublicDomain
+COMPONENT_LICENSE_FILE= LICENSE
+COMPONENT_SUMMARY=	Groovy is a Java-based scripting language
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/justmake.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+LN_S ?= $(LN) -s
+LN_SYM_REL = $(GNUBIN)/ln -s -r
+
+# This is an archive with prebuilt binaries, nothing to build
+$(BUILD_$(BITS)): $(SOURCE_DIR)/.prep
+	$(MKDIR) $(BUILD_DIR_$(BITS))
+	$(TOUCH) $@
+
+build: $(BUILD_32)
+
+$(INSTALL_32): $(BUILD_32) $(SOURCE_DIR)/.prep
+	$(MKDIR) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION) $(PROTOUSRBINDIR)
+	cd $(SOURCE_DIR) && \
+		$(CP) -pr \
+bin \
+conf \
+embeddable \
+grooid \
+indy \
+lib \
+LICENSE \
+licenses \
+NOTICE \
+		$(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+	$(RM) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/bin/*.bat
+	cd $(PROTOUSRBINDIR) && \
+		$(LN_SYM_REL) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/bin/* .
+	$(TOUCH) $@
+
+install: $(INSTALL_32)
+
+test: $(NO_TESTS)
+
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library

--- a/components/developer/groovy/files/Makefile
+++ b/components/developer/groovy/files/Makefile
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+#
+# This Makefile installs groovy into location specified by variables below,
+# as defined in common oi-userland framework (this file is included from
+# main recipe Makefile).
+# List of FS objects below coresponds to groovy-2.4.7 layout.
+#
+
+LN_S ?= $(LN) -s
+LN_SYM_REL = $(GNUBIN)/ln -s -r
+
+$(BUILD_DIR_$(BITS))/.installed-groovy: $(BUILD_$(BITS)) $(SOURCE_DIR)/.prep
+	$(MKDIR) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION) $(PROTOUSRBINDIR)
+	cd $(SOURCE_DIR) && \
+		$(CP) -pr \
+bin \
+conf \
+embeddable \
+grooid \
+indy \
+lib \
+LICENSE \
+licenses \
+NOTICE \
+		$(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+	$(RM) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/bin/*.bat
+	cd $(PROTOUSRBINDIR) && \
+		$(LN_SYM_REL) $(PROTOUSRSHAREDIR)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/bin/* .
+	$(TOUCH) $@
+
+install-groovy: $(BUILD_DIR_$(BITS))/.installed-groovy

--- a/components/developer/groovy/groovy.p5m
+++ b/components/developer/groovy/groovy.p5m
@@ -1,0 +1,126 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require-any \
+    fmri=developer/java/openjdk8 \
+    fmri=developer/java/openjdk7
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/grape
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovy
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovyConsole
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovyc
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovydoc
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovysh
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/java2groovy
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/startGroovy
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/conf/groovy-starter.conf
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/embeddable/groovy-all-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/embeddable/groovy-all-$(COMPONENT_VERSION).jar
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/grooid/groovy-$(COMPONENT_VERSION)-grooid.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/grooid/groovy-test-$(COMPONENT_VERSION)-grooid.jar
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-ant-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-bsf-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-console-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-docgenerator-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-groovydoc-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-groovysh-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-jmx-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-json-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-jsr223-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-nio-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-servlet-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-sql-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-swing-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-templates-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-test-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-testng-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-xml-$(COMPONENT_VERSION)-indy.jar
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-antlr-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-junit-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-launcher-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/bsf-2.4.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/commons-cli-1.2.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/commons-logging-1.2.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/gpars-1.2.1.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-ant-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-bsf-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-console-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-docgenerator-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-groovydoc-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-groovysh-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-jmx-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-json-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-jsr223-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-nio-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-servlet-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-sql-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-swing-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-templates-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-test-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-testng-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-xml-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy.icns
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/hamcrest-core-1.3.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ivy-2.4.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jansi-1.11.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jcommander-1.47.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jline-2.12.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jsp-api-2.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jsr166y-1.7.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/junit-4.12.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/multiverse-core-0.7.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/qdox-1.12.1.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/servlet-api-2.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/testng-6.8.13.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/xmlpull-1.1.3.1.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/xstream-1.4.7.jar
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/antlr2-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/asm-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/hamcrest-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/jline2-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/jsr166y-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/jsr223-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/junit-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/xstream-license.txt
+
+file path=usr/share/groovy-$(COMPONENT_VERSION)/LICENSE
+file path=usr/share/groovy-$(COMPONENT_VERSION)/NOTICE
+
+link path=usr/bin/grape target=../share/groovy-$(COMPONENT_VERSION)/bin/grape mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)
+link path=usr/bin/groovy target=../share/groovy-$(COMPONENT_VERSION)/bin/groovy mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)
+link path=usr/bin/groovyConsole target=../share/groovy-$(COMPONENT_VERSION)/bin/groovyConsole mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)
+link path=usr/bin/groovyc target=../share/groovy-$(COMPONENT_VERSION)/bin/groovyc mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)
+link path=usr/bin/groovydoc target=../share/groovy-$(COMPONENT_VERSION)/bin/groovydoc mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)
+link path=usr/bin/groovysh target=../share/groovy-$(COMPONENT_VERSION)/bin/groovysh mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)
+link path=usr/bin/java2groovy target=../share/groovy-$(COMPONENT_VERSION)/bin/java2groovy mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)
+link path=usr/bin/startGroovy target=../share/groovy-$(COMPONENT_VERSION)/bin/startGroovy mediator=$(COMPONENT_NAME) mediator-version=$(COMPONENT_VERSION)

--- a/components/developer/groovy/manifests/sample-manifest.p5m
+++ b/components/developer/groovy/manifests/sample-manifest.p5m
@@ -1,0 +1,120 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/bin/grape target=../share/groovy-$(COMPONENT_VERSION)/bin/grape
+link path=usr/bin/groovy target=../share/groovy-$(COMPONENT_VERSION)/bin/groovy
+link path=usr/bin/groovyConsole \
+    target=../share/groovy-$(COMPONENT_VERSION)/bin/groovyConsole
+link path=usr/bin/groovyc \
+    target=../share/groovy-$(COMPONENT_VERSION)/bin/groovyc
+link path=usr/bin/groovydoc \
+    target=../share/groovy-$(COMPONENT_VERSION)/bin/groovydoc
+link path=usr/bin/groovysh \
+    target=../share/groovy-$(COMPONENT_VERSION)/bin/groovysh
+link path=usr/bin/java2groovy \
+    target=../share/groovy-$(COMPONENT_VERSION)/bin/java2groovy
+link path=usr/bin/startGroovy \
+    target=../share/groovy-$(COMPONENT_VERSION)/bin/startGroovy
+file path=usr/share/groovy-$(COMPONENT_VERSION)/LICENSE
+file path=usr/share/groovy-$(COMPONENT_VERSION)/NOTICE
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/grape
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovy
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovyConsole
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovyc
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovydoc
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/groovysh
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/java2groovy
+file path=usr/share/groovy-$(COMPONENT_VERSION)/bin/startGroovy
+file path=usr/share/groovy-$(COMPONENT_VERSION)/conf/groovy-starter.conf
+file path=usr/share/groovy-$(COMPONENT_VERSION)/embeddable/groovy-all-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/embeddable/groovy-all-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/grooid/groovy-$(COMPONENT_VERSION)-grooid.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/grooid/groovy-test-$(COMPONENT_VERSION)-grooid.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-ant-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-bsf-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-console-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-docgenerator-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-groovydoc-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-groovysh-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-jmx-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-json-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-jsr223-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-nio-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-servlet-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-sql-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-swing-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-templates-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-test-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-testng-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/indy/groovy-xml-$(COMPONENT_VERSION)-indy.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-antlr-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-junit-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ant-launcher-1.9.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/bsf-2.4.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/commons-cli-1.2.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/commons-logging-1.2.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/gpars-1.2.1.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-ant-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-bsf-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-console-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-docgenerator-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-groovydoc-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-groovysh-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-jmx-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-json-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-jsr223-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-nio-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-servlet-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-sql-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-swing-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-templates-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-test-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-testng-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy-xml-$(COMPONENT_VERSION).jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/groovy.icns
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/hamcrest-core-1.3.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/ivy-2.4.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jansi-1.11.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jcommander-1.47.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jline-2.12.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jsp-api-2.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/jsr166y-1.7.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/junit-4.12.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/multiverse-core-0.7.0.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/qdox-1.12.1.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/servlet-api-2.4.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/testng-6.8.13.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/xmlpull-1.1.3.1.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/lib/xstream-1.4.7.jar
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/antlr2-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/asm-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/hamcrest-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/jline2-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/jsr166y-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/jsr223-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/junit-license.txt
+file path=usr/share/groovy-$(COMPONENT_VERSION)/licenses/xstream-license.txt


### PR DESCRIPTION
Just IPS packaging in our common directory layout for the upstream binary (JAR) distribution.

And a PoC for other Java-based distro integrations (think netbeans, glassfish, etc.)