### PR TITLE
Fix xorg-video-mach64

### DIFF
--- a/components/x11/xf86-video-mach64/Makefile
+++ b/components/x11/xf86-video-mach64/Makefile
@@ -38,6 +38,7 @@ COMPONENT_PREP_ACTION =        ( cd $(@D) && \
                                         automake -a -f -c &&\
                                         autoconf )
 
+CFLAGS+= -D__EXTENSIONS__
 # Paths to find libraries/modules to link with 
 
 SERVERMOD_SUBDIR.64=/$(MACH64)
@@ -61,3 +62,8 @@ COMPONENT_INSTALL_ARGS += $(COMPONENT_COMMON_ARGS)
 build: $(BUILD_32_and_64)
 
 install: $(INSTALL_32_and_64)
+
+REQUIRED_PACKAGES += diagnostic/scanpci
+REQUIRED_PACKAGES += library/graphics/pixman
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += x11/server/xorg


### PR DESCRIPTION
Fix for building with Xorg 1.18 and 1.19.