### PR TITLE
dnscrypt-proxy: update to version 1.9.5 and add test

### DIFF
--- a/components/network/dnscrypt-proxy/Makefile
+++ b/components/network/dnscrypt-proxy/Makefile
@@ -11,17 +11,18 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
+# Copyright 2017 Andreas Wacknitz
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= dnscrypt-proxy
-COMPONENT_VERSION= 1.6.1
+COMPONENT_VERSION= 1.9.5
 COMPONENT_SUMMARY= DNSCrypt client
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-  sha256:895ac36f5d4898dabf0ed65e0a579d0aa4d9a9be9cca4dca7b573a0ff170919a
+  sha256:e89f5b9039979ab392302faf369ef7593155d5ea21580402a75bbc46329d1bb6
 COMPONENT_ARCHIVE_URL= \
   https://github.com/jedisct1/dnscrypt-proxy/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://dnscrypt.org/
@@ -38,12 +39,17 @@ include $(WS_TOP)/make-rules/ips.mk
 COMPONENT_PRE_CONFIGURE_ACTION =        ($(CLONEY) $(SOURCE_DIR) $(@D))
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
+CONFIGURE_BINDIR.64=$(CONFIGURE_PREFIX)/bin
+CONFIGURE_SBINDIR.64=$(CONFIGURE_PREFIX)/sbin
 
-build: $(BUILD_32)
+build: $(BUILD_64)
 
-install: $(INSTALL_32)
+install: $(INSTALL_64)
 
-REQUIRED_PACKAGES += library/security/libsodium
+test: $(TEST_64)
+
 REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += library/libtool/libltdl
+REQUIRED_PACKAGES += library/security/libsodium
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/g++-4-runtime

--- a/components/network/dnscrypt-proxy/dnscrypt-proxy.p5m
+++ b/components/network/dnscrypt-proxy/dnscrypt-proxy.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
+# Copyright 2017 Andreas Wacknitz
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,9 +29,22 @@ user username=dnscrypt ftpuser=false gcos-field="DNSCrypt Reserved UID" group=dn
 
 file files/dnscrypt-proxy.xml path=lib/svc/manifest/network/dns/dnscrypt-proxy.xml
 
+file path=etc/dnscrypt-proxy.conf preserve=true
 file path=usr/bin/hostip
+file path=usr/include/dnscrypt/plugin.h
+file path=usr/include/dnscrypt/private.h
+file path=usr/include/dnscrypt/version.h
+file path=usr/lib/$(MACH64)/dnscrypt-proxy/libdcplugin_example.so
+file path=usr/lib/$(MACH64)/dnscrypt-proxy/libdcplugin_example_cache.so
+file path=usr/lib/$(MACH64)/dnscrypt-proxy/libdcplugin_example_logging.so
 file path=usr/sbin/dnscrypt-proxy
 file path=usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv
 file path=usr/share/dnscrypt-proxy/minisign.pub
+file path=usr/share/doc/dnscrypt-proxy/COPYING
+file path=usr/share/doc/dnscrypt-proxy/DNSCRYPT-V2-PROTOCOL.txt
+file path=usr/share/doc/dnscrypt-proxy/README-PLUGINS.markdown
+file path=usr/share/doc/dnscrypt-proxy/README.markdown
+file path=usr/share/doc/dnscrypt-proxy/dnscrypt-proxy.conf
 file path=usr/share/man/man8/dnscrypt-proxy.8
 file path=usr/share/man/man8/hostip.8
+

--- a/components/network/dnscrypt-proxy/manifests/sample-manifest.p5m
+++ b/components/network/dnscrypt-proxy/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,9 +22,21 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=etc/dnscrypt-proxy.conf
 file path=usr/bin/hostip
+file path=usr/include/dnscrypt/plugin.h
+file path=usr/include/dnscrypt/private.h
+file path=usr/include/dnscrypt/version.h
+file path=usr/lib/$(MACH64)/dnscrypt-proxy/libdcplugin_example.so
+file path=usr/lib/$(MACH64)/dnscrypt-proxy/libdcplugin_example_cache.so
+file path=usr/lib/$(MACH64)/dnscrypt-proxy/libdcplugin_example_logging.so
 file path=usr/sbin/dnscrypt-proxy
 file path=usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv
 file path=usr/share/dnscrypt-proxy/minisign.pub
+file path=usr/share/doc/dnscrypt-proxy/COPYING
+file path=usr/share/doc/dnscrypt-proxy/DNSCRYPT-V2-PROTOCOL.txt
+file path=usr/share/doc/dnscrypt-proxy/README-PLUGINS.markdown
+file path=usr/share/doc/dnscrypt-proxy/README.markdown
+file path=usr/share/doc/dnscrypt-proxy/dnscrypt-proxy.conf
 file path=usr/share/man/man8/dnscrypt-proxy.8
 file path=usr/share/man/man8/hostip.8


### PR DESCRIPTION
I have postponed 64 bit because of too many problems for now.
I haven't checked whether the service file also has to be changed.