### PR TITLE
Bump flac to 1.3.2

### DIFF
--- a/components/multimedia/flac/Makefile
+++ b/components/multimedia/flac/Makefile
@@ -14,18 +14,18 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		flac
-COMPONENT_VERSION=	1.3.1
+COMPONENT_VERSION=	1.3.2
 COMPONENT_FMRI=		codec/flac
 COMPONENT_CLASSIFICATION=System/Multimedia Libraries
 COMPONENT_PROJECT_URL=	http://flac.sourceforge.net/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:4773c0099dba767d963fd92143263be338c48702172e8754b9bc5103efe1c56c
-COMPONENT_ARCHIVE_URL=	http://downloads.us.xiph.org/releases/flac/$(COMPONENT_ARCHIVE)
+  sha256:91cfc3ed61dc40f47f050a109b08610667d73477af6ef36dcad31c31a4a8d53f
+COMPONENT_ARCHIVE_URL=\
+  http://downloads.us.xiph.org/releases/flac/$(COMPONENT_ARCHIVE)
 COMPONENT_BUGDB=	$(COMPONENT_FMRI)
 COMPONENT_LICENSE=	Xiph.org BSD-style, binaries & media player plugins also use GPL v2, LGPL v2.1, documentation uses FDL v1.2
-COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
 COMPONENT_SUMMARY=	An Open Source Lossless Audio Codec
 
 include $(WS_MAKE_RULES)/prep.mk
@@ -55,6 +55,7 @@ build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
-BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
-
-include $(WS_MAKE_RULES)/depend.mk
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/libogg
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/multimedia/flac/flac.p5m
+++ b/components/multimedia/flac/flac.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2014 Aurelien Larcher
+# Copyright 2014-2017 Aurelien Larcher
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -118,6 +118,11 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/classes.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/closed.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/decoder_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/decoder_8h_source.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_82f1aabeb3a09ba48ce6c9a754593e18.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_85302bdfc97134fb78a3f8830ade9a0d.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_95a333d4d8775f4941a81023327bcb3c.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_a1d6e3607eac7022395e55309dc6d4e2.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/doc.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/doxygen.css
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/doxygen.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dynsections.js
@@ -126,28 +131,19 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/encoder_8h_source.htm
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/export_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/export_8h_source.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/files.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/folderclosed.png
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/folderopen.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/format_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/format_8h_source.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2blank.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2doc.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2folderclosed.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2folderopen.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2lastnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2link.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2mlastnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2mnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2node.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2plastnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2pnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2splitbar.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2vertline.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_0x7e.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_b.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_c.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_d.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_e.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_f.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_0x7e.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_c.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_d.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_e.html
@@ -165,7 +161,6 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_t.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_u.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_v.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_w.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_~.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_g.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_i.html
@@ -182,7 +177,6 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_u.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_v.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_vars.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_w.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_~.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/globals.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/globals_defs.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/globals_enum.html
@@ -219,6 +213,8 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/group__porting__1__1_
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/hierarchy.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/index.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/jquery.js
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/menu.js
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/menudata.js
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/metadata_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/metadata_8h_source.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/modules.html
@@ -227,6 +223,7 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/nav_g.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/nav_h.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/open.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ordinals_8h_source.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/splitbar.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/stream__decoder_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/stream__decoder_8h_source.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/stream__encoder_8h.html

--- a/components/multimedia/flac/manifests/sample-manifest.p5m
+++ b/components/multimedia/flac/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -118,10 +118,11 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/classes.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/closed.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/decoder_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/decoder_8h_source.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_32d5daacd9072f37577d1e753fd50145.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_40e3cca2fd032e2932307a21ff01de47.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_7ee6ea9ff2660a8292060c344b0d27cf.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_87814b8d0e311eca8df6a5c7bdc64b1c.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_82f1aabeb3a09ba48ce6c9a754593e18.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_85302bdfc97134fb78a3f8830ade9a0d.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_95a333d4d8775f4941a81023327bcb3c.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dir_a1d6e3607eac7022395e55309dc6d4e2.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/doc.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/doxygen.css
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/doxygen.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/dynsections.js
@@ -130,28 +131,19 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/encoder_8h_source.htm
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/export_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/export_8h_source.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/files.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/folderclosed.png
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/folderopen.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/format_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/format_8h_source.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2blank.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2doc.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2folderclosed.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2folderopen.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2lastnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2link.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2mlastnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2mnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2node.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2plastnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2pnode.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2splitbar.png
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ftv2vertline.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_0x7e.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_b.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_c.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_d.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_e.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_f.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_0x7e.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_c.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_d.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_e.html
@@ -169,7 +161,6 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_t.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_u.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_v.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_w.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_func_~.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_g.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_i.html
@@ -186,7 +177,6 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_u.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_v.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_vars.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_w.html
-file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/functions_~.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/globals.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/globals_defs.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/globals_enum.html
@@ -223,6 +213,8 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/group__porting__1__1_
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/hierarchy.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/index.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/jquery.js
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/menu.js
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/menudata.js
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/metadata_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/metadata_8h_source.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/modules.html
@@ -231,6 +223,7 @@ file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/nav_g.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/nav_h.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/open.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/ordinals_8h_source.html
+file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/splitbar.png
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/stream__decoder_8h.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/stream__decoder_8h_source.html
 file path=usr/share/doc/flac-$(COMPONENT_VERSION)/html/api/stream__encoder_8h.html


### PR DESCRIPTION
ABI compatible: https://abi-laboratory.pro/tracker/timeline/flac/