### PR TITLE
Bump lcms2 to 2.8

### DIFF
--- a/components/library/lcms2/Makefile
+++ b/components/library/lcms2/Makefile
@@ -18,13 +18,12 @@
 #
 # CDDL HEADER END
 #
-# Copyright (c) 2015, Aurelien Larcher 
+# Copyright (c) 2015-2017, Aurelien Larcher 
 #
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =        lcms2
-COMPONENT_VERSION=      2.7
-COMPONENT_REVISION=     1
+COMPONENT_VERSION=      2.8
 COMPONENT_FMRI=         library/lcms2
 COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_SUMMARY=      The Little Color Management System
@@ -32,11 +31,10 @@ COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  http://www.littlecms.com/
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-    sha256:4524234ae7de185e6b6da5d31d6875085b2198bc63b1211f7dde6e2d197d6a53
-COMPONENT_ARCHIVE_URL=  http://sourceforge.net/projects/lcms/files/lcms/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	      utility/lcms2
+  sha256:66d02b229d2ea9474e62c2b6cd6720fde946155cd1d0d2bffdab829790a0fb22
+COMPONENT_ARCHIVE_URL=  \
+  http://sourceforge.net/projects/lcms/files/lcms/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=      MIT
-COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk

--- a/components/library/lcms2/lcms2.p5m
+++ b/components/library/lcms2/lcms2.p5m
@@ -34,13 +34,13 @@ file path=usr/bin/tificc
 file path=usr/bin/transicc
 file path=usr/include/lcms2/lcms2.h
 file path=usr/include/lcms2/lcms2_plugin.h
-link path=usr/lib/$(MACH64)/liblcms2.so target=liblcms2.so.2.0.7
-link path=usr/lib/$(MACH64)/liblcms2.so.2 target=liblcms2.so.2.0.7
-file path=usr/lib/$(MACH64)/liblcms2.so.2.0.7
+link path=usr/lib/$(MACH64)/liblcms2.so target=liblcms2.so.2.0.8
+link path=usr/lib/$(MACH64)/liblcms2.so.2 target=liblcms2.so.2.0.8
+file path=usr/lib/$(MACH64)/liblcms2.so.2.0.8
 file path=usr/lib/$(MACH64)/pkgconfig/lcms2.pc
-link path=usr/lib/liblcms2.so target=liblcms2.so.2.0.7
-link path=usr/lib/liblcms2.so.2 target=liblcms2.so.2.0.7
-file path=usr/lib/liblcms2.so.2.0.7
+link path=usr/lib/liblcms2.so target=liblcms2.so.2.0.8
+link path=usr/lib/liblcms2.so.2 target=liblcms2.so.2.0.8
+file path=usr/lib/liblcms2.so.2.0.8
 file path=usr/lib/pkgconfig/lcms2.pc
 file path=usr/share/man/man1/jpgicc.1
 file path=usr/share/man/man1/tificc.1

--- a/components/library/lcms2/manifests/sample-manifest.p5m
+++ b/components/library/lcms2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -34,13 +34,13 @@ file path=usr/bin/tificc
 file path=usr/bin/transicc
 file path=usr/include/lcms2/lcms2.h
 file path=usr/include/lcms2/lcms2_plugin.h
-link path=usr/lib/$(MACH64)/liblcms2.so target=liblcms2.so.2.0.7
-link path=usr/lib/$(MACH64)/liblcms2.so.2 target=liblcms2.so.2.0.7
-file path=usr/lib/$(MACH64)/liblcms2.so.2.0.7
+link path=usr/lib/$(MACH64)/liblcms2.so target=liblcms2.so.2.0.8
+link path=usr/lib/$(MACH64)/liblcms2.so.2 target=liblcms2.so.2.0.8
+file path=usr/lib/$(MACH64)/liblcms2.so.2.0.8
 file path=usr/lib/$(MACH64)/pkgconfig/lcms2.pc
-link path=usr/lib/liblcms2.so target=liblcms2.so.2.0.7
-link path=usr/lib/liblcms2.so.2 target=liblcms2.so.2.0.7
-file path=usr/lib/liblcms2.so.2.0.7
+link path=usr/lib/liblcms2.so target=liblcms2.so.2.0.8
+link path=usr/lib/liblcms2.so.2 target=liblcms2.so.2.0.8
+file path=usr/lib/liblcms2.so.2.0.8
 file path=usr/lib/pkgconfig/lcms2.pc
 file path=usr/share/man/man1/jpgicc.1
 file path=usr/share/man/man1/tificc.1


### PR DESCRIPTION
ABI compatible: https://abi-laboratory.pro/tracker/timeline/lcms2/