### PR TITLE
Build search index after IPS repo initialization

### DIFF
--- a/components/Makefile
+++ b/components/Makefile
@@ -97,6 +97,7 @@ $(WS_LOGS):
 $(WS_REPO):
 	$(PKGREPO) create $(PKG_REPO)
 	$(PKGREPO) add-publisher -s $(PKG_REPO) $(PUBLISHER)
+	$(PKGREPO) rebuild -s $(PKG_REPO)
 # Not required for OI
 #	$(PKGREPO) add-publisher -s $(PKG_REPO) $(PUBLISHER_LOCALIZABLE)
 


### PR DESCRIPTION
A while ago, user reported on the iRC that he was unable to search local IPS repo. @alarcher pointed out that the freshly initialized IPS repository does not contain build search index, so we should build it during the setup phase.

Without this change it looks like this:
<pre>
xenol@external oi-userland (rebuild-index) % pkg search httping        
INDEX                ACTION VALUE                                                                                                                           PACKAGE
basename             file   usr/bin/httping                                                                                                                 pkg:/diagnostic/httping@1.5.8-2016.0.0.0
com.oracle.info.name set    httping                                                                                                                         pkg:/diagnostic/httping@1.5.8-2016.0.0.0
pkg.description      set    Give httping an url, and it'll show you how long it takes to connect, send a request and retrieve the reply (only the headers). pkg:/diagnostic/httping@1.5.8-2016.0.0.0
pkg.fmri             set    openindiana.org/diagnostic/httping                                                                                              pkg:/diagnostic/httping@1.5.8-2016.0.0.0
pkg: Some repositories failed to respond appropriately:
userland:
file protocol error: code: E_FTP_WEIRD_PASS_REPLY (11) reason: Search temporarily unavailable.
Repository URL: 'file:///export/home/xenol/code/oi-userland/i386/repo'. (happened 4 times)
</pre>

After:
<pre>
xenol@external oi-userland (rebuild-index) % pkg search httping                  
INDEX                ACTION VALUE                                                                                                                           PACKAGE
basename             file   usr/bin/httping                                                                                                                 pkg:/diagnostic/httping@1.5.8-2016.0.0.0
com.oracle.info.name set    httping                                                                                                                         pkg:/diagnostic/httping@1.5.8-2016.0.0.0
pkg.description      set    Give httping an url, and it'll show you how long it takes to connect, send a request and retrieve the reply (only the headers). pkg:/diagnostic/httping@1.5.8-2016.0.0.0
pkg.fmri             set    openindiana.org/diagnostic/httping                                                                                              pkg:/diagnostic/httping@1.5.8-2016.0.0.0
</pre>

Please note that the search results are not showing from userland repo, even though the package is there: 
<pre>
xenol@external oi-userland (rebuild-index) % pkgrepo list -s i386/repo    
PUBLISHER NAME                                          O VERSION
userland  diagnostic/httping                              2.4-2017.0.0.0:20170301T231352Z
userland  diagnostic/httping                              2.4-2017.0.0.0:20170301T230600Z
userland  diagnostic/httping                              1.5.8-2017.0.0.0:20170301T224542Z
</pre>
I suppose this is because I am doing the search wrong. Anyhow, this commit remove the annoying search error message.