### PR TITLE
Bump gsl to 2.4

### DIFF
--- a/components/library/gsl/Makefile
+++ b/components/library/gsl/Makefile
@@ -15,11 +15,11 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           gsl
-COMPONENT_VERSION=        2.3
+COMPONENT_VERSION=        2.4
 COMPONENT_SUMMARY=        GSL - GNU Scientific Library
 COMPONENT_SRC=            $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=   sha256:562500b789cd599b3a4f88547a7a3280538ab2ff4939504c8b4ac4ca25feadfb
+COMPONENT_ARCHIVE_HASH=   sha256:4d46d07b946e7b31c19bbf33dda6204d7bedc2f5462a1bae1d4013426cd1ce9b
 COMPONENT_ARCHIVE_URL=    ftp://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=           developer/gsl
 COMPONENT_CLASSIFICATION= System/Libraries
@@ -34,6 +34,8 @@ include $(WS_MAKE_RULES)/ips.mk
 COMPONENT_BUILD_ENV +=	CFLAGS="$(CFLAGS)"
 
 CONFIGURE_OPTIONS 	+=--disable-static
+
+unexport SHELLOPTS
 
 	
 build:		$(BUILD_32_and_64)

--- a/components/library/gsl/gsl.p5m
+++ b/components/library/gsl/gsl.p5m
@@ -193,6 +193,7 @@ file path=usr/include/gsl/gsl_sf_expint.h
 file path=usr/include/gsl/gsl_sf_fermi_dirac.h
 file path=usr/include/gsl/gsl_sf_gamma.h
 file path=usr/include/gsl/gsl_sf_gegenbauer.h
+file path=usr/include/gsl/gsl_sf_hermite.h
 file path=usr/include/gsl/gsl_sf_hyperg.h
 file path=usr/include/gsl/gsl_sf_laguerre.h
 file path=usr/include/gsl/gsl_sf_lambert.h
@@ -272,28 +273,22 @@ file path=usr/include/gsl/gsl_vector_ushort.h
 file path=usr/include/gsl/gsl_version.h
 file path=usr/include/gsl/gsl_wavelet.h
 file path=usr/include/gsl/gsl_wavelet2d.h
-link path=usr/lib/$(MACH64)/libgsl.so target=libgsl.so.19.3.0
-link path=usr/lib/$(MACH64)/libgsl.so.19 target=libgsl.so.19.3.0
-file path=usr/lib/$(MACH64)/libgsl.so.19.3.0
+link path=usr/lib/$(MACH64)/libgsl.so target=libgsl.so.23.0.0
+link path=usr/lib/$(MACH64)/libgsl.so.23 target=libgsl.so.23.0.0
+file path=usr/lib/$(MACH64)/libgsl.so.23.0.0
 link path=usr/lib/$(MACH64)/libgslcblas.so target=libgslcblas.so.0.0.0
 link path=usr/lib/$(MACH64)/libgslcblas.so.0 target=libgslcblas.so.0.0.0
 file path=usr/lib/$(MACH64)/libgslcblas.so.0.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/gsl.pc
-link path=usr/lib/libgsl.so target=libgsl.so.19.3.0
-link path=usr/lib/libgsl.so.19 target=libgsl.so.19.3.0
-file path=usr/lib/libgsl.so.19.3.0
+link path=usr/lib/libgsl.so target=libgsl.so.23.0.0
+link path=usr/lib/libgsl.so.23 target=libgsl.so.23.0.0
+file path=usr/lib/libgsl.so.23.0.0
 link path=usr/lib/libgslcblas.so target=libgslcblas.so.0.0.0
 link path=usr/lib/libgslcblas.so.0 target=libgslcblas.so.0.0.0
 file path=usr/lib/libgslcblas.so.0.0.0
 file path=usr/lib/pkgconfig/gsl.pc
 file path=usr/share/aclocal/gsl.m4
 file path=usr/share/info/gsl-ref.info
-file path=usr/share/info/gsl-ref.info-1
-file path=usr/share/info/gsl-ref.info-2
-file path=usr/share/info/gsl-ref.info-3
-file path=usr/share/info/gsl-ref.info-4
-file path=usr/share/info/gsl-ref.info-5
-file path=usr/share/info/gsl-ref.info-6
 file path=usr/share/man/man1/gsl-config.1
 file path=usr/share/man/man1/gsl-histogram.1
 file path=usr/share/man/man1/gsl-randist.1

--- a/components/library/gsl/manifests/sample-manifest.p5m
+++ b/components/library/gsl/manifests/sample-manifest.p5m
@@ -192,6 +192,7 @@ file path=usr/include/gsl/gsl_sf_expint.h
 file path=usr/include/gsl/gsl_sf_fermi_dirac.h
 file path=usr/include/gsl/gsl_sf_gamma.h
 file path=usr/include/gsl/gsl_sf_gegenbauer.h
+file path=usr/include/gsl/gsl_sf_hermite.h
 file path=usr/include/gsl/gsl_sf_hyperg.h
 file path=usr/include/gsl/gsl_sf_laguerre.h
 file path=usr/include/gsl/gsl_sf_lambert.h
@@ -271,29 +272,22 @@ file path=usr/include/gsl/gsl_vector_ushort.h
 file path=usr/include/gsl/gsl_version.h
 file path=usr/include/gsl/gsl_wavelet.h
 file path=usr/include/gsl/gsl_wavelet2d.h
-link path=usr/lib/$(MACH64)/libgsl.so target=libgsl.so.19.3.0
-link path=usr/lib/$(MACH64)/libgsl.so.19 target=libgsl.so.19.3.0
-file path=usr/lib/$(MACH64)/libgsl.so.19.3.0
+link path=usr/lib/$(MACH64)/libgsl.so target=libgsl.so.23.0.0
+link path=usr/lib/$(MACH64)/libgsl.so.23 target=libgsl.so.23.0.0
+file path=usr/lib/$(MACH64)/libgsl.so.23.0.0
 link path=usr/lib/$(MACH64)/libgslcblas.so target=libgslcblas.so.0.0.0
 link path=usr/lib/$(MACH64)/libgslcblas.so.0 target=libgslcblas.so.0.0.0
 file path=usr/lib/$(MACH64)/libgslcblas.so.0.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/gsl.pc
-link path=usr/lib/libgsl.so target=libgsl.so.19.3.0
-link path=usr/lib/libgsl.so.19 target=libgsl.so.19.3.0
-file path=usr/lib/libgsl.so.19.3.0
+link path=usr/lib/libgsl.so target=libgsl.so.23.0.0
+link path=usr/lib/libgsl.so.23 target=libgsl.so.23.0.0
+file path=usr/lib/libgsl.so.23.0.0
 link path=usr/lib/libgslcblas.so target=libgslcblas.so.0.0.0
 link path=usr/lib/libgslcblas.so.0 target=libgslcblas.so.0.0.0
 file path=usr/lib/libgslcblas.so.0.0.0
 file path=usr/lib/pkgconfig/gsl.pc
 file path=usr/share/aclocal/gsl.m4
-file path=usr/share/info/dir
 file path=usr/share/info/gsl-ref.info
-file path=usr/share/info/gsl-ref.info-1
-file path=usr/share/info/gsl-ref.info-2
-file path=usr/share/info/gsl-ref.info-3
-file path=usr/share/info/gsl-ref.info-4
-file path=usr/share/info/gsl-ref.info-5
-file path=usr/share/info/gsl-ref.info-6
 file path=usr/share/man/man1/gsl-config.1
 file path=usr/share/man/man1/gsl-histogram.1
 file path=usr/share/man/man1/gsl-randist.1


### PR DESCRIPTION
ABI incompatible:
```
> pkg search -o pkg.name 'depend:require:developer/gsl'
PKG.NAME
scientific/gdl
image/editor/inkscape
```
All tests passed.