### PR TITLE
8143 developer/gdb build on SPARC stops with a fatal error

### DIFF
--- a/components/developer/gdb/Makefile
+++ b/components/developer/gdb/Makefile
@@ -20,6 +20,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
 #
 
@@ -27,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gdb
 COMPONENT_VERSION=	7.10.1
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
@@ -43,8 +44,7 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-# GDB wants the GNU utilities
-PATH=/usr/gnu/bin:/usr/bin:/usr/perl5/bin
+PATH = $(PATH.gnu)
 
 CFLAGS_sparc =	-g -O2 -mcpu=ultrasparc -mtune=ultrasparc
 CFLAGS_sparc +=	-mno-unaligned-doubles

--- a/components/developer/gdb/patches/gdb.gdb.sol2-core-regset.c.patch
+++ b/components/developer/gdb/patches/gdb.gdb.sol2-core-regset.c.patch
@@ -38,7 +38,7 @@
 +
 +#include <fcntl.h>
 +#include <errno.h>
-+#include "gdb_string.h"
++#include <string.h>
 +#include <time.h>
 +#ifdef HAVE_SYS_PROCFS_H
 +#include <sys/procfs.h>


### PR DESCRIPTION
This PR fixes the bug reported in 8143.  The same component files now build on both the SPARC and x86 hardware platforms.
