### PR TITLE
Bump libwebp to 0.6.0

### DIFF
--- a/components/library/libwebp/Makefile
+++ b/components/library/libwebp/Makefile
@@ -16,22 +16,33 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libwebp
-COMPONENT_VERSION= 0.4.0
+COMPONENT_VERSION= 0.6.0
+COMPONENT_FMRI= library/libwebp 
 COMPONENT_SUMMARY= WebP image format library
+COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:31913577e96386556855b41d210736449445fe96cfbe9289014e9b8afa944d69
+  sha256:e1bd8b81098b8094edba0f161baf89f9fb1492e3fca19cf1d28eff4b88518702
 COMPONENT_ARCHIVE_URL= \
-  http://webp.googlecode.com/files/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = https://developers.google.com/speed/webp/
+  https://github.com/webmproject/libwebp/archive/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_PROJECT_URL = https://github.com/webmproject/
+COMPONENT_LICENSE= BSD
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
+COMPONENT_PREP_ACTION= ( cd $(@D); sh autogen.sh; )
+
+# build with the distribution preferred libjpeg implementation
+CFLAGS   += $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
+CXXFLAGS += $(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
+LDFLAGS  += $(JPEG_LDFLAGS)
+
+CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --sysconfdir=/etc
 
 build: $(BUILD_32_and_64)
@@ -39,3 +50,10 @@ build: $(BUILD_32_and_64)
 install: $(INSTALL_32_and_64)
 
 test: $(NO_TESTS)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += image/library/libjpeg8-turbo
+REQUIRED_PACKAGES += image/library/libpng16
+REQUIRED_PACKAGES += image/library/libtiff
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/library/libwebp/libwebp.license
+++ b/components/library/libwebp/libwebp.license
@@ -1,0 +1,30 @@
+Copyright (c) 2010, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of Google nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/components/library/libwebp/libwebp.p5m
+++ b/components/library/libwebp/libwebp.p5m
@@ -1,10 +1,11 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL"). You may
-# only use this file in accordance with the terms of the CDDL.
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 
@@ -12,14 +13,14 @@
 # Copyright 2014 Alexander Pyhalov. All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/libwebp@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
-set name=info.classification value=org.opensolaris.category.2008:System/Libraries
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license COPYING license='BSD'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/$(MACH64)/cwebp
 file path=usr/bin/$(MACH64)/dwebp
@@ -28,13 +29,13 @@ file path=usr/bin/dwebp
 file path=usr/include/webp/decode.h
 file path=usr/include/webp/encode.h
 file path=usr/include/webp/types.h
-link path=usr/lib/$(MACH64)/libwebp.so target=libwebp.so.5.0.0
-link path=usr/lib/$(MACH64)/libwebp.so.5 target=libwebp.so.5.0.0
-file path=usr/lib/$(MACH64)/libwebp.so.5.0.0
+link path=usr/lib/$(MACH64)/libwebp.so target=libwebp.so.7.0.0
+link path=usr/lib/$(MACH64)/libwebp.so.7 target=libwebp.so.7.0.0
+file path=usr/lib/$(MACH64)/libwebp.so.7.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libwebp.pc
-link path=usr/lib/libwebp.so target=libwebp.so.5.0.0
-link path=usr/lib/libwebp.so.5 target=libwebp.so.5.0.0
-file path=usr/lib/libwebp.so.5.0.0
+link path=usr/lib/libwebp.so target=libwebp.so.7.0.0
+link path=usr/lib/libwebp.so.7 target=libwebp.so.7.0.0
+file path=usr/lib/libwebp.so.7.0.0
 file path=usr/lib/pkgconfig/libwebp.pc
 file path=usr/share/man/man1/cwebp.1
 file path=usr/share/man/man1/dwebp.1

--- a/components/library/libwebp/manifests/sample-manifest.p5m
+++ b/components/library/libwebp/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -29,15 +29,13 @@ file path=usr/bin/dwebp
 file path=usr/include/webp/decode.h
 file path=usr/include/webp/encode.h
 file path=usr/include/webp/types.h
-file path=usr/lib/$(MACH64)/libwebp.a
-link path=usr/lib/$(MACH64)/libwebp.so target=libwebp.so.5.0.0
-link path=usr/lib/$(MACH64)/libwebp.so.5 target=libwebp.so.5.0.0
-file path=usr/lib/$(MACH64)/libwebp.so.5.0.0
+link path=usr/lib/$(MACH64)/libwebp.so target=libwebp.so.7.0.0
+link path=usr/lib/$(MACH64)/libwebp.so.7 target=libwebp.so.7.0.0
+file path=usr/lib/$(MACH64)/libwebp.so.7.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libwebp.pc
-file path=usr/lib/libwebp.a
-link path=usr/lib/libwebp.so target=libwebp.so.5.0.0
-link path=usr/lib/libwebp.so.5 target=libwebp.so.5.0.0
-file path=usr/lib/libwebp.so.5.0.0
+link path=usr/lib/libwebp.so target=libwebp.so.7.0.0
+link path=usr/lib/libwebp.so.7 target=libwebp.so.7.0.0
+file path=usr/lib/libwebp.so.7.0.0
 file path=usr/lib/pkgconfig/libwebp.pc
 file path=usr/share/man/man1/cwebp.1
 file path=usr/share/man/man1/dwebp.1


### PR DESCRIPTION
Not ABI compatible.
Wait for corresponding PR for rebuilding components:
> pkg search -r -o pkg.name 'depend:require:library/libwebp'
PKG.NAME
image/graphicsmagick
image/imagemagick
library/desktop/webkitgtk2
library/gd

Could be merged with the update of imagemagick, will bump revision in the same PR when we decide about it.