### PR TITLE
caja: remove caja-convert-metadata

### DIFF
--- a/components/desktop/mate/caja/Makefile
+++ b/components/desktop/mate/caja/Makefile
@@ -19,6 +19,7 @@ COMPONENT_NAME=		caja
 COMPONENT_MJR_VERSION=	1.18
 COMPONENT_MNR_VERSION=	4
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
 COMPONENT_SUMMARY=	File manager for the MATE desktop
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -31,11 +32,11 @@ COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
 COMPONENT_CLASSIFICATION = System/Libraries
 COMPONENT_FMRI = desktop/mate/$(COMPONENT_NAME)
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
 COMPONENT_PREP_ACTION=	\
 	( cp $(COMPONENT_DIR)/files/icons/*.png $(@D)/icons && \

--- a/components/desktop/mate/caja/caja.p5m
+++ b/components/desktop/mate/caja/caja.p5m
@@ -53,7 +53,6 @@ link path=usr/lib/$(MACH64)/libcaja-extension.so.1 \
     target=libcaja-extension.so.1.4.0
 file path=usr/lib/$(MACH64)/libcaja-extension.so.1.4.0
 file path=usr/lib/$(MACH64)/pkgconfig/libcaja-extension.pc
-file path=usr/lib/caja/caja-convert-metadata mode=0555
 file path=usr/lib/girepository-1.0/Caja-2.0.typelib
 link path=usr/lib/libcaja-extension.so target=libcaja-extension.so.1.4.0
 link path=usr/lib/libcaja-extension.so.1 target=libcaja-extension.so.1.4.0

--- a/components/desktop/mate/caja/manifests/sample-manifest.p5m
+++ b/components/desktop/mate/caja/manifests/sample-manifest.p5m
@@ -48,7 +48,6 @@ link path=usr/lib/$(MACH64)/libcaja-extension.so.1 \
     target=libcaja-extension.so.1.4.0
 file path=usr/lib/$(MACH64)/libcaja-extension.so.1.4.0
 file path=usr/lib/$(MACH64)/pkgconfig/libcaja-extension.pc
-file path=usr/lib/caja/caja-convert-metadata
 file path=usr/lib/girepository-1.0/Caja-2.0.typelib
 link path=usr/lib/libcaja-extension.so target=libcaja-extension.so.1.4.0
 link path=usr/lib/libcaja-extension.so.1 target=libcaja-extension.so.1.4.0


### PR DESCRIPTION
Changelog says caja-convert-metadata has been removed on November 8th, 2016.