### PR TITLE
[WIP/DISCUSS] Dependency-tracking scripts

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1175,7 +1175,13 @@ endif
 
 include $(WS_MAKE_RULES)/environment.mk
 
-# A simple rule to print the value of any macro.  Ex:
+# Print the required packages as a listing, line by line
+print-required-packages::
+	@for fmri in $(REQUIRED_PACKAGES) ; do \
+		echo $$fmri ; \
+	 done
+
+# A simple rule to print the value of any macro (as MACRONAME=value).  Ex:
 #    $ gmake print-REQUIRED_PACKAGES
 # Note that some macros are set on a per target basis, so what you see
 # is not always what you get.

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -234,10 +234,12 @@ def main():
         # TODO: Should this loop over component_paths to build each (if several given)?
         # TODO: Should there be an order of dependencies/parallelism for several paths?
         # TODO: Should this use or pass the template_zone value somehow?
-        if component_arg:
-            proc = subprocess.Popen(['gmake'] + args, cwd = workspace + subdir + component_arg)
-        else:
-            proc = subprocess.Popen(['gmake'] + args, cwd = workspace)
+# NOTE: Per current usage in components/Makefile, this runs in whatever CWD is provided by caller; perhaps the other modes would benefit from spefial CLI flags
+#        if component_arg:
+#            proc = subprocess.Popen(['gmake'] + args, cwd = workspace + subdir + component_arg)
+#        else:
+#            proc = subprocess.Popen(['gmake'] + args, cwd = workspace)
+        proc = subprocess.Popen(['gmake'] + args)
         rc = proc.wait()
         sys.exit(rc)
 

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -42,18 +42,25 @@ def FindComponentPaths(path, debug=None, subdir='/components'):
     paths = []
 
     if debug:
-        print >>debug, "searching %s for component directories" % path
+        print >>debug, "searching %s for component directories" % (path+subdir)
 
+    found = 0
     for dirpath, dirnames, filenames in os.walk(path + subdir):
-        found = 0
 
         for name in filenames:
             if expression.match(name):
+                found = found +1
                 if debug:
                     print >>debug, "found %s" % dirpath
                 paths.append(dirpath)
                 del dirnames[:]
                 break
+
+    if found == 0:
+        print >>sys.stderr, "FindComponentPaths() found nothing, maybe %s contains nothing?" % (path+subdir)
+    else:
+        if debug:
+            print >>debug, "found %s items" % found
 
     return sorted(paths)
 
@@ -157,7 +164,11 @@ def main():
             assert False, "unknown option"
 
     if workspace is None:
-        print "FATAL: A --workspace argument or WS_TOP envvar is required"
+        print >>sys.stderr, "FATAL: A --workspace argument or WS_TOP envvar is required"
+        usage()
+
+    if (components_arg is None and make_arg is None):
+        print >>sys.stderr, "FATAL: No valid action was requested"
         usage()
 
     component_paths = FindComponentPaths(workspace, debug, subdir)
@@ -165,6 +176,10 @@ def main():
     if make_arg:
         if template_zone:
             print "using template zone %s to create a build environment for %s to run '%s'" % (template_zone, component_arg, ['gmake'] + args)
+        else:
+            print "using current zone as the build environment for %s to run '%s'" % (component_arg, ['gmake'] + args)
+        # TODO: Should this loop over component_paths to build each?
+        # TODO: Should this use or pass the template_zone value?
         proc = subprocess.Popen(['gmake'] + args)
         rc = proc.wait()
         sys.exit(rc)
@@ -186,8 +201,13 @@ def main():
                         component.required(components[d_path])):
                           print "%s: %s" % (c_path, d_path)
 
+        else:
+            print >>sys.stderr, "FATAL: Invalid value of --components argument: '%s'" % components_arg
+            usage()
+
         sys.exit(0)
 
+    print >>sys.stderr, "FATAL: FindComponentPaths() completed, but no further action was requested"
     sys.exit(1)
 
 if __name__ == "__main__":

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -221,13 +221,23 @@ def main():
     component_paths = FindComponentPaths(workspace, debug, subdir)
 
     if make_arg:
-        if template_zone:
-            print "using template zone %s to create a build environment for %s to run '%s'" % (template_zone, component_arg, ['gmake'] + args)
+        if component_arg:
+            if template_zone:
+                print "using template zone %s to create a build environment for %s to run '%s'" % (template_zone, component_arg, ['gmake'] + args)
+            else:
+                print "using current zone as the build environment for %s to run '%s'" % (component_arg, ['gmake'] + args)
         else:
-            print "using current zone as the build environment for %s to run '%s'" % (component_arg, ['gmake'] + args)
-        # TODO: Should this loop over component_paths to build each?
-        # TODO: Should this use or pass the template_zone value?
-        proc = subprocess.Popen(['gmake'] + args)
+            if template_zone:
+                print "using template zone %s to '%s' in workspace '%s'" % (template_zone, ['gmake'] + args, workspace)
+            else:
+                print "using current zone to run '%s' in workspace '%s'" % (['gmake'] + args, workspace)
+        # TODO: Should this loop over component_paths to build each (if several given)?
+        # TODO: Should there be an order of dependencies/parallelism for several paths?
+        # TODO: Should this use or pass the template_zone value somehow?
+        if component_arg:
+            proc = subprocess.Popen(['gmake'] + args, cwd = workspace + subdir + component_arg)
+        else:
+            proc = subprocess.Popen(['gmake'] + args, cwd = workspace)
         rc = proc.wait()
         sys.exit(rc)
 

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -104,7 +104,7 @@ class BassComponent:
     def required(self, component):
         result = False
 
-        if (required_path(component) or required_package(component)):
+        if (self.required_path(component) or self.required_package(component)):
             result = True
 
         return result

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -57,7 +57,7 @@ def FindComponentPaths(path, debug=None, subdir='/components'):
                 break
 
     if found == 0:
-        print >>sys.stderr, "FindComponentPaths() found nothing, maybe %s contains nothing?" % (path+subdir)
+        print >>sys.stderr, "FindComponentPaths() found nothing, maybe %s contains no p5m manifests?" % (path+subdir)
     else:
         if debug:
             print >>debug, "found %s items" % found
@@ -104,6 +104,8 @@ class BassComponent:
 
         if self.debug:
             proc.wait()
+            # No need to really "wait" above since stdout is read until closed
+            # Here we need this just to receive and process the error code
             if proc.returncode != 0:
                 print >>self.debug, "exit: %d, %s" % (proc.returncode, proc.stderr.read())
 
@@ -119,8 +121,10 @@ class BassComponent:
 
 def usage():
     print "Usage: %s [-c|--components=(path|depend)]" % (sys.argv[0].split('/')[-1])
-    print "     -c | --components 'path'    Print dirname of the component"
+    print "     Parse component(s) in specified workspace/subdir to list data"
+    print "     -c | --components 'path'    Print dirname of the component(s)"
     print "     -c | --components 'depend'  Print dependencies of the component"
+    print "                                 in a manner similar to makefile deps"
     print "Usage: %s --make [--template-zone=tzone] [--component=NAME] [--] args..." % (sys.argv[0].split('/')[-1])
     print "     Use the optional template zone to 'gmake args...' for building of the"
     print "     specified component (without template use the current workspace)"
@@ -210,7 +214,7 @@ def main():
             for path in component_paths:
                 print "%s" % path
 
-        elif components_arg in [ 'depend', 'dependencies' ]:
+        elif components_arg in [ 'depend', 'dep', 'deps', 'dependencies' ]:
             for path in component_paths:
                 components[path] = BassComponent(path, debug)
 

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -78,12 +78,33 @@ class BassComponent:
             # get required paths    (cd path ; gmake print-required-paths)
             self.required_paths = self.run_make(path, 'print-required-paths')
 
-    def required(self, component):
+            # get required packages (cd path ; gmake print-REQUIRED_PACKAGES)
+            self.required_packages = self.run_make(path, 'print-required-packages')
+
+    def required_path(self, component):
         result = False
 
         s1 = set(self.required_paths)
         s2 = set(component.supplied_paths)
         if s1.intersection(s2):
+            result = True
+
+        return result
+
+    def required_package(self, component):
+        result = False
+
+        s1 = set(self.required_packages)
+        s2 = set(component.supplied_packages)
+        if s1.intersection(s2):
+            result = True
+
+        return result
+
+    def required(self, component):
+        result = False
+
+        if (required_path(component) or required_package(component)):
             result = True
 
         return result
@@ -116,6 +137,7 @@ class BassComponent:
         result = result + "\tProvides Package(s):\n\t\t%s\n" % '\t\t'.join(self.supplied_packages)
         result = result + "\tProvides Path(s):\n\t\t%s\n" % '\t\t'.join(self.supplied_paths)
         result = result + "\tRequired Path(s):\n\t\t%s\n" % '\t\t'.join(self.required_paths)
+        result = result + "\tRequired Package(s):\n\t\t%s\n" % '\t\t'.join(self.required_packages)
 
         return result
 

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -141,7 +141,7 @@ def main():
     for opt, arg in opts:
         if opt in [ "-w", "--workspace" ]:
             workspace = arg
-        elif opt in [ "-l", "--components" ]:
+        elif opt in [ "-c", "--components", "-l" ]:
             components_arg = arg
         elif opt in [ "--make" ]:
             make_arg = True

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -156,6 +156,10 @@ def main():
         else:
             assert False, "unknown option"
 
+    if workspace is None:
+        print "FATAL: A --workspace argument or WS_TOP envvar is required"
+        usage()
+
     component_paths = FindComponentPaths(workspace, debug, subdir)
 
     if make_arg:

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -20,6 +20,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2010, Oracle and/or it's affiliates.  All rights reserved.
+# Copyright (c) 2017, Jim Klimov
 #
 #
 # bass-o-matic.py
@@ -98,7 +99,7 @@ class BassComponent:
             proc.wait()
             if proc.returncode != 0:
                 print >>self.debug, "exit: %d, %s" % (proc.returncode, proc.stderr.read())
-    
+
         return result
 
     def __str__(self):
@@ -117,7 +118,7 @@ def main():
     import getopt
     import sys
 
-    # FLUSH STDOUT 
+    # FLUSH STDOUT
     sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
 
     components = {}
@@ -161,14 +162,14 @@ def main():
         if template_zone:
             print "using template zone %s to create a build environment for %s to run '%s'" % (template_zone, component_arg, ['gmake'] + args)
         proc = subprocess.Popen(['gmake'] + args)
-	rc = proc.wait()
+        rc = proc.wait()
         sys.exit(rc)
 
     if components_arg:
         if components_arg in [ 'path', 'paths', 'dir', 'dirs', 'directories' ]:
             for path in component_paths:
                 print "%s" % path
-            
+
         elif components_arg in [ 'depend', 'dependencies' ]:
             for path in component_paths:
                 components[path] = BassComponent(path, debug)

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -118,7 +118,21 @@ class BassComponent:
         return result
 
 def usage():
-    print "Usage: %s [-c|--components=(path|depend)] [-z|--zone (zone)]" % (sys.argv[0].split('/')[-1])
+    print "Usage: %s [-c|--components=(path|depend)]" % (sys.argv[0].split('/')[-1])
+    print "     -c | --components 'path'    Print dirname of the component"
+    print "     -c | --components 'depend'  Print dependencies of the component"
+    print "Usage: %s --make [--template-zone=tzone] [--component=NAME] [--] args..." % (sys.argv[0].split('/')[-1])
+    print "     Use the optional template zone to 'gmake args...' for building of the"
+    print "     specified component (without template use the current workspace)"
+    print "     The '--' argument allows to pass dash-prefixed args to the gmake"
+    print "Common arguments:"
+    print "     -d | --debug                Enable printing of debug info (to stdout)"
+    print "     -d -d                       Use twice to print debug info onto stderr"
+    print "     -w | --workspace=WS_TOP     Provide absolute path to workspace root"
+    print "                                 (defaults to WS_TOP envvar if provided)"
+    print "     --subdir=COMP_TOP           Look for recipes for component(s) under"
+    print "                                 the directory named \$WS_TOP/\$COMP_TOP"
+    print "                                 (defaults to '/components')"
     sys.exit(1)
 
 def main():
@@ -137,6 +151,10 @@ def main():
     subdir="/components"
     workspace = os.getenv('WS_TOP')
 
+    # Note: arguments that do not start with "--" effectively cause the loop
+    # to break, and remaining things remain in args[] e.g. for --make to use.
+    # The standalone "--" argument also breaks out of the loop, allowing to
+    # pass dash-prefixed argumets to the make command.
     try:
         opts, args = getopt.getopt(sys.argv[1:], "w:c:d",
             [ "debug", "workspace=", "components=",
@@ -159,7 +177,10 @@ def main():
         elif opt in [ "--subdir" ]:
             subdir = arg
         elif opt in [ "-d", "--debug" ]:
-            debug = sys.stdout
+            if debug is None:
+                debug = sys.stdout
+            else:
+                debug = sys.stderr
         else:
             assert False, "unknown option"
 


### PR DESCRIPTION
Hi, following discussion on FOSDEM, I took a deeper look at the building blocks we need for building in zones, more reliable parallelization of component-building (considering dependencies), etc. - and particularly at bass-o-matic script.

The latter seems very... strange :) and most of its logic is not even used in our recipes (and perhaps for a good reason - I don't see how those bits could work). First of all it seems VERY unfinished or in a middle of re-work. It took a bit of pounding to just get it to do anything reasonable beside listing directories, and for the past tens of minutes it loops over my workspace with approx. 1402 found components so it would just report on what depends on what (`-c depends` codepath) - I hope it will finish today :)

I think its idea was to produce a series of dependencies as a file that can be fed into gmake, so when I ask it to 'make component_X' it will know which ones to refresh, if sources were also changed...
At least this sounds as a reasonable approach we could adopt, even if not intended by original authors :)

Optimization can be added in the form of caching the called commands' outputs `gmake print-(packaged|required)-(named|paths)`, to re-run quickly at least; this can be done with Make recipes that depend on current component's `Makefile`, maybe `$WS_TOP/make-rules/*.mk` (for common required-packages and/or required-paths which seem to not be set anywhere in our recipes), and maybe `*.p5m` in its dir (for listing of paths provided by package)

These listings could be possibly git-tracked and maybe even required, similar to sample-manifests and REQUIRED_PACKAGES we ask for today when components are added or bumped.

Also I *think* it currently lacks a recursive mode, to produce a chain of dependencies for requested component(s) with one command, and possibly minimizing the number of iterations and forks it does, and certainly the `--make` and zone support modes are utterly placeholders :) UPDATE: I see now that one usage of `--make` is present in the `components/Makefile` which my initial PR state might break, I'll look at it a bit later.

Also I *think* it currently is not able to provide an answer "what directory holds the Makefile responsible for certain PKG_FMRI?" which is a critical request for unrolling the dependency chain
