### PR TITLE
augeas: use gcc 6

### DIFF
--- a/components/ruby/augeas/Makefile
+++ b/components/ruby/augeas/Makefile
@@ -45,6 +45,8 @@ COMPONENT_LICENSE_FILE=	augeas.license
 
 TPNO=                   21871
 
+GCC_VERSION = 6
+
 # No gemspec is shipped with the gem. Create one
 COMPONENT_POST_UNPACK_ACTION= \
     $(GEM) spec $(USERLAND_ARCHIVES)$(COMPONENT_ARCHIVE) --ruby > $(SOURCE_DIR)/$(GEMSPEC)
@@ -53,6 +55,13 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/ips.mk
 include $(WS_MAKE_RULES)/gem.mk
 include $(WS_MAKE_RULES)/ruby.mk
+
+LD_OPTIONS=
+COMMON_ENV += LD_OPTIONS="-R$(GCC_ROOT)/lib"
+COMMON_ENV += CC=$(CC)
+
+COMPONENT_BUILD_ENV += $(COMMON_ENV)
+COMPONENT_INSTALL_ENV += $(COMMON_ENV)
 
 COMPONENT_TEST_CMD=	/usr/bin/rake
 COMPONENT_TEST_DIR=	$(SOURCE_DIR)

--- a/components/ruby/augeas/patches/01-use-CC.patch
+++ b/components/ruby/augeas/patches/01-use-CC.patch
@@ -1,0 +1,14 @@
+--- ruby-augeas-0.5.0/ext/augeas/extconf.rb.~1~	2018-01-31 20:55:16.911617952 +0000
++++ ruby-augeas-0.5.0/ext/augeas/extconf.rb	2018-01-31 20:58:00.300392901 +0000
+@@ -23,6 +23,11 @@
+
+ extension_name = '_augeas'
+
++RbConfig::CONFIG['CC'] = ENV['CC'] if ENV['CC']
++RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
++
++print RbConfig::CONFIG['CC']
++
+ unless pkg_config("augeas")
+     raise "augeas-devel not installed"
+ end

--- a/make-rules/gem.mk
+++ b/make-rules/gem.mk
@@ -34,7 +34,7 @@ GEMSPEC=$(COMPONENT_NAME).gemspec
 # Some gems projects have to be built using rake
 # Allow GEM build/install commands to be overwritten
 # to account for possible differences
-GEM_BUILD_ACTION=(cd $(@D); $(GEM) build $(GEM_BUILD_ARGS) $(GEMSPEC))
+GEM_BUILD_ACTION=(cd $(@D); $(ENV) $(COMPONENT_BUILD_ENV) $(GEM) build $(GEM_BUILD_ARGS) $(GEMSPEC))
 
 # Build install args in a more readable fashion
 ifeq ($(firstword $(subst .,$(space),$(RUBY_VERSION))),2)
@@ -49,7 +49,7 @@ GEM_INSTALL_ARGS += --bindir $(PROTO_DIR)/$(VENDOR_GEM_DIR)/bin
 # cd into build directory
 # gem 2.2.3 uses .gem from the cwd ignoring command line .gem file
 # gem 1.8.23.2 uses command line .gem file OR .gem from cwd
-GEM_INSTALL_ACTION= (cd $(@D); $(GEM) install $(GEM_INSTALL_ARGS) $(COMPONENT_NAME))
+GEM_INSTALL_ACTION= (cd $(@D); $(ENV) $(COMPONENT_INSTALL_ENV) $(GEM) install $(GEM_INSTALL_ARGS) $(COMPONENT_NAME))
 
 
 $(BUILD_DIR)/%/.built:  $(SOURCE_DIR)/.prep


### PR DESCRIPTION
This is not elegant , but works. 
The real issue is that ruby needs fixing. 
It sets LIBRUBYARG_SHARED in ruby*.pc:
LIBRUBYARG_SHARED=-Wl,-rpath,${libdir} -L${libdir} -l${RUBY_SO_NAME}
So we need LD_OPTIONS to overwrite it.
It sets CC=/usr/bin/gcc in /usr/ruby/2.X/lib/ruby/2.2.0/i386-solaris2.11/rbconfig.rb , 
so we need to overwrite it. 
