### PR TITLE
libfuse: remove non-linux arguments for mount/umount

### DIFF
--- a/components/library/libfuse/Makefile
+++ b/components/library/libfuse/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		libfuse
 COMPONENT_VERSION= 	20100615
 IPS_COMPONENT_VERSION=	2.7.6
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_FMRI=		library/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION = System/Libraries
 COMPONENT_SUMMARY=	FUSE stands for 'File system in User Space'. It provides a simple interface to allow implementation of a fully functional file system in user-space.

--- a/components/library/libfuse/patches/mount_util.c.patch
+++ b/components/library/libfuse/patches/mount_util.c.patch
@@ -15,7 +15,7 @@
 -        execl("/bin/mount", "/bin/mount", "-i", "-f", "-t", type, "-o", opts,
 -              fsname, mnt, NULL);
 -        fprintf(stderr, "%s: failed to execute /bin/mount: %s\n", progname,
-+        execle("/sbin/mount", "/sbin/mount", "-t", type, "-o", opts,
++        execle("/sbin/mount", "/sbin/mount", "-F", type, "-o", opts,
 +              fsname, mnt, NULL, &env);
 +        fprintf(stderr, "%s: failed to execute /sbin/mount: %s\n", progname,
                  strerror(errno));
@@ -31,7 +31,7 @@
 -        execl("/bin/umount", "/bin/umount", "-i", mnt, lazy ? "-l" : NULL,
 -              NULL);
 -        fprintf(stderr, "%s: failed to execute /bin/umount: %s\n", progname,
-+        execle("/sbin/umount", "/sbin/umount", "-a", mnt, 
++        execle("/sbin/umount", "/sbin/umount",  mnt,
 +                   NULL, &env);
 +        fprintf(stderr, "%s: failed to execute /sbin/umount: %s\n", progname,
                  strerror(errno));


### PR DESCRIPTION
-a for umount is not necessary
-t for mount was ignored