### PR TITLE
enlightenment: update to 0.21.8, fix reboot/poweroff

### DIFF
--- a/components/desktop/e/enlightenment/Makefile
+++ b/components/desktop/e/enlightenment/Makefile
@@ -23,8 +23,7 @@
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         enlightenment
-COMPONENT_VERSION=      0.21.7
-COMPONENT_REVISION=     1
+COMPONENT_VERSION=      0.21.8
 COMPONENT_FMRI=         desktop/window-manager/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=System/X11
 COMPONENT_SUMMARY=      Enlightenment - The Compositing Window Manager and Desktop Shell
@@ -32,7 +31,7 @@ COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  http://enlightenment.org
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-    sha256:914a305d1d1d8f51f2ae0c6a6b5a69f7cb783f701ed4d5d49efb2d57c6807df6
+    sha256:44332443b39ac6f0563713c3d85acbbba0011dd7659e6b7d500ec09e05896197
 COMPONENT_ARCHIVE_URL= \
     http://download.enlightenment.org/rel/apps/$(COMPONENT_SRC_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=      BSD
@@ -43,6 +42,7 @@ include $(WS_MAKE_RULES)/ips.mk
 
 CONFIGURE_BINDIR.64=$(USRBINDIR)
 
+CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 CONFIGURE_OPTIONS+=	--enable-shared
 CONFIGURE_OPTIONS+=	--disable-static
 CONFIGURE_OPTIONS+=	--disable-temperature
@@ -50,7 +50,7 @@ CONFIGURE_OPTIONS+=	--disable-device-udev
 CONFIGURE_OPTIONS+= --disable-mount-udisks
 
 COMPONENT_PREP_ACTION= \
-    ( cd $(@D); aclocal -I m4 --install && autoconf && automake -a; ) 
+    ( cd $(@D); aclocal -I m4 --install && autoconf && automake -a; )
 
 build: $(BUILD_64)
 
@@ -59,6 +59,7 @@ install: $(INSTALL_64)
 test: $(NO_TESTS)
 
 REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += library/audio/pulseaudio
 REQUIRED_PACKAGES += library/e/efl
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/desktop/e/enlightenment/enlightenment.p5m
+++ b/components/desktop/e/enlightenment/enlightenment.p5m
@@ -22,9 +22,10 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-<transform file path=usr/lib/(.*)/module.so$ -> default mode 0555>
 <transform file path=usr/lib/$(MACH64)/enlightenment/utils/(.*)$ -> default mode 0555>
 
+file path=etc/enlightenment/sysactions.conf mode=0644 preserve=true
+file path=etc/xdg/menus/e-applications.menu
 file path=usr/bin/emixer
 file path=usr/bin/enlightenment
 file path=usr/bin/enlightenment_filemanager
@@ -32,8 +33,6 @@ file path=usr/bin/enlightenment_imc
 file path=usr/bin/enlightenment_open
 file path=usr/bin/enlightenment_remote
 file path=usr/bin/enlightenment_start
-file path=usr/etc/enlightenment/sysactions.conf
-file path=usr/etc/xdg/menus/e-applications.menu
 file path=usr/include/enlightenment/e.h
 file path=usr/include/enlightenment/e_Efx.h
 file path=usr/include/enlightenment/e_about.h
@@ -204,7 +203,7 @@ file path=usr/lib/$(MACH64)/enlightenment/modules/backlight/module.desktop
 file path=usr/lib/$(MACH64)/enlightenment/modules/backlight/solaris2.11-i386-ver-0.21/module.so
 file path=usr/lib/$(MACH64)/enlightenment/modules/battery/e-module-battery.edj
 file path=usr/lib/$(MACH64)/enlightenment/modules/battery/module.desktop
-file path=usr/lib/$(MACH64)/enlightenment/modules/battery/solaris2.11-i386-ver-0.21/batget
+file path=usr/lib/$(MACH64)/enlightenment/modules/battery/solaris2.11-i386-ver-0.21/batget mode=0555
 file path=usr/lib/$(MACH64)/enlightenment/modules/battery/solaris2.11-i386-ver-0.21/module.so
 file path=usr/lib/$(MACH64)/enlightenment/modules/bluez4/e-module-bluez4.edj
 file path=usr/lib/$(MACH64)/enlightenment/modules/bluez4/module.desktop
@@ -257,7 +256,7 @@ file path=usr/lib/$(MACH64)/enlightenment/modules/connman/module.desktop
 file path=usr/lib/$(MACH64)/enlightenment/modules/connman/solaris2.11-i386-ver-0.21/module.so
 file path=usr/lib/$(MACH64)/enlightenment/modules/cpufreq/e-module-cpufreq.edj
 file path=usr/lib/$(MACH64)/enlightenment/modules/cpufreq/module.desktop
-file path=usr/lib/$(MACH64)/enlightenment/modules/cpufreq/solaris2.11-i386-ver-0.21/freqset
+file path=usr/lib/$(MACH64)/enlightenment/modules/cpufreq/solaris2.11-i386-ver-0.21/freqset mode=04555
 file path=usr/lib/$(MACH64)/enlightenment/modules/cpufreq/solaris2.11-i386-ver-0.21/module.so
 file path=usr/lib/$(MACH64)/enlightenment/modules/everything/e-module-everything-start.edj
 file path=usr/lib/$(MACH64)/enlightenment/modules/everything/e-module-everything.edj
@@ -368,12 +367,12 @@ file path=usr/lib/$(MACH64)/enlightenment/modules/xkbswitch/e-module-xkbswitch.e
 file path=usr/lib/$(MACH64)/enlightenment/modules/xkbswitch/module.desktop
 file path=usr/lib/$(MACH64)/enlightenment/modules/xkbswitch/solaris2.11-i386-ver-0.21/module.so
 file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_alert
-file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_backlight
+file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_backlight mode=04555
 file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_elm_cfgtool
 file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_fm
 file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_fm_op
 file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_static_grabber
-file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_sys
+file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_sys mode=04555
 file path=usr/lib/$(MACH64)/enlightenment/utils/enlightenment_thumb
 file path=usr/lib/$(MACH64)/pkgconfig/enlightenment.pc
 file path=usr/lib/$(MACH64)/pkgconfig/everything.pc

--- a/components/desktop/e/enlightenment/manifests/sample-manifest.p5m
+++ b/components/desktop/e/enlightenment/manifests/sample-manifest.p5m
@@ -22,6 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=etc/enlightenment/sysactions.conf
+file path=etc/xdg/menus/e-applications.menu
 file path=usr/bin/emixer
 file path=usr/bin/enlightenment
 file path=usr/bin/enlightenment_filemanager
@@ -29,8 +31,6 @@ file path=usr/bin/enlightenment_imc
 file path=usr/bin/enlightenment_open
 file path=usr/bin/enlightenment_remote
 file path=usr/bin/enlightenment_start
-file path=usr/etc/enlightenment/sysactions.conf
-file path=usr/etc/xdg/menus/e-applications.menu
 file path=usr/include/enlightenment/e.h
 file path=usr/include/enlightenment/e_Efx.h
 file path=usr/include/enlightenment/e_about.h

--- a/components/desktop/e/enlightenment/patches/01-sysactions.patch
+++ b/components/desktop/e/enlightenment/patches/01-sysactions.patch
@@ -1,0 +1,65 @@
+--- enlightenment-0.21.8/configure.ac.orig	2017-05-17 22:53:31.000000000 +0000
++++ enlightenment-0.21.8/configure.ac	2017-07-23 17:09:02.223271760 +0000
+@@ -975,6 +975,12 @@
+       UMOUNT="/sbin/umount"
+       EJECT="/usr/sbin/cdcontrol eject"
+       ;;
++   solaris*)
++      HALT="/sbin/init 5"
++      REBOOT="/sbin/init 6"
++      MOUNT="/sbin/mount"
++      UMOUNT="/sbin/umount"
++      ;;
+    *)
+       if test "x${have_systemd_user_session}" = "xyes"; then
+          HALT="/usr/bin/systemctl poweroff"
+--- enlightenment-0.21.8/data/etc/sysactions.conf.in.orig	2016-06-07 23:01:16.000000000 +0000
++++ enlightenment-0.21.8/data/etc/sysactions.conf.in	2017-07-26 12:13:22.301733762 +0000
+@@ -55,27 +55,27 @@
+ # root is allowed to do anything - but it needs to be here explicitly anyway
+ user:     root      allow: *
+ # members of operator, staff and admin groups should be able to do all
+-group:    operator  allow: *
+-group:    staff     allow: *
+-group:    admin     allow: *
+-group:    sys       allow: *
+-group:    wheel     allow: *
+-group:    adm       allow: *
++#group:    operator  allow: *
++#group:    staff     allow: *
++#group:    admin     allow: *
++#group:    sys       allow: *
++#group:    wheel     allow: *
++#group:    adm       allow: *
+ # common "user" groups for "console users" on desktops/laptops
+-group:    dialout   allow: *
+-group:    disk      allow: *
+-group:    adm       allow: *
+-group:    cdrom     allow: *
+-group:    floppy    allow: *
+-group:    audio     allow: *
+-group:    dip       allow: *
+-group:    plugdev   allow: *
+-group:    netdev    allow: *
+-group:    bluetooth allow: *
+-group:    video     allow: *
+-group:    voice     allow: *
+-group:    fax       allow: *
+-group:    tty       allow: *
++#group:    dialout   allow: *
++#group:    disk      allow: *
++#group:    adm       allow: *
++#group:    cdrom     allow: *
++#group:    floppy    allow: *
++#group:    audio     allow: *
++#group:    dip       allow: *
++#group:    plugdev   allow: *
++#group:    netdev    allow: *
++#group:    bluetooth allow: *
++#group:    video     allow: *
++#group:    voice     allow: *
++#group:    fax       allow: *
++#group:    tty       allow: *
+ # put in a list of other users and groups here that are allowed or denied etc.
+ # e.g.
+ # user:     myuser     allow:  *


### PR DESCRIPTION
Enlightenment expects the SUID bit to be set on a few files, so I took the liberty of restoring it. This also enables the 'Reboot' and 'Power Off' options which were previously greyed out.