### PR TITLE
Initial package for TrueType font Hack

### DIFF
--- a/components/fonts/hack-ttf/Makefile
+++ b/components/fonts/hack-ttf/Makefile
@@ -1,0 +1,61 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Tim Mooney <Timothy.V.Mooney@gmail.com>
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=	Hack
+# Both COMPONENT_VERSION and IPS_COMPONENT_VERSION are derived from this
+COMPONENT_FILE_VERSION= 2_020
+# transform _ in upstream version to .
+COMPONENT_VERSION=$(shell echo $(COMPONENT_FILE_VERSION) | sed -e 's/_/./g')
+# remove leading 0s in any part of the version.
+IPS_COMPONENT_VERSION= $(shell echo $(COMPONENT_VERSION) | sed -e 's/\.0*\([1-9]\)/.\1/')
+COMPONENT_SUMMARY= Hack, a typeface designed for source code
+COMPONENT_PROJECT_URL= http://sourcefoundry.org/hack/
+COMPONENT_FMRI=		system/font/truetype/hack
+COMPONENT_CLASSIFICATION=	System/Fonts
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(IPS_COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_NAME)-v$(COMPONENT_FILE_VERSION)-ttf.zip
+COMPONENT_ARCHIVE_URL=	\
+	https://github.com/chrissimpkins/Hack/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= \
+  sha256:048566ae79c580f725b68340d9d2a3b0fa125fb08c1d30cf0a7c327d07ab739a
+COMPONENT_LICENSE=	Hack Open Font License Version 2.0, BitStream Vera Font License
+COMPONENT_LICENSE_FILE=	hack.license
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/justmake.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+# doesn't extract into its own directory, so pass -r dir to the unpack target
+UNPACK_ARGS+=-r $(COMPONENT_SRC)
+
+FONT_TTF_DIR=/usr/share/fonts/TrueType
+THIS_FONT_DIR=$(FONT_TTF_DIR)/hack
+
+COMPONENT_BUILD_ACTION= cd $(@D) ; mkfontscale ; mkfontdir
+
+COMPONENT_INSTALL_ACTION= cd $(@D) && \
+	rm -rf $(PROTO_DIR)$(THIS_FONT_DIR) && mkdir -p $(PROTO_DIR)$(THIS_FONT_DIR) && \
+		$(INSTALL) -c -m 0444 *.ttf fonts.dir fonts.scale $(PROTO_DIR)$(THIS_FONT_DIR);
+
+build: $(BUILD_32)
+
+install: $(INSTALL_32)
+
+test: $(NO_TESTS)
+
+REQUIRED_PACKAGES+= x11/mkfontdir
+REQUIRED_PACKAGES+= x11/mkfontscale

--- a/components/fonts/hack-ttf/hack.license
+++ b/components/fonts/hack-ttf/hack.license
@@ -1,0 +1,64 @@
+## License
+
+Hack Copyright 2015, Christopher Simpkins with Reserved Font Name "Hack".
+
+Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
+
+DejaVu modifications of the original Bitstream Vera Sans Mono typeface have been committed to the public domain.
+
+
+
+This Font Software is licensed under the Hack Open Font License v2.0 and the Bitstream Vera License.
+
+These licenses are copied below.
+
+
+### Hack Open Font License v2.0
+
+(Version 1.0 - 06 September 2015)
+
+(Version 2.0 - 27 September 2015)
+
+Copyright 2015 by Christopher Simpkins. All Rights Reserved.
+
+DEFINITIONS
+
+"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+PERMISSION AND CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated source code, documentation, and binary files (the "Font Software"), to reproduce and distribute the modifications to the Bitstream Vera Font Software, including without limitation the rights to use, study, copy, merge, embed, modify, redistribute, and/or sell modified or unmodified copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
+
+(1) The above copyright notice and this permission notice shall be included in all modified and unmodified copies of the Font Software typefaces. These notices can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+(2) The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing the word "Hack".
+
+(3) Neither the Font Software nor any of its individual components, in original or modified versions, may be sold by itself.
+
+TERMINATION
+
+This license becomes null and void if any of the above conditions are not met.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+
+Except as contained in this notice, the names of Christopher Simpkins and the Author(s) of the Font Software shall not be used to promote, endorse or advertise any modified version, except to acknowledge the contribution(s) of Christopher Simpkins and the Author(s) or with their explicit written permission.  For further information, contact: chris at sourcefoundry dot org.
+
+
+
+### BITSTREAM VERA LICENSE
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated documentation files (the "Font Software"), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
+
+The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.
+
+The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words "Bitstream" or the word "Vera".
+
+This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the "Bitstream Vera" names.
+
+The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+
+Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org.

--- a/components/fonts/hack-ttf/hack.p5m
+++ b/components/fonts/hack-ttf/hack.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Tim Mooney <Timothy.V.Mooney@gmail.com>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=etc/X11/fontpath.d/hack:pri=42 target=../../../usr/share/fonts/TrueType/hack
+
+file path=usr/share/fonts/TrueType/hack/Hack-Bold.ttf
+file path=usr/share/fonts/TrueType/hack/Hack-BoldItalic.ttf
+file path=usr/share/fonts/TrueType/hack/Hack-Italic.ttf
+file path=usr/share/fonts/TrueType/hack/Hack-Regular.ttf
+file path=usr/share/fonts/TrueType/hack/fonts.dir
+file path=usr/share/fonts/TrueType/hack/fonts.scale

--- a/components/fonts/hack-ttf/manifests/sample-manifest.p5m
+++ b/components/fonts/hack-ttf/manifests/sample-manifest.p5m
@@ -1,0 +1,30 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/share/fonts/TrueType/hack/Hack-Bold.ttf
+file path=usr/share/fonts/TrueType/hack/Hack-BoldItalic.ttf
+file path=usr/share/fonts/TrueType/hack/Hack-Italic.ttf
+file path=usr/share/fonts/TrueType/hack/Hack-Regular.ttf
+file path=usr/share/fonts/TrueType/hack/fonts.dir
+file path=usr/share/fonts/TrueType/hack/fonts.scale

--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	8
+COMPONENT_REVISION=	9
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -77,6 +77,7 @@ depend type=require fmri=system/display-manager/desktop-startup
 depend type=require fmri=system/file-system/ntfsprogs
 depend type=require fmri=system/font/truetype/arphic-uming
 depend type=require fmri=system/font/truetype/dejavu
+depend type=require fmri=system/font/truetype/hack
 depend type=require fmri=system/font/truetype/hanyang-ko-core
 depend type=require fmri=system/font/truetype/ipafont
 depend type=require fmri=system/font/truetype/liberation


### PR DESCRIPTION
This is my first-ever hipster package, so I would appreciate it if both Alexander and Aurelien would review the Makefile and manifest carefully.  I'll happily take any and all feedback on things that should be done differently, any package information that might be missing, etc.  I used Aurelien's liberation-ttf Makefile and manifest as a starting point, and I've been following both [Building with oi-userland on the wiki](https://wiki.openindiana.org/oi/Building+with+oi-userland) and [Quick start for oi-userland](http://docs.openindiana.org/dev/userland/).

[Hack](http://sourcefoundry.org/hack/) is a beautiful monospaced font descended from BitStream Vera and DejaVu, but with many improvements.  It's designed specifically for viewing source code on a modern display.