### PR TITLE
Bump arpack to 3.5.0

### DIFF
--- a/components/scientific/arpack/Makefile
+++ b/components/scientific/arpack/Makefile
@@ -14,7 +14,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		arpack
-COMPONENT_VERSION=	3.3.0
+COMPONENT_VERSION=	3.5.0
 REAL_NAME=		arpack-ng
 COMPONENT_PROJECT_URL=	https://github.com/opencollab/arpack-ng
 COMPONENT_SUMMARY=	Collection of Fortran77 subroutines designed to solve large scale eigenvalue problems
@@ -23,7 +23,7 @@ COMPONENT_FMRI=         library/math/arpack
 COMPONENT_CLASSIFICATION=       System/Libraries
 COMPONENT_SRC=		$(REAL_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:ad59811e7d79d50b8ba19fd908f92a3683d883597b2c7759fdcc38f6311fe5b3
+COMPONENT_ARCHIVE_HASH=	sha256:50f7a3e3aec2e08e732a487919262238f8504c3ef927246ec3495617dde81239
 COMPONENT_ARCHIVE_URL=	https://github.com/opencollab/$(REAL_NAME)/archive/$(COMPONENT_VERSION).tar.gz
 COMPONENT_LICENSE=	BSD
 COMPONENT_LICENSE_FILE=	COPYING
@@ -34,6 +34,8 @@ include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf --force --install && libtoolize --force --copy )
+
+CONFIGURE_OPTIONS += --disable-dependency-tracking
 
 build:		$(BUILD_32_and_64)
 

--- a/components/scientific/arpack/arpack.p5m
+++ b/components/scientific/arpack/arpack.p5m
@@ -13,21 +13,21 @@
 # Copyright 2016 Sergey Avseyev
 #
 
-set name=pkg.fmri \
-    value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value='$(COMPONENT_SUMMARY)'
-set name=pkg.description value='$(COMPONENT_DESCRIPTION)'
-set name=info.classification value=$(COMPONENT_CLASSIFICATION)
-set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license $(COMPONENT_LICENSE_FILE) license=$(COMPONENT_LICENSE)
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=usr/lib/$(MACH64)/libarpack.a
 link path=usr/lib/$(MACH64)/libarpack.so target=libarpack.so.2.0.0
 link path=usr/lib/$(MACH64)/libarpack.so.2 target=libarpack.so.2.0.0
 file path=usr/lib/$(MACH64)/libarpack.so.2.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/arpack.pc
+file path=usr/lib/libarpack.a
 link path=usr/lib/libarpack.so target=libarpack.so.2.0.0
 link path=usr/lib/libarpack.so.2 target=libarpack.so.2.0.0
 file path=usr/lib/libarpack.so.2.0.0


### PR DESCRIPTION
ABI compatible.
All tests passed.
Added static libs for scientific computing software.