### PR TITLE
libtool and pkg-config should skip linker default paths 

### DIFF
--- a/components/Makefile
+++ b/components/Makefile
@@ -64,7 +64,7 @@ clobber:		TARGET = clobber
 test:			TARGET = test
 component-hook:		TARGET = component-hook
 prep build install pre-publish publish test:	TEMPLATE_ZONE=$(ZONE)
-prep build install pre-publish publish test:	LOG = >$(WS_LOGS)/$(@F).$(TARGET).log 2>&1
+prep build install pre-publish publish test:	LOG = >$(WS_LOGS)/$(subst /,.,$@).$(TARGET).log 2>&1
 
 # turn off pkglint for the individual component builds.
 ifeq   ($(strip $(PKGLINT_COMPONENT)),)

--- a/components/developer/libtool/Makefile
+++ b/components/developer/libtool/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libtool
 COMPONENT_VERSION=	2.4.6
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=	developer/build/libtool
 COMPONENT_SUMMARY=	GNU libtool
 COMPONENT_CLASSIFICATION=	Development/GNU

--- a/components/developer/libtool/patches/001-dlsearch.patch
+++ b/components/developer/libtool/patches/001-dlsearch.patch
@@ -1,0 +1,23 @@
+--- libtool-2.4.6/m4/libtool.m4.orig	Tue Jan 20 10:15:19 2015
++++ libtool-2.4.6/m4/libtool.m4	Fri Jan 26 23:33:45 2018
+@@ -2995,6 +2995,20 @@
+   hardcode_into_libs=yes
+   # ldd complains unless libraries are executable
+   postinstall_cmds='chmod +x $lib'
++
++  # Solaris runtime linker default search path for both 32 and 64 bit.
++  # /lib and /usr/lib are the default 32 bit paths.  The 64 bit paths
++  # are architecture dependent and also include a */64 symlink that
++  # is an equivalent to the architecture specific 64 bit path.
++  sys_lib_dlsearch_path_spec="/lib /usr/lib"
++  for ac_dir in $sys_lib_dlsearch_path_spec ; do
++    for ac_mach64 in 64 amd64 sparcv9 ; do
++      ac_dir_mach64=$ac_dir/$ac_mach64
++      if test -d $ac_dir_mach64 -o -L $ac_dir_mach64; then
++        sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $ac_dir_mach64"
++      fi
++    done
++  done
+   ;;
+ 
+ sunos4*)

--- a/components/developer/pkg-config/Makefile
+++ b/components/developer/pkg-config/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pkg-config
 COMPONENT_VERSION=	0.29.2
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=	developer/build/pkg-config
 COMPONENT_SUMMARY=	A tool to query library build-time information
 COMPONENT_CLASSIFICATION=	Development/System
@@ -48,6 +49,9 @@ include $(WS_MAKE_RULES)/ips.mk
 PATH=$(PATH.gnu)
 
 ASLR_MODE = $(ASLR_ENABLE)
+
+# have pkg-config strip any of the default linker search directories
+CONFIGURE_OPTIONS += --with-system-library-path='/lib:/usr/lib:/lib/${MACH64}:/usr/lib/${MACH64}:/lib/64:/usr/lib/64'
 
 COMPONENT_TEST_MASTER =	$(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 

--- a/components/developer/pkg-config/Makefile
+++ b/components/developer/pkg-config/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pkg-config
 COMPONENT_VERSION=	0.29.2
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_FMRI=	developer/build/pkg-config
 COMPONENT_SUMMARY=	A tool to query library build-time information
 COMPONENT_CLASSIFICATION=	Development/System

--- a/components/developer/pkg-config/patches/001-rpath.patch
+++ b/components/developer/pkg-config/patches/001-rpath.patch
@@ -1,0 +1,79 @@
+#
+# pkg-config --libs or --libs-only-L should strip linker flags
+# matching (-Wl,)?-((L|R) ?)|(rpath,)){path} where path matches
+# a system libpath, not just -Lpath.
+#
+
+--- pkg-config-0.29.2/pkg.c.orig	Mon Mar 20 11:34:23 2017
++++ pkg-config-0.29.2/pkg.c	Mon Jan 29 21:21:41 2018
+@@ -863,32 +863,54 @@
+       GList *system_dir_iter = system_directories;
+       Flag *flag = iter->data;
+ 
+-      if (!(flag->type & LIBS_L))
++      if (!(flag->type & (LIBS_L | LIBS_ANY)))
+         continue;
+ 
+       while (system_dir_iter != NULL)
+         {
++          gboolean is_Wl = FALSE;
+           gboolean is_system = FALSE;
+           const char *linker_arg = flag->arg;
++          const char *linker_path = NULL;
+           const char *system_libpath = system_dir_iter->data;
+ 
+-          if (strncmp (linker_arg, "-L ", 3) == 0 &&
+-              strcmp (linker_arg + 3, system_libpath) == 0)
+-            is_system = TRUE;
+-          else if (strncmp (linker_arg, "-L", 2) == 0 &&
+-              strcmp (linker_arg + 2, system_libpath) == 0)
+-            is_system = TRUE;
+-          if (is_system)
++          /*
++           * Skip any "-Wl," that might tell a compiler that a linker flag
++           * is comming.
++           */
++          if (strncmp(linker_arg, "-Wl,", 4) == 0)
+             {
+-              debug_spew ("Package %s has -L %s in Libs\n",
+-                          pkg->key, system_libpath);
+-              if (g_getenv ("PKG_CONFIG_ALLOW_SYSTEM_LIBS") == NULL)
++              linker_arg += 4;
++              is_Wl = TRUE;
++            }
++
++          /* Is this a linker flag that we might want to strip? */
++          if (strncmp (linker_arg, "-L", 2) == 0 ||
++              strncmp (linker_arg, "-R", 2) == 0)
++            linker_path = linker_arg + 2;
++          else if (strncmp (linker_arg, "-rpath", 6) == 0)
++            linker_path = linker_arg + 6;
++
++          if (linker_path != NULL)
++            {
++              /* Skip a leading space or comma. */
++              if (((is_Wl == FALSE) && (*linker_path == ' ')) ||
++                  ((is_Wl == TRUE) && (*linker_path == ',')))
++                linker_path++;
++
++              /* Does this match a system_libpath item? */
++              if (strcmp(linker_path, system_libpath) == 0)
+                 {
+-                  iter->data = NULL;
+-                  ++count;
+-                  debug_spew ("Removing -L %s from libs for %s\n",
+-                              system_libpath, pkg->key);
+-                  break;
++                  debug_spew ("Package %s has %s in Libs search path\n",
++                              pkg->key, system_libpath);
++                  if (g_getenv ("PKG_CONFIG_ALLOW_SYSTEM_LIBS") == NULL)
++                    {
++                      iter->data = NULL;
++                      ++count;
++                      debug_spew ("Removing %s from libs for %s\n",
++                                  flag->arg, pkg->key);
++                      break;
++                    }
+                 }
+             }
+           system_dir_iter = system_dir_iter->next;

--- a/tools/python/pkglint/userland.py
+++ b/tools/python/pkglint/userland.py
@@ -275,6 +275,14 @@ class UserlandActionChecker(base.ActionChecker):
 					match = True
 					break
 
+			# The RUNPATH shouldn't contain any runtime linker
+			# default paths (or the /64 equivalent link)
+			if dir in ['/lib', '/lib/64',
+				   '/lib/amd64', '/lib/sparcv9',
+				   '/usr/lib', '/usr/lib/64',
+				   '/usr/lib/amd64', '/usr/lib/sparcv9' ]:
+				list.append(dir)
+
 			if match == False:
 				list.append(dir)
 

--- a/tools/userland-mangler
+++ b/tools/userland-mangler
@@ -31,6 +31,9 @@
 import os
 import sys
 import re
+import subprocess
+import shutil
+
 
 import pkg.fmri
 import pkg.manifest
@@ -194,12 +197,70 @@ def mangle_manpage(manifest, action, text):
 
 	return result
 
-
 #
-# mangler.elf.strip = (true|false)
+# mangler.elf.strip_runpath = (true|false)
 #
 def mangle_elf(manifest, action, src, dest):
-	pass
+	strip_elf_runpath = action.attrs.pop('mangler.elf.strip_runpath', 'true')
+	if strip_elf_runpath is 'false':
+		return
+
+	#
+	# Strip any runtime linker default search path elements from the file
+	#
+	ELFEDIT = '/usr/bin/elfedit'
+
+	# runtime linker default search path elements + /64 link
+	rtld_default_dirs = [ '/lib', '/usr/lib',
+			      '/lib/64', '/usr/lib/64',
+			      '/lib/amd64', '/usr/lib/amd64',
+			      '/lib/sparcv9', '/usr/lib/sparcv9' ]
+
+	runpath_re = re.compile('.+\s(RPATH|RUNPATH)\s+\S+\s+(\S+)')
+
+	# Retreive the search path from the object file.  Use elfedit(1) because pkg.elf only
+	# retrieves the RUNPATH.  Note that dyn:rpath and dyn:runpath return both values.
+	# Both RPATH and RUNPATH are expected to be the same, but in an overabundand of caution,
+	# process each element found separately.
+	result = subprocess.Popen([ELFEDIT, '-re', 'dyn:runpath', src ],
+				  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result.wait()
+	if result.returncode != 0:	# no RUNPATH or RPATH to potentially strip
+		return
+
+	for line in result.stdout:
+		result = runpath_re.match(line)
+		if result != None:
+			element = result.group(1)
+			original_dirs = result.group(2).split(":")
+			keep_dirs = []
+			matched_dirs = []
+
+			for dir in original_dirs:
+				if dir not in rtld_default_dirs:
+					keep_dirs.append(dir)
+				else:
+					matched_dirs.append(dir)
+
+			if len(matched_dirs) != 0:
+				# Emit an "Error" message in case someone wants to look at the build log
+				# and fix the component build so that this is a NOP.
+				print >>sys.stderr, "Stripping %s from %s in %s" % (":".join(matched_dirs), element, src)
+
+				# Make sure that there is a destdir to copy the file into for mangling.
+				destdir = os.path.dirname(dest)
+				if not os.path.exists(destdir):
+					os.makedirs(destdir)
+				# Create a copy to mangle if it doesn't exist yet.
+				if os.path.isfile(dest) == False:
+					shutil.copy2(src, dest)
+
+				# Mangle the copy by deleting the tag if there is nothing left to keep
+				# or replacing the value if there is something left.
+				elfcmd = "dyn:delete %s" % element.lower()
+				if len(keep_dirs) > 0:
+					elfcmd = "dyn:%s '%s'" % (element.lower(), ":".join(keep_dirs))
+				subprocess.call([ELFEDIT, '-e', elfcmd, dest])
 
 #
 # mangler.script.file-magic =


### PR DESCRIPTION
The first changeset is unrelated, but addressed the case where the build overwrites log files from component directories that end in the same name.
The next changeset patches libtool so that it drops linker default paths instead of adding them to R*PATH
Then there is a pkglint check for linker default paths in RUNPATH
A userland-mangler change to strip linker default paths from R*PATH
Finally, two changesets to make sure pkg-config has all of the linker default paths when configured and to patch it to drop -R, -rpath, and -Wl, variants for --libs where the path is in the linker defaults.

A full build with and without the new libtool and pkg-config installed shows that fixing libtool and pkg-config addresses roughly half of the R*PATH issues across the gate.  I didn't go back and autoreconf things that weren't addressed, but I expect that would fix some more.  The userland-mangler change fixes things that weren't addressed in the component builds.  It emits a message to stderr (so in the log) letting you know when it makes R*PATH adjustments.