### PR TITLE
Bump gstreamer1 to 1.12.0, libvpx to 1.6.1, and soundtouch to 1.9.2

### DIFF
--- a/components/library/libvpx/Makefile
+++ b/components/library/libvpx/Makefile
@@ -16,12 +16,12 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libvpx
-COMPONENT_VERSION= 1.4.0
-COMPONENT_SUMMARY= The VP8 Codec SDK
+COMPONENT_VERSION= 1.6.1
+COMPONENT_SUMMARY= The WebM VP8/VP9 Codec SDK
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:eca30ea7fae954286c9fe9de9d377128f36b56ea6b8691427783b20c67bcfc13
+  sha256:cda8bb6f0e4848c018177d3a576fa83ed96d762554d7010fe4cfb9d70c22e588
 COMPONENT_ARCHIVE_URL= \
   https://github.com/webmproject/libvpx/archive/v$(COMPONENT_VERSION).tar.gz
 COMPONENT_PROJECT_URL = http://www.webmproject.org/
@@ -30,11 +30,11 @@ COMPONENT_LICENSE_FILE = LICENSE
 COMPONENT_CLASSIFICATION = System/Multimedia Libraries
 COMPONENT_FMRI = library/video/libvpx
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
 TARGET.32 = x86-solaris-gcc
 TARGET.64 = x86_64-solaris-gcc
@@ -47,6 +47,7 @@ CONFIGURE_OPTIONS += --enable-postproc
 CONFIGURE_OPTIONS += --enable-runtime-cpu-detect
 CONFIGURE_OPTIONS += --enable-shared
 CONFIGURE_OPTIONS += --disable-examples
+CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --disable-unit-tests
 CONFIGURE_OPTIONS += --target=$(TARGET.$(BITS))
 

--- a/components/library/libvpx/libvpx.p5m
+++ b/components/library/libvpx/libvpx.p5m
@@ -31,13 +31,13 @@ file path=usr/include/vpx/vpx_encoder.h
 file path=usr/include/vpx/vpx_frame_buffer.h
 file path=usr/include/vpx/vpx_image.h
 file path=usr/include/vpx/vpx_integer.h
-link path=usr/lib/$(MACH64)/libvpx.so target=libvpx.so.2.0.0
-link path=usr/lib/$(MACH64)/libvpx.so.2 target=libvpx.so.2.0.0
-link path=usr/lib/$(MACH64)/libvpx.so.2.0 target=libvpx.so.2.0.0
-file path=usr/lib/$(MACH64)/libvpx.so.2.0.0
+link path=usr/lib/$(MACH64)/libvpx.so target=libvpx.so.4.1.0
+link path=usr/lib/$(MACH64)/libvpx.so.4 target=libvpx.so.4.1.0
+link path=usr/lib/$(MACH64)/libvpx.so.4.1 target=libvpx.so.4.1.0
+file path=usr/lib/$(MACH64)/libvpx.so.4.1.0
 file path=usr/lib/$(MACH64)/pkgconfig/vpx.pc
-link path=usr/lib/libvpx.so target=libvpx.so.2.0.0
-link path=usr/lib/libvpx.so.2 target=libvpx.so.2.0.0
-link path=usr/lib/libvpx.so.2.0 target=libvpx.so.2.0.0
-file path=usr/lib/libvpx.so.2.0.0
+link path=usr/lib/libvpx.so target=libvpx.so.4.1.0
+link path=usr/lib/libvpx.so.4 target=libvpx.so.4.1.0
+link path=usr/lib/libvpx.so.4.1 target=libvpx.so.4.1.0
+file path=usr/lib/libvpx.so.4.1.0
 file path=usr/lib/pkgconfig/vpx.pc

--- a/components/library/libvpx/manifests/sample-manifest.p5m
+++ b/components/library/libvpx/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -31,15 +31,13 @@ file path=usr/include/vpx/vpx_encoder.h
 file path=usr/include/vpx/vpx_frame_buffer.h
 file path=usr/include/vpx/vpx_image.h
 file path=usr/include/vpx/vpx_integer.h
-file path=usr/lib/$(MACH64)/libvpx.a
-link path=usr/lib/$(MACH64)/libvpx.so target=libvpx.so.2.0.0
-link path=usr/lib/$(MACH64)/libvpx.so.2 target=libvpx.so.2.0.0
-link path=usr/lib/$(MACH64)/libvpx.so.2.0 target=libvpx.so.2.0.0
-file path=usr/lib/$(MACH64)/libvpx.so.2.0.0
+link path=usr/lib/$(MACH64)/libvpx.so target=libvpx.so.4.1.0
+link path=usr/lib/$(MACH64)/libvpx.so.4 target=libvpx.so.4.1.0
+link path=usr/lib/$(MACH64)/libvpx.so.4.1 target=libvpx.so.4.1.0
+file path=usr/lib/$(MACH64)/libvpx.so.4.1.0
 file path=usr/lib/$(MACH64)/pkgconfig/vpx.pc
-file path=usr/lib/libvpx.a
-link path=usr/lib/libvpx.so target=libvpx.so.2.0.0
-link path=usr/lib/libvpx.so.2 target=libvpx.so.2.0.0
-link path=usr/lib/libvpx.so.2.0 target=libvpx.so.2.0.0
-file path=usr/lib/libvpx.so.2.0.0
+link path=usr/lib/libvpx.so target=libvpx.so.4.1.0
+link path=usr/lib/libvpx.so.4 target=libvpx.so.4.1.0
+link path=usr/lib/libvpx.so.4.1 target=libvpx.so.4.1.0
+file path=usr/lib/libvpx.so.4.1.0
 file path=usr/lib/pkgconfig/vpx.pc

--- a/components/library/libvpx/patches/01-shared.patch
+++ b/components/library/libvpx/patches/01-shared.patch
@@ -1,13 +1,11 @@
---- libvpx-v1.2.0/configure	Wed Sep  4 20:49:22 2013
-+++ libvpx-v1.2.0/configure	Sat Sep 28 13:32:39 2013
-@@ -459,8 +459,8 @@
-         if ! enabled linux; then
-             if enabled gnu; then
-                 echo "--enable-shared is only supported on ELF; assuming this is OK"
--            else
--                die "--enable-shared only supported on ELF for now"
-+#            else
-+#                die "--enable-shared only supported on ELF for now"
-             fi
-         fi
-     fi
+--- libvpx-1.6.1/configure.orig	2017-06-09 19:27:10.353541785 +0000
++++ libvpx-1.6.1/configure	2017-06-09 19:28:03.679168380 +0000
+@@ -496,7 +496,7 @@
+         # here rather than at option parse time because the target auto-detect
+         # magic happens after the command line has been parsed.
+         case "${tgt_os}" in
+-        linux|os2|darwin*|iphonesimulator*)
++        linux|os2|darwin*|solaris|iphonesimulator*)
+             # Supported platforms
+             ;;
+         *)

--- a/components/library/libvpx/patches/02-mapfile.patch
+++ b/components/library/libvpx/patches/02-mapfile.patch
@@ -11,28 +11,3 @@
  endef
  
  define dl_template
---- libvpx-1.4.0/vpx/exports_enc.~1~	2015-07-21 16:26:10.298776976 +0300
-+++ libvpx-1.4.0/vpx/exports_enc	2015-07-21 16:26:48.308174527 +0300
-@@ -7,9 +7,3 @@
- text vpx_codec_get_global_headers
- text vpx_codec_get_preview_frame
- text vpx_codec_set_cx_data_buf
--text vpx_svc_dump_statistics
--text vpx_svc_encode
--text vpx_svc_get_message
--text vpx_svc_init
--text vpx_svc_release
--text vpx_svc_set_options
---- libvpx-1.4.0/vpx/exports_dec.~1~	2015-07-21 16:28:02.598217310 +0300
-+++ libvpx-1.4.0/vpx/exports_dec	2015-07-21 16:28:10.131279373 +0300
-@@ -1,10 +1,8 @@
- text vpx_codec_dec_init_ver
- text vpx_codec_decode
- text vpx_codec_get_frame
--text vpx_codec_get_mem_map
- text vpx_codec_get_stream_info
- text vpx_codec_peek_stream_info
- text vpx_codec_register_put_frame_cb
- text vpx_codec_register_put_slice_cb
- text vpx_codec_set_frame_buffer_functions
--text vpx_codec_set_mem_map

--- a/components/library/soundtouch/Makefile
+++ b/components/library/soundtouch/Makefile
@@ -13,15 +13,15 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
-include ../../make-rules/shared-macros.mk
+include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= soundtouch
-COMPONENT_VERSION= 1.9.0
+COMPONENT_VERSION= 1.9.2
 COMPONENT_SUMMARY= Audio Processing Library
 COMPONENT_SRC= $(COMPONENT_NAME)
 COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).zip
 COMPONENT_ARCHIVE_HASH= \
-  sha256:ebdc3d6484ee15fcd7145ccde9ba36a5b7d606a68158b1805b58c6d7a3e1052b
+  sha256:4aa443594d77986bf977c2856f5530a8015db406631e4b996f962b1e6809883e
 COMPONENT_ARCHIVE_URL= \
   http://www.surina.net/soundtouch/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://www.surina.net/soundtouch
@@ -30,9 +30,9 @@ COMPONENT_LICENSE_FILE = COPYING.TXT
 COMPONENT_CLASSIFICATION = System/Multimedia Libraries
 COMPONENT_FMRI = library/audio/soundtouch
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 COMPONENT_PREP_ACTION =        ( cd $(@D)  && \
 					$(CONFIG_SHELL) bootstrap )
@@ -46,3 +46,9 @@ CONFIGURE_ENV += AM_CXXFLAGS="$(CXXFLAGS)"
 build: $(BUILD_32_and_64)
 
 install: $(INSTALL_32_and_64)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/g++-4-runtime
+REQUIRED_PACKAGES += system/library/gcc-4-runtime
+REQUIRED_PACKAGES += system/library/math

--- a/components/library/soundtouch/manifests/sample-manifest.p5m
+++ b/components/library/soundtouch/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,13 +30,13 @@ file path=usr/include/soundtouch/FIFOSamplePipe.h
 file path=usr/include/soundtouch/STTypes.h
 file path=usr/include/soundtouch/SoundTouch.h
 file path=usr/include/soundtouch/soundtouch_config.h
-link path=usr/lib/$(MACH64)/libSoundTouch.so target=libSoundTouch.so.0.0.0
-link path=usr/lib/$(MACH64)/libSoundTouch.so.0 target=libSoundTouch.so.0.0.0
-file path=usr/lib/$(MACH64)/libSoundTouch.so.0.0.0
+link path=usr/lib/$(MACH64)/libSoundTouch.so target=libSoundTouch.so.1.0.0
+link path=usr/lib/$(MACH64)/libSoundTouch.so.1 target=libSoundTouch.so.1.0.0
+file path=usr/lib/$(MACH64)/libSoundTouch.so.1.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/soundtouch.pc
-link path=usr/lib/libSoundTouch.so target=libSoundTouch.so.0.0.0
-link path=usr/lib/libSoundTouch.so.0 target=libSoundTouch.so.0.0.0
-file path=usr/lib/libSoundTouch.so.0.0.0
+link path=usr/lib/libSoundTouch.so target=libSoundTouch.so.1.0.0
+link path=usr/lib/libSoundTouch.so.1 target=libSoundTouch.so.1.0.0
+file path=usr/lib/libSoundTouch.so.1.0.0
 file path=usr/lib/pkgconfig/soundtouch.pc
 file path=usr/share/aclocal/soundtouch.m4
 file path=usr/share/doc/soundtouch/COPYING.TXT

--- a/components/library/soundtouch/soundtouch.p5m
+++ b/components/library/soundtouch/soundtouch.p5m
@@ -30,13 +30,13 @@ file path=usr/include/soundtouch/FIFOSamplePipe.h
 file path=usr/include/soundtouch/STTypes.h
 file path=usr/include/soundtouch/SoundTouch.h
 file path=usr/include/soundtouch/soundtouch_config.h
-link path=usr/lib/$(MACH64)/libSoundTouch.so target=libSoundTouch.so.0.0.0
-link path=usr/lib/$(MACH64)/libSoundTouch.so.0 target=libSoundTouch.so.0.0.0
-file path=usr/lib/$(MACH64)/libSoundTouch.so.0.0.0
+link path=usr/lib/$(MACH64)/libSoundTouch.so target=libSoundTouch.so.1.0.0
+link path=usr/lib/$(MACH64)/libSoundTouch.so.1 target=libSoundTouch.so.1.0.0
+file path=usr/lib/$(MACH64)/libSoundTouch.so.1.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/soundtouch.pc
-link path=usr/lib/libSoundTouch.so target=libSoundTouch.so.0.0.0
-link path=usr/lib/libSoundTouch.so.0 target=libSoundTouch.so.0.0.0
-file path=usr/lib/libSoundTouch.so.0.0.0
+link path=usr/lib/libSoundTouch.so target=libSoundTouch.so.1.0.0
+link path=usr/lib/libSoundTouch.so.1 target=libSoundTouch.so.1.0.0
+file path=usr/lib/libSoundTouch.so.1.0.0
 file path=usr/lib/pkgconfig/soundtouch.pc
 file path=usr/share/aclocal/soundtouch.m4
 file path=usr/share/doc/soundtouch/COPYING.TXT

--- a/components/multimedia/gstreamer1/Makefile
+++ b/components/multimedia/gstreamer1/Makefile
@@ -16,7 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gstreamer1
-COMPONENT_VERSION= 1.10.3
+COMPONENT_VERSION= 1.12.0
 COMPONENT_SUMMARY= GNOME streaming media framework
 COMPONENT_PROJECT_URL = http://gstreamer.freedesktop.org/
 COMPONENT_FMRI= library/audio/gstreamer1
@@ -25,11 +25,10 @@ COMPONENT_SRC_NAME= gstreamer
 COMPONENT_SRC= $(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:85b9dc1b2991f224fa90d534ec57014896c479e061dc9fa1bc16ae17cbebb63d
+  sha256:14d5eef8297d2bf2a728d38fa43cd92cc267a0ad260cf83d770215212aff4302
 COMPONENT_ARCHIVE_URL= \
   http://gstreamer.freedesktop.org/src/$(COMPONENT_SRC_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE= LGPLv2
-COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
@@ -37,7 +36,7 @@ include $(WS_MAKE_RULES)/ips.mk
 
 gcc_OPT = -O2
 
-PATH = /usr/gnu/bin:/usr/bin
+PATH = $(PATH.gnu)
 
 CFLAGS += -I/usr/sfw/include -I/usr/X11/include
 

--- a/components/multimedia/gstreamer1/gstreamer1.p5m
+++ b/components/multimedia/gstreamer1/gstreamer1.p5m
@@ -64,11 +64,13 @@ file path=usr/include/gstreamer-1.0/gst/check/gstconsistencychecker.h
 file path=usr/include/gstreamer-1.0/gst/check/gstharness.h
 file path=usr/include/gstreamer-1.0/gst/check/gsttestclock.h
 file path=usr/include/gstreamer-1.0/gst/check/internal-check.h
+file path=usr/include/gstreamer-1.0/gst/controller/controller-enumtypes.h
 file path=usr/include/gstreamer-1.0/gst/controller/controller.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstargbcontrolbinding.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstdirectcontrolbinding.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstinterpolationcontrolsource.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstlfocontrolsource.h
+file path=usr/include/gstreamer-1.0/gst/controller/gstproxycontrolbinding.h
 file path=usr/include/gstreamer-1.0/gst/controller/gsttimedvaluecontrolsource.h
 file path=usr/include/gstreamer-1.0/gst/controller/gsttriggercontrolsource.h
 file path=usr/include/gstreamer-1.0/gst/glib-compat.h
@@ -95,6 +97,7 @@ file path=usr/include/gstreamer-1.0/gst/gstdevice.h
 file path=usr/include/gstreamer-1.0/gst/gstdevicemonitor.h
 file path=usr/include/gstreamer-1.0/gst/gstdeviceprovider.h
 file path=usr/include/gstreamer-1.0/gst/gstdeviceproviderfactory.h
+file path=usr/include/gstreamer-1.0/gst/gstdynamictypefactory.h
 file path=usr/include/gstreamer-1.0/gst/gstelement.h
 file path=usr/include/gstreamer-1.0/gst/gstelementfactory.h
 file path=usr/include/gstreamer-1.0/gst/gstelementmetadata.h
@@ -158,32 +161,33 @@ file path=usr/lib/$(MACH64)/girepository-1.0/GstBase-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GstCheck-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GstController-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GstNet-1.0.typelib
-file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-plugin-scanner
-file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-ptp-helper
+file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-completion-helper mode=0555
+file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-plugin-scanner mode=0555
+file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-ptp-helper mode=0555
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstcoreelements.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstcoretracers.so
-link path=usr/lib/$(MACH64)/libgstbase-1.0.so target=libgstbase-1.0.so.0.1003.0
+link path=usr/lib/$(MACH64)/libgstbase-1.0.so target=libgstbase-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstbase-1.0.so.0 \
-    target=libgstbase-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstbase-1.0.so.0.1003.0
+    target=libgstbase-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstbase-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcheck-1.0.so \
-    target=libgstcheck-1.0.so.0.1003.0
+    target=libgstcheck-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcheck-1.0.so.0 \
-    target=libgstcheck-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstcheck-1.0.so.0.1003.0
+    target=libgstcheck-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstcheck-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcontroller-1.0.so \
-    target=libgstcontroller-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcontroller-1.0.so.0 \
-    target=libgstcontroller-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstcontroller-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstnet-1.0.so target=libgstnet-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstnet-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstcontroller-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstnet-1.0.so target=libgstnet-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstnet-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstreamer-1.0.so \
-    target=libgstreamer-1.0.so.0.1003.0
+    target=libgstreamer-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstreamer-1.0.so.0 \
-    target=libgstreamer-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstreamer-1.0.so.0.1003.0
+    target=libgstreamer-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstreamer-1.0.so.0.1200.0
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-base-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-check-1.0.pc
@@ -194,27 +198,28 @@ file path=usr/lib/girepository-1.0/GstBase-1.0.typelib
 file path=usr/lib/girepository-1.0/GstCheck-1.0.typelib
 file path=usr/lib/girepository-1.0/GstController-1.0.typelib
 file path=usr/lib/girepository-1.0/GstNet-1.0.typelib
-file path=usr/lib/gstreamer-1.0/gst-plugin-scanner
-file path=usr/lib/gstreamer-1.0/gst-ptp-helper
+file path=usr/lib/gstreamer-1.0/gst-completion-helper mode=0555
+file path=usr/lib/gstreamer-1.0/gst-plugin-scanner mode=0555
+file path=usr/lib/gstreamer-1.0/gst-ptp-helper mode=0555
 file path=usr/lib/gstreamer-1.0/libgstcoreelements.so
 file path=usr/lib/gstreamer-1.0/libgstcoretracers.so
-link path=usr/lib/libgstbase-1.0.so target=libgstbase-1.0.so.0.1003.0
-link path=usr/lib/libgstbase-1.0.so.0 target=libgstbase-1.0.so.0.1003.0
-file path=usr/lib/libgstbase-1.0.so.0.1003.0
-link path=usr/lib/libgstcheck-1.0.so target=libgstcheck-1.0.so.0.1003.0
-link path=usr/lib/libgstcheck-1.0.so.0 target=libgstcheck-1.0.so.0.1003.0
-file path=usr/lib/libgstcheck-1.0.so.0.1003.0
+link path=usr/lib/libgstbase-1.0.so target=libgstbase-1.0.so.0.1200.0
+link path=usr/lib/libgstbase-1.0.so.0 target=libgstbase-1.0.so.0.1200.0
+file path=usr/lib/libgstbase-1.0.so.0.1200.0
+link path=usr/lib/libgstcheck-1.0.so target=libgstcheck-1.0.so.0.1200.0
+link path=usr/lib/libgstcheck-1.0.so.0 target=libgstcheck-1.0.so.0.1200.0
+file path=usr/lib/libgstcheck-1.0.so.0.1200.0
 link path=usr/lib/libgstcontroller-1.0.so \
-    target=libgstcontroller-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
 link path=usr/lib/libgstcontroller-1.0.so.0 \
-    target=libgstcontroller-1.0.so.0.1003.0
-file path=usr/lib/libgstcontroller-1.0.so.0.1003.0
-link path=usr/lib/libgstnet-1.0.so target=libgstnet-1.0.so.0.1003.0
-link path=usr/lib/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1003.0
-file path=usr/lib/libgstnet-1.0.so.0.1003.0
-link path=usr/lib/libgstreamer-1.0.so target=libgstreamer-1.0.so.0.1003.0
-link path=usr/lib/libgstreamer-1.0.so.0 target=libgstreamer-1.0.so.0.1003.0
-file path=usr/lib/libgstreamer-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
+file path=usr/lib/libgstcontroller-1.0.so.0.1200.0
+link path=usr/lib/libgstnet-1.0.so target=libgstnet-1.0.so.0.1200.0
+link path=usr/lib/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1200.0
+file path=usr/lib/libgstnet-1.0.so.0.1200.0
+link path=usr/lib/libgstreamer-1.0.so target=libgstreamer-1.0.so.0.1200.0
+link path=usr/lib/libgstreamer-1.0.so.0 target=libgstreamer-1.0.so.0.1200.0
+file path=usr/lib/libgstreamer-1.0.so.0.1200.0
 file path=usr/lib/pkgconfig/gstreamer-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-base-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-check-1.0.pc
@@ -224,13 +229,13 @@ file path=usr/share/aclocal/gst-element-check-1.0.m4
 file path=usr/share/bash-completion/completions/gst-inspect-1.0 mode=0555
 file path=usr/share/bash-completion/completions/gst-launch-1.0 mode=0555
 file path=usr/share/bash-completion/helpers/gst mode=0555
-file path=usr/share/bash-completion/helpers/gst-completion-helper-1.0 mode=0555
 file path=usr/share/gir-1.0/Gst-1.0.gir
 file path=usr/share/gir-1.0/GstBase-1.0.gir
 file path=usr/share/gir-1.0/GstCheck-1.0.gir
 file path=usr/share/gir-1.0/GstController-1.0.gir
 file path=usr/share/gir-1.0/GstNet-1.0.gir
 file path=usr/share/locale/af/LC_MESSAGES/gstreamer-1.0.mo
+file path=usr/share/locale/ast/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/az/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/be/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/bg/LC_MESSAGES/gstreamer-1.0.mo
@@ -245,6 +250,7 @@ file path=usr/share/locale/es/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/eu/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/fi/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/fr/LC_MESSAGES/gstreamer-1.0.mo
+file path=usr/share/locale/fur/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/gl/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/hr/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/hu/LC_MESSAGES/gstreamer-1.0.mo

--- a/components/multimedia/gstreamer1/manifests/sample-manifest.p5m
+++ b/components/multimedia/gstreamer1/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -52,11 +52,13 @@ file path=usr/include/gstreamer-1.0/gst/check/gstconsistencychecker.h
 file path=usr/include/gstreamer-1.0/gst/check/gstharness.h
 file path=usr/include/gstreamer-1.0/gst/check/gsttestclock.h
 file path=usr/include/gstreamer-1.0/gst/check/internal-check.h
+file path=usr/include/gstreamer-1.0/gst/controller/controller-enumtypes.h
 file path=usr/include/gstreamer-1.0/gst/controller/controller.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstargbcontrolbinding.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstdirectcontrolbinding.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstinterpolationcontrolsource.h
 file path=usr/include/gstreamer-1.0/gst/controller/gstlfocontrolsource.h
+file path=usr/include/gstreamer-1.0/gst/controller/gstproxycontrolbinding.h
 file path=usr/include/gstreamer-1.0/gst/controller/gsttimedvaluecontrolsource.h
 file path=usr/include/gstreamer-1.0/gst/controller/gsttriggercontrolsource.h
 file path=usr/include/gstreamer-1.0/gst/glib-compat.h
@@ -83,6 +85,7 @@ file path=usr/include/gstreamer-1.0/gst/gstdevice.h
 file path=usr/include/gstreamer-1.0/gst/gstdevicemonitor.h
 file path=usr/include/gstreamer-1.0/gst/gstdeviceprovider.h
 file path=usr/include/gstreamer-1.0/gst/gstdeviceproviderfactory.h
+file path=usr/include/gstreamer-1.0/gst/gstdynamictypefactory.h
 file path=usr/include/gstreamer-1.0/gst/gstelement.h
 file path=usr/include/gstreamer-1.0/gst/gstelementfactory.h
 file path=usr/include/gstreamer-1.0/gst/gstelementmetadata.h
@@ -146,32 +149,33 @@ file path=usr/lib/$(MACH64)/girepository-1.0/GstBase-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GstCheck-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GstController-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GstNet-1.0.typelib
+file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-completion-helper
 file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-plugin-scanner
 file path=usr/lib/$(MACH64)/gstreamer-1.0/gst-ptp-helper
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstcoreelements.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstcoretracers.so
-link path=usr/lib/$(MACH64)/libgstbase-1.0.so target=libgstbase-1.0.so.0.1003.0
+link path=usr/lib/$(MACH64)/libgstbase-1.0.so target=libgstbase-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstbase-1.0.so.0 \
-    target=libgstbase-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstbase-1.0.so.0.1003.0
+    target=libgstbase-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstbase-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcheck-1.0.so \
-    target=libgstcheck-1.0.so.0.1003.0
+    target=libgstcheck-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcheck-1.0.so.0 \
-    target=libgstcheck-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstcheck-1.0.so.0.1003.0
+    target=libgstcheck-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstcheck-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcontroller-1.0.so \
-    target=libgstcontroller-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstcontroller-1.0.so.0 \
-    target=libgstcontroller-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstcontroller-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstnet-1.0.so target=libgstnet-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstnet-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstcontroller-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstnet-1.0.so target=libgstnet-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstnet-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstreamer-1.0.so \
-    target=libgstreamer-1.0.so.0.1003.0
+    target=libgstreamer-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstreamer-1.0.so.0 \
-    target=libgstreamer-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstreamer-1.0.so.0.1003.0
+    target=libgstreamer-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstreamer-1.0.so.0.1200.0
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-base-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-check-1.0.pc
@@ -182,27 +186,28 @@ file path=usr/lib/girepository-1.0/GstBase-1.0.typelib
 file path=usr/lib/girepository-1.0/GstCheck-1.0.typelib
 file path=usr/lib/girepository-1.0/GstController-1.0.typelib
 file path=usr/lib/girepository-1.0/GstNet-1.0.typelib
+file path=usr/lib/gstreamer-1.0/gst-completion-helper
 file path=usr/lib/gstreamer-1.0/gst-plugin-scanner
 file path=usr/lib/gstreamer-1.0/gst-ptp-helper
 file path=usr/lib/gstreamer-1.0/libgstcoreelements.so
 file path=usr/lib/gstreamer-1.0/libgstcoretracers.so
-link path=usr/lib/libgstbase-1.0.so target=libgstbase-1.0.so.0.1003.0
-link path=usr/lib/libgstbase-1.0.so.0 target=libgstbase-1.0.so.0.1003.0
-file path=usr/lib/libgstbase-1.0.so.0.1003.0
-link path=usr/lib/libgstcheck-1.0.so target=libgstcheck-1.0.so.0.1003.0
-link path=usr/lib/libgstcheck-1.0.so.0 target=libgstcheck-1.0.so.0.1003.0
-file path=usr/lib/libgstcheck-1.0.so.0.1003.0
+link path=usr/lib/libgstbase-1.0.so target=libgstbase-1.0.so.0.1200.0
+link path=usr/lib/libgstbase-1.0.so.0 target=libgstbase-1.0.so.0.1200.0
+file path=usr/lib/libgstbase-1.0.so.0.1200.0
+link path=usr/lib/libgstcheck-1.0.so target=libgstcheck-1.0.so.0.1200.0
+link path=usr/lib/libgstcheck-1.0.so.0 target=libgstcheck-1.0.so.0.1200.0
+file path=usr/lib/libgstcheck-1.0.so.0.1200.0
 link path=usr/lib/libgstcontroller-1.0.so \
-    target=libgstcontroller-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
 link path=usr/lib/libgstcontroller-1.0.so.0 \
-    target=libgstcontroller-1.0.so.0.1003.0
-file path=usr/lib/libgstcontroller-1.0.so.0.1003.0
-link path=usr/lib/libgstnet-1.0.so target=libgstnet-1.0.so.0.1003.0
-link path=usr/lib/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1003.0
-file path=usr/lib/libgstnet-1.0.so.0.1003.0
-link path=usr/lib/libgstreamer-1.0.so target=libgstreamer-1.0.so.0.1003.0
-link path=usr/lib/libgstreamer-1.0.so.0 target=libgstreamer-1.0.so.0.1003.0
-file path=usr/lib/libgstreamer-1.0.so.0.1003.0
+    target=libgstcontroller-1.0.so.0.1200.0
+file path=usr/lib/libgstcontroller-1.0.so.0.1200.0
+link path=usr/lib/libgstnet-1.0.so target=libgstnet-1.0.so.0.1200.0
+link path=usr/lib/libgstnet-1.0.so.0 target=libgstnet-1.0.so.0.1200.0
+file path=usr/lib/libgstnet-1.0.so.0.1200.0
+link path=usr/lib/libgstreamer-1.0.so target=libgstreamer-1.0.so.0.1200.0
+link path=usr/lib/libgstreamer-1.0.so.0 target=libgstreamer-1.0.so.0.1200.0
+file path=usr/lib/libgstreamer-1.0.so.0.1200.0
 file path=usr/lib/pkgconfig/gstreamer-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-base-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-check-1.0.pc
@@ -212,13 +217,13 @@ file path=usr/share/aclocal/gst-element-check-1.0.m4
 file path=usr/share/bash-completion/completions/gst-inspect-1.0
 file path=usr/share/bash-completion/completions/gst-launch-1.0
 file path=usr/share/bash-completion/helpers/gst
-file path=usr/share/bash-completion/helpers/gst-completion-helper-1.0
 file path=usr/share/gir-1.0/Gst-1.0.gir
 file path=usr/share/gir-1.0/GstBase-1.0.gir
 file path=usr/share/gir-1.0/GstCheck-1.0.gir
 file path=usr/share/gir-1.0/GstController-1.0.gir
 file path=usr/share/gir-1.0/GstNet-1.0.gir
 file path=usr/share/locale/af/LC_MESSAGES/gstreamer-1.0.mo
+file path=usr/share/locale/ast/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/az/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/be/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/bg/LC_MESSAGES/gstreamer-1.0.mo
@@ -233,6 +238,7 @@ file path=usr/share/locale/es/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/eu/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/fi/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/fr/LC_MESSAGES/gstreamer-1.0.mo
+file path=usr/share/locale/fur/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/gl/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/hr/LC_MESSAGES/gstreamer-1.0.mo
 file path=usr/share/locale/hu/LC_MESSAGES/gstreamer-1.0.mo


### PR DESCRIPTION
ABI compatible: https://abi-laboratory.pro/tracker/timeline/gstreamer/
Tested on my workstation.

Bump libvpx at the same time:
helios> pkg search -r -o pkg.name 'depend:require:library/video/libvpx'
PKG.NAME
library/audio/gstreamer/plugin/bad
video/ffmpeg
media/vlc
library/audio/gstreamer1/plugin/good

Dependency library/gd removed as 2.2.4 depends on libwebp, merge with #3272 .

Bump soundtouch at the same time: required rebuild library/audio/gstreamer/plugin/bad.

Rebuilds are in #3226 .
