### PR TITLE
Minimal media are missing ddu-text

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	19
+COMPONENT_REVISION=	20
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -20,6 +20,7 @@ depend type=require fmri=developer/object-file
 depend type=require fmri=diagnostic/cpu-counters
 depend type=require fmri=diagnostic/ddu/data
 depend type=require fmri=diagnostic/ddu/library
+depend type=require fmri=diagnostic/ddu/text
 depend type=require fmri=diagnostic/scanpci
 depend type=require fmri=driver/audio
 depend type=require fmri=driver/crypto/dca


### PR DESCRIPTION
Installation menu option 'Install Additional Drivers' in minimal ISO
medium fails to execute with:

  `/usr/sbin/text-mode-menu[218]: /usr/bin/ddu-text: not found`

Adding 'ddu-text' to minimal include file.