### PR TITLE
8287 awesome window manager is missing lgi library for Lua 5.3

### DIFF
--- a/components/desktop/awesome/Makefile
+++ b/components/desktop/awesome/Makefile
@@ -14,6 +14,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         awesome
+COMPONENT_REVISION=     1
 COMPONENT_VERSION=      4.1
 COMPONENT_PROJECT_URL=  https://awesomewm.org
 COMPONENT_SUMMARY=      A highly configurable, next generation framework window manager for X.
@@ -32,9 +33,7 @@ include $(WS_MAKE_RULES)/ips.mk
 
 CONFIGURE_BINDIR.64=	$(CONFIGURE_BINDIR.32)
 
-
-# CMake bug workaround: https://gitlab.kitware.com/cmake/cmake/issues/16404
-CMAKE_OPTIONS += "-DLUA_INCLUDE_DIR=/usr/include/lua5.3"
+CMAKE_OPTIONS += "-DLUA_LIBRARY=/usr/lib/64/liblua.so"
 
 
 build:		$(BUILD_64)
@@ -48,7 +47,7 @@ REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
 REQUIRED_PACKAGES += library/desktop/startup-notification
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/xdg/libxdg-basedir
-REQUIRED_PACKAGES += runtime/lua-53
+REQUIRED_PACKAGES += runtime/lua
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/libdbus


### PR DESCRIPTION
According to the readme for the latest (0.9.1) `lgi`:
_... LGI is tested and compatible with standard Lua 5.1, Lua 5.2 and LuaJIT2.  Compatibility with other Lua implementations is not tested yet. ..._

In order to fix this issue (8287), I suggest forcing `CMake` to build the component for `lua-52`, at lease until `lgi` for `lua-53` is ready.