### PR TITLE
libfuse: fix wrong options and paths for mount/unmount

### DIFF
--- a/components/library/libfuse/Makefile
+++ b/components/library/libfuse/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		libfuse
 COMPONENT_VERSION= 	20100615
 IPS_COMPONENT_VERSION=	2.7.6
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_FMRI=		library/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION = System/Libraries
 COMPONENT_SUMMARY=	FUSE stands for 'File system in User Space'. It provides a simple interface to allow implementation of a fully functional file system in user-space.
@@ -30,9 +30,9 @@ COMPONENT_ARCHIVE_URL=  http://sfe.opencsw.org/files/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE =	LGPLv2
 COMPONENT_LICENSE_FILE=	COPYING.LIB
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/justmake.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/justmake.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 GMAKE=/usr/bin/dmake
 
@@ -58,4 +58,3 @@ install:	$(INSTALL_32_and_64)
 
 test:		$(NO_TESTS)
 
-include $(WS_TOP)/make-rules/depend.mk

--- a/components/library/libfuse/patches/mount_util.c.patch
+++ b/components/library/libfuse/patches/mount_util.c.patch
@@ -1,5 +1,9 @@
---- libfuse/mount_util.c.ref	2010-06-15 16:46:54.000000000 +0200
-+++ libfuse/mount_util.c	2016-05-03 21:36:52.782854200 +0200
+
+Options -i, -l do not exist in Illumos umount
+Options -i, -f do not exist or differ in meaning in Illumos mount
+ 
+--- libfuse/mount_util.c.orig	2017-12-05 22:13:00.030067695 +0000
++++ libfuse/mount_util.c	2017-12-05 22:14:22.818357506 +0000
 @@ -58,6 +58,7 @@
          return -1;
      }
@@ -7,19 +11,21 @@
 +        char *env = NULL;
          char templ[] = "/tmp/fusermountXXXXXX";
          char *tmp;
-
-@@ -79,8 +80,8 @@
+ 
+@@ -79,9 +80,9 @@
              exit(1);
          }
          rmdir(tmp);
 -        execl("/bin/mount", "/bin/mount", "-i", "-f", "-t", type, "-o", opts,
 -              fsname, mnt, NULL);
-+        execle("/bin/mount", "/bin/mount", "-i", "-f", "-t", type, "-o", opts,
+-        fprintf(stderr, "%s: failed to execute /bin/mount: %s\n", progname,
++        execle("/sbin/mount", "/sbin/mount", "-t", type, "-o", opts,
 +              fsname, mnt, NULL, &env);
-         fprintf(stderr, "%s: failed to execute /bin/mount: %s\n", progname,
++        fprintf(stderr, "%s: failed to execute /sbin/mount: %s\n", progname,
                  strerror(errno));
          exit(1);
-@@ -112,9 +113,16 @@
+     }
+@@ -112,10 +113,17 @@
          return -1;
      }
      if (res == 0) {
@@ -28,13 +34,15 @@
          setuid(geteuid());
 -        execl("/bin/umount", "/bin/umount", "-i", mnt, lazy ? "-l" : NULL,
 -              NULL);
+-        fprintf(stderr, "%s: failed to execute /bin/umount: %s\n", progname,
 +        if (lazy) {
-+            execle("/bin/umount", "/bin/umount", "-i", mnt, "-l",
++            execle("/sbin/umount", "/sbin/umount", "-a", mnt, 
 +                   NULL, &env);
 +        } else {
-+            execle("/bin/umount", "/bin/umount", "-i", mnt,
++            execle("/sbin/umount", "/sbin/umount", "-a", mnt,
 +                   NULL, &env);
 +        }
-         fprintf(stderr, "%s: failed to execute /bin/umount: %s\n", progname,
++        fprintf(stderr, "%s: failed to execute /sbin/umount: %s\n", progname,
                  strerror(errno));
          exit(1);
+     }

--- a/components/library/libfuse/patches/mount_util.c.patch
+++ b/components/library/libfuse/patches/mount_util.c.patch
@@ -1,9 +1,5 @@
-
-Options -i, -l do not exist in Illumos umount
-Options -i, -f do not exist or differ in meaning in Illumos mount
- 
---- libfuse/mount_util.c.orig	2017-12-05 22:13:00.030067695 +0000
-+++ libfuse/mount_util.c	2017-12-05 22:14:22.818357506 +0000
+--- libfuse/mount_util.c.orig	2017-12-06 22:17:00.200753628 +0000
++++ libfuse/mount_util.c	2017-12-06 22:16:13.152587853 +0000
 @@ -58,6 +58,7 @@
          return -1;
      }
@@ -25,7 +21,7 @@ Options -i, -f do not exist or differ in meaning in Illumos mount
                  strerror(errno));
          exit(1);
      }
-@@ -112,10 +113,17 @@
+@@ -112,10 +113,12 @@
          return -1;
      }
      if (res == 0) {
@@ -35,13 +31,8 @@ Options -i, -f do not exist or differ in meaning in Illumos mount
 -        execl("/bin/umount", "/bin/umount", "-i", mnt, lazy ? "-l" : NULL,
 -              NULL);
 -        fprintf(stderr, "%s: failed to execute /bin/umount: %s\n", progname,
-+        if (lazy) {
-+            execle("/sbin/umount", "/sbin/umount", "-a", mnt, 
++        execle("/sbin/umount", "/sbin/umount", "-a", mnt, 
 +                   NULL, &env);
-+        } else {
-+            execle("/sbin/umount", "/sbin/umount", "-a", mnt,
-+                   NULL, &env);
-+        }
 +        fprintf(stderr, "%s: failed to execute /sbin/umount: %s\n", progname,
                  strerror(errno));
          exit(1);


### PR DESCRIPTION
The paths for mount and umount were wrong.
And some options for the commands are not available in Illumos.

Dependent packages to recompile:
- [x] network/sshfs
- [x] system/file-system/ntfsprogs
- [x] system/virtualization/open-vm-tools
marked packages are recompiled and tested
