### PR TITLE
Add ck 0.5.2

### DIFF
--- a/components/library/ck/Makefile
+++ b/components/library/ck/Makefile
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Aurelien Larcher
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           ck
+COMPONENT_VERSION=        0.5.2
+COMPONENT_SUMMARY=        ck - Concurrency Kit
+COMPONENT_DESCRIPTION=    Concurrency primitives, safe memory reclamation mechanisms and non-blocking data structures for the research, design and implementation of high performance concurrent systems.
+COMPONENT_PROJECT_URL=    http://concurrencykit.org/
+COMPONENT_FMRI=           library/ck
+COMPONENT_CLASSIFICATION= System/Libraries  
+COMPONENT_SRC=            $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=    http://concurrencykit.org/releases/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= \
+  sha256:5cf44b33f9279c653ec9b2b085d628c86336e4da18897be449f074283e5c5b3a
+COMPONENT_LICENSE=        BSD
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CONFIGURE_OPTIONS+= --includedir=$(USRINCDIR)/$(COMPONENT_NAME)
+CONFIGURE_OPTIONS+= --environment=$(BITS)
+
+COMPONENT_TEST_TARGETS= regressions
+
+build:    $(BUILD_32_and_64)
+
+install:  $(INSTALL_32_and_64)
+
+# Tests are not supported out-of-source for now
+test:    $(TEST_32_and_64)
+
+REQUIRED_PACKAGES += system/library

--- a/components/library/ck/ck.license
+++ b/components/library/ck/ck.license
@@ -1,0 +1,54 @@
+Copyright 2010-2014 Samy Al Bahra.
+Copyright 2011-2013 AppNexus, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+Hazard Pointers (src/ck_hp.c) also includes this license:
+
+(c) Copyright 2008, IBM Corporation.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ck_pr_rtm leverages work from Andi Kleen:
+Copyright (c) 2012,2013 Intel Corporation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that: (1) source code distributions
+retain the above copyright notice and this paragraph in its entirety, (2)
+distributions including binary code include the above copyright notice and
+this paragraph in its entirety in the documentation or other materials
+provided with the distribution
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+

--- a/components/library/ck/ck.p5m
+++ b/components/library/ck/ck.p5m
@@ -1,0 +1,259 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/ck/ck_array.h
+file path=usr/include/ck/ck_backoff.h
+file path=usr/include/ck/ck_barrier.h
+file path=usr/include/ck/ck_bitmap.h
+file path=usr/include/ck/ck_brlock.h
+file path=usr/include/ck/ck_bytelock.h
+file path=usr/include/ck/ck_cc.h
+file path=usr/include/ck/ck_cohort.h
+file path=usr/include/ck/ck_elide.h
+file path=usr/include/ck/ck_epoch.h
+file path=usr/include/ck/ck_fifo.h
+file path=usr/include/ck/ck_hp.h
+file path=usr/include/ck/ck_hp_fifo.h
+file path=usr/include/ck/ck_hp_stack.h
+file path=usr/include/ck/ck_hs.h
+file path=usr/include/ck/ck_ht.h
+file path=usr/include/ck/ck_limits.h
+file path=usr/include/ck/ck_malloc.h
+file files/ck_md.h path=usr/include/ck/ck_md.h
+file path=usr/include/ck/ck_pflock.h
+file path=usr/include/ck/ck_pr.h
+file path=usr/include/ck/ck_queue.h
+file path=usr/include/ck/ck_rhs.h
+file path=usr/include/ck/ck_ring.h
+file path=usr/include/ck/ck_rwcohort.h
+file path=usr/include/ck/ck_rwlock.h
+file path=usr/include/ck/ck_sequence.h
+file path=usr/include/ck/ck_spinlock.h
+file path=usr/include/ck/ck_stack.h
+file path=usr/include/ck/ck_stdbool.h
+file path=usr/include/ck/ck_stddef.h
+file path=usr/include/ck/ck_stdint.h
+file path=usr/include/ck/ck_stdlib.h
+file path=usr/include/ck/ck_string.h
+file path=usr/include/ck/ck_swlock.h
+file path=usr/include/ck/ck_tflock.h
+file path=usr/include/ck/gcc/arm/ck_f_pr.h
+file path=usr/include/ck/gcc/arm/ck_pr.h
+file path=usr/include/ck/gcc/ck_cc.h
+file path=usr/include/ck/gcc/ck_f_pr.h
+file path=usr/include/ck/gcc/ck_pr.h
+file path=usr/include/ck/gcc/ppc/ck_f_pr.h
+file path=usr/include/ck/gcc/ppc/ck_pr.h
+file path=usr/include/ck/gcc/ppc64/ck_f_pr.h
+file path=usr/include/ck/gcc/ppc64/ck_pr.h
+file path=usr/include/ck/gcc/x86/ck_f_pr.h
+file path=usr/include/ck/gcc/x86/ck_pr.h
+file path=usr/include/ck/gcc/x86_64/ck_f_pr.h
+file path=usr/include/ck/gcc/x86_64/ck_pr.h
+file path=usr/include/ck/gcc/x86_64/ck_pr_rtm.h
+file path=usr/include/ck/spinlock/anderson.h
+file path=usr/include/ck/spinlock/cas.h
+file path=usr/include/ck/spinlock/clh.h
+file path=usr/include/ck/spinlock/dec.h
+file path=usr/include/ck/spinlock/fas.h
+file path=usr/include/ck/spinlock/hclh.h
+file path=usr/include/ck/spinlock/mcs.h
+file path=usr/include/ck/spinlock/ticket.h
+link path=usr/lib/$(MACH64)/libck.so target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libck.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libck.so.0 target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/pkgconfig/ck.pc
+link path=usr/lib/libck.so target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/libck.so.$(COMPONENT_VERSION)
+link path=usr/lib/libck.so.0 target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/pkgconfig/ck.pc
+file path=usr/share/man/man3/CK_ARRAY_FOREACH.3
+file path=usr/share/man/man3/CK_COHORT_INIT.3
+file path=usr/share/man/man3/CK_COHORT_INSTANCE.3
+file path=usr/share/man/man3/CK_COHORT_LOCK.3
+file path=usr/share/man/man3/CK_COHORT_PROTOTYPE.3
+file path=usr/share/man/man3/CK_COHORT_TRYLOCK.3
+file path=usr/share/man/man3/CK_COHORT_TRYLOCK_PROTOTYPE.3
+file path=usr/share/man/man3/CK_COHORT_UNLOCK.3
+file path=usr/share/man/man3/CK_HS_HASH.3
+file path=usr/share/man/man3/CK_RHS_HASH.3
+file path=usr/share/man/man3/CK_RWCOHORT_INIT.3
+file path=usr/share/man/man3/CK_RWCOHORT_INSTANCE.3
+file path=usr/share/man/man3/CK_RWCOHORT_PROTOTYPE.3
+file path=usr/share/man/man3/CK_RWCOHORT_READ_LOCK.3
+file path=usr/share/man/man3/CK_RWCOHORT_READ_UNLOCK.3
+file path=usr/share/man/man3/CK_RWCOHORT_WRITE_LOCK.3
+file path=usr/share/man/man3/CK_RWCOHORT_WRITE_UNLOCK.3
+file path=usr/share/man/man3/ck_array_buffer.3
+file path=usr/share/man/man3/ck_array_commit.3
+file path=usr/share/man/man3/ck_array_deinit.3
+file path=usr/share/man/man3/ck_array_init.3
+file path=usr/share/man/man3/ck_array_initialized.3
+file path=usr/share/man/man3/ck_array_length.3
+file path=usr/share/man/man3/ck_array_put.3
+file path=usr/share/man/man3/ck_array_put_unique.3
+file path=usr/share/man/man3/ck_array_remove.3
+file path=usr/share/man/man3/ck_bitmap_base.3
+file path=usr/share/man/man3/ck_bitmap_bits.3
+file path=usr/share/man/man3/ck_bitmap_bts.3
+file path=usr/share/man/man3/ck_bitmap_buffer.3
+file path=usr/share/man/man3/ck_bitmap_clear.3
+file path=usr/share/man/man3/ck_bitmap_init.3
+file path=usr/share/man/man3/ck_bitmap_iterator_init.3
+file path=usr/share/man/man3/ck_bitmap_next.3
+file path=usr/share/man/man3/ck_bitmap_reset.3
+file path=usr/share/man/man3/ck_bitmap_set.3
+file path=usr/share/man/man3/ck_bitmap_size.3
+file path=usr/share/man/man3/ck_bitmap_test.3
+file path=usr/share/man/man3/ck_bitmap_union.3
+file path=usr/share/man/man3/ck_brlock.3
+file path=usr/share/man/man3/ck_cohort.3
+file path=usr/share/man/man3/ck_elide.3
+file path=usr/share/man/man3/ck_epoch_barrier.3
+file path=usr/share/man/man3/ck_epoch_begin.3
+file path=usr/share/man/man3/ck_epoch_call.3
+file path=usr/share/man/man3/ck_epoch_end.3
+file path=usr/share/man/man3/ck_epoch_init.3
+file path=usr/share/man/man3/ck_epoch_poll.3
+file path=usr/share/man/man3/ck_epoch_reclaim.3
+file path=usr/share/man/man3/ck_epoch_recycle.3
+file path=usr/share/man/man3/ck_epoch_register.3
+file path=usr/share/man/man3/ck_epoch_synchronize.3
+file path=usr/share/man/man3/ck_epoch_unregister.3
+file path=usr/share/man/man3/ck_hs_apply.3
+file path=usr/share/man/man3/ck_hs_count.3
+file path=usr/share/man/man3/ck_hs_destroy.3
+file path=usr/share/man/man3/ck_hs_fas.3
+file path=usr/share/man/man3/ck_hs_gc.3
+file path=usr/share/man/man3/ck_hs_get.3
+file path=usr/share/man/man3/ck_hs_grow.3
+file path=usr/share/man/man3/ck_hs_init.3
+file path=usr/share/man/man3/ck_hs_iterator_init.3
+file path=usr/share/man/man3/ck_hs_move.3
+file path=usr/share/man/man3/ck_hs_next.3
+file path=usr/share/man/man3/ck_hs_put.3
+file path=usr/share/man/man3/ck_hs_put_unique.3
+file path=usr/share/man/man3/ck_hs_rebuild.3
+file path=usr/share/man/man3/ck_hs_remove.3
+file path=usr/share/man/man3/ck_hs_reset.3
+file path=usr/share/man/man3/ck_hs_reset_size.3
+file path=usr/share/man/man3/ck_hs_set.3
+file path=usr/share/man/man3/ck_hs_stat.3
+file path=usr/share/man/man3/ck_ht_count.3
+file path=usr/share/man/man3/ck_ht_destroy.3
+file path=usr/share/man/man3/ck_ht_entry_empty.3
+file path=usr/share/man/man3/ck_ht_entry_key.3
+file path=usr/share/man/man3/ck_ht_entry_key_direct.3
+file path=usr/share/man/man3/ck_ht_entry_key_length.3
+file path=usr/share/man/man3/ck_ht_entry_key_set.3
+file path=usr/share/man/man3/ck_ht_entry_key_set_direct.3
+file path=usr/share/man/man3/ck_ht_entry_set.3
+file path=usr/share/man/man3/ck_ht_entry_set_direct.3
+file path=usr/share/man/man3/ck_ht_entry_value.3
+file path=usr/share/man/man3/ck_ht_entry_value_direct.3
+file path=usr/share/man/man3/ck_ht_gc.3
+file path=usr/share/man/man3/ck_ht_get_spmc.3
+file path=usr/share/man/man3/ck_ht_grow_spmc.3
+file path=usr/share/man/man3/ck_ht_hash.3
+file path=usr/share/man/man3/ck_ht_hash_direct.3
+file path=usr/share/man/man3/ck_ht_init.3
+file path=usr/share/man/man3/ck_ht_iterator_init.3
+file path=usr/share/man/man3/ck_ht_next.3
+file path=usr/share/man/man3/ck_ht_put_spmc.3
+file path=usr/share/man/man3/ck_ht_remove_spmc.3
+file path=usr/share/man/man3/ck_ht_reset_size_spmc.3
+file path=usr/share/man/man3/ck_ht_reset_spmc.3
+file path=usr/share/man/man3/ck_ht_set_spmc.3
+file path=usr/share/man/man3/ck_ht_stat.3
+file path=usr/share/man/man3/ck_pflock.3
+file path=usr/share/man/man3/ck_pr.3
+file path=usr/share/man/man3/ck_pr_add.3
+file path=usr/share/man/man3/ck_pr_and.3
+file path=usr/share/man/man3/ck_pr_barrier.3
+file path=usr/share/man/man3/ck_pr_btc.3
+file path=usr/share/man/man3/ck_pr_btr.3
+file path=usr/share/man/man3/ck_pr_bts.3
+file path=usr/share/man/man3/ck_pr_cas.3
+file path=usr/share/man/man3/ck_pr_dec.3
+file path=usr/share/man/man3/ck_pr_faa.3
+file path=usr/share/man/man3/ck_pr_fas.3
+file path=usr/share/man/man3/ck_pr_fence_acquire.3
+file path=usr/share/man/man3/ck_pr_fence_atomic.3
+file path=usr/share/man/man3/ck_pr_fence_atomic_load.3
+file path=usr/share/man/man3/ck_pr_fence_atomic_store.3
+file path=usr/share/man/man3/ck_pr_fence_load.3
+file path=usr/share/man/man3/ck_pr_fence_load_atomic.3
+file path=usr/share/man/man3/ck_pr_fence_load_depends.3
+file path=usr/share/man/man3/ck_pr_fence_load_store.3
+file path=usr/share/man/man3/ck_pr_fence_memory.3
+file path=usr/share/man/man3/ck_pr_fence_release.3
+file path=usr/share/man/man3/ck_pr_fence_store.3
+file path=usr/share/man/man3/ck_pr_fence_store_atomic.3
+file path=usr/share/man/man3/ck_pr_fence_store_load.3
+file path=usr/share/man/man3/ck_pr_inc.3
+file path=usr/share/man/man3/ck_pr_load.3
+file path=usr/share/man/man3/ck_pr_neg.3
+file path=usr/share/man/man3/ck_pr_not.3
+file path=usr/share/man/man3/ck_pr_or.3
+file path=usr/share/man/man3/ck_pr_rtm.3
+file path=usr/share/man/man3/ck_pr_stall.3
+file path=usr/share/man/man3/ck_pr_store.3
+file path=usr/share/man/man3/ck_pr_sub.3
+file path=usr/share/man/man3/ck_pr_xor.3
+file path=usr/share/man/man3/ck_queue.3
+file path=usr/share/man/man3/ck_rhs_apply.3
+file path=usr/share/man/man3/ck_rhs_count.3
+file path=usr/share/man/man3/ck_rhs_destroy.3
+file path=usr/share/man/man3/ck_rhs_fas.3
+file path=usr/share/man/man3/ck_rhs_gc.3
+file path=usr/share/man/man3/ck_rhs_get.3
+file path=usr/share/man/man3/ck_rhs_grow.3
+file path=usr/share/man/man3/ck_rhs_init.3
+file path=usr/share/man/man3/ck_rhs_iterator_init.3
+file path=usr/share/man/man3/ck_rhs_move.3
+file path=usr/share/man/man3/ck_rhs_next.3
+file path=usr/share/man/man3/ck_rhs_put.3
+file path=usr/share/man/man3/ck_rhs_put_unique.3
+file path=usr/share/man/man3/ck_rhs_rebuild.3
+file path=usr/share/man/man3/ck_rhs_remove.3
+file path=usr/share/man/man3/ck_rhs_reset.3
+file path=usr/share/man/man3/ck_rhs_reset_size.3
+file path=usr/share/man/man3/ck_rhs_set.3
+file path=usr/share/man/man3/ck_rhs_stat.3
+file path=usr/share/man/man3/ck_ring_capacity.3
+file path=usr/share/man/man3/ck_ring_dequeue_spmc.3
+file path=usr/share/man/man3/ck_ring_dequeue_spsc.3
+file path=usr/share/man/man3/ck_ring_enqueue_spmc.3
+file path=usr/share/man/man3/ck_ring_enqueue_spmc_size.3
+file path=usr/share/man/man3/ck_ring_enqueue_spsc.3
+file path=usr/share/man/man3/ck_ring_enqueue_spsc_size.3
+file path=usr/share/man/man3/ck_ring_init.3
+file path=usr/share/man/man3/ck_ring_size.3
+file path=usr/share/man/man3/ck_ring_trydequeue_spmc.3
+file path=usr/share/man/man3/ck_rwcohort.3
+file path=usr/share/man/man3/ck_rwlock.3
+file path=usr/share/man/man3/ck_sequence.3
+file path=usr/share/man/man3/ck_spinlock.3
+file path=usr/share/man/man3/ck_swlock.3
+file path=usr/share/man/man3/ck_tflock.3

--- a/components/library/ck/files/ck_md.h
+++ b/components/library/ck/files/ck_md.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2011-2012 Samy Al Bahra.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef CK_MD_H
+#define CK_MD_H
+
+#ifndef CK_MD_CACHELINE
+#define CK_MD_CACHELINE (64)
+#endif
+
+#ifndef CK_MD_PAGESIZE
+#define CK_MD_PAGESIZE (4096)
+#endif
+
+#ifndef CK_MD_RTM_DISABLE
+#define CK_MD_RTM_DISABLE
+#endif /* CK_MD_RTM_DISABLE */
+
+#ifndef CK_MD_POINTER_PACK_DISABLE
+#define CK_MD_POINTER_PACK_DISABLE
+#endif /* CK_MD_POINTER_PACK_DISABLE */
+
+#ifndef CK_MD_VMA_BITS 
+#if defined(__x86__)
+#define CK_MD_VMA_BITS 32ULL
+#elif defined(__x86_64__)
+#define CK_MD_VMA_BITS 48ULL
+#else
+#error "CK_MD_VMA_BITS: unsupported platform definition"
+#endif
+#endif /* CK_MD_VMA_BITS */
+
+#ifndef CK_MD_TSO
+#define CK_MD_TSO
+#endif /* CK_MD_TSO */
+
+#define CK_VERSION "0.5.2"
+#define CK_GIT_SHA "f8503f8"
+
+#endif /* CK_MD_H */

--- a/components/library/ck/manifests/sample-manifest.p5m
+++ b/components/library/ck/manifests/sample-manifest.p5m
@@ -1,0 +1,263 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/ck/ck_array.h
+file path=usr/include/ck/ck_backoff.h
+file path=usr/include/ck/ck_barrier.h
+file path=usr/include/ck/ck_bitmap.h
+file path=usr/include/ck/ck_brlock.h
+file path=usr/include/ck/ck_bytelock.h
+file path=usr/include/ck/ck_cc.h
+file path=usr/include/ck/ck_cohort.h
+file path=usr/include/ck/ck_elide.h
+file path=usr/include/ck/ck_epoch.h
+file path=usr/include/ck/ck_fifo.h
+file path=usr/include/ck/ck_hp.h
+file path=usr/include/ck/ck_hp_fifo.h
+file path=usr/include/ck/ck_hp_stack.h
+file path=usr/include/ck/ck_hs.h
+file path=usr/include/ck/ck_ht.h
+file path=usr/include/ck/ck_limits.h
+file path=usr/include/ck/ck_malloc.h
+file path=usr/include/ck/ck_md.h
+file path=usr/include/ck/ck_pflock.h
+file path=usr/include/ck/ck_pr.h
+file path=usr/include/ck/ck_queue.h
+file path=usr/include/ck/ck_rhs.h
+file path=usr/include/ck/ck_ring.h
+file path=usr/include/ck/ck_rwcohort.h
+file path=usr/include/ck/ck_rwlock.h
+file path=usr/include/ck/ck_sequence.h
+file path=usr/include/ck/ck_spinlock.h
+file path=usr/include/ck/ck_stack.h
+file path=usr/include/ck/ck_stdbool.h
+file path=usr/include/ck/ck_stddef.h
+file path=usr/include/ck/ck_stdint.h
+file path=usr/include/ck/ck_stdlib.h
+file path=usr/include/ck/ck_string.h
+file path=usr/include/ck/ck_swlock.h
+file path=usr/include/ck/ck_tflock.h
+file path=usr/include/ck/gcc/$(MACH64)/ck_f_pr.h
+file path=usr/include/ck/gcc/$(MACH64)/ck_pr.h
+file path=usr/include/ck/gcc/arm/ck_f_pr.h
+file path=usr/include/ck/gcc/arm/ck_pr.h
+file path=usr/include/ck/gcc/ck_cc.h
+file path=usr/include/ck/gcc/ck_f_pr.h
+file path=usr/include/ck/gcc/ck_pr.h
+file path=usr/include/ck/gcc/ppc/ck_f_pr.h
+file path=usr/include/ck/gcc/ppc/ck_pr.h
+file path=usr/include/ck/gcc/ppc64/ck_f_pr.h
+file path=usr/include/ck/gcc/ppc64/ck_pr.h
+file path=usr/include/ck/gcc/x86/ck_f_pr.h
+file path=usr/include/ck/gcc/x86/ck_pr.h
+file path=usr/include/ck/gcc/x86_64/ck_f_pr.h
+file path=usr/include/ck/gcc/x86_64/ck_pr.h
+file path=usr/include/ck/gcc/x86_64/ck_pr_rtm.h
+file path=usr/include/ck/spinlock/anderson.h
+file path=usr/include/ck/spinlock/cas.h
+file path=usr/include/ck/spinlock/clh.h
+file path=usr/include/ck/spinlock/dec.h
+file path=usr/include/ck/spinlock/fas.h
+file path=usr/include/ck/spinlock/hclh.h
+file path=usr/include/ck/spinlock/mcs.h
+file path=usr/include/ck/spinlock/ticket.h
+file path=usr/lib/$(MACH64)/libck.a
+link path=usr/lib/$(MACH64)/libck.so target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libck.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libck.so.0 target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/pkgconfig/ck.pc
+file path=usr/lib/libck.a
+link path=usr/lib/libck.so target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/libck.so.$(COMPONENT_VERSION)
+link path=usr/lib/libck.so.0 target=libck.so.$(COMPONENT_VERSION)
+file path=usr/lib/pkgconfig/ck.pc
+file path=usr/share/man/man3/CK_ARRAY_FOREACH.3
+file path=usr/share/man/man3/CK_COHORT_INIT.3
+file path=usr/share/man/man3/CK_COHORT_INSTANCE.3
+file path=usr/share/man/man3/CK_COHORT_LOCK.3
+file path=usr/share/man/man3/CK_COHORT_PROTOTYPE.3
+file path=usr/share/man/man3/CK_COHORT_TRYLOCK.3
+file path=usr/share/man/man3/CK_COHORT_TRYLOCK_PROTOTYPE.3
+file path=usr/share/man/man3/CK_COHORT_UNLOCK.3
+file path=usr/share/man/man3/CK_HS_HASH.3
+file path=usr/share/man/man3/CK_RHS_HASH.3
+file path=usr/share/man/man3/CK_RWCOHORT_INIT.3
+file path=usr/share/man/man3/CK_RWCOHORT_INSTANCE.3
+file path=usr/share/man/man3/CK_RWCOHORT_PROTOTYPE.3
+file path=usr/share/man/man3/CK_RWCOHORT_READ_LOCK.3
+file path=usr/share/man/man3/CK_RWCOHORT_READ_UNLOCK.3
+file path=usr/share/man/man3/CK_RWCOHORT_WRITE_LOCK.3
+file path=usr/share/man/man3/CK_RWCOHORT_WRITE_UNLOCK.3
+file path=usr/share/man/man3/ck_array_buffer.3
+file path=usr/share/man/man3/ck_array_commit.3
+file path=usr/share/man/man3/ck_array_deinit.3
+file path=usr/share/man/man3/ck_array_init.3
+file path=usr/share/man/man3/ck_array_initialized.3
+file path=usr/share/man/man3/ck_array_length.3
+file path=usr/share/man/man3/ck_array_put.3
+file path=usr/share/man/man3/ck_array_put_unique.3
+file path=usr/share/man/man3/ck_array_remove.3
+file path=usr/share/man/man3/ck_bitmap_base.3
+file path=usr/share/man/man3/ck_bitmap_bits.3
+file path=usr/share/man/man3/ck_bitmap_bts.3
+file path=usr/share/man/man3/ck_bitmap_buffer.3
+file path=usr/share/man/man3/ck_bitmap_clear.3
+file path=usr/share/man/man3/ck_bitmap_init.3
+file path=usr/share/man/man3/ck_bitmap_iterator_init.3
+file path=usr/share/man/man3/ck_bitmap_next.3
+file path=usr/share/man/man3/ck_bitmap_reset.3
+file path=usr/share/man/man3/ck_bitmap_set.3
+file path=usr/share/man/man3/ck_bitmap_size.3
+file path=usr/share/man/man3/ck_bitmap_test.3
+file path=usr/share/man/man3/ck_bitmap_union.3
+file path=usr/share/man/man3/ck_brlock.3
+file path=usr/share/man/man3/ck_cohort.3
+file path=usr/share/man/man3/ck_elide.3
+file path=usr/share/man/man3/ck_epoch_barrier.3
+file path=usr/share/man/man3/ck_epoch_begin.3
+file path=usr/share/man/man3/ck_epoch_call.3
+file path=usr/share/man/man3/ck_epoch_end.3
+file path=usr/share/man/man3/ck_epoch_init.3
+file path=usr/share/man/man3/ck_epoch_poll.3
+file path=usr/share/man/man3/ck_epoch_reclaim.3
+file path=usr/share/man/man3/ck_epoch_recycle.3
+file path=usr/share/man/man3/ck_epoch_register.3
+file path=usr/share/man/man3/ck_epoch_synchronize.3
+file path=usr/share/man/man3/ck_epoch_unregister.3
+file path=usr/share/man/man3/ck_hs_apply.3
+file path=usr/share/man/man3/ck_hs_count.3
+file path=usr/share/man/man3/ck_hs_destroy.3
+file path=usr/share/man/man3/ck_hs_fas.3
+file path=usr/share/man/man3/ck_hs_gc.3
+file path=usr/share/man/man3/ck_hs_get.3
+file path=usr/share/man/man3/ck_hs_grow.3
+file path=usr/share/man/man3/ck_hs_init.3
+file path=usr/share/man/man3/ck_hs_iterator_init.3
+file path=usr/share/man/man3/ck_hs_move.3
+file path=usr/share/man/man3/ck_hs_next.3
+file path=usr/share/man/man3/ck_hs_put.3
+file path=usr/share/man/man3/ck_hs_put_unique.3
+file path=usr/share/man/man3/ck_hs_rebuild.3
+file path=usr/share/man/man3/ck_hs_remove.3
+file path=usr/share/man/man3/ck_hs_reset.3
+file path=usr/share/man/man3/ck_hs_reset_size.3
+file path=usr/share/man/man3/ck_hs_set.3
+file path=usr/share/man/man3/ck_hs_stat.3
+file path=usr/share/man/man3/ck_ht_count.3
+file path=usr/share/man/man3/ck_ht_destroy.3
+file path=usr/share/man/man3/ck_ht_entry_empty.3
+file path=usr/share/man/man3/ck_ht_entry_key.3
+file path=usr/share/man/man3/ck_ht_entry_key_direct.3
+file path=usr/share/man/man3/ck_ht_entry_key_length.3
+file path=usr/share/man/man3/ck_ht_entry_key_set.3
+file path=usr/share/man/man3/ck_ht_entry_key_set_direct.3
+file path=usr/share/man/man3/ck_ht_entry_set.3
+file path=usr/share/man/man3/ck_ht_entry_set_direct.3
+file path=usr/share/man/man3/ck_ht_entry_value.3
+file path=usr/share/man/man3/ck_ht_entry_value_direct.3
+file path=usr/share/man/man3/ck_ht_gc.3
+file path=usr/share/man/man3/ck_ht_get_spmc.3
+file path=usr/share/man/man3/ck_ht_grow_spmc.3
+file path=usr/share/man/man3/ck_ht_hash.3
+file path=usr/share/man/man3/ck_ht_hash_direct.3
+file path=usr/share/man/man3/ck_ht_init.3
+file path=usr/share/man/man3/ck_ht_iterator_init.3
+file path=usr/share/man/man3/ck_ht_next.3
+file path=usr/share/man/man3/ck_ht_put_spmc.3
+file path=usr/share/man/man3/ck_ht_remove_spmc.3
+file path=usr/share/man/man3/ck_ht_reset_size_spmc.3
+file path=usr/share/man/man3/ck_ht_reset_spmc.3
+file path=usr/share/man/man3/ck_ht_set_spmc.3
+file path=usr/share/man/man3/ck_ht_stat.3
+file path=usr/share/man/man3/ck_pflock.3
+file path=usr/share/man/man3/ck_pr.3
+file path=usr/share/man/man3/ck_pr_add.3
+file path=usr/share/man/man3/ck_pr_and.3
+file path=usr/share/man/man3/ck_pr_barrier.3
+file path=usr/share/man/man3/ck_pr_btc.3
+file path=usr/share/man/man3/ck_pr_btr.3
+file path=usr/share/man/man3/ck_pr_bts.3
+file path=usr/share/man/man3/ck_pr_cas.3
+file path=usr/share/man/man3/ck_pr_dec.3
+file path=usr/share/man/man3/ck_pr_faa.3
+file path=usr/share/man/man3/ck_pr_fas.3
+file path=usr/share/man/man3/ck_pr_fence_acquire.3
+file path=usr/share/man/man3/ck_pr_fence_atomic.3
+file path=usr/share/man/man3/ck_pr_fence_atomic_load.3
+file path=usr/share/man/man3/ck_pr_fence_atomic_store.3
+file path=usr/share/man/man3/ck_pr_fence_load.3
+file path=usr/share/man/man3/ck_pr_fence_load_atomic.3
+file path=usr/share/man/man3/ck_pr_fence_load_depends.3
+file path=usr/share/man/man3/ck_pr_fence_load_store.3
+file path=usr/share/man/man3/ck_pr_fence_memory.3
+file path=usr/share/man/man3/ck_pr_fence_release.3
+file path=usr/share/man/man3/ck_pr_fence_store.3
+file path=usr/share/man/man3/ck_pr_fence_store_atomic.3
+file path=usr/share/man/man3/ck_pr_fence_store_load.3
+file path=usr/share/man/man3/ck_pr_inc.3
+file path=usr/share/man/man3/ck_pr_load.3
+file path=usr/share/man/man3/ck_pr_neg.3
+file path=usr/share/man/man3/ck_pr_not.3
+file path=usr/share/man/man3/ck_pr_or.3
+file path=usr/share/man/man3/ck_pr_rtm.3
+file path=usr/share/man/man3/ck_pr_stall.3
+file path=usr/share/man/man3/ck_pr_store.3
+file path=usr/share/man/man3/ck_pr_sub.3
+file path=usr/share/man/man3/ck_pr_xor.3
+file path=usr/share/man/man3/ck_queue.3
+file path=usr/share/man/man3/ck_rhs_apply.3
+file path=usr/share/man/man3/ck_rhs_count.3
+file path=usr/share/man/man3/ck_rhs_destroy.3
+file path=usr/share/man/man3/ck_rhs_fas.3
+file path=usr/share/man/man3/ck_rhs_gc.3
+file path=usr/share/man/man3/ck_rhs_get.3
+file path=usr/share/man/man3/ck_rhs_grow.3
+file path=usr/share/man/man3/ck_rhs_init.3
+file path=usr/share/man/man3/ck_rhs_iterator_init.3
+file path=usr/share/man/man3/ck_rhs_move.3
+file path=usr/share/man/man3/ck_rhs_next.3
+file path=usr/share/man/man3/ck_rhs_put.3
+file path=usr/share/man/man3/ck_rhs_put_unique.3
+file path=usr/share/man/man3/ck_rhs_rebuild.3
+file path=usr/share/man/man3/ck_rhs_remove.3
+file path=usr/share/man/man3/ck_rhs_reset.3
+file path=usr/share/man/man3/ck_rhs_reset_size.3
+file path=usr/share/man/man3/ck_rhs_set.3
+file path=usr/share/man/man3/ck_rhs_stat.3
+file path=usr/share/man/man3/ck_ring_capacity.3
+file path=usr/share/man/man3/ck_ring_dequeue_spmc.3
+file path=usr/share/man/man3/ck_ring_dequeue_spsc.3
+file path=usr/share/man/man3/ck_ring_enqueue_spmc.3
+file path=usr/share/man/man3/ck_ring_enqueue_spmc_size.3
+file path=usr/share/man/man3/ck_ring_enqueue_spsc.3
+file path=usr/share/man/man3/ck_ring_enqueue_spsc_size.3
+file path=usr/share/man/man3/ck_ring_init.3
+file path=usr/share/man/man3/ck_ring_size.3
+file path=usr/share/man/man3/ck_ring_trydequeue_spmc.3
+file path=usr/share/man/man3/ck_rwcohort.3
+file path=usr/share/man/man3/ck_rwlock.3
+file path=usr/share/man/man3/ck_sequence.3
+file path=usr/share/man/man3/ck_spinlock.3
+file path=usr/share/man/man3/ck_swlock.3
+file path=usr/share/man/man3/ck_tflock.3

--- a/components/library/ck/patches/01-configure.patch
+++ b/components/library/ck/patches/01-configure.patch
@@ -1,0 +1,53 @@
+--- ck-0.5.2/configure.orig	2017-01-19 20:18:43.836138156 +0100
++++ ck-0.5.2/configure	2017-01-19 20:28:55.730816846 +0100
+@@ -195,6 +195,7 @@
+ 		echo "  --memory-model=N         Specify memory model (currently tso, pso or rmo)"
+ 		echo "  --vma-bits=N             Specify valid number of VMA bits"
+ 		echo "  --platform=N             Force the platform type, instead of relying on autodetection"
++		echo "  --bits=N                 Set 32-bit or 64-bit build on Solaris/illumos"
+ 		echo "  --use-cc-builtins        Use the compiler atomic bultin functions, instead of the CK implementation"
+ 		echo
+ 		echo "The following options affect regression testing."
+@@ -235,6 +236,9 @@
+ 	--enable-rtm)
+ 		RTM_ENABLE_SET="CK_MD_RTM_ENABLE"
+ 		;;
++	--environment=*)
++		ENVIRONMENT=$value
++		;;
+ 	--cores=*)
+ 		CORES=$value
+ 		;;
+@@ -421,16 +425,26 @@
+ 	"i86pc")
+ 		RTM_ENABLE="CK_MD_RTM_DISABLE"
+ 		MM="${MM:-"CK_MD_TSO"}"
+-		if test -z "$ISA"; then ISA=`isainfo -n 2> /dev/null || echo i386` ; fi
+-		case "$ISA" in
+-			"amd64")
++		if test "x$ENVIRONMENT" = "x"; then
++			if test -z "$ISA"; then ISA=`isainfo -n 2> /dev/null || echo i386` ; fi
++			case "$ISA" in
++				"amd64")
++					ENVIRONMENT=64
++					;;
++				*)
++					ENVIRONMENT=32
++					;;
++			esac
++		fi
++		case "$ENVIRONMENT" in
++			"64")
+ 				RTM_ENABLE=${RTM_ENABLE_SET:-"CK_MD_RTM_DISABLE"}
+ 				PLATFORM=x86_64
+-				ENVIRONMENT=64
+ 				;;
+-			*)
++			"32")
+ 				PLATFORM=x86
+-				ENVIRONMENT=32
++				;;
++			*)
+ 				assert "$PLATFORM $ENVIRONMENT" "$PLATFORM $ENVIRONMENT" "unsupported"
+ 				;;
+ 		esac

--- a/components/library/ck/patches/02-manpages.patch
+++ b/components/library/ck/patches/02-manpages.patch
@@ -1,0 +1,55 @@
+--- ck-0.5.2/doc/Makefile.in.orig	2017-01-20 17:23:59.365885969 +0100
++++ ck-0.5.2/doc/Makefile.in	2017-01-20 17:28:59.305434266 +0100
+@@ -2,7 +2,7 @@
+ 
+ MANDIR=@MANDIR@
+ GZIP=@GZIP@
+-GZIP_SUFFIX=.3@GZIP_SUFFIX@
++MAN_SUFFIX=.3
+ BUILD_DIR=@BUILD_DIR@
+ SRC_DIR=@SRC_DIR@
+ HTML_SUFFIX=.html
+@@ -180,7 +180,7 @@
+ 
+ all: 
+ 	for target in $(OBJECTS); do 			   \
+-		$(GZIP) $(SRC_DIR)/doc/$$target > $(BUILD_DIR)/doc/$$target$(GZIP_SUFFIX); \
++		cp $(SRC_DIR)/doc/$$target $(BUILD_DIR)/doc/$$target$(MAN_SUFFIX); \
+ 	done
+ 
+ html:
+@@ -188,14 +188,14 @@
+ 		echo $$target;				   		\
+ 		groff -man -Tascii $(SRC_DIR)/doc/$$target | col -bx >	\
+ 		   $(BUILD_DIR)/doc/$$target$(HTML_SUFFIX); 		\
+-		sed -i.bk 's/\&/\&amp\;/g;s/>/\&gt\;/g;s/</\&lt\;/g;'	\
++		gsed -i.bk 's/\&/\&amp\;/g;s/>/\&gt\;/g;s/</\&lt\;/g;'	\
+ 		   $(BUILD_DIR)/doc/$$target$(HTML_SUFFIX); 		\
+ 	done
+ 
+ # check for entries that are missing in OBJECTS
+ objcheck: all
+-	for file in `ls * | egrep '(ck|CK)_' | egrep -v "($(GZIP_SUFFIX)|$(HTML_SUFFIX))$$"`; do \
+-		if [ ! -f $${file}$(GZIP_SUFFIX) ]; then	\
++	for file in `ls * | egrep '(ck|CK)_' | egrep -v "($(MAN_SUFFIX)|$(HTML_SUFFIX))$$"`; do \
++		if [ ! -f $${file}$(MAN_SUFFIX) ]; then	\
+ 			echo "$$file is missing from OBJECTS" >&2;	\
+ 		fi;						\
+ 	done
+@@ -206,13 +206,13 @@
+ 
+ install:
+ 	mkdir -p $(DESTDIR)/$(MANDIR)/man3 || exit
+-	cp *$(GZIP_SUFFIX) $(DESTDIR)/$(MANDIR)/man3 || exit
++	cp *$(MAN_SUFFIX) $(DESTDIR)/$(MANDIR)/man3 || exit
+ 
+ uninstall:
+ 	for target in $(OBJECTS); do 			  \
+-		rm -f $(DESTDIR)/$(MANDIR)/man3/$$target$(GZIP_SUFFIX); \
++		rm -f $(DESTDIR)/$(MANDIR)/man3/$$target$(MAN_SUFFIX); \
+ 	done
+ 
+ clean:
+-	rm -f $(BUILD_DIR)/doc/*~ $(BUILD_DIR)/doc/*$(GZIP_SUFFIX) $(BUILD_DIR)/doc/*$(HTML_SUFFIX)
++	rm -f $(BUILD_DIR)/doc/*~ $(BUILD_DIR)/doc/*$(MAN_SUFFIX) $(BUILD_DIR)/doc/*$(HTML_SUFFIX)
+ 


### PR DESCRIPTION
- Patched configure to allow 32-bit build on amd64.
- Header should be split between MARCH32/MACH64 due to specific values, same as Circonus/OmniOS.
- Tests do not work due to unsupported out-of-source build, do not throw error, checked manually 100% passed.