### PR TITLE
mtr: update to 0.87

### DIFF
--- a/components/sysutils/mtr/Makefile
+++ b/components/sysutils/mtr/Makefile
@@ -10,26 +10,34 @@
 
 #
 # Copyright 2012, Jon Tibble
+# Copyright 2017, Adam Stevko 
 #
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mtr
-COMPONENT_VERSION=	0.82
+COMPONENT_VERSION=	0.87
+COMPONENT_FMRI=		diagnostic/mtr
+COMPONENT_SUMMARY=	MTR - My Traceroute.  Diagnostic tool combining ping and traceroute.
 COMPONENT_PROJECT_URL=	http://www.bitwizard.nl/mtr/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:f3b457c9623ae03565688a7ffd49d4843a5e2505ccaf3ba8d9fbd86e3ce9b6a0
+COMPONENT_CLASSIFICATION=	Applications/System Utilities
+COMPONENT_ARCHIVE_HASH=	sha256:193947c61d23b154c8dc03677e90e8fd912f8f18567ab76ce619b7856c4af19f
 COMPONENT_ARCHIVE_URL=	ftp://ftp.bitwizard.nl/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	GPLv2
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-COMPILER=	gcc
+CONFIGURE_SBINDIR.64 = $(CONFIGURE_SBINDIR.32)
 
-CONFIGURE_OPTIONS+=	LIBS="-L/usr/gnu/lib -R/usr/gnu/lib -lncurses"
+CONFIGURE_OPTIONS+=	--without-gtk
 
-build:		$(BUILD_32)
+build:		$(BUILD_64)
 
-install:	$(INSTALL_32)
+install:	$(INSTALL_64)
 
+REQUIRED_PACKAGES += library/ncurses
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/sysutils/mtr/files/exec_attr
+++ b/components/sysutils/mtr/files/exec_attr
@@ -1,0 +1,1 @@
+Forced Privilege:solaris:cmd:RO::/usr/sbin/mtr:privs=net_icmpaccess,net_rawaccess

--- a/components/sysutils/mtr/manifests/sample-manifest.p5m
+++ b/components/sysutils/mtr/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/sysutils/mtr/mtr.p5m
+++ b/components/sysutils/mtr/mtr.p5m
@@ -1,32 +1,27 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL"). You may
-# only use this file in accordance with the terms of the CDDL.
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 
 #
-# Copyright 2012, Jon Tibble
+# Copyright 2017 Adam Stevko
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
-
-set name=pkg.fmri value=pkg:/diagnostic/mtr@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="MTR - My Traceroute.  Diagnostic tool combining ping and traceroute."
-set name=info.classification value="org.opensolaris.category.2008:Applications/System Utilities"
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license mtr.license license='GPLv2'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-dir  path=usr
-dir  path=usr/sbin
-file path=usr/sbin/mtr
-dir  path=usr/share
-dir  path=usr/share/man
-dir  path=usr/share/man/man8
+file files/exec_attr path=etc/security/exec_attr.d/network:mtr
+file path=usr/sbin/mtr mode=4555
 file path=usr/share/man/man8/mtr.8

--- a/components/sysutils/mtr/patches/01-filio.h.patch
+++ b/components/sysutils/mtr/patches/01-filio.h.patch
@@ -1,0 +1,11 @@
+diff -ruN mtr-0.87.orig/net.c mtr-0.87/net.c
+--- mtr-0.87.orig/net.c	2016-08-01 06:07:58.000000000 -0700
++++ mtr-0.87/net.c	2017-05-18 14:19:23.699279140 -0700
+@@ -27,6 +27,7 @@
+ #include <sys/socket.h>
+ #include <sys/ioctl.h>
+ #include <sys/select.h>
++#include <sys/filio.h>
+ #include <netinet/in.h>
+ #include <memory.h>
+ #include <unistd.h>


### PR DESCRIPTION
- explicitly disable gtk
- change from 32-bit to 64-bit
- install RBAC and ship as SUID binary, so ordinary user can execute it