### PR TITLE
Add Apache commons BSF

### DIFF
--- a/components/library/java-commons-bsf/Makefile
+++ b/components/library/java-commons-bsf/Makefile
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, Wiselabs Software Ltda - http://www.wiselabs.com.br . All rights reserved.
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		java-commons-bsf
+COMPONENT_VERSION=	2.4.0
+COMPONENT_SUMMARY= Bean Scripting Framework (BSF) is a set of Java classes which provides scripting language support within Java applications, and access to Java objects and methods from scripting languages.
+COMPONENT_PROJECT_URL=	https://commons.apache.org/proper/commons-bsf
+COMPONENT_SRC=		bsf-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	bsf-bin-$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:28bbd69c6218922a94ae0c2fcbf5a7bf2a8de5dabc849167687933e4c986c3d7
+COMPONENT_ARCHIVE_URL=  http://ftp.unicamp.br/pub/apache/commons/bsf/binaries/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=	library/java/commons-bsf
+COMPONENT_CLASSIFICATION=	Development/Java
+COMPONENT_LICENSE=	ASLv1.1
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_POST_UNPACK_ACTION= $(MV) $(COMPONENT_SRC)/lib/bsf.jar $(COMPONENT_SRC)/lib/bsf-$(COMPONENT_VERSION).jar
+
+build:
+
+install: prep
+	[ -d $(PROTO_DIR)/usr/share/lib/java ] || mkdir -p $(PROTO_DIR)/usr/share/lib/java
+	[ -f $(PROTO_DIR)/usr/share/lib/java/bsf-$(COMPONENT_VERSION).jar ] || \
+		$(CP) $(SOURCE_DIR)/lib/bsf-$(COMPONENT_VERSION).jar $(PROTO_DIR)/usr/share/lib/java
+
+clean::
+	rm -rf $(BUILD_DIR)
+

--- a/components/library/java-commons-bsf/java-commons-bsf.license
+++ b/components/library/java-commons-bsf/java-commons-bsf.license
@@ -1,0 +1,59 @@
+/* ====================================================================
+ * The Apache Software License, Version 1.1
+ *
+ * Copyright (c) 2000 The Apache Software Foundation.  All rights
+ * reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The end-user documentation included with the redistribution,
+ *    if any, must include the following acknowledgment:
+ *       "This product includes software developed by the
+ *        Apache Software Foundation (http://www.apache.org/)."
+ *    Alternately, this acknowledgment may appear in the software itself,
+ *    if and wherever such third-party acknowledgments normally appear.
+ *
+ * 4. The names "Apache" and "Apache Software Foundation" must
+ *    not be used to endorse or promote products derived from this
+ *    software without prior written permission. For written
+ *    permission, please contact apache@apache.org.
+ *
+ * 5. Products derived from this software may not be called "Apache",
+ *    nor may "Apache" appear in their name, without prior written
+ *    permission of the Apache Software Foundation.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ * Portions of this software are based upon public domain software
+ * originally written at the National Center for Supercomputing Applications,
+ * University of Illinois, Urbana-Champaign.
+ */
+
+

--- a/components/library/java-commons-bsf/java-commons-bsf.p5m
+++ b/components/library/java-commons-bsf/java-commons-bsf.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017, Wiselabs Software Ltda - http://www.wiselabs.com.br . All rights reserved.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/share/lib/java/bsf-$(COMPONENT_VERSION).jar
+link path=usr/share/lib/java/bsf.jar target=bsf-$(COMPONENT_VERSION).jar
+

--- a/components/library/java-commons-bsf/manifests/sample-manifest.p5m
+++ b/components/library/java-commons-bsf/manifests/sample-manifest.p5m
@@ -1,0 +1,25 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/share/lib/java/bsf-$(COMPONENT_VERSION).jar


### PR DESCRIPTION
Apache commons BSF is necessary to my future Apache ANT revision (to support script in build targets).