### PR TITLE
8120 developer/beanshell requires a specific Java compiler version

### DIFF
--- a/components/developer/beanshell/Makefile
+++ b/components/developer/beanshell/Makefile
@@ -18,13 +18,14 @@
 #
 # CDDL HEADER END
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 #
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		beanshell
 COMPONENT_VERSION=	2.0b6
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	http://www.beanshell.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_VERSION).tar.gz

--- a/components/developer/beanshell/patches/javac.patch
+++ b/components/developer/beanshell/patches/javac.patch
@@ -1,0 +1,10 @@
+--- beanshell-2.0b6/build.xml-orig	   :: 
++++ beanshell-2.0b6/build.xml	   :: 
+@@ -170,6 +170,7 @@
+ 			deprecation="${deprecation}"
+ 			optimize="on"
+ 			debug="on"
++      source="1.5"
+       target="1.5"
+ 			includes="**/*.java"
+ 			excludes="${excludes},**/bak/**"


### PR DESCRIPTION
This PR fixes 8120 for the developer/beanshell component of oi-userland.  The only change is the addition of a patch called javac.patch .  Of course, COMPONENT_REVISION is also incremented in Makefile .  With this change, the component builds on both SPARC and x86 hardware platforms.
