### PR TITLE
8124 sysutils/ipmitool build stops with a compiler options error

### DIFF
--- a/components/sysutils/ipmitool/Makefile
+++ b/components/sysutils/ipmitool/Makefile
@@ -10,6 +10,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright 2016 Alexander Pyhalov
 #
 
@@ -17,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= ipmitool
 COMPONENT_VERSION= 1.8.17
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= IPMI management tool
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -30,9 +32,9 @@ COMPONENT_LICENSE = BSD
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = system/management/ipmitool
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 CPPFLAGS += -D__EXTENSIONS__
 

--- a/components/sysutils/ipmitool/patches/07-xopen.patch
+++ b/components/sysutils/ipmitool/patches/07-xopen.patch
@@ -1,0 +1,22 @@
+--- ipmitool-1.8.17/lib/ipmi_main.c-orig	   :: 
++++ ipmitool-1.8.17/lib/ipmi_main.c	   :: 
+@@ -29,7 +29,7 @@
+  * LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE THIS SOFTWARE,
+  * EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+  */
+-#define _XOPEN_SOURCE 700
++#define _XOPEN_SOURCE 600
+ #define _BSD_SOURCE || \
+ 	(_XOPEN_SOURCE >= 500 || \
+ 	_XOPEN_SOURCE && _XOPEN_SOURCE_EXTENDED) && \
+--- ipmitool-1.8.17/src/ipmievd.c-orig	   :: 
++++ ipmitool-1.8.17/src/ipmievd.c	   :: 
+@@ -29,7 +29,7 @@
+  * LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE THIS SOFTWARE,
+  * EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+  */
+-#define _XOPEN_SOURCE 700
++#define _XOPEN_SOURCE 600
+ #define _BSD_SOURCE
+ 
+ #include <stdio.h>


### PR DESCRIPTION
Old versions of sys/feature_tests.h do not recognize _XOPEN_SOURCE larger than 600 or POSIX_C_SOURCE larger than 200112L, resulting in the error message:

Compiler or options invalid for pre-UNIX 03 X/Open applications and pre-2001 POSIX applications

This patch fixes that problem and permits the build to succeed.  It also makes the component more flexible.
