### PR TITLE
Bump to Jenkins weekly 2.88

### DIFF
--- a/components/developer/jenkins-core-lts/check-version.sh
+++ b/components/developer/jenkins-core-lts/check-version.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Find the latest (tarball) release under original site
+#
+# Copyright 2016-2017 Jim Klimov
+#
+
+BASE_URL="http://mirrors.jenkins.io/war-stable/"
+
+echo "=== Checking latest numbered release under $BASE_URL..."
+VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'DIR.*[0-9]*\.[0-9]*' | grep -vw latest | tail -1 | sed 's,^.*a href="\([0-9]*\.[0-9]*\.[0-9]*\)/*".*,\1,'`" \
+    && [ -n "$VERSION" ] && echo "Latest VERSION   = $VERSION" \
+    || echo "WARNING: Could not fetch a VERSION" >&2
+
+CHECKSUM="`wget -O - "$BASE_URL/latest/jenkins.war.sha256" 2>/dev/null`" \
+    && [ -n "$CHECKSUM" ] && echo "Latest SHA256SUM = sha256:$CHECKSUM" \
+    || echo "WARNING: Could not fetch a CHECKSUM" >&2
+
+echo "=== Data in current `dirname $0`/Makefile:"
+egrep '(^[\t\ ]*(COMPONENT_[A-Z]*_VERSION.*=|JENKINS_RELEASE.*=)|sha256:)' "`dirname $0`/Makefile"

--- a/components/developer/jenkins-core-weekly/Makefile
+++ b/components/developer/jenkins-core-weekly/Makefile
@@ -27,9 +27,9 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		jenkins
 JENKINS_RELEASE=weekly
 COMPONENT_MAJOR_VERSION=	2
-COMPONENT_MINOR_VERSION=	87
+COMPONENT_MINOR_VERSION=	88
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:0ead9cf2ec71224a358eea5aac78fd01e6fa731ab2879dca5652641bac4dfadb
+	sha256:357a456d7ddb2d00d7d35ac273d11e64fd31a8368af209bb0e618c23fdb25018
 # See $(COMPONENT_ARCHIVE_URL).sha256 e.g. for current weekly release, run
 #   wget -O - http://mirrors.jenkins-ci.org/war/latest/jenkins.war.sha256
 # or for LTS

--- a/components/developer/jenkins-core-weekly/check-version.sh
+++ b/components/developer/jenkins-core-weekly/check-version.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Find the latest (tarball) release under original site
+#
+# Copyright 2016-2017 Jim Klimov
+#
+
+BASE_URL="http://mirrors.jenkins-ci.org/war/"
+
+echo "=== Checking latest numbered release under $BASE_URL..."
+VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'DIR.*[0-9]*\.[0-9]*' | grep -vw latest | tail -1 | sed 's,^.*a href="\([0-9]*\.[0-9]*\)/*".*,\1,'`" \
+    && [ -n "$VERSION" ] && echo "Latest VERSION   = $VERSION" \
+    || echo "WARNING: Could not fetch a VERSION" >&2
+
+CHECKSUM="`wget -O - "$BASE_URL/latest/jenkins.war.sha256" 2>/dev/null`" \
+    && [ -n "$CHECKSUM" ] && echo "Latest SHA256SUM = sha256:$CHECKSUM" \
+    || echo "WARNING: Could not fetch a CHECKSUM" >&2
+
+echo "=== Data in current `dirname $0`/Makefile:"
+egrep '(^[\t\ ]*(COMPONENT_[A-Z]*_VERSION.*=|JENKINS_RELEASE.*=)|sha256:)' "`dirname $0`/Makefile"


### PR DESCRIPTION
Also add helper scripts to both weekly and LTS to download the sha256 data and current version number.