### PR TITLE
Bump libass to 0.13.4

### DIFF
--- a/components/library/libass/Makefile
+++ b/components/library/libass/Makefile
@@ -16,25 +16,26 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libass
-COMPONENT_VERSION= 0.12.3
+COMPONENT_VERSION= 0.13.4
+COMPONENT_FMRI = library/video/libass
 COMPONENT_SUMMARY= Portable renderer for the ASS/SSA (Substation Alpha) subtitle format
+COMPONENT_CLASSIFICATION = System/Multimedia Libraries
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:5aa6b02b00de7aa2d795e8afa77def47485fcc68a190f4326b6e4d40aee30560
+  sha256:6711469df5fcc47d06e92f7383dcebcf1282591002d2356057997e8936840792
 COMPONENT_ARCHIVE_URL= \
   https://github.com/libass/libass/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://github.com/libass/libass
 COMPONENT_LICENSE = ISC
 COMPONENT_LICENSE_FILE = COPYING
-COMPONENT_CLASSIFICATION = System/Multimedia Libraries
-COMPONENT_FMRI = library/video/libass
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 CONFIGURE_OPTIONS += --disable-asm
+CONFIGURE_OPTIONS += --disable-static
 
 build: $(BUILD_32_and_64)
 

--- a/components/library/libass/libass.p5m
+++ b/components/library/libass/libass.p5m
@@ -24,11 +24,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.5.1.2
-link path=usr/lib/$(MACH64)/libass.so.5 target=libass.so.5.1.2
-file path=usr/lib/$(MACH64)/libass.so.5.1.2
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.5.3.2
+link path=usr/lib/$(MACH64)/libass.so.5 target=libass.so.5.3.2
+file path=usr/lib/$(MACH64)/libass.so.5.3.2
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-link path=usr/lib/libass.so target=libass.so.5.1.2
-link path=usr/lib/libass.so.5 target=libass.so.5.1.2
-file path=usr/lib/libass.so.5.1.2
+link path=usr/lib/libass.so target=libass.so.5.3.2
+link path=usr/lib/libass.so.5 target=libass.so.5.3.2
+file path=usr/lib/libass.so.5.3.2
 file path=usr/lib/pkgconfig/libass.pc

--- a/components/library/libass/manifests/sample-manifest.p5m
+++ b/components/library/libass/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,13 +24,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-file path=usr/lib/$(MACH64)/libass.a
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.5.1.2
-link path=usr/lib/$(MACH64)/libass.so.5 target=libass.so.5.1.2
-file path=usr/lib/$(MACH64)/libass.so.5.1.2
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.5.3.2
+link path=usr/lib/$(MACH64)/libass.so.5 target=libass.so.5.3.2
+file path=usr/lib/$(MACH64)/libass.so.5.3.2
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-file path=usr/lib/libass.a
-link path=usr/lib/libass.so target=libass.so.5.1.2
-link path=usr/lib/libass.so.5 target=libass.so.5.1.2
-file path=usr/lib/libass.so.5.1.2
+link path=usr/lib/libass.so target=libass.so.5.3.2
+link path=usr/lib/libass.so.5 target=libass.so.5.3.2
+file path=usr/lib/libass.so.5.3.2
 file path=usr/lib/pkgconfig/libass.pc


### PR DESCRIPTION
ABI compatible: https://abi-laboratory.pro/tracker/timeline/libass/