### PR TITLE
8153 openal build on oi_151a8 stops with pthread.h - not found

### DIFF
--- a/components/multimedia/openal/Makefile
+++ b/components/multimedia/openal/Makefile
@@ -10,6 +10,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright 2017 Alexander Pyhalov
 #
 
@@ -17,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= openal
 COMPONENT_VERSION= 1.16.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= OpenAL is a cross-platform 3D audio API
 COMPONENT_SRC= $(COMPONENT_NAME)-soft-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2

--- a/components/multimedia/openal/patches/04-solaris.patch
+++ b/components/multimedia/openal/patches/04-solaris.patch
@@ -1,0 +1,14 @@
+--- openal-soft-1.16.0/CMakeLists.txt-opch	   :: 
++++ openal-soft-1.16.0/CMakeLists.txt	   :: 
+@@ -62,8 +62,9 @@
+     SET(LIBNAME openal)
+ 
+     # These are needed on non-Windows systems for extra features
+-    ADD_DEFINITIONS(-D_GNU_SOURCE=1 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700)
+-    SET(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -D_GNU_SOURCE=1 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700")
++    # Old Solaris and illumos versions only know about 200112L and 600
++    ADD_DEFINITIONS(-D_GNU_SOURCE=1 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600)
++    SET(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -D_GNU_SOURCE=1 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600")
+ ENDIF()
+ 
+ # Set defines for large file support


### PR DESCRIPTION
This PR fixes 8153 with a patch that reduces the POSIX level in CMakeLists.txt from 200809 to 200112.  This change works with both old and new versions of OI because the code itself does not actually use any features from the higher level.
