### PR TITLE
Vagrant: Support host IO cache on SATA, and, optionaly, SSD-aware fea…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,20 @@ Vagrant.configure("2") do |config|
 
     v.customize ["modifyvm", :id, "--memory", mem]
     v.customize ["modifyvm", :id, "--cpus", cpus]
+    v.customize ["storagectl", :id, "--name", "SATA Controller", "--hostiocache", "on"]
+    # Enable following line, if oi-userland directory is on non-rotational
+    # drive (e.g. SSD). (This could be automated, but with all those storage
+    # technologies (LVM, partitions, ...) on all three operationg systems,
+    # it's actually error prone to detect it automatically.) macOS has it
+    # enabled by default as recent Macs have SSD anyway.
+    if host =~ /darwin/
+      v.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 0, "--nonrotational", "on"]
+    else
+      #v.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 0, "--nonrotational", "on"]
+    end
+    # Should we ever support `--discard` option, we need to switch to VDI
+    # virtual disk format first.
+    #v.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 0, "--discard", "on"]
   end
 
   # Once vagrant is able to chown files on OpenIndiana, chown line should be

--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -47,6 +47,12 @@ provider is supported. Vagrant is suitable for cases when you don't have access 
 
   And restart.
 
+* If your VirtualBox home directory, usually `~username/VirtualBox VMs/`, is on SSD disk, enable `--nonrotational` configuration option in `Vagrantfile` in `oi-userland/` directory by uncommenting the respective line:
+
+  ```
+  v.customize ["storageattach", :id, "--storagectl", "SATA Controller", "--port", 0, "--nonrotational", "on"]
+  ```
+
 * Start the VM by running:
 
   ```


### PR DESCRIPTION
…tures

Host IO cache: trade IO speed for security on e.g. host power failure,
more here: https://www.virtualbox.org/manual/ch05.html#iocaching.

`--nonrotational` (optional): This switch allows to enable the
non-rotational flag for virtual hard disks. Some guests (i.e.
Windows 7+) treat such disks like SSDs and don't perform disk
fragmentation on such media.

`--discard` (not implemented): This switch enables the auto-discard
feature for the virtual hard disks. This specifies that a VDI image
will be shrunk in response to the trim command from the guest OS.

https://www.virtualbox.org/manual/ch08.html#vboxmanage-storageattach

Tested on openSUSE Leap 42.2 with Vagrant 1.9.5 from upstream RPM.