### PR TITLE
X11 updates

### DIFF
--- a/components/x11/libXcursor/Makefile
+++ b/components/x11/libXcursor/Makefile
@@ -16,23 +16,23 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           libXcursor
-COMPONENT_VERSION=        1.1.14
+COMPONENT_VERSION=        1.1.15
 COMPONENT_FMRI=           x11/library/libxcursor
 COMPONENT_CLASSIFICATION= System/X11
 COMPONENT_SUMMARY=  libXcursor - Client-side cursor loading library
 COMPONENT_SRC=      $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=  $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-  sha256:9bc6acb21ca14da51bda5bc912c8955bc6e5e433f0ab00c5e8bef842596c33df
+  sha256:294e670dd37cd23995e69aae626629d4a2dfe5708851bbc13d032401b7a3df6b
 COMPONENT_ARCHIVE_URL= \
   https://www.x.org/releases/individual/lib/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://www.x.org/
 COMPONENT_LICENSE=      MIT License
 COMPONENT_LICENSE_FILE= libXcursor.license
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 PATH=/usr/gnu/bin:/usr/bin
 

--- a/components/x11/libXfont/Makefile
+++ b/components/x11/libXfont/Makefile
@@ -16,12 +16,12 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libXfont
-COMPONENT_VERSION= 1.5.3
+COMPONENT_VERSION= 1.5.4
 COMPONENT_SUMMARY= libXfont - library for X servers and utilities to access font files
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-  sha256:ab85c10fd2683481dfef672a77fe60e6a2039558cbc0e9bf56b5e1df471c93d0
+  sha256:1a7f7490774c87f2052d146d1e0e64518d32e6848184a18654e8d0bb57883242
 COMPONENT_ARCHIVE_URL= \
   http://xorg.freedesktop.org/archive/individual/lib/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org

--- a/components/x11/libXfont2/Makefile
+++ b/components/x11/libXfont2/Makefile
@@ -16,7 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libXfont2
-COMPONENT_VERSION= 2.0.2
+COMPONENT_VERSION= 2.0.3
 COMPONENT_SUMMARY= libXfont2 - library for X servers and utilities to access font files
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_CLASSIFICATION = System/X11
@@ -26,7 +26,7 @@ COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_URL= \
   http://xorg.freedesktop.org/archive/individual/lib/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_HASH= \
-  sha256:94088d3b87f7d42c7116d9adaad155859e93330c6e47f5989f2de600b9a6c111
+  sha256:0e8ab7fd737ccdfe87e1f02b55f221f0bd4503a1c5f28be4ed6a54586bac9c4e
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 


### PR DESCRIPTION
libXcursor: CVE-2017-16612
libXfont, libXfont2: CVE-2017-16611