### PR TITLE
spidermonkey: add patch for gcc6

### DIFF
--- a/components/library/spidermonkey/Makefile
+++ b/components/library/spidermonkey/Makefile
@@ -16,6 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=	          spidermonkey
 COMPONENT_VERSION=        1.8.5
+COMPONENT_REVISION=       1
 COMPONENT_SUMMARY=        Javascript engine
 COMPONENT_PROJECT_URL=    https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
 COMPONENT_FMRI=	          library/spidermonkey

--- a/components/library/spidermonkey/patches/13-gcc6.patch
+++ b/components/library/spidermonkey/patches/13-gcc6.patch
@@ -1,0 +1,158 @@
+shamelessly stolen from https://gitweb.gentoo.org/repo/gentoo.git/diff/dev-lang/spidermonkey/files/spidermonkey-1.8.5-gcc6.patch
+added ctypes/CTypes.cpp
+
+diff -upr js-1.8.5/jsapi.cpp js-1.8.5/jsapi.cpp
+--- js-1.8.5/jsapi.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/jsapi.cpp	2016-02-29 18:10:49.302307353 -0600
+@@ -3985,7 +3985,7 @@ JS_Enumerate(JSContext *cx, JSObject *ob
+     AutoIdVector props(cx);
+     JSIdArray *ida;
+     if (!GetPropertyNames(cx, obj, JSITER_OWNONLY, &props) || !VectorToIdArray(cx, props, &ida))
+-        return false;
++        return NULL;
+     for (size_t n = 0; n < size_t(ida->length); ++n)
+         JS_ASSERT(js_CheckForStringIndex(ida->vector[n]) == ida->vector[n]);
+     return ida;
+diff -upr js-1.8.5/jsfun.cpp js-1.8.5/jsfun.cpp
+--- js-1.8.5/jsfun.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/jsfun.cpp	2016-02-29 18:21:45.249674890 -0600
+@@ -2051,7 +2051,7 @@ fun_toStringHelper(JSContext *cx, JSObje
+ 
+     JSString *str = JS_DecompileFunction(cx, fun, indent);
+     if (!str)
+-        return false;
++        return NULL;
+ 
+     if (!indent)
+         cx->compartment->toSourceCache.put(fun, str);
+@@ -2657,7 +2657,7 @@ LookupInterpretedFunctionPrototype(JSCon
+     const Shape *shape = funobj->nativeLookup(id);
+     if (!shape) {
+         if (!ResolveInterpretedFunctionPrototype(cx, funobj))
+-            return false;
++            return NULL;
+         shape = funobj->nativeLookup(id);
+     }
+     JS_ASSERT(!shape->configurable());
+diff -upr js-1.8.5/jsiter.cpp js-1.8.5/jsiter.cpp
+--- js-1.8.5/jsiter.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/jsiter.cpp	2016-02-29 18:24:22.494659919 -0600
+@@ -425,7 +425,7 @@ NewIteratorObject(JSContext *cx, uintN f
+          */
+         JSObject *obj = js_NewGCObject(cx, FINALIZE_OBJECT0);
+         if (!obj)
+-            return false;
++            return NULL;
+         obj->init(cx, &js_IteratorClass, NULL, NULL, NULL, false);
+         obj->setMap(cx->compartment->emptyEnumeratorShape);
+         return obj;
+diff -upr js-1.8.5/jsparse.cpp js-1.8.5/jsparse.cpp
+--- js-1.8.5/jsparse.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/jsparse.cpp	2016-02-29 18:29:03.997437475 -0600
+@@ -3352,7 +3352,7 @@ Parser::functionDef(JSAtom *funAtom, Fun
+     if (!outertc->inFunction() && bodyLevel && funAtom && !lambda && outertc->compiling()) {
+         JS_ASSERT(pn->pn_cookie.isFree());
+         if (!DefineGlobal(pn, outertc->asCodeGenerator(), funAtom))
+-            return false;
++            return NULL;
+     }
+ 
+     pn->pn_blockid = outertc->blockid();
+diff -upr js-1.8.5/jsstr.cpp js-1.8.5/jsstr.cpp
+--- js-1.8.5/jsstr.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/jsstr.cpp	2016-02-29 19:01:45.857779836 -0600
+@@ -1734,7 +1734,7 @@ class RegExpGuard
+         if (flat) {
+             patstr = flattenPattern(cx, fm.patstr);
+             if (!patstr)
+-                return false;
++                return NULL;
+         } else {
+             patstr = fm.patstr;
+         }
+@@ -3400,7 +3400,7 @@ js_InitStringClass(JSContext *cx, JSObje
+                                  UndefinedValue(), NULL, NULL,
+                                  JSPROP_READONLY | JSPROP_PERMANENT | JSPROP_SHARED, 0, 0,
+                                  NULL)) {
+-        return JS_FALSE;
++        return NULL;
+     }
+ 
+     return proto;
+diff -upr js-1.8.5/jstypedarray.cpp js-1.8.5/jstypedarray.cpp
+--- js-1.8.5/jstypedarray.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/jstypedarray.cpp	2016-02-29 19:08:53.541136191 -0600
+@@ -1334,7 +1334,7 @@ class TypedArrayTemplate
+         if (size != 0 && count >= INT32_MAX / size) {
+             JS_ReportErrorNumber(cx, js_GetErrorMessage, NULL,
+                                  JSMSG_NEED_DIET, "size and count");
+-            return false;
++            return NULL;
+         }
+ 
+         int32 bytelen = size * count;
+@@ -1668,7 +1668,7 @@ TypedArrayConstruct(JSContext *cx, jsint
+ 
+       default:
+         JS_NOT_REACHED("shouldn't have gotten here");
+-        return false;
++        return NULL;
+     }
+ }
+ 
+diff -upr js-1.8.5/jsxml.cpp js-1.8.5/jsxml.cpp
+--- js-1.8.5/jsxml.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/jsxml.cpp	2016-02-29 19:17:10.363279731 -0600
+@@ -282,7 +282,7 @@ NewXMLNamespace(JSContext *cx, JSLinearS
+ 
+     obj = NewBuiltinClassInstanceXML(cx, &js_NamespaceClass);
+     if (!obj)
+-        return JS_FALSE;
++        return NULL;
+     JS_ASSERT(JSVAL_IS_VOID(obj->getNamePrefixVal()));
+     JS_ASSERT(JSVAL_IS_VOID(obj->getNameURIVal()));
+     JS_ASSERT(JSVAL_IS_VOID(obj->getNamespaceDeclared()));
+@@ -431,7 +431,7 @@ ConvertQNameToString(JSContext *cx, JSOb
+         size_t length = str->length();
+         jschar *chars = (jschar *) cx->malloc((length + 2) * sizeof(jschar));
+         if (!chars)
+-            return JS_FALSE;
++            return NULL;
+         *chars = '@';
+         const jschar *strChars = str->getChars(cx);
+         if (!strChars) {
+diff -upr js-1.8.5/methodjit/InvokeHelpers.cpp js-1.8.5/methodjit/InvokeHelpers.cpp
+--- js-1.8.5/methodjit/InvokeHelpers.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/methodjit/InvokeHelpers.cpp	2016-02-29 20:34:14.496983346 -0600
+@@ -728,7 +728,7 @@ AtSafePoint(JSContext *cx)
+ {
+     JSStackFrame *fp = cx->fp();
+     if (fp->hasImacropc())
+-        return false;
++        return NULL;
+ 
+     JSScript *script = fp->script();
+     return script->maybeNativeCodeForPC(fp->isConstructing(), cx->regs->pc);
+diff -upr js-1.8.5/nanojit/NativeX64.cpp js-1.8.5/nanojit/NativeX64.cpp
+--- js-1.8.5/nanojit/NativeX64.cpp	2011-03-31 14:08:36.000000000 -0500
++++ js-1.8.5/nanojit/NativeX64.cpp	2016-02-29 20:19:56.487934808 -0600
+@@ -1899,7 +1899,7 @@ namespace nanojit
+          }
+     }
+ 
+-    static const AVMPLUS_ALIGN16(int64_t) negateMask[] = {0x8000000000000000LL,0};
++    static const AVMPLUS_ALIGN16(int64_t) negateMask[] = {int64_t(0x8000000000000000LL),0};
+ 
+     void Assembler::asm_fneg(LIns *ins) {
+         Register rr, ra;
+--- js-1.8.5/ctypes/CTypes.cpp.orig	2017-12-02 02:06:21.976748900 +0000
++++ js-1.8.5/ctypes/CTypes.cpp	2017-12-02 02:08:03.515194847 +0000
+@@ -4766,7 +4766,7 @@
+   for (JSUint32 i = 0; i < argLength; ++i) {
+     bool isEllipsis;
+     if (!IsEllipsis(cx, argTypes[i], &isEllipsis))
+-      return false;
++      return NULL;
+     if (isEllipsis) {
+       fninfo->mIsVariadic = true;
+       if (i < 1) {


### PR DESCRIPTION
Compiles with gcc6 and passes the test.

I changed in ../../../make-rules/shared-macros.mk 
GCC_VERSION = 4.9
to
GCC_VERSION = 6
to test the patch.
Is this the correct way?