### PR TITLE
8251 The babl component requires the GNU version of awk

### DIFF
--- a/components/library/babl/Makefile
+++ b/components/library/babl/Makefile
@@ -10,6 +10,7 @@
 #
 
 #
+# Copyright 2017 Gary Mills
 # Copyright 2017 Alexander Pyhalov
 #
 
@@ -17,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= babl
 COMPONENT_VERSION= 0.1.18
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= Babl is a dynamic, any to any, pixel format conversion library
 COMPONENT_FMRI = image/library/babl
 COMPONENT_CLASSIFICATION = System/Multimedia Libraries
@@ -34,8 +36,11 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
+# Need GNU version of awk
+export AWK=gawk
+
 COMPONENT_PREP_ACTION = ( cd $(@D)  && \
-                                autoreconf -f -i)
+                                autoreconf -f -i -I m4)
 
 
 CONFIGURE_OPTIONS+= --sysconfdir=$(ETCDIR)

--- a/components/library/babl/patches/01-no-pthread.patch
+++ b/components/library/babl/patches/01-no-pthread.patch
@@ -1,6 +1,6 @@
---- babl-0.1.18/tests/Makefile.am.~1~	2016-06-13 00:25:43.000000000 +0300
-+++ babl-0.1.18/tests/Makefile.am	2017-01-17 15:06:50.148609683 +0300
-@@ -31,7 +31,6 @@
+--- babl-0.1.10/tests/Makefile.am	2012-03-17 13:16:40.000000000 +0100
++++ babl-0.1.10/tests/Makefile.am	2014-03-15 10:21:07.343360636 +0100
+@@ -21,7 +21,6 @@
  
  AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/babl
  if OS_UNIX
@@ -8,16 +8,3 @@
  endif
  
  LDADD = $(top_builddir)/babl/libbabl-@BABL_API_VERSION@.la \
---- babl-0.1.18/configure.ac.~1~	2016-06-13 00:34:53.000000000 +0300
-+++ babl-0.1.18/configure.ac	2017-01-17 15:06:50.149283925 +0300
-@@ -119,9 +119,7 @@
- AC_PROG_CC
- AC_PROG_CC_C99
- 
--# Initialize libtool
--LT_PREREQ([2.2])
--LT_INIT([disable-static win32-dll])
-+AC_PROG_LIBTOOL
- 
- BABL_VARIADIC_MACROS
- 


### PR DESCRIPTION
This PR fixes 8251 for the library/babl component of oi-userland.  The Makefile exports the variable AWK that is used by the index.html.awk script to generate HTML files.  This bug may only appear when old versions of awk are in the PATH.  In addition, the Makefile adds the -I flag to autoreconf so that it will use macros from the m4 directory.  Finally, the change removes a portion of the 01-no-pthread.patch that changed the way that libtool was initialized in the configure script.  This portion of the patch is no longer required.

With these changes, the component builds successfully on both the SPARC and x86 hardware platforms.
