### PR TITLE
Bump nghttp2 to 1.27.0

### DIFF
--- a/components/library/nghttp2/Makefile
+++ b/components/library/nghttp2/Makefile
@@ -13,15 +13,15 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
-include ../../make-rules/shared-macros.mk
+include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= nghttp2
-COMPONENT_VERSION= 1.3.4
+COMPONENT_VERSION= 1.27.0
 COMPONENT_SUMMARY= HTTP/2 C Library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-  sha256:63c1d70e50f0c8514e261be88b66720df095269791aa008d76c09e0c3a4c085f
+  sha256:d3c9542e26c3819c50963e02d285973b38ec1dd2816133c852a224f0bd911952
 COMPONENT_ARCHIVE_URL= \
   https://github.com/tatsuhiro-t/nghttp2/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://nghttp2.org/
@@ -30,17 +30,33 @@ COMPONENT_LICENSE = MIT
 COMPONENT_CLASSIFICATION = System/Libraries
 COMPONENT_FMRI = library/nghttp2
 
-include ../../make-rules/prep.mk
-include ../../make-rules/configure.mk
-include ../../make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-CONFIGURE_OPTIONS += --disable-examples
+CONFIGURE_OPTIONS += --disable-static
+CONFIGURE_OPTIONS += --enable-examples
 CONFIGURE_OPTIONS += --disable-python-bindings
 CONFIGURE_OPTIONS += --disable-app
+
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
+
+COMPONENT_TEST_TRANSFORMS += \
+        '-n ' \
+        '-e "/TOTAL:/p" ' \
+        '-e "/SKIP:/p" ' \
+        '-e "/PASS:/p" ' \
+        '-e "/FAIL:/p" ' \
+        '-e "/ERROR:/p" '
 
 build: $(BUILD_32_and_64)
 
 install: $(INSTALL_32_and_64)
 
-# test suite is empty
 test: $(TEST_32_and_64)
+
+# Build dependencies
+REQUIRED_PACKAGES += developer/cunit
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/library/nghttp2/manifests/sample-manifest.p5m
+++ b/components/library/nghttp2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,15 +24,13 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/nghttp2/nghttp2.h
 file path=usr/include/nghttp2/nghttp2ver.h
-file path=usr/lib/$(MACH64)/libnghttp2.a
-link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.1.4
-link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.1.4
-file path=usr/lib/$(MACH64)/libnghttp2.so.14.1.4
+link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.14.0
+link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.14.0
+file path=usr/lib/$(MACH64)/libnghttp2.so.14.14.0
 file path=usr/lib/$(MACH64)/pkgconfig/libnghttp2.pc
-file path=usr/lib/libnghttp2.a
-link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.1.4
-link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.1.4
-file path=usr/lib/libnghttp2.so.14.1.4
+link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.14.0
+link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.14.0
+file path=usr/lib/libnghttp2.so.14.14.0
 file path=usr/lib/pkgconfig/libnghttp2.pc
 file path=usr/share/doc/nghttp2/README.rst
 file path=usr/share/man/man1/h2load.1

--- a/components/library/nghttp2/nghttp2.p5m
+++ b/components/library/nghttp2/nghttp2.p5m
@@ -24,13 +24,13 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/nghttp2/nghttp2.h
 file path=usr/include/nghttp2/nghttp2ver.h
-link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.1.4
-link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.1.4
-file path=usr/lib/$(MACH64)/libnghttp2.so.14.1.4
+link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.14.0
+link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.14.0
+file path=usr/lib/$(MACH64)/libnghttp2.so.14.14.0
 file path=usr/lib/$(MACH64)/pkgconfig/libnghttp2.pc
-link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.1.4
-link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.1.4
-file path=usr/lib/libnghttp2.so.14.1.4
+link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.14.0
+link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.14.0
+file path=usr/lib/libnghttp2.so.14.14.0
 file path=usr/lib/pkgconfig/libnghttp2.pc
 file path=usr/share/doc/nghttp2/README.rst
 file path=usr/share/man/man1/h2load.1

--- a/components/library/nghttp2/test/results-all.master
+++ b/components/library/nghttp2/test/results-all.master
@@ -1,0 +1,16 @@
+# TOTAL: 0
+# PASS:  0
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+PASS: main
+PASS: failmalloc
+# TOTAL: 2
+# PASS:  2
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0


### PR DESCRIPTION
Moving to category and updating at the same time, but:

pkg search -r -o pkg.name 'depend:require:library/nghttp2'
PKG.NAME
web/curl
web/server/apache-24

so some testing needed.