### PR TITLE
8141 desktop/xscreensaver build stops with gcc option error

### DIFF
--- a/components/desktop/xscreensaver/Makefile
+++ b/components/desktop/xscreensaver/Makefile
@@ -10,6 +10,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright 2017 Alexander Pyhalov
 #
 
@@ -17,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		xscreensaver
 COMPONENT_VERSION=	5.35
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	http://www.jwz.org/xscreensaver/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -27,9 +28,9 @@ COMPONENT_ARCHIVE_URL=	http://ftp.lfs-matrix.net/pub/blfs/conglomeration/xscreen
 
 PATCH_LEVEL=		0
 
-include ../../../make-rules/prep.mk
-include ../../../make-rules/configure.mk
-include ../../../make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 COMPONENT_POST_UNPACK_ACTION=	( cp -r $(COMPONENT_DIR)/files/po-sun/* $(SOURCE_DIR)/po && \
 					cp $(COMPONENT_DIR)/files/*.p5i.in $(SOURCE_DIR)/driver && \
@@ -43,7 +44,7 @@ COMPONENT_PRE_CONFIGURE_ACTION += chmod -R u+r $(SOURCE_DIR)/ && \
 			cp -r $(SOURCE_DIR)/* $(@D) && \
                         cd $(@D) && autoconf
 
-PATH=/usr/gnu/bin:/usr/bin:/usr/perl5/bin
+PATH = $(PATH.gnu)
 
 CONFIGURE_SCRIPT=	$(@D)/configure
 

--- a/components/desktop/xscreensaver/patches/xscreensaver-27-precomp.patch
+++ b/components/desktop/xscreensaver/patches/xscreensaver-27-precomp.patch
@@ -1,0 +1,23 @@
+--- configure.in-opch	   :: 
++++ configure.in	   :: 
+@@ -480,12 +480,6 @@
+ AC_DEFUN([AC_NO_MISPLACED_DECLARATIONS],
+          [AC_CHECK_GCC_ARG(no_decl_after, -Wdeclaration-after-statement)])
+ 
+-# Need to disable Objective C extensions in ANSI C on MacOS X to work
+-# around an Apple-specific gcc bug.
+-#
+-AC_DEFUN([AC_NO_OBJECTIVE_C],
+-         [AC_CHECK_GCC_ARG(no_cpp_precomp, -no-cpp-precomp)])
+-
+ ###############################################################################
+ #
+ #       Function to figure out how to disable // comments in ANSI C code.
+@@ -1214,7 +1208,6 @@
+ AC_PROG_CC_ANSI
+ AC_NO_LONG_STRING_WARNINGS
+ AC_NO_MISPLACED_DECLARATIONS
+-AC_NO_OBJECTIVE_C
+ AC_NO_CPLUSPLUS_COMMENTS_IN_C_CODE
+ AC_PROG_CPP
+ AC_C_CONST


### PR DESCRIPTION
This PR fixes 8141 for the desktop/xscreensaver component of oi-userland.  With this change, the component builds on both SPARC and x86 hardware.  The new patch removes the AC_NO_OBJECTIVE_C statements from the configure.in file.  These were used, perhaps incorrectly, to add an Apple-specific option to gcc.
