### PR TITLE
8172 Fine-grained optimization needed for the gcc compiler

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -957,8 +957,12 @@ CFLAGS.studio +=	$(studio_OPT) $(studio_XBITS) $(studio_XREGS) \
 # component build with CONFIGURE_OPTIONS += CFLAGS="$(CFLAGS)" or similiar.
 #
 
-# GCC Compiler optimization flag
-gcc_OPT =	-O3
+# Control the GCC optimization level.
+gcc_OPT.sparc.32 =	-O3
+gcc_OPT.sparc.64 =	-O3
+gcc_OPT.i386.32 =	-O3
+gcc_OPT.i386.64 =	-O3
+gcc_OPT =		$(gcc_OPT.$(MACH).$(BITS))
 
 # GCC PIC code generation.  Use CC_PIC instead to select PIC code generation.
 gcc_PIC =	-fPIC -DPIC


### PR DESCRIPTION
This PR adds four optimization settings for the gcc compiler to the make-rules/shared-macros.mk file.  These are useful when optimization needs to be different for certain types of builds.  GCC optimization settings already in component Makefiles are not affected.
