### PR TITLE
Rebuild gst-plugins-bad1 with libwebp 0.6.0

### DIFF
--- a/components/encumbered/gst-plugins-bad1/Makefile
+++ b/components/encumbered/gst-plugins-bad1/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gst-plugins-bad1
 COMPONENT_VERSION= 1.12.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= GNOME streaming media framework plugins
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 COMPONENT_FMRI= library/audio/gstreamer1/plugin/bad


### PR DESCRIPTION
Missing rebuild due to non listed dependency.