### PR TITLE
Bump libao to 1.2.2

### DIFF
--- a/components/library/libao/Makefile
+++ b/components/library/libao/Makefile
@@ -15,7 +15,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=        libao
-COMPONENT_VERSION=     1.2.0
+COMPONENT_VERSION=     1.2.2
 COMPONENT_SUMMARY=     libao - cross-platform audio library
 COMPONENT_PROJECT_URL= https://www.xiph.org/ao/
 COMPONENT_FMRI=        library/audio/libao
@@ -23,14 +23,16 @@ COMPONENT_CLASSIFICATION=System/Multimedia Libraries
 COMPONENT_SRC=         $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=     $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL= \
-  https://downloads.xiph.org/releases/ao/$(COMPONENT_ARCHIVE)
+  https://github.com/xiph/libao/archive/$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:03ad231ad1f9d64b52474392d63c31197b0bc7bd416e58b1c10a329a5ed89caf
+  sha256:df8a6d0e238feeccb26a783e778716fb41a801536fe7b6fce068e313c0e2bf4d
 COMPONENT_LICENSE=     GPLv2
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_PREP_ACTION= ( cd $(@D); sh autogen.sh )
 
 build:		$(BUILD_32_and_64)
 

--- a/components/library/libao/libao.p5m
+++ b/components/library/libao/libao.p5m
@@ -29,17 +29,17 @@ file path=usr/lib/$(MACH64)/ao/plugins-4/liboss.so
 file path=usr/lib/$(MACH64)/ao/plugins-4/libpulse.so
 file path=usr/lib/$(MACH64)/ao/plugins-4/libsun.so
 file path=usr/lib/$(MACH64)/ckport/db/libao.ckport
-link path=usr/lib/$(MACH64)/libao.so target=libao.so.4.1.0
-link path=usr/lib/$(MACH64)/libao.so.4 target=libao.so.4.1.0
-file path=usr/lib/$(MACH64)/libao.so.4.1.0
+link path=usr/lib/$(MACH64)/libao.so target=libao.so.4.1.1
+link path=usr/lib/$(MACH64)/libao.so.4 target=libao.so.4.1.1
+file path=usr/lib/$(MACH64)/libao.so.4.1.1
 file path=usr/lib/$(MACH64)/pkgconfig/ao.pc
 file path=usr/lib/ao/plugins-4/liboss.so
 file path=usr/lib/ao/plugins-4/libpulse.so
 file path=usr/lib/ao/plugins-4/libsun.so
 file path=usr/lib/ckport/db/libao.ckport
-link path=usr/lib/libao.so target=libao.so.4.1.0
-link path=usr/lib/libao.so.4 target=libao.so.4.1.0
-file path=usr/lib/libao.so.4.1.0
+link path=usr/lib/libao.so target=libao.so.4.1.1
+link path=usr/lib/libao.so.4 target=libao.so.4.1.1
+file path=usr/lib/libao.so.4.1.1
 file path=usr/lib/pkgconfig/ao.pc
 file path=usr/share/aclocal/ao.m4
 file path=usr/share/doc/libao-$(COMPONENT_VERSION)/ao_append_option.html

--- a/components/library/libao/manifests/sample-manifest.p5m
+++ b/components/library/libao/manifests/sample-manifest.p5m
@@ -29,17 +29,17 @@ file path=usr/lib/$(MACH64)/ao/plugins-4/liboss.so
 file path=usr/lib/$(MACH64)/ao/plugins-4/libpulse.so
 file path=usr/lib/$(MACH64)/ao/plugins-4/libsun.so
 file path=usr/lib/$(MACH64)/ckport/db/libao.ckport
-link path=usr/lib/$(MACH64)/libao.so target=libao.so.4.1.0
-link path=usr/lib/$(MACH64)/libao.so.4 target=libao.so.4.1.0
-file path=usr/lib/$(MACH64)/libao.so.4.1.0
+link path=usr/lib/$(MACH64)/libao.so target=libao.so.4.1.1
+link path=usr/lib/$(MACH64)/libao.so.4 target=libao.so.4.1.1
+file path=usr/lib/$(MACH64)/libao.so.4.1.1
 file path=usr/lib/$(MACH64)/pkgconfig/ao.pc
 file path=usr/lib/ao/plugins-4/liboss.so
 file path=usr/lib/ao/plugins-4/libpulse.so
 file path=usr/lib/ao/plugins-4/libsun.so
 file path=usr/lib/ckport/db/libao.ckport
-link path=usr/lib/libao.so target=libao.so.4.1.0
-link path=usr/lib/libao.so.4 target=libao.so.4.1.0
-file path=usr/lib/libao.so.4.1.0
+link path=usr/lib/libao.so target=libao.so.4.1.1
+link path=usr/lib/libao.so.4 target=libao.so.4.1.1
+file path=usr/lib/libao.so.4.1.1
 file path=usr/lib/pkgconfig/ao.pc
 file path=usr/share/aclocal/ao.m4
 file path=usr/share/doc/libao-$(COMPONENT_VERSION)/ao_append_option.html


### PR DESCRIPTION
ABI compatible.
No consumer in oi-userland.