### PR TITLE
8152 guile build on SPARC hardware stops with USERLIMIT undeclared

### DIFF
--- a/components/library/guile/Makefile
+++ b/components/library/guile/Makefile
@@ -18,12 +18,14 @@
 #
 # CDDL HEADER END
 #
+# Copyright 2017 Gary Mills
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 #
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           guile
 COMPONENT_VERSION=        1.8.8
+COMPONENT_REVISION=       1
 COMPONENT_SUMMARY=        GNU guile utility
 COMPONENT_PROJECT_URL=    http://www.gnu.org/software/guile/
 COMPONENT_CLASSIFICATION= Development/Other Languages
@@ -39,7 +41,7 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-CONFIGURE_ENV+= CPP="/usr/bin/gcc -E"
+CONFIGURE_ENV+= CPP="$(GCC_ROOT)/bin/gcc -E"
 CONFIGURE_OPTIONS +=	CPPFLAGS="-I/usr/include/gmp -D__USE_LEGACY_PROTOTYPES__"
 CONFIGURE_OPTIONS +=	--disable-static 
 CONFIGURE_OPTIONS +=	--disable-error-on-warning

--- a/components/library/guile/patches/fix-solaris-stackbase-detection.patch
+++ b/components/library/guile/patches/fix-solaris-stackbase-detection.patch
@@ -1,0 +1,28 @@
+Problems with building guile version 1.8.8 on Solaris SPARC:
+
+.../components/guile/guile-1.8.8/libguile/gc_os_dep.c:720:37: error: 'USERLIMIT' undeclared (first use in this function)
+ #       define STACKBOTTOM ((ptr_t) USRSTACK)
+...
+
+See guile-devel email thread at:
+
+  https://lists.gnu.org/archive/html/guile-devel/2011-04/msg00236.html
+
+for more details.
+
+Upstream already know about this.
+
+--- guile-1.8.8/libguile/gc_os_dep.c.orig	Mon Dec 13 19:25:01 2010
++++ guile-1.8.8/libguile/gc_os_dep.c	Fri Apr 15 14:03:13 2011
+@@ -714,11 +714,8 @@
+ /*      # define STACKBOTTOM ((ptr_t)(_start)) worked through 2.7,      */
+ /*      but reportedly breaks under 2.8.  It appears that the stack     */
+ /*      base is a property of the executable, so this should not break  */
+ /*      old executables.                                                */
+-/*      HEURISTIC2 probably works, but this appears to be preferable.   */
+-#       include <sys/vm.h>
+-#       define STACKBOTTOM ((ptr_t) USRSTACK)
+ #	ifndef USE_MMAP
+ #	    define USE_MMAP
+ #	endif
+ #       ifdef USE_MMAP


### PR DESCRIPTION
This PR fixes 8152 by applying a well-known patch to gc_os_dep.c .  It only affects the SPARC build.  It also fixes the CPP definition recently added to Makefile .  With these changes, the library/guile component of oi-userland builds on both SPARC and x86 hardware.
