### PR TITLE
codec/jasper: build with jpeg-turbo8

### DIFF
--- a/components/multimedia/jasper/Makefile
+++ b/components/multimedia/jasper/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= jasper
 COMPONENT_VERSION= 1.900.1
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= A free software-based reference implementation of the JPEG-2000 Part-1 CODEC
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).zip
@@ -35,6 +35,11 @@ include $(WS_TOP)/make-rules/prep.mk
 include $(WS_TOP)/make-rules/configure.mk
 include $(WS_TOP)/make-rules/ips.mk
 
+# build with the distribution preferred libjpeg implementation
+CFLAGS            +=    $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
+CXXFLAGS          +=    $(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
+LDFLAGS           +=    $(JPEG_LDFLAGS)
+
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --enable-shared
 CONFIGURE_OPTIONS += --with-pic
@@ -43,3 +48,7 @@ CONFIGURE_OPTIONS += --without-docs
 build: $(BUILD_32_and_64)
 
 install: $(INSTALL_32_and_64)
+
+REQUIRED_PACKAGES += image/library/$(JPEG_IMPLEM)
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math


### PR DESCRIPTION
Build codec/jasper with the hipster preferred jpeg-turbo8.

Previous package did not have any REQUIRED_PACKAGES so I ran `gmake REQUIRED_PACKAGES` and edited as apporopriate.

All dynamic links in the updated component are against jpeg-turbo8:

```bash
$ pkg info codec/jasper
             Name: codec/jasper
          Summary: A free software-based reference implementation of the
                   JPEG-2000 Part-1 CODEC
         Category: System/Multimedia Libraries
            State: Installed
        Publisher: userland
          Version: 1.900.1
           Branch: 2017.0.0.2
   Packaging Date:  3 March 2017 07:23:26 PM
Last Install Time:  3 March 2017 07:28:15 PM
             Size: 1.14 MB
             FMRI: pkg://userland/codec/jasper@1.900.1-2017.0.0.2:20170303T192326Z
      Project URL: http://www.ece.uvic.ca/~frodo/jasper/
       Source URL: http://www.ece.uvic.ca/~frodo/jasper/software/jasper-1.900.1.zip

$ for f in `pkg contents codec/jasper | egrep -v PATH | sed -e 's@^@/@'`
   do test -x $f && echo $f && ldd $f 2>/dev/null | egrep -i jpeg
 done
/usr/bin/amd64/imgcmp
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/imginfo
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/jasper
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tmrdemo
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/imgcmp
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/imginfo
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/jasper
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tmrdemo
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/lib/amd64/libjasper.so
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/lib/amd64/libjasper.so.1
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/lib/amd64/libjasper.so.1.0.0
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/lib/libjasper.so
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/lib/libjasper.so.1
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/lib/libjasper.so.1.0.0
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
```