### PR TITLE
image/library/libtiff: build with libjpeg8-turbo

### DIFF
--- a/components/library/tiff/Makefile
+++ b/components/library/tiff/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= tiff
 COMPONENT_VERSION= 4.0.7
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= libtiff - library for reading and writing TIFF
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
@@ -24,7 +25,7 @@ COMPONENT_ARCHIVE_HASH= \
   sha256:9f43a2cfb9589e5cecaa66e16bf87f814c945f22df7ba600d63aac4632c4f019
 COMPONENT_ARCHIVE_URL= \
   http://download.osgeo.org/libtiff/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://www.remotesensing.org/libtiff/
+COMPONENT_PROJECT_URL = http://www.simplesystems.org/libtiff/
 COMPONENT_LICENSE_FILE = COPYRIGHT
 COMPONENT_LICENSE = BSD-like
 COMPONENT_FMRI = image/library/libtiff
@@ -34,6 +35,11 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
+# build with the distribution preferred libjpeg implementation
+CFLAGS            +=    $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
+CXXFLAGS          +=    $(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
+LDFLAGS           +=    $(JPEG_LDFLAGS)
+
 CONFIGURE_OPTIONS += --libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
 CONFIGURE_OPTIONS += --disable-cxx
 
@@ -41,16 +47,22 @@ COMPONENT_POST_INSTALL_ACTION= \
             (cd $(PROTOUSRDIR) ;  \
              $(MV) include/tiffconf.h include/tiffconf-$(BITS).h)
 
+# Needed for "gmake test" to work successfully.
+# If SHELLOPTS is exported (as it is by the userland makefiles),
+# then all shell options get exported to child invocations of bash,
+# which results in test failures due to nounset and xtrace being
+# set unexpectedly, and errors such as "$1: unbound variable" and
+# diffs failing due to script tracing in output files.
+unexport SHELLOPTS
 
 build: $(BUILD_32_and_64)
 
 install: $(INSTALL_32_and_64)
 
-test: $(NO_TESTS)
+test: $(TEST_32_and_64)
 
 REQUIRED_PACKAGES += compress/xz
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/$(JPEG_IMPLEM)
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math


### PR DESCRIPTION
Rebuild image/library/libtiff with libjpeg8-turbo.

Besides the standard stuff (updating REQUIRED_PACKAGES, bumping COMPONENT_REVISION, adding the necessary CFLAGS/CPPFLAGS/CXXFLAGS/LDFLAGS), I updated the COMPONENT_PROJECT_URL.  The old one results in a 404.

Also, the component doesn't specify any test suite, but libtiff does have a "check" target that passes for both i86 and amd64 when I run them manually from the respective build directory.  I tried switching the test target to 'test: $(TEST_32_and_64)' but then all the tests fail with a libtool error, so I left the test target as it is.

Finally, after the rebuild:

```bash
/usr/bin/amd64/fax2ps
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/fax2tiff
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/pal2rgb
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/ppm2tiff
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/raw2tiff
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiff2bw
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiff2pdf
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiff2ps
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiff2rgba
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffcmp
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffcp
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffcrop
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffdither
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffdump
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffinfo
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffmedian
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffset
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/amd64/tiffsplit
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/bin/fax2ps
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/fax2tiff
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/pal2rgb
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/ppm2tiff
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/raw2tiff
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiff2bw
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiff2pdf
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiff2ps
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiff2rgba
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffcmp
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffcp
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffcrop
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffdither
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffdump
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffinfo
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffmedian
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffset
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/bin/tiffsplit
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/lib/amd64/libtiff.so
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/lib/amd64/libtiff.so.5
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/lib/amd64/libtiff.so.5.2.5
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/amd64/libjpeg.so.8
/usr/lib/libtiff.so
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/lib/libtiff.so.5
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
/usr/lib/libtiff.so.5.2.5
        libjpeg.so.8 =>  /usr/lib/libjpeg8-turbo/lib/libjpeg.so.8
