### PR TITLE
graphviz: add missing binaries for ocaml 32bit

### DIFF
--- a/components/image/graphviz/graphviz-ocaml.p5m
+++ b/components/image/graphviz/graphviz-ocaml.p5m
@@ -40,6 +40,11 @@ file path=usr/lib/$(MACH64)/graphviz/ocaml/gv.cma
 file path=usr/lib/$(MACH64)/graphviz/ocaml/gv.cmi
 file path=usr/lib/$(MACH64)/graphviz/ocaml/gv.cmo
 file path=usr/lib/$(MACH64)/graphviz/ocaml/libgv_ocaml.so
+file path=usr/lib/graphviz/ocaml/META.gv
+file path=usr/lib/graphviz/ocaml/gv.cma
+file path=usr/lib/graphviz/ocaml/gv.cmi
+file path=usr/lib/graphviz/ocaml/gv.cmo
+file path=usr/lib/graphviz/ocaml/libgv_ocaml.so
 file usr/share/man/man3/gv.3ocaml path=usr/share/man/man3/gv-ocaml.3
 
 license COPYING license=EPL1.0


### PR DESCRIPTION
Sorry, erroneously deleted.