### PR TITLE
Add missing MATE symlink in openindiana-backgrounds

### DIFF
--- a/components/openindiana/openindiana-backgrounds/Makefile
+++ b/components/openindiana/openindiana-backgrounds/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		openindiana-backgrounds
 COMPONENT_VERSION=	1.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_PROJECT_URL=	https://github.com/OpenIndiana/openindiana-backgrounds
 COMPONENT_SUMMARY=	Selection of OpenIndiana backgrounds for the desktop
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/openindiana/openindiana-backgrounds/os-backgrounds.p5m
+++ b/components/openindiana/openindiana-backgrounds/os-backgrounds.p5m
@@ -13,3 +13,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/share/gnome-background-properties/openindiana-backgrounds.xml
 file path=usr/share/pixmaps/backgrounds/openindiana/openindiana-default.jpg
+
+# Mate symlink
+link path=usr/share/mate-background-properties/openindiana-backgrounds.xml \
+  target=../gnome-background-properties/openindiana-backgrounds.xml


### PR DESCRIPTION
@pyhalov just saw your message about the missing symlink. I am not at home right now so cannot test on the desktop. Let me know if this is enough for now to get a working component. I'll fix the openindiana-backgrounds installation later this week. EDIT: at least installing on the laptop seems to work.