### PR TITLE
Bump lcms2 to 2.9 and import test transforms from solaris-userland

### DIFF
--- a/components/library/lcms2/Makefile
+++ b/components/library/lcms2/Makefile
@@ -23,7 +23,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =        lcms2
-COMPONENT_VERSION=      2.8
+COMPONENT_VERSION=      2.9
 COMPONENT_FMRI=         library/lcms2
 COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_SUMMARY=      The Little Color Management System
@@ -31,7 +31,7 @@ COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  http://www.littlecms.com/
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:66d02b229d2ea9474e62c2b6cd6720fde946155cd1d0d2bffdab829790a0fb22
+  sha256:48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d20
 COMPONENT_ARCHIVE_URL=  \
   http://sourceforge.net/projects/lcms/files/lcms/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=      MIT
@@ -46,12 +46,38 @@ CFLAGS             +=           $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
 CXXFLAGS           +=           $(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
 LDFLAGS            +=           $(JPEG_LDFLAGS)
 
+# Seems that we have no other way to designate that we want large file support.
+CFLAGS += $(CPP_LARGEFILES)
+
+# Need to ensure lcms custom chunk memory allocator aligns properly for all
+# of our platforms - see _cmsALIGNMEM macro in src/lcms2_internal.h and
+# _MAX_ALIGNMENT definition in per-platform sections of <sys/isa_defs.h>
+CPPFLAGS += -DCMS_PTR_ALIGNMENT=_MAX_ALIGNMENT
+
 CONFIGURE_OPTIONS  +=           --includedir=/usr/include/lcms2
 CONFIGURE_OPTIONS  +=           --enable-shared
 CONFIGURE_OPTIONS  +=           --disable-static
+CONFIGURE_OPTIONS  +=           --with-jpeg
+CONFIGURE_OPTIONS  +=           --with-tiff
 CONFIGURE_OPTIONS  +=           --with-zlib
 CONFIGURE_OPTIONS  +=           --with-pic
 
+COMPONENT_PRE_TEST_ACTION = ( cd $(@D); $(MAKE) -C testbed clean )
+
+# One test fails in 32-bit
+COMPONENT_TEST_ARGS = -k -i
+
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "s|^.*test bed.*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^.*MPixel.*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^.*Single block hit.*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^.*$(CC).*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^.*source=.*libtool=no.*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^.*DEPDIR=.deps.*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^make.*(ignored)*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^make.*: Leaving directory.*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "s|^make.*: Entering directory.*$$|XXX_REMOVE_XXX|g" ' \
+	'-e "/^XXX_REMOVE_XXX$$/d" '
 
 build: $(BUILD_32_and_64)
 

--- a/components/library/lcms2/test/results-32.master
+++ b/components/library/lcms2/test/results-32.master
@@ -1,0 +1,194 @@
+Making check in src
+make[2]: Nothing to be done for 'check'.
+Making check in include
+make[2]: Nothing to be done for 'check'.
+Making check in utils/tificc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/transicc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/linkicc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/jpgicc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/psicc
+make[2]: Nothing to be done for 'check'.
+Making check in testbed
+/usr/gnu/bin/make  testcms
+depbase=`echo testcms2.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
+mv -f $depbase.Tpo $depbase.Po
+depbase=`echo testplugin.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
+mv -f $depbase.Tpo $depbase.Po
+depbase=`echo zoo_icc.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
+mv -f $depbase.Tpo $depbase.Po
+if [ $(SOURCE_DIR) != .. ]; then \
+	cp $(SOURCE_DIR)/testbed/*.ic? ../testbed; \
+fi
+LD_LIBRARY_PATH=../src/.libs ./testcms
+
+Installing debug memory plug-in ... done.
+Installing error logger ... done.
+Supported intents:
+	0 - Perceptual
+	1 - Relative colorimetric
+	2 - Saturation
+	3 - Absolute colorimetric
+	10 - Perceptual preserving black ink
+	11 - Relative colorimetric preserving black ink
+	12 - Saturation preserving black ink
+	13 - Perceptual preserving black plane
+	14 - Relative colorimetric preserving black plane
+	15 - Saturation preserving black plane
+
+Checking Base types ...Ok.
+Checking endianess ...Ok.
+Checking quick floor ...Ok.
+Checking quick floor word ...Ok.
+Checking Fixed point 15.16 representation ...Ok.
+Checking Fixed point 8.8 representation ...Ok.
+Checking D50 roundtrip ...Ok.
+Checking Creation of test profiles .................Ok.
+Checking 1D interpolation in 2pt tables ...Ok.
+Checking 1D interpolation in 3pt tables ...Ok.
+Checking 1D interpolation in 4pt tables ...Ok.
+Checking 1D interpolation in 6pt tables ...Ok.
+Checking 1D interpolation in 18pt tables ...Ok.
+Checking 1D interpolation in descending 2pt tables ...Ok.
+Checking 1D interpolation in descending 3pt tables ...Ok.
+Checking 1D interpolation in descending 6pt tables ...Ok.
+Checking 1D interpolation in descending 18pt tables ...Ok.
+Checking 3D interpolation Tetrahedral (float)  ...Ok.
+Checking 3D interpolation Trilinear (float)  ...Ok.
+Checking 3D interpolation Tetrahedral (16)  ...Ok.
+Checking 3D interpolation Trilinear (16)  ...Ok.
+Checking Reverse interpolation 3 -> 3 ...Ok.
+Checking Reverse interpolation 4 -> 3 ......Ok.
+Checking 3D interpolation ...Ok.
+Checking 3D interpolation with granularity ...Ok.
+Checking 4D interpolation ...Ok.
+Checking 4D interpolation with granularity ...Ok.
+Checking 5D interpolation with granularity ...Ok.
+Checking 6D interpolation with granularity ...Ok.
+Checking 7D interpolation with granularity ...Ok.
+Checking 8D interpolation with granularity ...Ok.
+Checking Lab to LCh and back (float only)  ...Ok.
+Checking Lab to XYZ and back (float only)  ...Ok.
+Checking Lab to xyY and back (float only)  ...Ok.
+Checking Lab V2 encoding ...Ok.
+Checking Lab V4 encoding ...Ok.
+Checking Blackbody radiator ...Ok.
+Checking Linear gamma curves (16 bits) ....Ok.
+Checking Linear gamma curves (float) ....Ok.
+Checking Curve 1.8 (float) ...|Err|<0.001953 .Ok.
+Checking Curve 2.2 (float) ...|Err|<0.001953 .Ok.
+Checking Curve 3.0 (float) ...|Err|<0.001953 .Ok.
+Checking Curve 1.8 (table) ...|Err|<0.053287 .Ok.
+Checking Curve 2.2 (table) ...|Err|<0.024062 .Ok.
+Checking Curve 3.0 (table) ...|Err|<0.049726 .Ok.
+Checking Curve 1.8 (word table) ...|Err|<0.990786 .Ok.
+Checking Curve 2.2 (word table) ...|Err|<0.972654 .Ok.
+Checking Curve 3.0 (word table) ...|Err|<0.986603 .Ok.
+Checking Parametric curves ...FAIL!
+Parametric curves:
+	(param_5): Must be 0.230000, But is 0.556105 
+Checking Join curves ...Ok.
+Checking Join curves descending ...Ok.
+Checking Join curves degenerated ...Ok.
+Checking Join curves sRGB (Float) ...Ok.
+Checking Join curves sRGB (16 bits) ...Ok.
+Checking Join curves sigmoidal ...Ok.
+Checking LUT creation & dup ...Ok.
+Checking 1 Stage LUT  ...Ok.
+Checking 2 Stage LUT  ...Ok.
+Checking 2 Stage LUT (16 bits) ...Ok.
+Checking 3 Stage LUT  ...Ok.
+Checking 3 Stage LUT (16 bits) ...Ok.
+Checking 4 Stage LUT  ...Ok.
+Checking 4 Stage LUT (16 bits) ...Ok.
+Checking 5 Stage LUT  ...Ok.
+Checking 5 Stage LUT (16 bits)  ...Ok.
+Checking 6 Stage LUT  ...Ok.
+Checking 6 Stage LUT (16 bits)  ...Ok.
+Checking Lab to Lab LUT (float only)  ...Ok.
+Checking XYZ to XYZ LUT (float only)  ...Ok.
+Checking Lab to Lab MAT LUT (float only)  ...Ok.
+Checking Named Color LUT ...Ok.
+Checking Usual formatters ...Ok.
+Checking Floating point formatters ...Ok.
+Checking HALF formatters ...Ok.
+Checking ChangeBuffersFormat ...Ok.
+Checking Multilocalized Unicode ...Ok.
+Checking Named color lists ...Ok.
+Checking Profile creation .............................................Ok.
+Checking Header version ...Ok.
+Checking Multilocalized profile ...Ok.
+Checking Error reporting on bad profiles ...Ok.
+Checking Error reporting on bad transforms ...Ok.
+Checking Curves only transforms .........Ok.
+Checking Float Lab->Lab transforms .......Ok.
+Checking Encoded Lab->Lab transforms ...Ok.
+Checking Stored identities .......Ok.
+Checking Matrix-shaper transform (float) ...Ok.
+Checking Matrix-shaper transform (16 bits) ...Ok.
+Checking Matrix-shaper transform (8 bits) ...Ok.
+Checking Primaries of sRGB ...Ok.
+Checking Known values across matrix-shaper ...Ok.
+Checking Gray input profile ...Ok.
+Checking Gray Lab input profile ...Ok.
+Checking Gray output profile ...Ok.
+Checking Gray Lab output profile ...Ok.
+Checking Matrix-shaper proofing transform (float) ...Ok.
+Checking Matrix-shaper proofing transform (16 bits) ...Ok.
+Checking Gamut check .....Ok.
+Checking CMYK roundtrip on perceptual transform ...Ok.
+Checking CMYK perceptual transform ...Ok.
+Checking Black ink only preservation ...Ok.
+Checking Black plane preservation ...Ok.
+Checking Deciding curve types ...Ok.
+Checking Black point detection ...Ok.
+Checking TAC detection ...Ok.
+Checking CGATS parser ..............Ok.
+Checking CGATS parser on junk ...Ok.
+Checking CGATS parser on overflow ...Ok.
+Checking PostScript generator ...Ok.
+Checking Segment maxima GBD ........Ok.
+Checking MD5 digest ...Ok.
+Checking Linking ...Ok.
+Checking floating point tags on XYZ ...Ok.
+Checking RGB->Lab->RGB with alpha on FLT ...Ok.
+Checking Parametric curve on Rec709 ...Ok.
+Checking Floating Point sampled curve with non-zero start ...Ok.
+Checking Floating Point segmented curve with short sampled segement ...Ok.
+Checking Read RAW portions .....Ok.
+Checking Check MetaTag ...Ok.
+Checking Null transform on floats ...Ok.
+Checking Set free a tag ...Ok.
+Checking Matrix simplification ...Ok.
+Checking Planar 8 optimization ...Ok.
+Checking Swap endian feature ...Ok.
+Checking Transform line stride RGB ...Ok.
+Checking Forged MPE profile ...Ok.
+Checking Proofing intersection ...Ok.
+Checking Context memory handling ...Ok.
+Checking Simple context functionality ...Ok.
+Checking Alarm codes context ...Ok.
+Checking Adaptation state context ...Ok.
+Checking 1D interpolation plugin ...Ok.
+Checking 3D interpolation plugin ...Ok.
+Checking Parametric curve plugin ...Ok.
+Checking Formatters plugin ...Ok.
+Checking Tag type plugin ...Ok.
+Checking MPE type plugin ...Ok.
+Checking Optimization plugin ...Ok.
+Checking Rendering intent plugin ...Ok.
+Checking Full transform plugin ...Ok.
+Checking Mutex plugin ...Ok.
+
+
+P E R F O R M A N C E   T E S T S
+=================================
+
+[Memory statistics]
+if [ $(SOURCE_DIR) != .. ]; then \
+	rm -f ../testbed/*.ic?; \
+fi
+/usr/gnu/bin/make  check-local

--- a/components/library/lcms2/test/results-64.master
+++ b/components/library/lcms2/test/results-64.master
@@ -1,0 +1,196 @@
+Making check in src
+make[2]: Nothing to be done for 'check'.
+Making check in include
+make[2]: Nothing to be done for 'check'.
+Making check in utils/tificc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/transicc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/linkicc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/jpgicc
+make[2]: Nothing to be done for 'check'.
+Making check in utils/psicc
+make[2]: Nothing to be done for 'check'.
+Making check in testbed
+/usr/gnu/bin/make  testcms
+depbase=`echo testcms2.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
+mv -f $depbase.Tpo $depbase.Po
+$(SOURCE_DIR)/testbed/testcms2.c: In function ‘DbgThread’:
+$(SOURCE_DIR)/testbed/testcms2.c:104:25: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
+     return (cmsContext) (void*)(n++ % 0xff0);
+                         ^
+depbase=`echo testplugin.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
+mv -f $depbase.Tpo $depbase.Po
+depbase=`echo zoo_icc.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
+mv -f $depbase.Tpo $depbase.Po
+if [ $(SOURCE_DIR) != .. ]; then \
+	cp $(SOURCE_DIR)/testbed/*.ic? ../testbed; \
+fi
+LD_LIBRARY_PATH=../src/.libs ./testcms
+
+Installing debug memory plug-in ... done.
+Installing error logger ... done.
+Supported intents:
+	0 - Perceptual
+	1 - Relative colorimetric
+	2 - Saturation
+	3 - Absolute colorimetric
+	10 - Perceptual preserving black ink
+	11 - Relative colorimetric preserving black ink
+	12 - Saturation preserving black ink
+	13 - Perceptual preserving black plane
+	14 - Relative colorimetric preserving black plane
+	15 - Saturation preserving black plane
+
+Checking Base types ...Ok.
+Checking endianess ...Ok.
+Checking quick floor ...Ok.
+Checking quick floor word ...Ok.
+Checking Fixed point 15.16 representation ...Ok.
+Checking Fixed point 8.8 representation ...Ok.
+Checking D50 roundtrip ...Ok.
+Checking Creation of test profiles .................Ok.
+Checking 1D interpolation in 2pt tables ...Ok.
+Checking 1D interpolation in 3pt tables ...Ok.
+Checking 1D interpolation in 4pt tables ...Ok.
+Checking 1D interpolation in 6pt tables ...Ok.
+Checking 1D interpolation in 18pt tables ...Ok.
+Checking 1D interpolation in descending 2pt tables ...Ok.
+Checking 1D interpolation in descending 3pt tables ...Ok.
+Checking 1D interpolation in descending 6pt tables ...Ok.
+Checking 1D interpolation in descending 18pt tables ...Ok.
+Checking 3D interpolation Tetrahedral (float)  ...Ok.
+Checking 3D interpolation Trilinear (float)  ...Ok.
+Checking 3D interpolation Tetrahedral (16)  ...Ok.
+Checking 3D interpolation Trilinear (16)  ...Ok.
+Checking Reverse interpolation 3 -> 3 ...Ok.
+Checking Reverse interpolation 4 -> 3 ......Ok.
+Checking 3D interpolation ...Ok.
+Checking 3D interpolation with granularity ...Ok.
+Checking 4D interpolation ...Ok.
+Checking 4D interpolation with granularity ...Ok.
+Checking 5D interpolation with granularity ...Ok.
+Checking 6D interpolation with granularity ...Ok.
+Checking 7D interpolation with granularity ...Ok.
+Checking 8D interpolation with granularity ...Ok.
+Checking Lab to LCh and back (float only)  ...Ok.
+Checking Lab to XYZ and back (float only)  ...Ok.
+Checking Lab to xyY and back (float only)  ...Ok.
+Checking Lab V2 encoding ...Ok.
+Checking Lab V4 encoding ...Ok.
+Checking Blackbody radiator ...Ok.
+Checking Linear gamma curves (16 bits) ....Ok.
+Checking Linear gamma curves (float) ....Ok.
+Checking Curve 1.8 (float) ...|Err|<0.001953 .Ok.
+Checking Curve 2.2 (float) ...|Err|<0.001953 .Ok.
+Checking Curve 3.0 (float) ...|Err|<0.001953 .Ok.
+Checking Curve 1.8 (table) ...|Err|<0.053287 .Ok.
+Checking Curve 2.2 (table) ...|Err|<0.024062 .Ok.
+Checking Curve 3.0 (table) ...|Err|<0.049726 .Ok.
+Checking Curve 1.8 (word table) ...|Err|<0.990786 .Ok.
+Checking Curve 2.2 (word table) ...|Err|<0.972654 .Ok.
+Checking Curve 3.0 (word table) ...|Err|<0.986603 .Ok.
+Checking Parametric curves ...Ok.
+Checking Join curves ...Ok.
+Checking Join curves descending ...Ok.
+Checking Join curves degenerated ...Ok.
+Checking Join curves sRGB (Float) ...Ok.
+Checking Join curves sRGB (16 bits) ...Ok.
+Checking Join curves sigmoidal ...Ok.
+Checking LUT creation & dup ...Ok.
+Checking 1 Stage LUT  ...Ok.
+Checking 2 Stage LUT  ...Ok.
+Checking 2 Stage LUT (16 bits) ...Ok.
+Checking 3 Stage LUT  ...Ok.
+Checking 3 Stage LUT (16 bits) ...Ok.
+Checking 4 Stage LUT  ...Ok.
+Checking 4 Stage LUT (16 bits) ...Ok.
+Checking 5 Stage LUT  ...Ok.
+Checking 5 Stage LUT (16 bits)  ...Ok.
+Checking 6 Stage LUT  ...Ok.
+Checking 6 Stage LUT (16 bits)  ...Ok.
+Checking Lab to Lab LUT (float only)  ...Ok.
+Checking XYZ to XYZ LUT (float only)  ...Ok.
+Checking Lab to Lab MAT LUT (float only)  ...Ok.
+Checking Named Color LUT ...Ok.
+Checking Usual formatters ...Ok.
+Checking Floating point formatters ...Ok.
+Checking HALF formatters ...Ok.
+Checking ChangeBuffersFormat ...Ok.
+Checking Multilocalized Unicode ...Ok.
+Checking Named color lists ...Ok.
+Checking Profile creation .............................................Ok.
+Checking Header version ...Ok.
+Checking Multilocalized profile ...Ok.
+Checking Error reporting on bad profiles ...Ok.
+Checking Error reporting on bad transforms ...Ok.
+Checking Curves only transforms .........Ok.
+Checking Float Lab->Lab transforms .......Ok.
+Checking Encoded Lab->Lab transforms ...Ok.
+Checking Stored identities .......Ok.
+Checking Matrix-shaper transform (float) ...Ok.
+Checking Matrix-shaper transform (16 bits) ...Ok.
+Checking Matrix-shaper transform (8 bits) ...Ok.
+Checking Primaries of sRGB ...Ok.
+Checking Known values across matrix-shaper ...Ok.
+Checking Gray input profile ...Ok.
+Checking Gray Lab input profile ...Ok.
+Checking Gray output profile ...Ok.
+Checking Gray Lab output profile ...Ok.
+Checking Matrix-shaper proofing transform (float) ...Ok.
+Checking Matrix-shaper proofing transform (16 bits) ...Ok.
+Checking Gamut check .....Ok.
+Checking CMYK roundtrip on perceptual transform ...Ok.
+Checking CMYK perceptual transform ...Ok.
+Checking Black ink only preservation ...Ok.
+Checking Black plane preservation ...Ok.
+Checking Deciding curve types ...Ok.
+Checking Black point detection ...Ok.
+Checking TAC detection ...Ok.
+Checking CGATS parser ..............Ok.
+Checking CGATS parser on junk ...Ok.
+Checking CGATS parser on overflow ...Ok.
+Checking PostScript generator ...Ok.
+Checking Segment maxima GBD ........Ok.
+Checking MD5 digest ...Ok.
+Checking Linking ...Ok.
+Checking floating point tags on XYZ ...Ok.
+Checking RGB->Lab->RGB with alpha on FLT ...Ok.
+Checking Parametric curve on Rec709 ...Ok.
+Checking Floating Point sampled curve with non-zero start ...Ok.
+Checking Floating Point segmented curve with short sampled segement ...Ok.
+Checking Read RAW portions .....Ok.
+Checking Check MetaTag ...Ok.
+Checking Null transform on floats ...Ok.
+Checking Set free a tag ...Ok.
+Checking Matrix simplification ...Ok.
+Checking Planar 8 optimization ...Ok.
+Checking Swap endian feature ...Ok.
+Checking Transform line stride RGB ...Ok.
+Checking Forged MPE profile ...Ok.
+Checking Proofing intersection ...Ok.
+Checking Context memory handling ...Ok.
+Checking Simple context functionality ...Ok.
+Checking Alarm codes context ...Ok.
+Checking Adaptation state context ...Ok.
+Checking 1D interpolation plugin ...Ok.
+Checking 3D interpolation plugin ...Ok.
+Checking Parametric curve plugin ...Ok.
+Checking Formatters plugin ...Ok.
+Checking Tag type plugin ...Ok.
+Checking MPE type plugin ...Ok.
+Checking Optimization plugin ...Ok.
+Checking Rendering intent plugin ...Ok.
+Checking Full transform plugin ...Ok.
+Checking Mutex plugin ...Ok.
+
+
+P E R F O R M A N C E   T E S T S
+=================================
+
+[Memory statistics]
+if [ $(SOURCE_DIR) != .. ]; then \
+	rm -f ../testbed/*.ic?; \
+fi
+/usr/gnu/bin/make  check-local


### PR DESCRIPTION
ABI compatible, maintenance release.
One test failure in 32-bit, same as 2.8.0.