### PR TITLE
Bump harfbuzz to 1.4.7

### DIFF
--- a/components/library/harfbuzz/Makefile
+++ b/components/library/harfbuzz/Makefile
@@ -23,7 +23,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         harfbuzz
-COMPONENT_VERSION=      1.4.6
+COMPONENT_VERSION=      1.4.7
 COMPONENT_FMRI=         library/c++/harfbuzz
 COMPONENT_SUMMARY=      HarfBuzz - an OpenType text shaping engine. 
 COMPONENT_CLASSIFICATION= System/Libraries
@@ -31,7 +31,7 @@ COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  http://www.freedesktop.org/wiki/Software/HarfBuzz/
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:21a78b81cd20cbffdb04b59ac7edfb410e42141869f637ae1d6778e74928d293
+    sha256:b85f6627425d54f32118308e053b939c63a388de9bf455b3830f68cad406bc6d
 COMPONENT_ARCHIVE_URL=	\
     http://www.freedesktop.org/software/harfbuzz/release/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=      MIT

--- a/components/library/harfbuzz/harfbuzz.p5m
+++ b/components/library/harfbuzz/harfbuzz.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2015-2016, Aurelien Larcher
+# Copyright 2015-2017, Aurelien Larcher
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -52,20 +52,20 @@ file path=usr/include/harfbuzz/hb-unicode.h
 file path=usr/include/harfbuzz/hb-version.h
 file path=usr/include/harfbuzz/hb.h
 link path=usr/lib/$(MACH64)/libharfbuzz-icu.so \
-    target=libharfbuzz-icu.so.0.10400.6
+    target=libharfbuzz-icu.so.0.10400.7
 link path=usr/lib/$(MACH64)/libharfbuzz-icu.so.0 \
-    target=libharfbuzz-icu.so.0.10400.6
-file path=usr/lib/$(MACH64)/libharfbuzz-icu.so.0.10400.6
-link path=usr/lib/$(MACH64)/libharfbuzz.so target=libharfbuzz.so.0.10400.6
-link path=usr/lib/$(MACH64)/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.6
-file path=usr/lib/$(MACH64)/libharfbuzz.so.0.10400.6
+    target=libharfbuzz-icu.so.0.10400.7
+file path=usr/lib/$(MACH64)/libharfbuzz-icu.so.0.10400.7
+link path=usr/lib/$(MACH64)/libharfbuzz.so target=libharfbuzz.so.0.10400.7
+link path=usr/lib/$(MACH64)/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.7
+file path=usr/lib/$(MACH64)/libharfbuzz.so.0.10400.7
 file path=usr/lib/$(MACH64)/pkgconfig/harfbuzz-icu.pc
 file path=usr/lib/$(MACH64)/pkgconfig/harfbuzz.pc
-link path=usr/lib/libharfbuzz-icu.so target=libharfbuzz-icu.so.0.10400.6
-link path=usr/lib/libharfbuzz-icu.so.0 target=libharfbuzz-icu.so.0.10400.6
-file path=usr/lib/libharfbuzz-icu.so.0.10400.6
-link path=usr/lib/libharfbuzz.so target=libharfbuzz.so.0.10400.6
-link path=usr/lib/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.6
-file path=usr/lib/libharfbuzz.so.0.10400.6
+link path=usr/lib/libharfbuzz-icu.so target=libharfbuzz-icu.so.0.10400.7
+link path=usr/lib/libharfbuzz-icu.so.0 target=libharfbuzz-icu.so.0.10400.7
+file path=usr/lib/libharfbuzz-icu.so.0.10400.7
+link path=usr/lib/libharfbuzz.so target=libharfbuzz.so.0.10400.7
+link path=usr/lib/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.7
+file path=usr/lib/libharfbuzz.so.0.10400.7
 file path=usr/lib/pkgconfig/harfbuzz-icu.pc
 file path=usr/lib/pkgconfig/harfbuzz.pc

--- a/components/library/harfbuzz/manifests/sample-manifest.p5m
+++ b/components/library/harfbuzz/manifests/sample-manifest.p5m
@@ -52,20 +52,20 @@ file path=usr/include/harfbuzz/hb-unicode.h
 file path=usr/include/harfbuzz/hb-version.h
 file path=usr/include/harfbuzz/hb.h
 link path=usr/lib/$(MACH64)/libharfbuzz-icu.so \
-    target=libharfbuzz-icu.so.0.10400.6
+    target=libharfbuzz-icu.so.0.10400.7
 link path=usr/lib/$(MACH64)/libharfbuzz-icu.so.0 \
-    target=libharfbuzz-icu.so.0.10400.6
-file path=usr/lib/$(MACH64)/libharfbuzz-icu.so.0.10400.6
-link path=usr/lib/$(MACH64)/libharfbuzz.so target=libharfbuzz.so.0.10400.6
-link path=usr/lib/$(MACH64)/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.6
-file path=usr/lib/$(MACH64)/libharfbuzz.so.0.10400.6
+    target=libharfbuzz-icu.so.0.10400.7
+file path=usr/lib/$(MACH64)/libharfbuzz-icu.so.0.10400.7
+link path=usr/lib/$(MACH64)/libharfbuzz.so target=libharfbuzz.so.0.10400.7
+link path=usr/lib/$(MACH64)/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.7
+file path=usr/lib/$(MACH64)/libharfbuzz.so.0.10400.7
 file path=usr/lib/$(MACH64)/pkgconfig/harfbuzz-icu.pc
 file path=usr/lib/$(MACH64)/pkgconfig/harfbuzz.pc
-link path=usr/lib/libharfbuzz-icu.so target=libharfbuzz-icu.so.0.10400.6
-link path=usr/lib/libharfbuzz-icu.so.0 target=libharfbuzz-icu.so.0.10400.6
-file path=usr/lib/libharfbuzz-icu.so.0.10400.6
-link path=usr/lib/libharfbuzz.so target=libharfbuzz.so.0.10400.6
-link path=usr/lib/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.6
-file path=usr/lib/libharfbuzz.so.0.10400.6
+link path=usr/lib/libharfbuzz-icu.so target=libharfbuzz-icu.so.0.10400.7
+link path=usr/lib/libharfbuzz-icu.so.0 target=libharfbuzz-icu.so.0.10400.7
+file path=usr/lib/libharfbuzz-icu.so.0.10400.7
+link path=usr/lib/libharfbuzz.so target=libharfbuzz.so.0.10400.7
+link path=usr/lib/libharfbuzz.so.0 target=libharfbuzz.so.0.10400.7
+file path=usr/lib/libharfbuzz.so.0.10400.7
 file path=usr/lib/pkgconfig/harfbuzz-icu.pc
 file path=usr/lib/pkgconfig/harfbuzz.pc


### PR DESCRIPTION
ABI compatible: https://abi-laboratory.pro/tracker/timeline/harfbuzz/