### PR TITLE
mesa: re-enable gbm

### DIFF
--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= mesa
 COMPONENT_VERSION= 13.0.6
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_SUMMARY= The Mesa 3-D Graphics Library
 COMPONENT_SRC= mesa-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= mesa-$(COMPONENT_VERSION).tar.xz
@@ -71,7 +71,7 @@ CONFIGURE_OPTIONS += --with-dri-driverdir='$(X11_SERVERMODS_DIR)/dri$(SERVERMOD_
 CONFIGURE_OPTIONS += --with-dri-drivers='$(DRI_DRIVER_LIST)'
 CONFIGURE_OPTIONS += --disable-gallium-llvm
 CONFIGURE_OPTIONS += --enable-egl
-CONFIGURE_OPTIONS += --disable-gbm
+CONFIGURE_OPTIONS += --enable-gbm
 CONFIGURE_OPTIONS += --with-gallium-drivers=
 CONFIGURE_OPTIONS += --enable-shared-glapi
 CONFIGURE_OPTIONS += --enable-texture-float


### PR DESCRIPTION
Without gbm enabled files referenced by the p5m file are missing (on a fresh system).