### PR TITLE
git: depend on GNU gettext at runtime, for shell scripts

### DIFF
--- a/components/developer/git/Makefile
+++ b/components/developer/git/Makefile
@@ -24,6 +24,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		git
 COMPONENT_VERSION=	2.14.2
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	https://git-scm.com/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
@@ -36,6 +37,7 @@ COMPONENT_LICENSE_FILE=	git.license
 COMPONENT_SUMMARY=	git - Fast Version Control System
 COMPONENT_DESCRIPTION=	Git is a free & open source, distributed version control system designed to handle everything from small to very large projects with speed and efficiency.
 COMPONENT_CLASSIFICATION=	Development/Source Code Management
+
 
 #
 # man pages are a separate archive

--- a/components/developer/git/Makefile
+++ b/components/developer/git/Makefile
@@ -38,7 +38,6 @@ COMPONENT_SUMMARY=	git - Fast Version Control System
 COMPONENT_DESCRIPTION=	Git is a free & open source, distributed version control system designed to handle everything from small to very large projects with speed and efficiency.
 COMPONENT_CLASSIFICATION=	Development/Source Code Management
 
-
 #
 # man pages are a separate archive
 #

--- a/components/developer/git/git.p5m
+++ b/components/developer/git/git.p5m
@@ -35,6 +35,9 @@ set name=org.opensolaris.arc-caseid value=LSARC/2008/360
 
 license $(COMPONENT_LICENSE_FILE) license=$(COMPONENT_LICENSE)
 
+# Needed at runtime for localization in shell scripts
+depend fmri=text/gnu-gettext type=require
+
 file path=usr/bin/diff-highlight
 file path=usr/bin/gitk
 file path=usr/lib/git-core/git


### PR DESCRIPTION
I added this to both `REQUIRED_PACKAGES` and the manifest directly, since `REQUIRED_PACKAGES` seems to not actually work.  That may just mean I'm missing something about how oi-userland and other userlands differ.