### PR TITLE
mesa: Remove libGLw dependency

### DIFF
--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= mesa
 COMPONENT_VERSION= 13.0.6
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= The Mesa 3-D Graphics Library
 COMPONENT_SRC= mesa-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= mesa-$(COMPONENT_VERSION).tar.xz
@@ -104,11 +105,11 @@ REQUIRED_PACKAGES += system/library/g++-4-runtime
 REQUIRED_PACKAGES += system/library/gcc-4-runtime
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/glu
-REQUIRED_PACKAGES += x11/library/glw
 REQUIRED_PACKAGES += x11/library/libdrm
 REQUIRED_PACKAGES += x11/library/libx11
 REQUIRED_PACKAGES += x11/library/libxcb
 REQUIRED_PACKAGES += x11/library/libxdamage
 REQUIRED_PACKAGES += x11/library/libxext
 REQUIRED_PACKAGES += x11/library/libxfixes
+REQUIRED_PACKAGES += x11/library/libxshmfence
 REQUIRED_PACKAGES += x11/library/libxxf86vm

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -94,9 +94,6 @@ link path=usr/X11/lib/libglapi.so.0.0.0 target=GL/libglapi.so.0.0.0 pkg.linted.u
 # libGLU has moved to x11/library/glu 
 depend fmri=pkg:/x11/library/glu@9.0.0 type=require
 
-# libGLw has moved to x11/library/glw 
-depend fmri=pkg:/x11/library/glw@8.0.0 type=require
-
 # Runtime links are provided by ogl-select
 depend fmri=pkg:/service/opengl/ogl-select type=require
 


### PR DESCRIPTION
The OpenGL widget library (provided by x11/library/glw) is neither required to build nor use Mesa's core drivers/libs. It seems to be a historical relic that it gets included with the package at all. If it is desirable to continue delivering glw along with mesa, I'd like to propose setting its depend type to group so that it, and the legacy packages it depends on, can be avoided. Otherwise, I see no harm in simply removing it from the manifest.