### PR TITLE
shared-macros: Add PHONY download target

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1171,7 +1171,7 @@ COMPONENT_INSTALL_ENV += $(COMPONENT_INSTALL_ENV.$(BITS))
 COMPONENT_INSTALL_ARGS += $(COMPONENT_INSTALL_ARGS.$(BITS))
 
 # declare these phony so that we avoid filesystem conflicts.
-.PHONY:	prep build install publish test clean clobber parfait
+.PHONY:	download prep build install publish test clean clobber parfait
 
 # If there are no tests to execute
 NO_TESTS =	test-nothing


### PR DESCRIPTION
Some components do not specify/require a 'download' target. We do not
want the top level 'gmake download' operation to fail in this case.