### PR TITLE
8097 Better patch for callers of notify_notification_new()

### DIFF
--- a/components/desktop/gnome2/seahorse/Makefile
+++ b/components/desktop/gnome2/seahorse/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2014 Alexander Pyhalov
 #
 
@@ -16,7 +17,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		seahorse
 COMPONENT_VERSION=	2.32.0
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_PROJECT_URL=	https://wiki.gnome.org/action/show/Apps/Seahorse
 COMPONENT_SUMMARY=	Seahorse is a GNOME application for managing encryption keys
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -25,11 +26,11 @@ COMPONENT_ARCHIVE_HASH=	\
     sha256:f55468237246a485317d59e2fbc1b1ef5f5bd4c5a7b9ff6f40c3d921af0ed52d
 COMPONENT_ARCHIVE_URL=	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/2.32/$(COMPONENT_ARCHIVE)
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH = $(PATH.gnu)
 
 COMPONENT_PREP_ACTION =        ( cd $(@D) && \
                                         aclocal -I. && \
@@ -48,3 +49,18 @@ build:		$(BUILD_32)
 install:	$(INSTALL_32)
 
 test:		$(NO_TESTS)
+
+REQUIRED_PACKAGES += crypto/gnupg
+REQUIRED_PACKAGES += gnome/config/gconf
+REQUIRED_PACKAGES += gnome/gnome-keyring
+REQUIRED_PACKAGES += library/desktop/atk
+REQUIRED_PACKAGES += library/desktop/gtk2
+REQUIRED_PACKAGES += library/desktop/pango
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/gnome/gnome-keyring
+REQUIRED_PACKAGES += library/libnotify
+REQUIRED_PACKAGES += library/libsoup
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/libdbus
+REQUIRED_PACKAGES += system/library/libdbus-glib
+REQUIRED_PACKAGES += system/network/avahi

--- a/components/desktop/gnome2/seahorse/patches/98-libnotify-0.7.patch
+++ b/components/desktop/gnome2/seahorse/patches/98-libnotify-0.7.patch
@@ -1,11 +1,18 @@
---- seahorse-2.32.0/libseahorse/seahorse-notification.c.1	2016-04-13 22:55:03.865535987 +0300
-+++ seahorse-2.32.0/libseahorse/seahorse-notification.c	2016-04-13 22:55:30.684272035 +0300
-@@ -231,7 +231,7 @@
+--- seahorse-2.32.0/libseahorse/seahorse-notification.c-orig	   :: 
++++ seahorse-2.32.0/libseahorse/seahorse-notification.c	   :: 
+@@ -231,7 +231,15 @@
      heading = format_key_text (snotif->heading);
      message = format_key_text (snotif->message);
      
--    notif = notify_notification_new (heading, message, snotif->icon, attachto);
++#ifdef NOTIFY_CHECK_VERSION
++#if NOTIFY_CHECK_VERSION (0, 7, 0)
 +    notif = notify_notification_new (heading, message, snotif->icon);
++#else
+     notif = notify_notification_new (heading, message, snotif->icon, attachto);
++#endif
++#else
++    notif = notify_notification_new (heading, message, snotif->icon, attachto);
++#endif
      
      g_free (heading);
      g_free (message);

--- a/components/desktop/gnome2/zenity/Makefile
+++ b/components/desktop/gnome2/zenity/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2014 Alexander Pyhalov. All rights reserved
 #
 
@@ -16,7 +17,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zenity
 COMPONENT_VERSION=	2.32.1
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	http://www.gnome.org
 COMPONENT_SUMMARY=	GNOME graphical dialog box generator
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -25,11 +26,11 @@ COMPONENT_ARCHIVE_HASH=	\
     sha256:8838be041a07364b62a4281c971392e4a09bb01bb3237a836ec0457ec0ea18ac
 COMPONENT_ARCHIVE_URL=	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/2.32/$(COMPONENT_ARCHIVE)
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH = $(PATH.gnu)
 
 LDFLAGS += -lX11
 
@@ -43,6 +44,8 @@ install:	$(INSTALL_32)
 
 test:		$(NO_TESTS)
 
-BUILD_PKG_DEPENDENCIES = $(BUILD_TOOLS)
-
-include $(WS_TOP)/make-rules/depend.mk
+REQUIRED_PACKAGES += library/desktop/gtk2
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/libnotify
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/desktop/gnome2/zenity/patches/libnotify-0.7.patch
+++ b/components/desktop/gnome2/zenity/patches/libnotify-0.7.patch
@@ -1,19 +1,5 @@
-https://bugzilla.gnome.org/show_bug.cgi?id=631737
-From 977600de4a7519d1ddf56b6f4feb846e2a9ae71d Mon Sep 17 00:00:00 2001
-From: William Jon McCann <jmccann@redhat.com>
-Date: Sat, 9 Oct 2010 04:59:44 -0400
-Subject: [PATCH] Require libnotify 0.6.1
-
-https://bugzilla.gnome.org/show_bug.cgi?id=631737
----
- configure.in       |   18 +----
- src/notification.c |  198 +++++++++++++++++-----------------------------------
- 2 files changed, 67 insertions(+), 149 deletions(-)
-
-diff --git a/src/notification.c b/src/notification.c
-index 99a2e36..531aed2 100644
---- a/src/notification.c
-+++ b/src/notification.c
+--- zenity-2.32.1/src/notification.c-orig	   :: 
++++ zenity-2.32.1/src/notification.c	   :: 
 @@ -24,75 +24,31 @@
  
  #include <config.h>
@@ -45,9 +31,12 @@ index 99a2e36..531aed2 100644
  {
 -  GdkPixbuf *pixbuf;
 -  GError *error = NULL;
--
++  ZenityData *zen_data;
+ 
 -  pixbuf = gdk_pixbuf_new_from_file_at_scale (icon_file, icon_size, icon_size, TRUE, &error);
--
++  zen_data = (ZenityData *)user_data;
++  notify_notification_close (n, NULL);
+ 
 -  if (error) {
 -    g_warning ("Could not load notification icon '%s': %s",
 -               icon_file, error->message);
@@ -57,7 +46,8 @@ index 99a2e36..531aed2 100644
 -    pixbuf = gdk_pixbuf_new_from_file_at_scale (ZENITY_IMAGE_FULLPATH ("zenity-notification.png"),
 -                                                icon_size, icon_size, TRUE, NULL);
 -  }
--
++  zen_data->exit_code = zenity_util_return_exit_code (ZENITY_OK);
+ 
 -  gtk_status_icon_set_from_pixbuf (status_icon, pixbuf);
 -
 -  if (pixbuf) {
@@ -80,27 +70,23 @@ index 99a2e36..531aed2 100644
 -
 -    return TRUE;
 -  }
-+  ZenityData *zen_data;
- 
+-
 -  return FALSE;
 -}
-+  zen_data = (ZenityData *)user_data;
-+  notify_notification_close (n, NULL);
- 
+-
 -static gboolean
 -zenity_notification_icon_activate_cb (GtkWidget *widget,
 -				      ZenityData *data)
 -{
 -  data->exit_code = zenity_util_return_exit_code (ZENITY_OK);
-+  zen_data->exit_code = zenity_util_return_exit_code (ZENITY_OK);
- 
+-
    gtk_main_quit ();
 -
 -  return TRUE;
  }
  
  static gboolean
-@@ -145,26 +101,14 @@ zenity_notification_handle_stdin (GIOChannel *channel,
+@@ -145,26 +101,14 @@
        while (*value && g_ascii_isspace (*value)) value++;
  
        if (!g_ascii_strcasecmp (command, "icon")) {
@@ -128,7 +114,7 @@ index 99a2e36..531aed2 100644
            gchar **message;
            error = NULL;
  
-@@ -178,46 +122,37 @@ zenity_notification_handle_stdin (GIOChannel *channel,
+@@ -178,46 +122,61 @@
              continue;
            }
  
@@ -137,30 +123,42 @@ index 99a2e36..531aed2 100644
 -          } else if (icon_file) {
 -            icon = freeme = g_filename_to_uri (icon_file, NULL, NULL);
 -          }
--
++#ifdef NOTIFY_CHECK_VERSION
++#if NOTIFY_CHECK_VERSION (0, 7, 0)
++          notif = notify_notification_new (message[0] /* title */,
++                                           message[1] /* summary */,
++                                           icon_file);
++#else
++          notif = notify_notification_new (message[0] /* title */,
++                                           message[1] /* summary */,
++                                           icon_file, NULL);
++#endif
++#else
++          notif = notify_notification_new (message[0] /* title */,
++                                           message[1] /* summary */,
++                                           icon_file, NULL);
++#endif
+ 
 -          notif = notify_notification_new_with_status_icon (
 -                              message[0] /* title */,
 -                              message[1] /* summary */,
 -                              icon, status_icon);
-+          notif = notify_notification_new (message[0] /* title */,
-+                                           message[1] /* summary */,
-+                                           icon_file);
- 
+-
            g_strfreev (message);
 -          g_free (freeme);
  
 -	  notify_notification_show (notif, &error);
--
--	  if (error) {
--	    g_warning ("Error showing notification: %s", error->message);
--	    g_error_free (error);
--	  }
 +          notify_notification_show (notif, &error);
 +          if (error) {
 +            g_warning ("Error showing notification: %s", error->message);
 +            g_error_free (error);
 +          }
  
+-	  if (error) {
+-	    g_warning ("Error showing notification: %s", error->message);
+-	    g_error_free (error);
+-	  }
+-
  	  g_object_unref (notif);
 -	} else {
 -#else
@@ -178,9 +176,21 @@ index 99a2e36..531aed2 100644
 +        } else {
 +          NotifyNotification *notif;
 +
++#ifdef NOTIFY_CHECK_VERSION
++#if NOTIFY_CHECK_VERSION (0, 7, 0)
 +          notif = notify_notification_new (value,
 +                                           NULL,
 +                                           icon_file);
++#else
++          notif = notify_notification_new (value,
++                                           NULL,
++                                           icon_file, NULL);
++#endif
++#else
++          notif = notify_notification_new (value,
++                                           NULL,
++                                           icon_file, NULL);
++#endif
 +          notify_notification_show (notif, &error);
 +          if (error) {
 +            g_warning ("Error showing notification: %s", error->message);
@@ -197,7 +207,7 @@ index 99a2e36..531aed2 100644
        } else {
  	g_warning ("Unknown command '%s'", command);
        }
-@@ -249,55 +184,52 @@ zenity_notification_listen_on_stdin (ZenityData *data)
+@@ -249,55 +208,60 @@
  		  zenity_notification_handle_stdin, data);
  }
  
@@ -246,12 +256,23 @@ index 99a2e36..531aed2 100644
 +    if (notification_data->notification_text == NULL) {
 +      exit (1);
 +    }
-+
+ 
+-  /* Show icon and wait */
+-  gtk_status_icon_set_visible (status_icon, TRUE);
++#ifdef NOTIFY_CHECK_VERSION
++#if NOTIFY_CHECK_VERSION (0, 7, 0)
 +    notification = notify_notification_new (notification_data->notification_text, NULL, data->window_icon);
++#else
++    notification = notify_notification_new (notification_data->notification_text, NULL, data->window_icon, NULL);
++#endif
++#else
++    notification = notify_notification_new (notification_data->notification_text, NULL, data->window_icon, NULL);
++#endif
 +    if (notification == NULL) {
 +      exit (1);
 +    }
-+
+ 
+-  if(data->timeout_delay > 0) {
 +    /* if we aren't listening for changes, then close on default action */
 +    notify_notification_add_action (notification,
 +                                    "default",
@@ -269,12 +290,9 @@ index 99a2e36..531aed2 100644
 +      }
 +      exit (1);
 +    }
- 
--  /* Show icon and wait */
--  gtk_status_icon_set_visible (status_icon, TRUE);
++
 +  }
- 
--  if(data->timeout_delay > 0) {
++
 +  if (data->timeout_delay > 0) {
      g_timeout_add_seconds (data->timeout_delay, (GSourceFunc) zenity_util_timeout_handle, NULL);
    }
@@ -285,5 +303,3 @@ index 99a2e36..531aed2 100644
 -  g_object_unref (status_icon);
 -  g_free (icon_file);
  }
--- 
-1.7.2.3

--- a/components/desktop/notification-daemon/Makefile
+++ b/components/desktop/notification-daemon/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2014 Alexander Pyhalov
 #
 
@@ -16,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		notification-daemon
 COMPONENT_VERSION=	0.4.0
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_PROJECT_URL=	http://www.galago-project.org/news/index.php
 COMPONENT_SUMMARY=	Window Navigator Construction Kit Library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -25,11 +26,11 @@ COMPONENT_ARCHIVE_HASH=	\
     sha256:29aaf4ed090589e69ca5dbbb9125a27c9a194e535cb3b96d26e95bd80ffea530
 COMPONENT_ARCHIVE_URL=	http://www.galago-project.org/files/releases/source/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH = $(PATH.gnu)
 
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 CONFIGURE_OPTIONS+=	--libexecdir=/usr/lib
@@ -42,6 +43,17 @@ install:	$(INSTALL_32)
 
 test:		$(NO_TESTS)
 
-BUILD_PKG_DEPENDENCIES = $(BUILD_TOOLS)
-
-include $(WS_TOP)/make-rules/depend.mk
+REQUIRED_PACKAGES += gnome/config/gconf
+REQUIRED_PACKAGES += gnome/gnome-panel
+REQUIRED_PACKAGES += library/audio/gstreamer
+REQUIRED_PACKAGES += library/desktop/atk
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += library/desktop/gtk2
+REQUIRED_PACKAGES += library/desktop/libglade
+REQUIRED_PACKAGES += library/desktop/libsexy
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/libnotify
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/libdbus
+REQUIRED_PACKAGES += system/library/libdbus-glib
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/desktop/notification-daemon/patches/02-libnotify-0.7.patch
+++ b/components/desktop/notification-daemon/patches/02-libnotify-0.7.patch
@@ -1,12 +1,28 @@
---- notification-daemon-0.4.0/src/capplet/notification-properties.c.1	2016-04-13 22:02:08.110762333 +0300
-+++ notification-daemon-0.4.0/src/capplet/notification-properties.c	2016-04-13 22:02:41.902130716 +0300
-@@ -434,8 +434,7 @@
- 
+--- notification-daemon-0.4.0/src/capplet/notification-properties.c-orig	   :: 
++++ notification-daemon-0.4.0/src/capplet/notification-properties.c	   :: 
+@@ -431,12 +431,21 @@
+ 		g_object_unref(dialog->preview);
+ 		dialog->preview = NULL;
+ 	}
+-
++#ifdef NOTIFY_CHECK_VERSION
++#if NOTIFY_CHECK_VERSION (0, 7, 0)
  	dialog->preview = notify_notification_new(_("Notification Test"),
  											  _("Just a test"),
 -											  "gnome-util",
 -											  NULL);
+-
 +											  "gnome-util");
- 
++#else
++	dialog->preview = notify_notification_new(_("Notification Test"),
++											  _("Just a test"),
++											  "gnome-util", NULL);
++#endif
++#else
++	dialog->preview = notify_notification_new(_("Notification Test"),
++											  _("Just a test"),
++											  "gnome-util", NULL);
++#endif
  	if (!notify_notification_show(dialog->preview, &error))
  	{
+ 		char *message = g_strdup_printf(

--- a/components/desktop/ospm/Makefile
+++ b/components/desktop/ospm/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright 2015 Alexander Pyhalov
 #
 
@@ -16,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ospm
 COMPONENT_VERSION=	1.4.11
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	Print Monitor
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
@@ -28,11 +29,11 @@ COMPONENT_CLASSIFICATION=	System/Printing
 COMPONENT_LICENSE =	GPLv2
 COMPONENT_LICENSE_FILE =	COPYING
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH = $(PATH.gnu)
 
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 
@@ -47,3 +48,18 @@ build:		$(BUILD_32)
 install:	$(INSTALL_32)
 
 test:		$(NO_TESTS)
+
+REQUIRED_PACKAGES += gnome/config/gconf
+REQUIRED_PACKAGES += library/desktop/atk
+REQUIRED_PACKAGES += library/desktop/gtk2
+REQUIRED_PACKAGES += library/desktop/libglade
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/libnotify
+REQUIRED_PACKAGES += library/libxml2
+REQUIRED_PACKAGES += library/popt
+REQUIRED_PACKAGES += library/print/open-printing
+REQUIRED_PACKAGES += service/hal
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/libdbus
+REQUIRED_PACKAGES += system/library/libdbus-glib

--- a/components/desktop/ospm/patches/02-libnotify-0.7.patch
+++ b/components/desktop/ospm/patches/02-libnotify-0.7.patch
@@ -1,11 +1,19 @@
---- ospm-1.4.11/applet/ospm-status-dialog.c.1	2016-04-14 01:20:14.360705025 +0300
-+++ ospm-1.4.11/applet/ospm-status-dialog.c	2016-04-14 01:23:51.940803072 +0300
-@@ -139,7 +139,7 @@
+--- ospm-1.4.11/applet/ospm-status-dialog.c-orig	   :: 
++++ ospm-1.4.11/applet/ospm-status-dialog.c	   :: 
+@@ -139,7 +139,15 @@
          if (!notify_init (PACKAGE))
                  exit (1);
  
 -        notify = notify_notification_new_with_status_icon ("ospm-applet", NULL, NULL, icon);
++#ifdef NOTIFY_CHECK_VERSION
++#if NOTIFY_CHECK_VERSION (0, 7, 0)
 +        notify = notify_notification_new ("ospm-applet", NULL, NULL);
++#else
++        notify = notify_notification_new ("ospm-applet", NULL, NULL, NULL);
++#endif
++#else
++        notify = notify_notification_new ("ospm-applet", NULL, NULL, NULL);
++#endif
  
          notify_notification_add_action (notify, "default", "default action", notify_action_cb, icon, NULL);
  


### PR DESCRIPTION
This PR contains the updated patches for 8097 along with Makefile changes required whenever a component is changed.  All of the components required `gmake REQUIRED_PACKAGES' to add that section to the Makefiles.  These four had completely successful builds.
