### PR TITLE
open-vm-tools: fix vmhgfs-fuse

### DIFF
--- a/components/sysutils/open-vm-tools/Makefile
+++ b/components/sysutils/open-vm-tools/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		open-vm-tools
 COMPONENT_VERSION=	10.1.15
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY=	open-vm-tools is a set of services and modules that enable several features in VMware products for better management of, and seamless user interactions with, guests.
 COMPONENT_PROJECT_URL=	https://github.com/vmware/open-vm-tools
 COMPONENT_FMRI=		system/virtualization/open-vm-tools

--- a/components/sysutils/open-vm-tools/patches/10-vmhgfs-fuse-config.patch
+++ b/components/sysutils/open-vm-tools/patches/10-vmhgfs-fuse-config.patch
@@ -1,0 +1,11 @@
+--- open-vm-tools-stable-10.1.15/vmhgfs-fuse/config.c.orig	2017-12-06 09:38:47.632555186 +0000
++++ open-vm-tools-stable-10.1.15/vmhgfs-fuse/config.c	2017-12-06 09:40:15.229651388 +0000
+@@ -496,7 +496,7 @@
+ #ifdef VMX86_DEVEL
+    config.logLevel = LOGLEVEL_THRESHOLD;
+ #endif
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(__sun)
+    /* osxfuse does not have option 'big_writes'. */
+    config.addBigWrites = FALSE;
+ #else


### PR DESCRIPTION
Changed to support libfuse 2.7.6.
Recompiled with libfuse


Tested in VMware with a VM running under Workstation 12.5.7 with updated open-vm-tools und driver/fuse 

```bash
# show the name of the share defined in VM Workstation
# mount the share via fuse
# list the content
# unmount the share
root@oi-p3:~# vmware-hgfsclient
shared
root@oi-p3:~# vmhgfs-fuse -o allow_other /mnt/hgfs
root@oi-p3:~# ls -la /mnt/hgfs/shared/
total 10
drwxrwxrwx   1 root     root           0 Dec  6 10:58 .
dr-xr-xr-x   1 root     root        4192 Dec  6 17:28 ..
-rwxrwxrwx   1 root     root          22 Dec  6 10:58 a.txt
root@oi-p3:~# umount /mnt/hgfs/
```