### PR TITLE
ogl-select should require diagnostic/constype

### DIFF
--- a/components/x11/ogl-select/Makefile
+++ b/components/x11/ogl-select/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ogl-select
 COMPONENT_VERSION=	0.5.11
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	ogl-select - boot time selection of OpenGL vendor files
 COMPONENT_PROJECT_URL = https://hg.java.net/hg/solaris-x11~x-s12-clone
 COMPONENT_FMRI= service/opengl/ogl-select

--- a/components/x11/ogl-select/ogl-select.p5m
+++ b/components/x11/ogl-select/ogl-select.p5m
@@ -21,6 +21,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+depend fmri=diagnostic/constype type=require
+
 <transform file path=lib/opengl/ogl_select/.* ->  default restart_fmri svc:/application/opengl/ogl-select:default>
 <transform file path=lib/opengl/ogl_select/.* ->  default mode 0555>
 <transform link path=.* -> default pkg.linted.userland.action002.0 true>


### PR DESCRIPTION
`ogl-select` script uses `constype` binary, but the package does not require `diagnostic/constype` component:
```
components/x11/ogl-select/files/ogl-select:101:DRIVER="$(/usr/bin/constype)"
```
This is visible when VirtualBox Guest Additions on a system from Minimal medium is installed.

![constype](https://user-images.githubusercontent.com/4632197/33566072-3a371e3e-d91f-11e7-96c9-420f25e91f48.jpg)