### PR TITLE
Asterisk

### DIFF
--- a/components/network/asterisk/Makefile
+++ b/components/network/asterisk/Makefile
@@ -28,7 +28,7 @@ include $(WS_TOP)/make-rules/prep.mk
 include $(WS_TOP)/make-rules/configure.mk
 include $(WS_TOP)/make-rules/ips.mk
 
-COMPONENT_PRE_CONFIGURE_ACTION += ($(CLONEY) $(SOURCE_DIR) $(@D));
+COMPONENT_PRE_CONFIGURE_ACTION += ($(CLONEY) $(SOURCE_DIR) $(@D))
 
 PATCH_LEVEL = 0
 
@@ -36,6 +36,7 @@ CONFIGURE_OPTIONS +=	--sysconfdir=/etc
 CONFIGURE_OPTIONS +=	--localstatedir=/var
 CONFIGURE_OPTIONS +=	--without-oss
 CONFIGURE_OPTIONS +=	--with-gsm=internal
+CONFIGURE_OPTIONS +=  --with-netsnmp=$(BINDIR)
 
 COMPONENT_INSTALL_TARGETS += samples
 


### PR DESCRIPTION
compiled with net-snmp-5.7.3 and amd64 as default for SNMP creates this error:
ERROR userland.action001.2        64-bit object 'usr/lib/asterisk/modules/res_snmp.so' in 32-bit path

This patch is just to avoid the lint error message.
