### PR TITLE
Bump libpng16 to 1.6.31

### DIFF
--- a/components/library/libpng16/Makefile
+++ b/components/library/libpng16/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		libpng
 COMPONENT_VERSION_SUP=1
 COMPONENT_VERSION_MAJ=6
-COMPONENT_VERSION_MIN=29
+COMPONENT_VERSION_MIN=31
 COMPONENT_VERSION_PAT=0
 COMPONENT_VERSION=	$(COMPONENT_VERSION_SUP).$(COMPONENT_VERSION_MAJ).$(COMPONENT_VERSION_MIN)
 # The XY in "libpngXY" file and directory names
@@ -30,7 +30,7 @@ COMPONENT_SUMMARY=	Portable Network Graphics library version $(COMPONENT_VERSION
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:4245b684e8fe829ebb76186327bb37ce5a639938b219882b53d64bd3cfc5f239
+    sha256:232a602de04916b2b5ce6f901829caf419519e6a16cc9cd7c1c91187d3ee8b41
 COMPONENT_ARCHIVE_URL=	http://sourceforge.net/projects/libpng/files/libpng16/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)/download
 COMPONENT_LICENSE=	libpng
 COMPONENT_LICENSE_FILE=	LICENSE
@@ -49,7 +49,20 @@ PKG_OPTIONS +=  -D COMPONENT_VERSION_TAG="$(COMPONENT_VERSION_TAG)"
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 
 # for tests to pass
-ENV=/usr/bin/env -i
+unexport SHELLOPTS
+
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
+
+COMPONENT_TEST_TRANSFORMS= \
+	'-n ' \
+  '-e "/TOTAL/p" ' \
+  '-e "/PASS/p" '  \
+  '-e "/SKIP/p" '  \
+  '-e "/XFAIL/p" ' \
+  '-e "/FAIL/p" '  \
+  '-e "/XPASS/p" ' \
+  '-e "/ERROR/p" ' 
+ 
 
 # common targets
 build:		$(BUILD_32_and_64)

--- a/components/library/libpng16/manifests/sample-manifest.p5m
+++ b/components/library/libpng16/manifests/sample-manifest.p5m
@@ -39,19 +39,17 @@ link path=usr/include/pnglibconf.h target=libpng16/pnglibconf.h
 link path=usr/lib/$(MACH64)/libpng.a target=libpng16.a
 link path=usr/lib/$(MACH64)/libpng.so target=libpng16.so
 file path=usr/lib/$(MACH64)/libpng16.a
-link path=usr/lib/$(MACH64)/libpng16.so target=libpng16.so.16.29.0
-link path=usr/lib/$(MACH64)/libpng16.so.16 target=libpng16.so.16.29.0
-file path=usr/lib/$(MACH64)/libpng16.so.16.27.0
-file path=usr/lib/$(MACH64)/libpng16.so.16.29.0
+link path=usr/lib/$(MACH64)/libpng16.so target=libpng16.so.16.31.0
+link path=usr/lib/$(MACH64)/libpng16.so.16 target=libpng16.so.16.31.0
+file path=usr/lib/$(MACH64)/libpng16.so.16.31.0
 link path=usr/lib/$(MACH64)/pkgconfig/libpng.pc target=libpng16.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpng16.pc
 link path=usr/lib/libpng.a target=libpng16.a
 link path=usr/lib/libpng.so target=libpng16.so
 file path=usr/lib/libpng16.a
-link path=usr/lib/libpng16.so target=libpng16.so.16.29.0
-link path=usr/lib/libpng16.so.16 target=libpng16.so.16.29.0
-file path=usr/lib/libpng16.so.16.27.0
-file path=usr/lib/libpng16.so.16.29.0
+link path=usr/lib/libpng16.so target=libpng16.so.16.31.0
+link path=usr/lib/libpng16.so.16 target=libpng16.so.16.31.0
+file path=usr/lib/libpng16.so.16.31.0
 link path=usr/lib/pkgconfig/libpng.pc target=libpng16.pc
 file path=usr/lib/pkgconfig/libpng16.pc
 file path=usr/share/man/man3/libpng.3

--- a/components/library/libpng16/test/results-all.master
+++ b/components/library/libpng16/test/results-all.master
@@ -1,0 +1,41 @@
+PASS: tests/pngtest
+PASS: tests/pngvalid-gamma-16-to-8
+PASS: tests/pngvalid-gamma-alpha-mode
+PASS: tests/pngvalid-gamma-background
+PASS: tests/pngvalid-gamma-expand16-alpha-mode
+PASS: tests/pngvalid-gamma-expand16-background
+PASS: tests/pngvalid-gamma-expand16-transform
+PASS: tests/pngvalid-gamma-sbit
+PASS: tests/pngvalid-gamma-threshold
+PASS: tests/pngvalid-gamma-transform
+PASS: tests/pngvalid-progressive-size
+PASS: tests/pngvalid-progressive-interlace-standard
+PASS: tests/pngvalid-transform
+PASS: tests/pngvalid-progressive-standard
+PASS: tests/pngvalid-standard
+PASS: tests/pngstest-1.8
+PASS: tests/pngstest-1.8-alpha
+PASS: tests/pngstest-linear
+PASS: tests/pngstest-linear-alpha
+PASS: tests/pngstest-none
+PASS: tests/pngstest-none-alpha
+PASS: tests/pngstest-sRGB
+PASS: tests/pngstest-sRGB-alpha
+PASS: tests/pngunknown-IDAT
+PASS: tests/pngunknown-discard
+PASS: tests/pngunknown-if-safe
+PASS: tests/pngunknown-sAPI
+PASS: tests/pngunknown-sTER
+PASS: tests/pngunknown-save
+PASS: tests/pngunknown-vpAg
+PASS: tests/pngimage-quick
+PASS: tests/pngimage-full
+# TOTAL: 32
+# PASS:  32
+# SKIP:  0
+# XFAIL: 0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# XPASS: 0
+# ERROR: 0


### PR DESCRIPTION
ABI compatible: https://abi-laboratory.pro/tracker/timeline/libpng/