### PR TITLE
exiv2: add exv_conf.h to package

### DIFF
--- a/components/library/exiv2/Makefile
+++ b/components/library/exiv2/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= exiv2
 COMPONENT_VERSION= 0.25
+COMPONENT_REVISION = 1
 COMPONENT_SUMMARY= Image metadata library and tools
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz

--- a/components/library/exiv2/exiv2.p5m
+++ b/components/library/exiv2/exiv2.p5m
@@ -26,6 +26,7 @@ file usr/bin/$(MACH64)/exiv2 path=usr/bin/exiv2
 file path=usr/include/exiv2/basicio.hpp
 file path=usr/include/exiv2/bmpimage.hpp
 file path=usr/include/exiv2/config.h
+file path=usr/include/exiv2/exv_conf.h
 file path=usr/include/exiv2/convert.hpp
 file path=usr/include/exiv2/cr2image.hpp
 file path=usr/include/exiv2/crwimage.hpp


### PR DESCRIPTION
The header is needed to build other OSS components