### PR TITLE
8258 library/protobuf build requires the symbol SOLARIS_64BIT_ENABLED

### DIFF
--- a/components/library/protobuf/Makefile
+++ b/components/library/protobuf/Makefile
@@ -18,6 +18,7 @@
 #
 # CDDL HEADER END
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2015, Predrag Zecevic. All rights reserved.
 # Copyright (c) 2015, Aurelien Larcher. All rights reserved.
 #
@@ -25,6 +26,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		protobuf
 COMPONENT_VERSION=	2.6.1
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		library/c++/protobuf
 COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -36,9 +38,9 @@ COMPONENT_LICENSE=	BSD
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license 
 COMPONENT_SUMMARY=	Protocol Buffers - Google data interchange format
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 CONFIGURE_OPTIONS+=	--disable-static
 
@@ -48,6 +50,6 @@ install: $(INSTALL_32_and_64)
 
 test: $(NO_TESTS)
 
-BUILD_PKG_DEPENDENCIES =    $(BUILD_TOOLS)
-
-include $(WS_TOP)/make-rules/depend.mk
+REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/library/protobuf/patches/01-sparc-compile.patch
+++ b/components/library/protobuf/patches/01-sparc-compile.patch
@@ -1,0 +1,61 @@
+From 97fa4ca1565d216d102af9510b17966c28c7a52a Mon Sep 17 00:00:00 2001
+From: Mohamed El-Tahan <meltahan@bloomberg.net>
+Date: Wed, 2 Sep 2015 11:34:23 -0400
+Subject: [PATCH] Fixing compile errors on Solaris in 64-bit mode
+
+---
+ m4/acx_check_suncc.m4                                  | 17 ++++++-----------
+ src/google/protobuf/compiler/command_line_interface.cc |  5 +++++
+ src/google/protobuf/stubs/atomicops.h                  |  2 +-
+ src/google/protobuf/stubs/platform_macros.h            |  2 +-
+ 4 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/src/google/protobuf/compiler/command_line_interface.cc b/src/google/protobuf/compiler/command_line_interface.cc
+index 26a4f0b066..a77cdc236b 100644
+--- a/src/google/protobuf/compiler/command_line_interface.cc
++++ b/src/google/protobuf/compiler/command_line_interface.cc
+@@ -33,6 +33,7 @@
+ //  Sanjay Ghemawat, Jeff Dean, and others.
+ 
+ #include <google/protobuf/compiler/command_line_interface.h>
++#include <google/protobuf/stubs/platform_macros.h>
+ 
+ #include <stdio.h>
+ #include <sys/types.h>
+@@ -48,6 +49,10 @@
+ #include <iostream>
+ #include <ctype.h>
+ 
++#ifdef GOOGLE_PROTOBUF_ARCH_SPARC
++#include <limits.h> //For PATH_MAX
++#endif
++
+ #include <google/protobuf/stubs/hash.h>
+ #include <memory>
+ 
+diff --git a/src/google/protobuf/stubs/atomicops.h b/src/google/protobuf/stubs/atomicops.h
+index 5fa31b0ae9..6deab3185a 100644
+--- a/src/google/protobuf/stubs/atomicops.h
++++ b/src/google/protobuf/stubs/atomicops.h
+@@ -76,7 +76,7 @@ typedef int32 Atomic32;
+ #ifdef GOOGLE_PROTOBUF_ARCH_64_BIT
+ // We need to be able to go between Atomic64 and AtomicWord implicitly.  This
+ // means Atomic64 and AtomicWord should be the same type on 64-bit.
+-#if defined(__ILP32__) || defined(GOOGLE_PROTOBUF_OS_NACL) || defined(GOOGLE_PROTOBUF_ARCH_SPARC)
++#if defined(__ILP32__) || defined(GOOGLE_PROTOBUF_OS_NACL)
+ // NaCl's intptr_t is not actually 64-bits on 64-bit!
+ // http://code.google.com/p/nativeclient/issues/detail?id=1162
+ // sparcv9's pointer type is 32bits
+diff --git a/src/google/protobuf/stubs/platform_macros.h b/src/google/protobuf/stubs/platform_macros.h
+index 9e0344d8f9..55d32759d2 100644
+--- a/src/google/protobuf/stubs/platform_macros.h
++++ b/src/google/protobuf/stubs/platform_macros.h
+@@ -65,7 +65,7 @@
+ #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
+ #elif defined(sparc)
+ #define GOOGLE_PROTOBUF_ARCH_SPARC 1
+-#ifdef SOLARIS_64BIT_ENABLED
++#if defined(__sparc_v9__) || defined(__sparcv9) || defined(__arch64__)
+ #define GOOGLE_PROTOBUF_ARCH_64_BIT 1
+ #else
+ #define GOOGLE_PROTOBUF_ARCH_32_BIT 1


### PR DESCRIPTION
This PR fixes 8258 for the library/protobuf component of oi-userland.  It does this by defining the SOLARIS_64BIT_ENABLED symbol for 64-bit builds.  Note that the CADD.32 macro is undefined, so that it expands to an empty string.  This is the desired behavior for 32-bit builds.
