### PR TITLE
Fix cmake build after recent ips.mk changes

### DIFF
--- a/components/developer/cmake/Makefile
+++ b/components/developer/cmake/Makefile
@@ -32,11 +32,15 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cmake
 COMPONENT_VERSION=	3.5.2
+COMPONENT_REVISION=	1
 COMPONENT_LICENSE=	BSD, MIT, GPLv2, Curl, PD
 COMPONENT_LICENSE_FILE= cmake.license
 COMPONENT_CLASSIFICATION=Development/Distribution Tools
 COMPONENT_SUMMARY=A cross-platform, open-source make system
-COMPONENT_DESCRIPTION="CMake is a family of tools designed to build, test and package software.  It is used to control the software compilation process using simple platform and compiler-independent configuration files.  CMake generates native makefiles and workspaces that can be used in the compiler environment of your choice."
+COMPONENT_DESCRIPTION=CMake is a family of tools designed to build, test and package software. \
+It is used to control the software compilation process using simple platform and \
+compiler-independent configuration files.  CMake generates native makefiles and \
+workspaces that can be used in the compiler environment of your choice.
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\

--- a/components/developer/cmake/cmake.p5m
+++ b/components/developer/cmake/cmake.p5m
@@ -26,7 +26,7 @@
 set name=pkg.fmri \
     value=pkg:/developer/build/cmake@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
-set name=pkg.description value=$(COMPONENT_DESCRIPTION)
+set name=pkg.description value="$(COMPONENT_DESCRIPTION)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)


### PR DESCRIPTION
This one moved the PACKAGE_DESCRIPTION's double quotes from the Makefile to the package file and inserted some line breaks into the description.