### PR TITLE
dnsmasq: remove unsupported privilege sets in SMF manifest

### DIFF
--- a/components/network/dnsmasq/files/dnsmasq.xml
+++ b/components/network/dnsmasq/files/dnsmasq.xml
@@ -66,10 +66,6 @@
     <exec_method type='method' name='start'
                  exec='/usr/lib/inet/dnsmasq'
                  timeout_seconds='60' >
-      <method_context>
-        <method_credential user='daemon' group='daemon'
-          privileges='basic,{net_privaddr}:53/udp,{net_privaddr}:53/tcp,{net_privaddr}:67/udp,{net_privaddr}:69/udp,{net_privaddr}:547/udp,net_icmpaccess' />
-      </method_context>
     </exec_method> 
 
     <exec_method type='method' name='stop' exec=':kill' timeout_seconds='60' />


### PR DESCRIPTION
our SMF version does not support the privilege sets specified in <method_credential/>