### PR TITLE
Make pkgdepend ignore GCC runtime libraries in /usr/lib and /usr/lib/…

### DIFF
--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -62,6 +62,10 @@ GENERATE_TRANSFORMS +=		$(WS_TOP)/transforms/generate-cleanup
 PKGMOGRIFY_TRANSFORMS +=	$(WS_TOP)/transforms/libtool-drop
 PKGMOGRIFY_TRANSFORMS +=	$(WS_TOP)/transforms/ignore-libs
 
+ifneq ($(GCC_ROOT), /usr/gcc/4.9)
+PKGMOGRIFY_TRANSFORMS +=	$(WS_TOP)/transforms/ignore-gcc-usr-lib
+endif
+
 COMPARISON_TRANSFORMS +=	$(WS_TOP)/transforms/comparison-cleanup
 COMPARISON_TRANSFORMS +=	$(PKGMOGRIFY_TRANSFORMS)
 

--- a/transforms/ignore-gcc-usr-lib
+++ b/transforms/ignore-gcc-usr-lib
@@ -1,0 +1,17 @@
+# Don't depend on GCC libraries in /usr/lib or /usr/lib/$(MACH64)
+<transform file -> add pkg.depend.bypass-generate usr/lib/libgcc_s\\.so\\.1 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libgcc_s\\.so\\.1 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/libgfortran\\.so\\.3 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libgfortran\\.so\\.3 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/libgomp\\.so\\.1 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libgomp\\.so\\.1 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/libgobjc\\.so\\.4 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libgobjc\\.so\\.4 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/libgobjc_gc\\.so\\.4 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libgobjc_gc\\.so\\.4 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/libquadmath\\.so\\.0 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libquadmath\\.so\\.0 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/libssp\\.so\\.0 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libssp\\.so\\.0 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/libstdc\\+\\+\\.so\\.6 >
+<transform file -> add pkg.depend.bypass-generate usr/lib/$(MACH64)/libstdc\\+\\+\\.so\\.6 >


### PR DESCRIPTION
…$(MACH64) if  current compiler is not gcc-4