### PR TITLE
Bump gst-plugins-base1 to 1.12.0

### DIFF
--- a/components/multimedia/gst-plugins-base1/Makefile
+++ b/components/multimedia/gst-plugins-base1/Makefile
@@ -10,13 +10,13 @@
 #
 
 #
-# Copyright 2016 Aurelien Larcher.  All rights reserved.
+# Copyright 2016-2017 Aurelien Larcher.  All rights reserved.
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gst-plugins-base1
-COMPONENT_VERSION= 1.10.3
+COMPONENT_VERSION= 1.12.0
 COMPONENT_SUMMARY= GNOME streaming media framework plugins
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 COMPONENT_FMRI= library/audio/gstreamer1/plugin/base
@@ -24,7 +24,7 @@ COMPONENT_SRC_NAME= gst-plugins-base
 COMPONENT_SRC= $(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:e6299617d705a0cbfb535107c1d3a8fc0f0967f14193a8c5c7583f46a88b1710
+  sha256:345fc6877f54b8b6e97aacf2996be37a51a0e369f53fc2cf83108af9f764364d
 COMPONENT_ARCHIVE_URL= \
   http://gstreamer.freedesktop.org/src/$(COMPONENT_SRC_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL= http://gstreamer.freedesktop.org/
@@ -36,7 +36,7 @@ include $(WS_MAKE_RULES)/ips.mk
 
 gcc_OPT = -O2
 
-PATH = /usr/gnu/bin:/usr/bin
+PATH = $(PATH.gnu)
 
 CFLAGS += -I/usr/sfw/include -I/usr/X11/include
 

--- a/components/multimedia/gst-plugins-base1/gst-plugins-base1.p5m
+++ b/components/multimedia/gst-plugins-base1/gst-plugins-base1.p5m
@@ -31,6 +31,7 @@ file path=usr/bin/gst-play-1.0
 file path=usr/include/gstreamer-1.0/gst/allocators/allocators.h
 file path=usr/include/gstreamer-1.0/gst/allocators/gstdmabuf.h
 file path=usr/include/gstreamer-1.0/gst/allocators/gstfdmemory.h
+file path=usr/include/gstreamer-1.0/gst/app/app-enumtypes.h
 file path=usr/include/gstreamer-1.0/gst/app/app.h
 file path=usr/include/gstreamer-1.0/gst/app/gstappsink.h
 file path=usr/include/gstreamer-1.0/gst/app/gstappsrc.h
@@ -103,6 +104,7 @@ file path=usr/include/gstreamer-1.0/gst/sdp/gstsdpmessage.h
 file path=usr/include/gstreamer-1.0/gst/sdp/sdp.h
 file path=usr/include/gstreamer-1.0/gst/tag/gsttagdemux.h
 file path=usr/include/gstreamer-1.0/gst/tag/gsttagmux.h
+file path=usr/include/gstreamer-1.0/gst/tag/tag-enumtypes.h
 file path=usr/include/gstreamer-1.0/gst/tag/tag.h
 file path=usr/include/gstreamer-1.0/gst/tag/xmpwriter.h
 file path=usr/include/gstreamer-1.0/gst/video/colorbalance.h
@@ -152,13 +154,15 @@ file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudioconvert.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudiorate.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudioresample.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudiotestsrc.so
-file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstencodebin.so
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstencoding.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstgio.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstlibvisual.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstogg.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstopus.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstpango.so
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstpbtypes.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstplayback.so
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstrawparse.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstsubparse.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgsttcp.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgsttheora.so
@@ -172,48 +176,48 @@ file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstvorbis.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstximagesink.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstxvimagesink.so
 link path=usr/lib/$(MACH64)/libgstallocators-1.0.so \
-    target=libgstallocators-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstallocators-1.0.so.0 \
-    target=libgstallocators-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstallocators-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstapp-1.0.so target=libgstapp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstapp-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstallocators-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstapp-1.0.so target=libgstapp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstapp-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstaudio-1.0.so \
-    target=libgstaudio-1.0.so.0.1003.0
+    target=libgstaudio-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstaudio-1.0.so.0 \
-    target=libgstaudio-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstaudio-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstfft-1.0.so target=libgstfft-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstfft-1.0.so.0.1003.0
+    target=libgstaudio-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstaudio-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstfft-1.0.so target=libgstfft-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstfft-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstpbutils-1.0.so \
-    target=libgstpbutils-1.0.so.0.1003.0
+    target=libgstpbutils-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstpbutils-1.0.so.0 \
-    target=libgstpbutils-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstpbutils-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstriff-1.0.so target=libgstriff-1.0.so.0.1003.0
+    target=libgstpbutils-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstpbutils-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstriff-1.0.so target=libgstriff-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstriff-1.0.so.0 \
-    target=libgstriff-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstriff-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1003.0
+    target=libgstriff-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstriff-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstrtsp-1.0.so.0 \
-    target=libgstrtsp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstrtsp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgsttag-1.0.so target=libgsttag-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgsttag-1.0.so.0.1003.0
+    target=libgstrtsp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstrtsp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgsttag-1.0.so target=libgsttag-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgsttag-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstvideo-1.0.so \
-    target=libgstvideo-1.0.so.0.1003.0
+    target=libgstvideo-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstvideo-1.0.so.0 \
-    target=libgstvideo-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstvideo-1.0.so.0.1003.0
+    target=libgstvideo-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstvideo-1.0.so.0.1200.0
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-allocators-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-app-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-audio-1.0.pc
@@ -242,13 +246,15 @@ file path=usr/lib/gstreamer-1.0/libgstaudioconvert.so
 file path=usr/lib/gstreamer-1.0/libgstaudiorate.so
 file path=usr/lib/gstreamer-1.0/libgstaudioresample.so
 file path=usr/lib/gstreamer-1.0/libgstaudiotestsrc.so
-file path=usr/lib/gstreamer-1.0/libgstencodebin.so
+file path=usr/lib/gstreamer-1.0/libgstencoding.so
 file path=usr/lib/gstreamer-1.0/libgstgio.so
 file path=usr/lib/gstreamer-1.0/libgstlibvisual.so
 file path=usr/lib/gstreamer-1.0/libgstogg.so
 file path=usr/lib/gstreamer-1.0/libgstopus.so
 file path=usr/lib/gstreamer-1.0/libgstpango.so
+file path=usr/lib/gstreamer-1.0/libgstpbtypes.so
 file path=usr/lib/gstreamer-1.0/libgstplayback.so
+file path=usr/lib/gstreamer-1.0/libgstrawparse.so
 file path=usr/lib/gstreamer-1.0/libgstsubparse.so
 file path=usr/lib/gstreamer-1.0/libgsttcp.so
 file path=usr/lib/gstreamer-1.0/libgsttheora.so
@@ -262,40 +268,40 @@ file path=usr/lib/gstreamer-1.0/libgstvorbis.so
 file path=usr/lib/gstreamer-1.0/libgstximagesink.so
 file path=usr/lib/gstreamer-1.0/libgstxvimagesink.so
 link path=usr/lib/libgstallocators-1.0.so \
-    target=libgstallocators-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
 link path=usr/lib/libgstallocators-1.0.so.0 \
-    target=libgstallocators-1.0.so.0.1003.0
-file path=usr/lib/libgstallocators-1.0.so.0.1003.0
-link path=usr/lib/libgstapp-1.0.so target=libgstapp-1.0.so.0.1003.0
-link path=usr/lib/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1003.0
-file path=usr/lib/libgstapp-1.0.so.0.1003.0
-link path=usr/lib/libgstaudio-1.0.so target=libgstaudio-1.0.so.0.1003.0
-link path=usr/lib/libgstaudio-1.0.so.0 target=libgstaudio-1.0.so.0.1003.0
-file path=usr/lib/libgstaudio-1.0.so.0.1003.0
-link path=usr/lib/libgstfft-1.0.so target=libgstfft-1.0.so.0.1003.0
-link path=usr/lib/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1003.0
-file path=usr/lib/libgstfft-1.0.so.0.1003.0
-link path=usr/lib/libgstpbutils-1.0.so target=libgstpbutils-1.0.so.0.1003.0
-link path=usr/lib/libgstpbutils-1.0.so.0 target=libgstpbutils-1.0.so.0.1003.0
-file path=usr/lib/libgstpbutils-1.0.so.0.1003.0
-link path=usr/lib/libgstriff-1.0.so target=libgstriff-1.0.so.0.1003.0
-link path=usr/lib/libgstriff-1.0.so.0 target=libgstriff-1.0.so.0.1003.0
-file path=usr/lib/libgstriff-1.0.so.0.1003.0
-link path=usr/lib/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1003.0
-file path=usr/lib/libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1003.0
-link path=usr/lib/libgstrtsp-1.0.so.0 target=libgstrtsp-1.0.so.0.1003.0
-file path=usr/lib/libgstrtsp-1.0.so.0.1003.0
-link path=usr/lib/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1003.0
-file path=usr/lib/libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/libgsttag-1.0.so target=libgsttag-1.0.so.0.1003.0
-link path=usr/lib/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1003.0
-file path=usr/lib/libgsttag-1.0.so.0.1003.0
-link path=usr/lib/libgstvideo-1.0.so target=libgstvideo-1.0.so.0.1003.0
-link path=usr/lib/libgstvideo-1.0.so.0 target=libgstvideo-1.0.so.0.1003.0
-file path=usr/lib/libgstvideo-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
+file path=usr/lib/libgstallocators-1.0.so.0.1200.0
+link path=usr/lib/libgstapp-1.0.so target=libgstapp-1.0.so.0.1200.0
+link path=usr/lib/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1200.0
+file path=usr/lib/libgstapp-1.0.so.0.1200.0
+link path=usr/lib/libgstaudio-1.0.so target=libgstaudio-1.0.so.0.1200.0
+link path=usr/lib/libgstaudio-1.0.so.0 target=libgstaudio-1.0.so.0.1200.0
+file path=usr/lib/libgstaudio-1.0.so.0.1200.0
+link path=usr/lib/libgstfft-1.0.so target=libgstfft-1.0.so.0.1200.0
+link path=usr/lib/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1200.0
+file path=usr/lib/libgstfft-1.0.so.0.1200.0
+link path=usr/lib/libgstpbutils-1.0.so target=libgstpbutils-1.0.so.0.1200.0
+link path=usr/lib/libgstpbutils-1.0.so.0 target=libgstpbutils-1.0.so.0.1200.0
+file path=usr/lib/libgstpbutils-1.0.so.0.1200.0
+link path=usr/lib/libgstriff-1.0.so target=libgstriff-1.0.so.0.1200.0
+link path=usr/lib/libgstriff-1.0.so.0 target=libgstriff-1.0.so.0.1200.0
+file path=usr/lib/libgstriff-1.0.so.0.1200.0
+link path=usr/lib/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1200.0
+file path=usr/lib/libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1200.0
+link path=usr/lib/libgstrtsp-1.0.so.0 target=libgstrtsp-1.0.so.0.1200.0
+file path=usr/lib/libgstrtsp-1.0.so.0.1200.0
+link path=usr/lib/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1200.0
+file path=usr/lib/libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/libgsttag-1.0.so target=libgsttag-1.0.so.0.1200.0
+link path=usr/lib/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1200.0
+file path=usr/lib/libgsttag-1.0.so.0.1200.0
+link path=usr/lib/libgstvideo-1.0.so target=libgstvideo-1.0.so.0.1200.0
+link path=usr/lib/libgstvideo-1.0.so.0 target=libgstvideo-1.0.so.0.1200.0
+file path=usr/lib/libgstvideo-1.0.so.0.1200.0
 file path=usr/lib/pkgconfig/gstreamer-allocators-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-app-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-audio-1.0.pc
@@ -333,6 +339,7 @@ file path=usr/share/locale/es/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/eu/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/fi/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/fr/LC_MESSAGES/gst-plugins-base-1.0.mo
+file path=usr/share/locale/fur/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/gl/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/hr/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/hu/LC_MESSAGES/gst-plugins-base-1.0.mo

--- a/components/multimedia/gst-plugins-base1/manifests/sample-manifest.p5m
+++ b/components/multimedia/gst-plugins-base1/manifests/sample-manifest.p5m
@@ -31,6 +31,7 @@ file path=usr/bin/gst-play-1.0
 file path=usr/include/gstreamer-1.0/gst/allocators/allocators.h
 file path=usr/include/gstreamer-1.0/gst/allocators/gstdmabuf.h
 file path=usr/include/gstreamer-1.0/gst/allocators/gstfdmemory.h
+file path=usr/include/gstreamer-1.0/gst/app/app-enumtypes.h
 file path=usr/include/gstreamer-1.0/gst/app/app.h
 file path=usr/include/gstreamer-1.0/gst/app/gstappsink.h
 file path=usr/include/gstreamer-1.0/gst/app/gstappsrc.h
@@ -103,6 +104,7 @@ file path=usr/include/gstreamer-1.0/gst/sdp/gstsdpmessage.h
 file path=usr/include/gstreamer-1.0/gst/sdp/sdp.h
 file path=usr/include/gstreamer-1.0/gst/tag/gsttagdemux.h
 file path=usr/include/gstreamer-1.0/gst/tag/gsttagmux.h
+file path=usr/include/gstreamer-1.0/gst/tag/tag-enumtypes.h
 file path=usr/include/gstreamer-1.0/gst/tag/tag.h
 file path=usr/include/gstreamer-1.0/gst/tag/xmpwriter.h
 file path=usr/include/gstreamer-1.0/gst/video/colorbalance.h
@@ -152,13 +154,15 @@ file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudioconvert.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudiorate.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudioresample.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstaudiotestsrc.so
-file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstencodebin.so
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstencoding.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstgio.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstlibvisual.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstogg.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstopus.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstpango.so
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstpbtypes.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstplayback.so
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstrawparse.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstsubparse.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgsttcp.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgsttheora.so
@@ -172,48 +176,48 @@ file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstvorbis.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstximagesink.so
 file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstxvimagesink.so
 link path=usr/lib/$(MACH64)/libgstallocators-1.0.so \
-    target=libgstallocators-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstallocators-1.0.so.0 \
-    target=libgstallocators-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstallocators-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstapp-1.0.so target=libgstapp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstapp-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstallocators-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstapp-1.0.so target=libgstapp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstapp-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstaudio-1.0.so \
-    target=libgstaudio-1.0.so.0.1003.0
+    target=libgstaudio-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstaudio-1.0.so.0 \
-    target=libgstaudio-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstaudio-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstfft-1.0.so target=libgstfft-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstfft-1.0.so.0.1003.0
+    target=libgstaudio-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstaudio-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstfft-1.0.so target=libgstfft-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstfft-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstpbutils-1.0.so \
-    target=libgstpbutils-1.0.so.0.1003.0
+    target=libgstpbutils-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstpbutils-1.0.so.0 \
-    target=libgstpbutils-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstpbutils-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstriff-1.0.so target=libgstriff-1.0.so.0.1003.0
+    target=libgstpbutils-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstpbutils-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstriff-1.0.so target=libgstriff-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstriff-1.0.so.0 \
-    target=libgstriff-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstriff-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1003.0
+    target=libgstriff-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstriff-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstrtsp-1.0.so.0 \
-    target=libgstrtsp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstrtsp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgsttag-1.0.so target=libgsttag-1.0.so.0.1003.0
-link path=usr/lib/$(MACH64)/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgsttag-1.0.so.0.1003.0
+    target=libgstrtsp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstrtsp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgsttag-1.0.so target=libgsttag-1.0.so.0.1200.0
+link path=usr/lib/$(MACH64)/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgsttag-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstvideo-1.0.so \
-    target=libgstvideo-1.0.so.0.1003.0
+    target=libgstvideo-1.0.so.0.1200.0
 link path=usr/lib/$(MACH64)/libgstvideo-1.0.so.0 \
-    target=libgstvideo-1.0.so.0.1003.0
-file path=usr/lib/$(MACH64)/libgstvideo-1.0.so.0.1003.0
+    target=libgstvideo-1.0.so.0.1200.0
+file path=usr/lib/$(MACH64)/libgstvideo-1.0.so.0.1200.0
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-allocators-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-app-1.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gstreamer-audio-1.0.pc
@@ -242,13 +246,15 @@ file path=usr/lib/gstreamer-1.0/libgstaudioconvert.so
 file path=usr/lib/gstreamer-1.0/libgstaudiorate.so
 file path=usr/lib/gstreamer-1.0/libgstaudioresample.so
 file path=usr/lib/gstreamer-1.0/libgstaudiotestsrc.so
-file path=usr/lib/gstreamer-1.0/libgstencodebin.so
+file path=usr/lib/gstreamer-1.0/libgstencoding.so
 file path=usr/lib/gstreamer-1.0/libgstgio.so
 file path=usr/lib/gstreamer-1.0/libgstlibvisual.so
 file path=usr/lib/gstreamer-1.0/libgstogg.so
 file path=usr/lib/gstreamer-1.0/libgstopus.so
 file path=usr/lib/gstreamer-1.0/libgstpango.so
+file path=usr/lib/gstreamer-1.0/libgstpbtypes.so
 file path=usr/lib/gstreamer-1.0/libgstplayback.so
+file path=usr/lib/gstreamer-1.0/libgstrawparse.so
 file path=usr/lib/gstreamer-1.0/libgstsubparse.so
 file path=usr/lib/gstreamer-1.0/libgsttcp.so
 file path=usr/lib/gstreamer-1.0/libgsttheora.so
@@ -262,40 +268,40 @@ file path=usr/lib/gstreamer-1.0/libgstvorbis.so
 file path=usr/lib/gstreamer-1.0/libgstximagesink.so
 file path=usr/lib/gstreamer-1.0/libgstxvimagesink.so
 link path=usr/lib/libgstallocators-1.0.so \
-    target=libgstallocators-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
 link path=usr/lib/libgstallocators-1.0.so.0 \
-    target=libgstallocators-1.0.so.0.1003.0
-file path=usr/lib/libgstallocators-1.0.so.0.1003.0
-link path=usr/lib/libgstapp-1.0.so target=libgstapp-1.0.so.0.1003.0
-link path=usr/lib/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1003.0
-file path=usr/lib/libgstapp-1.0.so.0.1003.0
-link path=usr/lib/libgstaudio-1.0.so target=libgstaudio-1.0.so.0.1003.0
-link path=usr/lib/libgstaudio-1.0.so.0 target=libgstaudio-1.0.so.0.1003.0
-file path=usr/lib/libgstaudio-1.0.so.0.1003.0
-link path=usr/lib/libgstfft-1.0.so target=libgstfft-1.0.so.0.1003.0
-link path=usr/lib/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1003.0
-file path=usr/lib/libgstfft-1.0.so.0.1003.0
-link path=usr/lib/libgstpbutils-1.0.so target=libgstpbutils-1.0.so.0.1003.0
-link path=usr/lib/libgstpbutils-1.0.so.0 target=libgstpbutils-1.0.so.0.1003.0
-file path=usr/lib/libgstpbutils-1.0.so.0.1003.0
-link path=usr/lib/libgstriff-1.0.so target=libgstriff-1.0.so.0.1003.0
-link path=usr/lib/libgstriff-1.0.so.0 target=libgstriff-1.0.so.0.1003.0
-file path=usr/lib/libgstriff-1.0.so.0.1003.0
-link path=usr/lib/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1003.0
-file path=usr/lib/libgstrtp-1.0.so.0.1003.0
-link path=usr/lib/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1003.0
-link path=usr/lib/libgstrtsp-1.0.so.0 target=libgstrtsp-1.0.so.0.1003.0
-file path=usr/lib/libgstrtsp-1.0.so.0.1003.0
-link path=usr/lib/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1003.0
-file path=usr/lib/libgstsdp-1.0.so.0.1003.0
-link path=usr/lib/libgsttag-1.0.so target=libgsttag-1.0.so.0.1003.0
-link path=usr/lib/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1003.0
-file path=usr/lib/libgsttag-1.0.so.0.1003.0
-link path=usr/lib/libgstvideo-1.0.so target=libgstvideo-1.0.so.0.1003.0
-link path=usr/lib/libgstvideo-1.0.so.0 target=libgstvideo-1.0.so.0.1003.0
-file path=usr/lib/libgstvideo-1.0.so.0.1003.0
+    target=libgstallocators-1.0.so.0.1200.0
+file path=usr/lib/libgstallocators-1.0.so.0.1200.0
+link path=usr/lib/libgstapp-1.0.so target=libgstapp-1.0.so.0.1200.0
+link path=usr/lib/libgstapp-1.0.so.0 target=libgstapp-1.0.so.0.1200.0
+file path=usr/lib/libgstapp-1.0.so.0.1200.0
+link path=usr/lib/libgstaudio-1.0.so target=libgstaudio-1.0.so.0.1200.0
+link path=usr/lib/libgstaudio-1.0.so.0 target=libgstaudio-1.0.so.0.1200.0
+file path=usr/lib/libgstaudio-1.0.so.0.1200.0
+link path=usr/lib/libgstfft-1.0.so target=libgstfft-1.0.so.0.1200.0
+link path=usr/lib/libgstfft-1.0.so.0 target=libgstfft-1.0.so.0.1200.0
+file path=usr/lib/libgstfft-1.0.so.0.1200.0
+link path=usr/lib/libgstpbutils-1.0.so target=libgstpbutils-1.0.so.0.1200.0
+link path=usr/lib/libgstpbutils-1.0.so.0 target=libgstpbutils-1.0.so.0.1200.0
+file path=usr/lib/libgstpbutils-1.0.so.0.1200.0
+link path=usr/lib/libgstriff-1.0.so target=libgstriff-1.0.so.0.1200.0
+link path=usr/lib/libgstriff-1.0.so.0 target=libgstriff-1.0.so.0.1200.0
+file path=usr/lib/libgstriff-1.0.so.0.1200.0
+link path=usr/lib/libgstrtp-1.0.so target=libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/libgstrtp-1.0.so.0 target=libgstrtp-1.0.so.0.1200.0
+file path=usr/lib/libgstrtp-1.0.so.0.1200.0
+link path=usr/lib/libgstrtsp-1.0.so target=libgstrtsp-1.0.so.0.1200.0
+link path=usr/lib/libgstrtsp-1.0.so.0 target=libgstrtsp-1.0.so.0.1200.0
+file path=usr/lib/libgstrtsp-1.0.so.0.1200.0
+link path=usr/lib/libgstsdp-1.0.so target=libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/libgstsdp-1.0.so.0 target=libgstsdp-1.0.so.0.1200.0
+file path=usr/lib/libgstsdp-1.0.so.0.1200.0
+link path=usr/lib/libgsttag-1.0.so target=libgsttag-1.0.so.0.1200.0
+link path=usr/lib/libgsttag-1.0.so.0 target=libgsttag-1.0.so.0.1200.0
+file path=usr/lib/libgsttag-1.0.so.0.1200.0
+link path=usr/lib/libgstvideo-1.0.so target=libgstvideo-1.0.so.0.1200.0
+link path=usr/lib/libgstvideo-1.0.so.0 target=libgstvideo-1.0.so.0.1200.0
+file path=usr/lib/libgstvideo-1.0.so.0.1200.0
 file path=usr/lib/pkgconfig/gstreamer-allocators-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-app-1.0.pc
 file path=usr/lib/pkgconfig/gstreamer-audio-1.0.pc
@@ -333,6 +339,7 @@ file path=usr/share/locale/es/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/eu/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/fi/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/fr/LC_MESSAGES/gst-plugins-base-1.0.mo
+file path=usr/share/locale/fur/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/gl/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/hr/LC_MESSAGES/gst-plugins-base-1.0.mo
 file path=usr/share/locale/hu/LC_MESSAGES/gst-plugins-base-1.0.mo


### PR DESCRIPTION
One plugin was moved from bad to good: gst-plugins-bad1 should be uninstalled before the update on the build server.