### PR TITLE
Bump gawk to 4.1.4

### DIFF
--- a/components/text/gawk/Makefile
+++ b/components/text/gawk/Makefile
@@ -19,41 +19,57 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, Aurelien Larcher
 #
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gawk
-COMPONENT_VERSION=	4.1.3
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	4.1.4
+COMPONENT_FMRI=	text/gawk
+COMPONENT_SUMMARY=	GNU awk
+COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/gawk/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:e3cf55e91e31ea2845f8338bedd91e40671fc30e4d82ea147d220e687abda625
+    sha256:53e184e2d0f90def9207860531802456322be091c7b48f23fdc79cda65adc266
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/gawk/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	utility/gawk
+COMPONENT_LICENSE=	GPLv3, FDLv1.3
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 CFLAGS+= -std=c89
+CFLAGS+= -I$(USRINCDIR)/mpfr -I$(USRINCDIR)/gmp
 
 CONFIGURE_OPTIONS	+=	--infodir=$(CONFIGURE_INFODIR)
 CONFIGURE_OPTIONS	+=	--libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
+CONFIGURE_OPTIONS	+=	--with-mpfr=$(LIBDIR.$(BITS))
 
-COMPONENT_TEST_TRANSFORMS += '-e "/\/usr\/gnu\/bin\/make/d"' 
+CONFIGURE_BINDIR.64 = $(CONFIGURE_BINDIR.32)
+
+COMPONENT_TEST_ENV+= LANG=C LC_ALL=C
+
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "/\/usr\/gnu\/bin\/make/d" ' \
+	'-e "/^make/d" ' \
+	'-e "/^Making/d" ' \
+	'-e "/^--- _/d" ' \
+	'-e "s|\(\*\*\* \\$$(SOURCE_DIR)/test/[^[:space:]]*\).*|\1|g" '
 
 # common targets
-build:		$(BUILD_32)
+build:		$(BUILD_64)
 
-install:	$(INSTALL_32)
+install:	$(INSTALL_64)
 
-test:		$(TEST_32)
+test:		$(TEST_64)
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += library/gmp
 REQUIRED_PACKAGES += library/libsigsegv
+REQUIRED_PACKAGES += library/mpfr
 REQUIRED_PACKAGES += library/readline
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/text/gawk/gawk.p5m
+++ b/components/text/gawk/gawk.p5m
@@ -1,58 +1,44 @@
 #
-# CDDL HEADER START
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
-# The contents of this file are subject to the terms of the
-# Common Development and Distribution License (the "License").
-# You may not use this file except in compliance with the License.
-#
-# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-# or http://www.opensolaris.org/os/licensing.
-# See the License for the specific language governing permissions
-# and limitations under the License.
-#
-# When distributing Covered Code, include this CDDL HEADER in each
-# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-# If applicable, add the following below this CDDL HEADER, with the
-# fields enclosed by brackets "[]" replaced with your own identifying
-# information: Portions Copyright [yyyy] [name of copyright owner]
-#
-# CDDL HEADER END
-#
-# Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
-set name=pkg.fmri \
-    value=pkg:/text/gawk@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.description \
-    value="The awk utility interprets a special-purpose programming language that makes it possible to handle many data-reformatting jobs with just a few lines of code."
-set name=pkg.summary value="GNU awk"
-set name=com.oracle.info.description value="GNU awk"
-set name=com.oracle.info.tpno value=6808
-set name=info.classification \
-    value="org.opensolaris.category.2008:Applications/System Utilities"
-set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+#
+# Copyright 2017 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
-set name=org.opensolaris.arc-caseid \
-    value=PSARC/2008/594
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
 file usr/bin/gawk path=usr/gnu/bin/awk
 file path=usr/bin/igawk
 file path=usr/include/gawkapi.h
-file path=usr/lib/awk/grcat mode=0555
-file path=usr/lib/awk/pwcat mode=0555
-file path=usr/lib/gawk/filefuncs.so
-file path=usr/lib/gawk/fnmatch.so
-file path=usr/lib/gawk/fork.so
-file path=usr/lib/gawk/inplace.so
-file path=usr/lib/gawk/ordchr.so
-file path=usr/lib/gawk/readdir.so
-file path=usr/lib/gawk/readfile.so
-file path=usr/lib/gawk/revoutput.so
-file path=usr/lib/gawk/revtwoway.so
-file path=usr/lib/gawk/rwarray.so
-file path=usr/lib/gawk/testext.so
-file path=usr/lib/gawk/time.so
+file path=usr/lib/$(MACH64)/awk/grcat mode=0555
+file path=usr/lib/$(MACH64)/awk/pwcat mode=0555
+file path=usr/lib/$(MACH64)/gawk/filefuncs.so
+file path=usr/lib/$(MACH64)/gawk/fnmatch.so
+file path=usr/lib/$(MACH64)/gawk/fork.so
+file path=usr/lib/$(MACH64)/gawk/inplace.so
+file path=usr/lib/$(MACH64)/gawk/ordchr.so
+file path=usr/lib/$(MACH64)/gawk/readdir.so
+file path=usr/lib/$(MACH64)/gawk/readfile.so
+file path=usr/lib/$(MACH64)/gawk/revoutput.so
+file path=usr/lib/$(MACH64)/gawk/revtwoway.so
+file path=usr/lib/$(MACH64)/gawk/rwarray.so
+file path=usr/lib/$(MACH64)/gawk/testext.so
+file path=usr/lib/$(MACH64)/gawk/time.so
 file path=usr/share/awk/assert.awk
 file path=usr/share/awk/bits2str.awk
 file path=usr/share/awk/cliff_rand.awk
@@ -85,6 +71,7 @@ file path=usr/share/locale/de/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/es/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/fi/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/fr/LC_MESSAGES/gawk.mo
+file path=usr/share/locale/id/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/it/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/ja/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/ms/LC_MESSAGES/gawk.mo
@@ -92,9 +79,11 @@ file path=usr/share/locale/nl/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/pl/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/sv/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/vi/LC_MESSAGES/gawk.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/gawk.mo
 file usr/share/man/man1/gawk.1 path=usr/gnu/share/man/man1/awk.1
 file path=usr/share/man/man1/igawk.1
-license gawk.license license="GPLv3, FDLv1.3"
+
+# Compatibility links
 link path=usr/bin/gawk target=../gnu/bin/awk facet.compat.gnulinks=true
 link path=usr/share/man/man1/gawk.1 \
     target=../../../gnu/share/man/man1/awk.1 facet.compat.gnulinks=all

--- a/components/text/gawk/manifests/sample-manifest.p5m
+++ b/components/text/gawk/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,24 +23,24 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 link path=usr/bin/awk target=gawk
-file path=usr/bin/gawk
-hardlink path=usr/bin/gawk-$(COMPONENT_VERSION) target=gawk
+hardlink path=usr/bin/gawk target=gawk-$(COMPONENT_VERSION)
+file path=usr/bin/gawk-$(COMPONENT_VERSION)
 file path=usr/bin/igawk
 file path=usr/include/gawkapi.h
-file path=usr/lib/awk/grcat
-file path=usr/lib/awk/pwcat
-file path=usr/lib/gawk/filefuncs.so
-file path=usr/lib/gawk/fnmatch.so
-file path=usr/lib/gawk/fork.so
-file path=usr/lib/gawk/inplace.so
-file path=usr/lib/gawk/ordchr.so
-file path=usr/lib/gawk/readdir.so
-file path=usr/lib/gawk/readfile.so
-file path=usr/lib/gawk/revoutput.so
-file path=usr/lib/gawk/revtwoway.so
-file path=usr/lib/gawk/rwarray.so
-file path=usr/lib/gawk/testext.so
-file path=usr/lib/gawk/time.so
+file path=usr/lib/$(MACH64)/awk/grcat
+file path=usr/lib/$(MACH64)/awk/pwcat
+file path=usr/lib/$(MACH64)/gawk/filefuncs.so
+file path=usr/lib/$(MACH64)/gawk/fnmatch.so
+file path=usr/lib/$(MACH64)/gawk/fork.so
+file path=usr/lib/$(MACH64)/gawk/inplace.so
+file path=usr/lib/$(MACH64)/gawk/ordchr.so
+file path=usr/lib/$(MACH64)/gawk/readdir.so
+file path=usr/lib/$(MACH64)/gawk/readfile.so
+file path=usr/lib/$(MACH64)/gawk/revoutput.so
+file path=usr/lib/$(MACH64)/gawk/revtwoway.so
+file path=usr/lib/$(MACH64)/gawk/rwarray.so
+file path=usr/lib/$(MACH64)/gawk/testext.so
+file path=usr/lib/$(MACH64)/gawk/time.so
 file path=usr/share/awk/assert.awk
 file path=usr/share/awk/bits2str.awk
 file path=usr/share/awk/cliff_rand.awk
@@ -74,6 +74,7 @@ file path=usr/share/locale/de/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/es/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/fi/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/fr/LC_MESSAGES/gawk.mo
+file path=usr/share/locale/id/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/it/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/ja/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/ms/LC_MESSAGES/gawk.mo
@@ -81,6 +82,7 @@ file path=usr/share/locale/nl/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/pl/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/sv/LC_MESSAGES/gawk.mo
 file path=usr/share/locale/vi/LC_MESSAGES/gawk.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/gawk.mo
 file path=usr/share/man/man1/gawk.1
 file path=usr/share/man/man1/igawk.1
 file path=usr/share/man/man3/filefuncs.3am

--- a/components/text/gawk/test/results-64.master
+++ b/components/text/gawk/test/results-64.master
@@ -1,28 +1,3 @@
-make[1]: Entering directory '$(@D)'
-Making check in .
-make[2]: Entering directory '$(@D)'
-make[3]: Entering directory '$(@D)'
-make[3]: Leaving directory '$(@D)'
-make[2]: Leaving directory '$(@D)'
-Making check in doc
-make[2]: Entering directory '$(@D)/doc'
-make[2]: Nothing to be done for 'check'.
-make[2]: Leaving directory '$(@D)/doc'
-Making check in awklib
-make[2]: Entering directory '$(@D)/awklib'
-make[2]: Nothing to be done for 'check'.
-make[2]: Leaving directory '$(@D)/awklib'
-Making check in po
-make[2]: Entering directory '$(@D)/po'
-make[2]: Nothing to be done for 'check'.
-make[2]: Leaving directory '$(@D)/po'
-Making check in extension
-make[2]: Entering directory '$(@D)/extension'
-make[3]: Entering directory '$(@D)/extension'
-make[3]: Leaving directory '$(@D)/extension'
-make[2]: Leaving directory '$(@D)/extension'
-Making check in test
-make[2]: Entering directory '$(@D)/test'
 
 Any output from "cmp" is bad news, although some differences
 in floating point values are probably benign -- in particular,
@@ -36,6 +11,7 @@ Locale environment:
 addcomma
 anchgsub
 argarray
+arrayind1
 arrayparm
 arrayprm2
 arrayprm3
@@ -55,6 +31,7 @@ aryprm5
 aryprm6
 aryprm7
 aryprm8
+aryprm9
 arysubnm
 asgext
 awkpath
@@ -102,6 +79,7 @@ fordel
 forref
 forsimp
 fsbs
+fsnul1
 fsrs
 fsspcoln
 fstabplus
@@ -126,6 +104,7 @@ gsubtst6
 gsubtst7
 gsubtst8
 hex
+hex2
 hsprint
 inpref
 inputred
@@ -164,6 +143,7 @@ noloop2
 nonl
 noparms
 nors
+nulinsrc
 nulrsend
 numindex
 numsubstr
@@ -173,6 +153,7 @@ ofmta
 ofmtbig
 ofmtfidl
 ofmts
+ofmtstrnum
 ofs1
 onlynl
 opasnidx
@@ -198,6 +179,7 @@ prt1eval
 prtoeval
 rand
 range1
+readbuf
 rebrackloc
 rebt8b1
 redfilnm
@@ -211,6 +193,7 @@ reparse
 resplit
 rri1
 rs
+rscompat
 rsnul1nl
 rsnulbig
 rsnulbig2
@@ -223,6 +206,7 @@ rswhite
 scalar
 sclforin
 sclifin
+sigpipe1
 sortempty
 sortglos
 splitargv
@@ -234,6 +218,7 @@ strcat1
 strnum1
 strtod
 subamp
+subback
 subi18n
 subsepnm
 subslash
@@ -290,6 +275,10 @@ binmode1
 charasbytes
 colonwarn
 clos1way
+clos1way2
+clos1way3
+clos1way4
+clos1way5
 crlf
 dbugeval
 delsub
@@ -303,6 +292,7 @@ fpat1
 fpat2
 fpat3
 fpat4
+fpat5
 fpatnull
 fsfwfs
 funlen
@@ -341,11 +331,14 @@ indirectcall2
 lint
 lintold
 lintwarn
+mixed1
 manyfiles
 match1
 match2
 match3
 mbstr1
+mbstr2
+muldimposix
 nastyparm
 negtime
 next
@@ -367,6 +360,7 @@ profile4
 profile5
 profile6
 profile7
+profile8
 pty1
 rebuf
 regnul1
@@ -383,6 +377,7 @@ rsstart3
 rstest6
 shadow
 sortfor
+sortfor2
 sortu
 split_after_fpat
 splitarg4
@@ -398,6 +393,8 @@ symtab6
 symtab7
 symtab8
 symtab9
+symtab10
+watchpoint1
 ======== Done with gawk extension tests ========
 ======== Starting machine-specific tests ========
 double1
@@ -405,9 +402,35 @@ double2
 fmtspcl
 intformat
 ======== Done with machine-specific tests ========
-%%%%%%%%%% Inadequate locale support: skipping charset tests.
+======== Starting tests that can vary based on character set or locale support ========
+**************************************************************************
+* Some or all of these tests may fail if you have inadequate or missing  *
+* locale support. At least en_US.UTF-8, ru_RU.UTF-8 and ja_JP.UTF-8 are  *
+* needed. However, if you see this message, the Makefile thinks you have *
+* what you need ...                                                      *
+**************************************************************************
+asort
+asorti
+backbigs1
+backsmalls1
+$(SOURCE_DIR)/test/backsmalls1.ok _backsmalls1 differ: char 3, line 2
+backsmalls2
+fmttest
+fnarydel
+fnparydl
+jarebug
+lc_num1
+mbfw1
+mbprintf1
+mbprintf2
+mbprintf3
+mbprintf4
+rebt8b2
+rtlenmb
+sort1
+sprintfc
+======== Done with tests that can vary based on character set or locale support ========
 ======== Starting shared library tests ========
-make[3]: Entering directory '$(@D)/test'
 fnmatch
 filefuncs
 fork
@@ -427,13 +450,47 @@ revtwoway
 rwarray
 testext
 time
-make[3]: Leaving directory '$(@D)/test'
 ======== Done with shared library tests ========
 ======== Starting MPFR tests ========
-MPFR tests not supported on this system
+mpfrnr
+mpfrnegzero
+mpfrmemok1
+mpfrrem
+mpfrrnd
+mpfrieee
+mpfrexprange
+mpfrsort
+mpfrsqrt
+mpfrbigint
 ======== Done with MPFR tests ========
-make[3]: Entering directory '$(@D)/test'
-ALL TESTS PASSED
-make[3]: Leaving directory '$(@D)/test'
-make[2]: Leaving directory '$(@D)/test'
-make[1]: Leaving directory '$(@D)'
+1 TESTS FAILED
+for i in _* ; \
+do  \
+	if [ "$i" != "_*" ]; then \
+	echo ============== $i ============= ; \
+	base=`echo $i | sed 's/^_//'` ; \
+	if [ -r ${base}.ok ]; then \
+	diff -c ${base}.ok $i ; \
+	else \
+	diff -c "$(SOURCE_DIR)/test"/${base}.ok  $i ; \
+	fi ; \
+	fi ; \
+done | more
+============== _backsmalls1 =============
+*** $(SOURCE_DIR)/test/backsmalls1.ok
+***************
+*** 1,5 ****
+   
+-  
+   
+   
+   
+--- 1,4 ----
+***************
+*** 10,14 ****
+   
+   
+   
+-  
+  　
+--- 9,12 ----


### PR DESCRIPTION
Build moved to 64-bit and with MPFR support as issues have been reported againt non-MPFR 64-bit builds.
One test failure reported as related to locale support, happens also with 64-bit 4.1.3.
Two weeks of testing so far, need to check dependent packages.
