### PR TITLE
Add gcc-7 to build-essential and remove clang-34

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
 COMPONENT_VERSION=	1.0
-COMPONENT_REVISION=	8
+COMPONENT_REVISION=	9
 
 include ../../../make-rules/ips.mk
 

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -38,7 +38,7 @@ depend fmri=developer/linker type=require
 
 # Compilers
 depend fmri=developer/gcc-49 type=require
-depend fmri=developer/clang-34 type=require
+depend fmri=developer/gcc-7 type=require
 depend fmri=developer/sunstudio12u1 type=require
 
 # Headers


### PR DESCRIPTION
No component in oi-userland depends on clang-34 but now a few depend on gcc-7.