### PR TITLE
Bump freeglut to 3.0.0

### DIFF
--- a/components/x11/freeglut/Makefile
+++ b/components/x11/freeglut/Makefile
@@ -10,36 +10,35 @@
 #
 
 #
-# Copyright 2015 Aurelien Larcher
+# Copyright 2015-2017 Aurelien Larcher
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           freeglut
-COMPONENT_VERSION=        2.8.1
+COMPONENT_VERSION=        3.0.0
 COMPONENT_FMRI=           x11/library/freeglut
+COMPONENT_SUMMARY= \
+  freeglut - open-source alternative to the OpenGL Utility Toolkit (GLUT) library
+COMPONENT_PROJECT_URL = http://freeglut.sourceforge.net/
 COMPONENT_CLASSIFICATION= System/X11
-COMPONENT_SUMMARY=  freeglut - open-source alternative to the OpenGL Utility Toolkit (GLUT) librarys
-COMPONENT_SRC=      $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=  $(COMPONENT_SRC).tar.gz
+COMPONENT_SRC=            $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:dde46626a62a1cd9cf48a11951cdd592e7067c345cffe193a149dfd47aef999a
+  sha256:2a43be8515b01ea82bcfa17d29ae0d40bd128342f0930cd1f375f1ff999f76a2
 COMPONENT_ARCHIVE_URL= \
   http://downloads.sourceforge.net/project/freeglut/freeglut/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://freeglut.sourceforge.net/
 COMPONENT_LICENSE=      MIT License
-COMPONENT_LICENSE_FILE= freeglut.license
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/cmake.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
-CONFIGURE_OPTIONS+= --disable-static
-CONFIGURE_OPTIONS+= --enable-shared
-CONFIGURE_OPTIONS+= --x-includes=/usr/include
-CONFIGURE_OPTIONS+= --x-libraries=/usr/lib/$(LIBSUBDIR)
+CMAKE_OPTIONS+= -DCMAKE_BUILD_TYPE=Release
+CMAKE_OPTIONS+= -DFREEGLUT_BUILD_DEMOS=OFF
+CMAKE_OPTIONS+= -DFREEGLUT_BUILD_STATIC_LIBS=OFF
 
 CPPFLAGS += -D__posix__ -D__unix__
 
@@ -49,7 +48,7 @@ install: $(INSTALL_32_and_64)
 
 test: $(NO_TESTS)
 
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libx11

--- a/components/x11/freeglut/freeglut.p5m
+++ b/components/x11/freeglut/freeglut.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 Aurelien Larcher
+# Copyright 2016-2017 Aurelien Larcher
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,20 +22,20 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-link path=usr/lib/GL/$(MACH64)/libglut.so target=../../$(MACH64)/libglut.so.3.9.0
-link path=usr/lib/GL/$(MACH64)/libglut.so.3 target=../../$(MACH64)/libglut.so.3.9.0
-link path=usr/lib/GL/libglut.so target=../libglut.so.3.9.0
-link path=usr/lib/GL/libglut.so.3 target=../libglut.so.3.9.0
+link path=usr/lib/GL/$(MACH64)/libglut.so target=../../$(MACH64)/libglut.so.3.10.0
+link path=usr/lib/GL/$(MACH64)/libglut.so.3 target=../../$(MACH64)/libglut.so.3.10.0
+link path=usr/lib/GL/libglut.so target=../libglut.so.3.10.0
+link path=usr/lib/GL/libglut.so.3 target=../libglut.so.3.10.0
 
 file path=usr/include/GL/freeglut.h
 file path=usr/include/GL/freeglut_ext.h
 file path=usr/include/GL/freeglut_std.h
 file path=usr/include/GL/glut.h
-link path=usr/lib/$(MACH64)/libglut.so target=libglut.so.3.9.0
-link path=usr/lib/$(MACH64)/libglut.so.3 target=libglut.so.3.9.0
-file path=usr/lib/$(MACH64)/libglut.so.3.9.0 pkg.depend.bypass-generate=.*GL\.so.*
-
-link path=usr/lib/libglut.so target=libglut.so.3.9.0
-link path=usr/lib/libglut.so.3 target=libglut.so.3.9.0
-file path=usr/lib/libglut.so.3.9.0 pkg.depend.bypass-generate=.*GL\.so.*
-
+link path=usr/lib/$(MACH64)/libglut.so target=libglut.so.3
+link path=usr/lib/$(MACH64)/libglut.so.3 target=libglut.so.3.10.0
+file path=usr/lib/$(MACH64)/libglut.so.3.10.0 pkg.depend.bypass-generate=.*GL\.so.*
+file path=usr/lib/$(MACH64)/pkgconfig/freeglut.pc
+link path=usr/lib/libglut.so target=libglut.so.3
+link path=usr/lib/libglut.so.3 target=libglut.so.3.10.0
+file path=usr/lib/libglut.so.3.10.0 pkg.depend.bypass-generate=.*GL\.so.*
+file path=usr/lib/pkgconfig/freeglut.pc

--- a/components/x11/freeglut/manifests/sample-manifest.p5m
+++ b/components/x11/freeglut/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,9 +26,11 @@ file path=usr/include/GL/freeglut.h
 file path=usr/include/GL/freeglut_ext.h
 file path=usr/include/GL/freeglut_std.h
 file path=usr/include/GL/glut.h
-link path=usr/lib/$(MACH64)/libglut.so target=libglut.so.3.9.0
-link path=usr/lib/$(MACH64)/libglut.so.3 target=libglut.so.3.9.0
-file path=usr/lib/$(MACH64)/libglut.so.3.9.0
-link path=usr/lib/libglut.so target=libglut.so.3.9.0
-link path=usr/lib/libglut.so.3 target=libglut.so.3.9.0
-file path=usr/lib/libglut.so.3.9.0
+link path=usr/lib/$(MACH64)/libglut.so target=libglut.so.3
+link path=usr/lib/$(MACH64)/libglut.so.3 target=libglut.so.3.10.0
+file path=usr/lib/$(MACH64)/libglut.so.3.10.0
+file path=usr/lib/$(MACH64)/pkgconfig/freeglut.pc
+link path=usr/lib/libglut.so target=libglut.so.3
+link path=usr/lib/libglut.so.3 target=libglut.so.3.10.0
+file path=usr/lib/libglut.so.3.10.0
+file path=usr/lib/pkgconfig/freeglut.pc


### PR DESCRIPTION
ABI compatible: https://abi-laboratory.pro/tracker/timeline/freeglut/