### PR TITLE
8205 /usr/bin/compiz fails to fallback to metacity when  fails

### DIFF
--- a/components/desktop/compiz/Makefile
+++ b/components/desktop/compiz/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		compiz
 COMPONENT_VERSION=	0.8.10
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_FMRI=		desktop/compiz
 COMPONENT_PROJECT_URL=	http://www.northfield.ws/
 COMPONENT_SUMMARY=	OpenGL compositing window manager

--- a/components/desktop/compiz/files/compiz
+++ b/components/desktop/compiz/files/compiz
@@ -173,5 +173,5 @@ for ((  i = 0 ;  i <= $NUM_SCREEN;  i++  ))
 do
   $DECORATOR $DECORATOR_OPTIONS --display=:0.$i &
 done
-exec $COMPIZ_BIN "$@" $COMPIZ_OPTIONS $COMPIZ_PLUGINS $COMPIZ_INDIRECT || abort_with_metacity
+$COMPIZ_BIN "$@" $COMPIZ_OPTIONS $COMPIZ_PLUGINS $COMPIZ_INDIRECT || abort_with_metacity
 


### PR DESCRIPTION
since we exec COMPIZ_BIN, we will never reach || exit_with_metacity