### PR TITLE
build with the hipster default jpeg implementation

### DIFF
--- a/components/mrxvt/Makefile
+++ b/components/mrxvt/Makefile
@@ -16,6 +16,7 @@ include ../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mrxvt
 COMPONENT_VERSION=	0.5.4
+COMPONENT_REVISION=     1
 COMPONENT_PROJECT_URL=	http://materm.sourceforge.net/wiki/pmwiki.php
 COMPONENT_SUMMARY=	Mrxvt - lightweight multi-tabbed terminal emulator
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -34,6 +35,11 @@ include $(WS_TOP)/make-rules/ips.mk
 
 PATH=/usr/gnu/bin:/usr/bin
 
+# build with the system default libjpeg
+CFLAGS            +=	$(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
+CXXFLAGS          +=	$(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
+LDFLAGS           +=	$(JPEG_LDFLAGS)
+
 CONFIGURE_OPTIONS +=	--sysconfdir=/etc
 CONFIGURE_OPTIONS +=	--enable-everything
 CONFIGURE_OPTIONS +=	--disable-debug
@@ -44,3 +50,13 @@ build:		$(BUILD_32)
 install:	$(INSTALL_32)
 
 test:		$(NO_TESTS)
+
+REQUIRED_PACKAGES += image/library/$(JPEG_IMPLEM)
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/fontconfig
+REQUIRED_PACKAGES += x11/library/libice
+REQUIRED_PACKAGES += x11/library/libsm
+REQUIRED_PACKAGES += x11/library/libx11
+REQUIRED_PACKAGES += x11/library/libxft
+REQUIRED_PACKAGES += x11/library/libxpm
+REQUIRED_PACKAGES += x11/library/libxrender


### PR DESCRIPTION
Update terminal/mrxvt to build with libjpeg8-turbo.

@pyhalov and @alarcher , please review my changes carefully.

I can't get either pkg://openindiana.org/terminal/mrxvt@0.5.4-2016.0.0.0:20160730T005926Z or my updated version that uses libjpeg8-turbo to load a background JPEG pixmap, but at least mrxvt seems to be functioning as it did before.

mrxvt had no REQUIRED_PACKAGES specified; I've only added image/library/$(JPEG_IMPLEM), not any of the other missing packages.

If these changes appear to be correct and are merged, I will update [the illumos issue tracker issue 7391](https://www.illumos.org/issues/7391) and then try some of the other "easy" components.

During testing, I was not able to install my updated terminal/mrxvt because it was blocked by userland-incorporation.  tomww from irc oi-dev suggested using a version unlock on terminal/mrxvt, which worked.  If that's preferred over uninstalling userland-incorporation, I'll also create a pull request for the docs to mention that testing updates for some components may require you to version unlock.

