### PR TITLE
Fix 'pkg publisher' option in DDU

### DIFF
--- a/components/osol/ddu/Makefile
+++ b/components/osol/ddu/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= ddu
 COMPONENT_VERSION= 1.3.1
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_SUMMARY= Device Driver Utility (DDU)
 COMPONENT_PROJECT_URL= http://www.openindiana.org/
 COMPONENT_FMRI= diagnostic/ddu

--- a/components/osol/ddu/srcs/usr/ddu/scripts/pkg_relate.sh
+++ b/components/osol/ddu/srcs/usr/ddu/scripts/pkg_relate.sh
@@ -46,7 +46,7 @@ builtin printf
 #
 function fetch_repo
 {
-    pfexec pkg publisher -Ha > /tmp/repo_temp_store 2>>$err_log
+    pfexec pkg publisher -H > /tmp/repo_temp_store 2>>$err_log
     if [ $? -ne 0 ]; then
         print -u2 "$0: Error found when getting repo list"
         exit 1


### PR DESCRIPTION
Repository (`F5`) option of DDU ends with:
```
root@ddu:~# ddu-text
Traceback (most recent call last):
  File "/usr/bin/ddu-text", line 79, in <module>
    screen = screen.show()
  File "/usr/ddu/ddu-text/utils/device_scan.py", line 251, in show
    return self.main_win.process_input(self)
  File "/usr/ddu/ddu-text/utils/main_window.py", line 151, in
process_input
    input = self.central_area.process(input)
  File "/usr/ddu/ddu-text/utils/inner_window.py", line 865, in process
    return handler(input)
  File "/usr/ddu/ddu-text/utils/inner_window.py", line 839, in on_key_f5
    self.repo_candi = ddu_build_repo_list(repo_list)
  File "/usr/lib/python2.7/vendor-packages/DDU/ddu_function.py", line
39, in ddu_build_repo_list
    "Arg is not a non-empty ips_repo_list")
DDU.ddu_errors.RepositoryNotFoundException: Arg is not a non-empty
ips_repo_list
```
It's due to:
```
root@ddu:~# cat /tmp/ddu_err.log
pkg publisher: illegal option -- a
Usage:
        pkg publisher [-HPn] [-F format] [publisher ...]
```
With `-P` instead of `-a` option installation of packages from publisher
works again.