### PR TITLE
8012 Add PATH symbols to shared-macros.mk

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -18,10 +18,19 @@
 #
 # CDDL HEADER END
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
 #
 
-PATH=/usr/bin:/usr/gnu/bin
+# These symbols should be used in component Makefiles
+# whenever PATH is to be defined there:
+#     PATH = $(PATH.ill)
+#     PATH = $(PATH.gnu)
+PATH.ill=$(USRBINDIR):$(GNUBIN)
+PATH.gnu=$(GNUBIN):$(USRBINDIR)
+
+# Default PATH
+PATH = $(PATH.ill)
 
 # The location of an internal mirror of community source archives that we build
 # in this gate.  This mirror has been seeded to include "custom" source archives


### PR DESCRIPTION
This change has no effect by itself, but once the component Makefiles are changed to use the symbols to set PATH, a change in shared-macros.mk will be propagated to all the component Makefiles.
