### PR TITLE
8261 library/openssl/openssl-1.0.2 build uses cc options with gcc

### DIFF
--- a/components/library/openssl/openssl-1.0.2/Makefile
+++ b/components/library/openssl/openssl-1.0.2/Makefile
@@ -18,6 +18,7 @@
 #
 # CDDL HEADER END
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
 #
 include ../../../../make-rules/shared-macros.mk
@@ -26,7 +27,7 @@ COMPONENT_NAME =	openssl
 # When new version of OpenSSL comes in, you must update both COMPONENT_VERSION
 # and IPS_COMPONENT_VERSION.
 COMPONENT_VERSION =	1.0.2k
-COMPONENT_REVISION =	1
+COMPONENT_REVISION =	2
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
 IPS_COMPONENT_VERSION = 1.0.2.11
@@ -45,7 +46,7 @@ include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 include $(WS_MAKE_RULES)/lint-libraries.mk
 
-PATH=$(GCC_ROOT)/bin:/usr/bin:/usr/gnu/bin:/usr/perl5/bin
+PATH=$(GCC_ROOT)/bin:$(PATH.illumos)
 
 # OpenSSL does not use autoconf but its own configure system.
 CONFIGURE_SCRIPT = $(SOURCE_DIR)/Configure
@@ -105,9 +106,9 @@ CONFIGURE_OPTIONS += --enginesdir=$(ENGINESDIR_$(BITS))
 # We define our own compiler and linker option sets for Solaris. See Configure
 # for more information.
 CONFIGURE_OPTIONS32_i386 =	solaris-x86-gcc-sunw
-CONFIGURE_OPTIONS32_sparc =	solaris-sparcv9-cc-sunw
+CONFIGURE_OPTIONS32_sparc =	solaris-sparcv9-gcc-sunw
 CONFIGURE_OPTIONS64_i386 =	solaris64-x86_64-gcc-sunw
-CONFIGURE_OPTIONS64_sparc =	solaris64-sparcv9-cc-sunw
+CONFIGURE_OPTIONS64_sparc =	solaris64-sparcv9-gcc-sunw
 
 # Options specific to regular build.
 # They must not be specified as common, as they cannot be overridden.

--- a/components/library/openssl/openssl-1.0.2/engines/pkcs11/e_pk11.c
+++ b/components/library/openssl/openssl-1.0.2/engines/pkcs11/e_pk11.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2017 Gary Mills
  * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
  */
 
@@ -3707,6 +3708,15 @@ hw_aes_instruction_set_present(void)
 #if defined(__amd64) || defined(__i386)
 		present = (ui & AV_386_AES) > 0;
 #elif defined(__sparc)
+/*
+ * These symbols should already be defined from /usr/include/sys/auxv_SPARC.h
+ */
+#ifndef AV_SPARC_AES
+#define AV_SPARC_AES 0
+#endif
+#ifndef AV_SPARC_FJAES
+#define AV_SPARC_FJAES 0
+#endif
 		present = (ui & (AV_SPARC_AES|AV_SPARC_FJAES)) > 0;
 #endif
 		}

--- a/components/library/openssl/openssl-1.0.2/patches/Configure.gcc.patch
+++ b/components/library/openssl/openssl-1.0.2/patches/Configure.gcc.patch
@@ -1,13 +1,25 @@
---- openssl-1.0.2d/Configure.1	2015-11-02 12:30:27.711343670 +0300
-+++ openssl-1.0.2d/Configure	2015-11-02 12:34:24.967048043 +0300
-@@ -282,8 +282,10 @@
- 
+--- openssl-1.0.2j/Configure-pch-nogcc	   :: 
++++ openssl-1.0.2j/Configure	   :: 
+@@ -290,11 +290,22 @@
  #### Solaris configs, used for OpenSSL as delivered by S11.
  "solaris-x86-cc-sunw","cc:-m32 -xO3 -xspace -Xa::-D_REENTRANT::-lsocket -lnsl -lc:BN_LLONG RC4_CHUNK DES_PTR DES_UNROLL BF_PTR:${x86_elf_asm}:dlfcn:solaris-shared:-KPIC:-m32 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign -M/usr/lib/ld/map.noexdata:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ #
 +"solaris-x86-gcc-sunw","gcc:-O3 -march=pentium -Wall -DL_ENDIAN -DOPENSSL_NO_INLINE_ASM::-D_REENTRANT::-lsocket -lnsl -ldl:BN_LLONG RC4_CHUNK BF_PTR ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:dlfcn:solaris-shared:-fPIC:-shared -Wl,-z,text -Wl,-zdefs -Wl,-Bdirect -Wl,-zignore -Wl,-M,/usr/lib/ld/map.pagealign -Wl,-M,/usr/lib/ld/map.noexdata:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)","solaris-x86-gcc-sunw","gcc:-O3 -march=pentium -Wall -DL_ENDIAN -DOPENSSL_NO_INLINE_ASM::-D_REENTRANT::-lsocket -lnsl -ldl:BN_LLONG RC4_CHUNK BF_PTR ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:dlfcn:solaris-shared:-fPIC:-shared -Wl,-z,text -Wl,-zdefs -Wl,-Bdirect -Wl,-zignore -Wl,-M,/usr/lib/ld/map.pagealign -Wl,-M,/usr/lib/ld/map.noexdata:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
- #
++#
  "solaris64-x86_64-cc-sunw","cc:-xO3 -m64 -xstrconst -Xa -DL_ENDIAN::-D_REENTRANT::-lsocket -lnsl -lc:SIXTY_FOUR_BIT_LONG RC4_CHUNK BF_PTR DES_PTR DES_INT DES_UNROLL:${x86_64_asm}:elf:dlfcn:solaris-shared:-KPIC:-m64 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign -M/usr/lib/ld/map.noexdata:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
-+"solaris64-x86_64-gcc-sunw","gcc:-m64 -O3 -Wall -DL_ENDIAN::-D_REENTRANT::-lsocket -lnsl -ldl:SIXTY_FOUR_BIT_LONG RC4_CHUNK BF_PTR DES_PTR DES_INT DES_UNROLL:${x86_64_asm}:elf:dlfcn:solaris-shared:-fPIC:-m64 -shared -static-libgcc -Wl,-z,text -Wl,-zdefs -Wl,-Bdirect -Wl,-zignore -Wl,-M,/usr/lib/ld/map.pagealign -Wl,-M,/usr/lib/ld/map.noexdata:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
  #
++"solaris64-x86_64-gcc-sunw","gcc:-m64 -O3 -Wall -DL_ENDIAN::-D_REENTRANT::-lsocket -lnsl -ldl:SIXTY_FOUR_BIT_LONG RC4_CHUNK BF_PTR DES_PTR DES_INT DES_UNROLL:${x86_64_asm}:elf:dlfcn:solaris-shared:-fPIC:-m64 -shared -static-libgcc -Wl,-z,text -Wl,-zdefs -Wl,-Bdirect -Wl,-zignore -Wl,-M,/usr/lib/ld/map.pagealign -Wl,-M,/usr/lib/ld/map.noexdata:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++#
  "solaris-sparcv9-cc-sunw","cc:-xtarget=ultra -m32 -Qoption cg -xregs=no%appl -xO5 -xstrconst -xdepend -Xa -DB_ENDIAN -DBN_DIV2W::-D_REENTRANT:ULTRASPARC:-lsocket -lnsl -lc:BN_LLONG RC4_CHUNK_LL DES_PTR DES_RISC1 DES_UNROLL BF_PTR:${sparcv9_asm}:dlfcn:solaris-shared:-KPIC:-m32 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
  #
++# gcc with /usr/bin/ld
++"solaris-sparcv9-gcc-sunw","gcc:-m32 -O3 -Wall -DB_ENDIAN -DBN_DIV2W::-D_REENTRANT:ULTRASPARC:-lsocket -lnsl -ldl:BN_LLONG RC4_CHUNK_LL DES_PTR DES_RISC1 DES_UNROLL BF_PTR:${sparcv9_asm}:dlfcn:solaris-shared:-fPIC:-m32 -shared -Wl,-z,text -Wl,-zdefs -Wl,-Bdirect -Wl,-zignore -Wl,-M,/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++#
+ "solaris64-sparcv9-cc-sunw","cc:-xtarget=ultra -m64 -Qoption cg -xregs=no%appl -xO5 -xstrconst -xdepend -xspace -Xa -DB_ENDIAN::-D_REENTRANT:ULTRASPARC:-lsocket -lnsl -lc:BN_LLONG RC4_CHUNK DES_INT DES_PTR DES_RISC1 DES_UNROLL BF_PTR:${sparcv9_asm}:dlfcn:solaris-shared:-KPIC:-m64 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR):/usr/bin/ar rs::/64",
++#
++# gcc with /usr/bin/ld
++"solaris64-sparcv9-gcc-sunw","gcc:-mcpu=v9 -m64 -O3 -Wall -DB_ENDIAN::-D_REENTRANT:ULTRASPARC:-lsocket -lnsl -lc:BN_LLONG RC4_CHUNK DES_INT DES_PTR DES_RISC1 DES_UNROLL BF_PTR:${sparcv9_asm}:dlfcn:solaris-shared:-fPIC:-m64 -shared -Wl,-z,text -Wl,-zdefs -Wl,-Bdirect -Wl,-zignore -Wl,-M,/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR):/usr/bin/ar rs::/64",
++#
+ "solaris-fips-sparcv9-cc-sunw","cc:-xtarget=ultra -m32 -Qoption cg -xregs=no%appl -xO5 -xstrconst -xdepend -Xa -DB_ENDIAN -DBN_DIV2W::-D_REENTRANT:ULTRASPARC:-lsocket -lnsl -lc -lsoftcrypto -R /lib/openssl/fips-140:BN_LLONG RC4_CHUNK_LL DES_PTR DES_RISC1 DES_UNROLL BF_PTR:${fips_sparcv9_asm}:dlfcn:solaris-shared:-KPIC:-m32 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "solaris64-fips-sparcv9-cc-sunw","cc:-xtarget=ultra -m64 -Qoption cg -xregs=no%appl -xO5 -xstrconst -xdepend -xspace -Xa -DB_ENDIAN::-D_REENTRANT:ULTRASPARC:-lsocket -lnsl -lc:BN_LLONG RC4_CHUNK DES_INT DES_PTR DES_RISC1 DES_UNROLL BF_PTR:${fips_sparcv9_asm}:dlfcn:solaris-shared:-KPIC:-m64 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR):/usr/bin/ar rs::/64",
+ # Option -xF=%all instructs the compiler to place functions and data


### PR DESCRIPTION
This PR fixes 8261 for the library/openssl/openssl-1.0.2 component of oi-userland.  The changes only affect the SPARC build of this component.  The x86 build is completely unaffected.  Patch Configure.gcc.patch is changed to include SPARC configurations.  These are selected by the CONFIGURE_OPTIONS32_sparc and CONFIGURE_OPTIONS64_sparc lines in the Makefile.  In addition, the engines/pkcs11/e_pk11.c file is changed, again only for SPARC, to define two symbols if these happen to be missing from the /usr/include/sys/auxv_SPARC.h header.

As a test, I built this component on x86 hipster.  This build was successful too.
