### PR TITLE
Add xf86-video-vbox 1.0.1

### DIFF
--- a/components/meta-packages/xorg-video/Makefile
+++ b/components/meta-packages/xorg-video/Makefile
@@ -16,6 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		xorg-video
 COMPONENT_VERSION=	0.5.11
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY=	Xorg server video drivers group
 
 include ../../../make-rules/ips.mk

--- a/components/meta-packages/xorg-video/xorg-video.p5m
+++ b/components/meta-packages/xorg-video/xorg-video.p5m
@@ -33,4 +33,5 @@ depend fmri=pkg:/x11/server/xorg/driver/xorg-video-r128 type=require
 depend fmri=pkg:/x11/server/xorg/driver/xorg-video-savage type=require
 depend fmri=pkg:/x11/server/xorg/driver/xorg-video-trident type=require
 depend fmri=pkg:/x11/server/xorg/driver/xorg-video-vesa type=require
+depend fmri=pkg:/x11/server/xorg/driver/xorg-video-vboxvideo type=require
 depend fmri=pkg:/x11/server/xorg/driver/xorg-video-vmware type=require

--- a/components/x11/xf86-video-vbox/Makefile
+++ b/components/x11/xf86-video-vbox/Makefile
@@ -1,0 +1,85 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017 Aurelien Larcher
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= xf86-video-vbox
+# Use version string from Xorg module
+COMPONENT_VERSION= 1.0.1
+COMPONENT_SUMMARY= xf86-video-vbox - VirtualBox UMS driver for the Xorg X server
+COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_GIT_HASH)
+COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.xz
+COMPONENT_GIT_HASH=  ab07f97612d045d8c0a376174b39a294d028fef2
+COMPONENT_ARCHIVE_HASH= \
+  sha256:0b89efa6830fbf65b76482a98c06a95c027f49266725a7d4cf98e1a95b8e9467
+COMPONENT_ARCHIVE_URL= \
+  https://cgit.freedesktop.org/xorg/driver/xf86-video-vbox/snapshot/$(COMPONENT_NAME)-$(COMPONENT_GIT_HASH).tar.xz
+COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
+COMPONENT_CLASSIFICATION= Drivers/Display
+COMPONENT_LICENSE = MIT
+COMPONENT_LICENSE_FILE = COPYING
+COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-vboxvideo
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_PREP_ACTION = ( cd $(@D) && \
+                          libtoolize --automake --copy --force && \
+                          aclocal && \
+                          autoheader && \
+                          automake -a -f -c && \
+                          autoconf )
+
+CFLAGS+= -std=gnu99
+
+# Paths to find libraries/modules to link with
+
+SERVERMOD_SUBDIR.64=/$(MACH64)
+SERVERMOD_SUBDIR=$(SERVERMOD_SUBDIR.$(BITS))
+X11_SERVERMODS_DIR=/usr/lib/xorg/modules
+MESA_XSERVERMODS_DIR=/usr/lib/mesa/modules
+X11_SERVERLIBS_DIR=/usr/lib/xorg
+
+LD_OPTIONS+= \
+	     -L$(X11_SERVERMODS_DIR)$(SERVERMOD_SUBDIR) \
+	     -L$(MESA_XSERVERMODS_DIR)/extensions$(SERVERMOD_SUBDIR) \
+	     -L$(X11_SERVERMODS_DIR)/extensions$(SERVERMOD_SUBDIR) \
+	     -L$(X11_SERVERLIBS_DIR)$(ARCHLIBSUBDIR) \
+	     -R$(X11_SERVERMODS_DIR)$(SERVERMOD_SUBDIR) \
+	     -R$(MESA_XSERVERMODS_DIR)/extensions$(SERVERMOD_SUBDIR) \
+	     -R$(X11_SERVERMODS_DIR)/extensions$(SERVERMOD_SUBDIR) \
+	     -R$(X11_SERVERLIBS_DIR)$(SERVERMOD_SUBDIR)
+
+CONFIGURE_OPTIONS+= --with-xorg-module-dir=$(X11_SERVERMODS_DIR)$(SERVERMOD_SUBDIR)
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+# Build dependencies
+REQUIRED_PACKAGES += x11/header/xproto
+REQUIRED_PACKAGES += x11/header/xf86driproto
+REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/glproto
+REQUIRED_PACKAGES += system/header/header-drm
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += diagnostic/scanpci
+REQUIRED_PACKAGES += library/graphics/pixman
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libdrm
+REQUIRED_PACKAGES += x11/server/xorg

--- a/components/x11/xf86-video-vbox/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-vbox/manifests/sample-manifest.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/xorg/modules/$(MACH64)/drivers/vboxvideo_drv.so
+file path=usr/lib/xorg/modules/drivers/vboxvideo_drv.so
+file path=usr/share/man/man7/vboxvideo.7

--- a/components/x11/xf86-video-vbox/xf86-video-vbox.p5m
+++ b/components/x11/xf86-video-vbox/xf86-video-vbox.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2017 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/xorg/modules/$(MACH64)/drivers/vboxvideo_drv.so
+file path=usr/lib/xorg/modules/drivers/vboxvideo_drv.so
+file path=usr/share/man/man7/vboxvideo.7


### PR DESCRIPTION
People can install that after installing the guest additions from the ISO.
It provides the virtualbox driver for Xorg 1.19:

```
[   243.842] (==) Matched vboxvideo as autoconfigured driver 0
[   243.842] (==) Matched vesa as autoconfigured driver 1
[   243.842] (==) Assigned the driver to the xf86ConfigLayout
[   243.842] (II) LoadModule: "vboxvideo"
[   243.843] (II) Loading /usr/lib/xorg/modules/amd64/drivers/vboxvideo_drv.so
[   243.843] (II) Module vboxvideo: vendor="Oracle Corporation"
[   243.843]    compiled for 1.19.5, module version = 1.0.1
[   243.843]    Module class: X.Org Video Driver
[   243.843]    ABI class: X.Org Video Driver, version 23.0
```

Courtesy of Michael Thayer and the Solaris Xorg team.