### PR TITLE
awesome requires lgi-53

### DIFF
--- a/components/desktop/awesome/Makefile
+++ b/components/desktop/awesome/Makefile
@@ -14,7 +14,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         awesome
-COMPONENT_REVISION=     1
+COMPONENT_REVISION=     2
 COMPONENT_VERSION=      4.1
 COMPONENT_PROJECT_URL=  https://awesomewm.org
 COMPONENT_SUMMARY=      A highly configurable, next generation framework window manager for X.

--- a/components/desktop/awesome/awesome.p5m
+++ b/components/desktop/awesome/awesome.p5m
@@ -22,6 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+depend type=require fmri=library/lua/lgi-53
+
 file path=usr/bin/awesome
 file path=usr/bin/awesome-client
 file path=usr/etc/xdg/awesome/rc.lua


### PR DESCRIPTION
Starting `awesome` without lgi-53 package fails:

```
$ awesome
error while running function!
stack traceback:
        [C]: in function 'require'
        /usr/share/awesome/lib/gears/color.lua:15: in main chunk
        [C]: in function 'require'
        /usr/share/awesome/lib/gears/init.lua:10: in main chunk
        [C]: in function 'require'
        /usr/etc/xdg/awesome/rc.lua:2: in main chunk
error: /usr/share/awesome/lib/gears/color.lua:15: module 'lgi' not
found:
        no field package.preload['lgi']
        no file '/usr/share/lua/5.3/lgi.lua'
        no file '/usr/share/lua/5.3/lgi/init.lua'
        no file '/usr/lib/lua/5.3/lgi.lua'
        no file '/usr/lib/lua/5.3/lgi/init.lua'
        no file './lgi.lua'
        no file './lgi/init.lua'
        no file '/export/home/newman/.config/awesome/lgi.lua'
        no file '/export/home/newman/.config/awesome/lgi/init.lua'
        no file '/etc/xdg/awesome/lgi.lua'
        no file '/etc/xdg/awesome/lgi/init.lua'
        no file '/usr/share/awesome/lib/lgi.lua'
        no file '/usr/share/awesome/lib/lgi/init.lua'
        no file '/usr/lib/lua/5.3/64/lgi.so'
        no file '/usr/lib/lua/5.3/64/loadall.so'
        no file './64/lgi.so'
        no file '/export/home/newman/.config/awesome/64/lgi.so'
        no file '/etc/xdg/awesome/64/lgi.so'
        no file '/usr/share/awesome/lib/64/lgi.so'
2017-06-22 02:26:39 E: awesome: main:774: couldn't find any rc file
```