### PR TITLE
Bump cirrus driver and set default depth to 16 bpp

### DIFF
--- a/components/x11/xf86-video-cirrus/Makefile
+++ b/components/x11/xf86-video-cirrus/Makefile
@@ -11,18 +11,18 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2017 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-cirrus
-COMPONENT_VERSION= 1.5.2
-COMPONENT_REVISION=1
+COMPONENT_VERSION= 1.5.3
 COMPONENT_SUMMARY= xf86-video-cirrus - Cirrus Logic video driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-  sha256:3361e1a65d9b84c464752fd612bdf6087622c6dd204121715366a170e5c3ccd7
+  sha256:edc87b20a55259126b5239b5c1ef913419eab7ded0ed12ae9ae989460d7351ab
 COMPONENT_ARCHIVE_URL= \
   http://xorg.freedesktop.org/archive/individual/driver/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
@@ -58,3 +58,14 @@ LD_OPTIONS= \
 build: $(BUILD_32_and_64)
 
 install: $(INSTALL_32_and_64)
+
+REQUIRED_PACKAGES += developer/build/autoconf/xorg-macros
+REQUIRED_PACKAGES += developer/build/pkg-config
+REQUIRED_PACKAGES += x11/server/xorg
+REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/randrproto
+REQUIRED_PACKAGES += x11/header/renderproto
+REQUIRED_PACKAGES += x11/header/videoproto
+REQUIRED_PACKAGES += x11/header/xextproto
+REQUIRED_PACKAGES += x11/header/xproto
+REQUIRED_PACKAGES += diagnostic/scanpci

--- a/components/x11/xf86-video-cirrus/patches/01.no-accel.patch
+++ b/components/x11/xf86-video-cirrus/patches/01.no-accel.patch
@@ -1,0 +1,37 @@
+From 23da6073369ef6a99d1789de967e57359d1fe3b0 Mon Sep 17 00:00:00 2001
+From: Stefan Dirsch <sndirsch@suse.de>
+Date: Tue, 26 Apr 2016 16:26:49 +0200
+Subject: Disable "acceleration" under qemu
+
+Disable "acceleration" under qemu, since taking the hypercall trap
+is really quite expensive and you're better off doing noaccel. Patch
+is based on the one by "Adam Jackson" <ajax@redhat.com>
+
+http://pkgs.fedoraproject.org/cgit/rpms/xorg-x11-drv-cirrus.git/tree/cirrus-1.2.0-qemu.patch?id=daccd1c8174623500eddfa297d8ea76a86d3c5d9
+
+Reviewed-by: Adam Jackson <ajax@redhat.com>
+
+diff --git a/src/alp_driver.c b/src/alp_driver.c
+index bd5e52f..ba55247 100644
+--- a/src/alp_driver.c
++++ b/src/alp_driver.c
+@@ -774,6 +774,16 @@ AlpPreInit(ScrnInfoPtr pScrn, int flags)
+      else
+  	xf86SetDDCproperties(pScrn,xf86PrintEDID(
+ 		 xf86DoEDID_DDC2(XF86_SCRN_ARG(pScrn),pCir->I2CPtr1)));
++
++#ifdef XSERVER_LIBPCIACCESS
++     #ifndef PCI_CHIP_QEMU
++     #define PCI_CHIP_QEMU 0x1af4
++     #endif
++     if (!pScrn->monitor->DDC &&
++	((pCir->PciInfo->subvendor_id & 0xffff) == PCI_CHIP_QEMU)) {
++	pCir->NoAccel = TRUE;
++     }
++#endif
+  
+      /* Probe the possible LCD display */
+      AlpProbeLCD(pScrn);
+-- 
+cgit v0.10.2
+

--- a/components/x11/xf86-video-cirrus/patches/02.cirrus-alpine-default-16bits-depth.patch
+++ b/components/x11/xf86-video-cirrus/patches/02.cirrus-alpine-default-16bits-depth.patch
@@ -1,0 +1,17 @@
+alpine: Default to 16bpp
+
+24bpp support is going away, so since we can't do 32bpp and these cards
+have basically no VRAM to begin with, drop to 16bpp.
+
+Based on: https://cgit.freedesktop.org/xorg/driver/xf86-video-cirrus/patch/?id=c6f5096252923b1a344291e8045a15045e98dd27
+--- a/src/alp_driver.c	2015-05-06 22:46:42.000000000 +0200
+--- b/src/alp_driver.c	2015-05-06 22:46:42.000000000 +0200
+@@ -555,7 +555,7 @@ AlpPreInit(ScrnInfoPtr pScrn, int flags)
+ 	 * The first thing we should figure out is the depth, bpp, etc.
+ 	 * We support both 24bpp and 32bpp layouts, so indicate that.
+ 	 */
+-	if (!xf86SetDepthBpp(pScrn, 0, 0, 24, depth_flags)) {
++	if (!xf86SetDepthBpp(pScrn, 0, 0, 16, depth_flags)) {
+ 		return FALSE;
+ 	} else {
+ 		/* Check that the returned depth is one we support */

--- a/components/x11/xf86-video-cirrus/patches/03.mapfiles.patch
+++ b/components/x11/xf86-video-cirrus/patches/03.mapfiles.patch
@@ -18,13 +18,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-diff -urp -x '*~' -x '*.orig' src/Makefile.am src/Makefile.am
---- a/src/Makefile.am	2008-03-19 07:29:23.000000000 -0700
-+++ b/src/Makefile.am	2009-01-10 19:15:45.025364000 -0800
-@@ -57,3 +57,41 @@ cirrus_laguna_la_SOURCES = \
-          lg_i2c.c \
+--- a/src/Makefile.am	2015-05-06 22:46:42.000000000 +0200
++++ b/src/Makefile.am	2017-02-13 23:27:56.026088988 +0100
+@@ -64,3 +64,41 @@ cirrus_laguna_la_SOURCES += \
           lg_xaa.c \
           lg_xaa.h
+ endif
 +
 +
 +# Generate linker mapfiles for symbols found in other modules and use them

--- a/components/x11/xf86-video-cirrus/patches/04.solaris-port.patch
+++ b/components/x11/xf86-video-cirrus/patches/04.solaris-port.patch
@@ -1,14 +1,3 @@
---- a/src/cir.h	Mon Mar  2 13:27:44 2015
-+++ b/src/cir.h	Mon Mar  2 13:27:54 2015
-@@ -23,7 +23,7 @@
- 	ScrnInfoPtr		pScrn;
- 	CARD32			properties;
- 	pciVideoPtr		PciInfo;
--	PCITAG			PciTag;
-+	CARD32			PciTag;
- 	unsigned long		PIOReg;
-     union {
- 	struct lgRec		*lg;
 --- a/src/alp.h	Thu Jul 16 09:58:14 2015
 +++ b/src/alp.h	Thu Jul 16 09:58:26 2015
 @@ -3,8 +3,8 @@
@@ -37,7 +26,7 @@
  
 --- a/src/cir.h	Thu Jul 16 09:53:49 2015
 +++ b/src/cir.h	Thu Jul 16 09:57:12 2015
-@@ -75,27 +75,27 @@
+@@ -77,27 +77,27 @@
  } CirRec, *CirPtr;
  
  /* CirrusClk.c */


### PR DESCRIPTION
Current xf86-video-cirrus X11 driver does not work with Qemu emulated
GD5446 graphics adapter (on Linux Qemu v2.6.2 at least) - opening
terminal results in distorted, visally unstable window.

This is now fixed with setting default depth to 16 bpp (was 24 bpp).

Also the driver was bumped to version 1.5.3 and `NoAccel` set as a
default. All changes are from upstream. Two OpenIndiana-specific
patches were updated.

Tested with current OpenIndiana on Linux Qemu KVM v2.8.0 with `-vga
cirrus`.