### PR TITLE
Add 'nvme' driver to installation media

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	18
+COMPONENT_REVISION=	19
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -103,6 +103,7 @@ depend type=require fmri=driver/storage/mega_sas
 depend type=require fmri=driver/storage/mpt_sas
 depend type=require fmri=driver/storage/mr_sas
 depend type=require fmri=driver/storage/nv_sata
+depend type=require fmri=driver/storage/nvme
 depend type=require fmri=driver/storage/pmcs
 depend type=require fmri=driver/storage/pvscsi
 depend type=require fmri=driver/storage/sbp2


### PR DESCRIPTION
With `nvme` driver OpenIndiana can be installed to NVMe devices.

On VirtualBox OI installs but won't boot as that is possible only in
UEFI mode: https://www.virtualbox.org/manual/ch05.html#harddiskcontrollers.

QEMU should boot as NVMe support was added to it's BIOS recently
(https://www.seabios.org/Releases#SeaBIOS_1.11.0) but won't install due
to illumos#8808 bug.