### PR TITLE
xvfb: Update runtime dependencies

### DIFF
--- a/components/x11/xorg-server/Makefile
+++ b/components/x11/xorg-server/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xorg-server
 COMPONENT_VERSION= 1.19.6
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= Xorg - X11R7 X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -143,6 +143,7 @@ REQUIRED_PACKAGES += x11/library/xtrans
 REQUIRED_PACKAGES += system/header/header-audio
 REQUIRED_PACKAGES += system/header/header-drm
 REQUIRED_PACKAGES += developer/debug/mdb
+REQUIRED_PACKAGES += developer/build/autoconf/xorg-macros
 
 # Sustained dependencies
 REQUIRED_PACKAGES += x11/library/libxmu

--- a/components/x11/xorg-server/xvfb.p5m
+++ b/components/x11/xorg-server/xvfb.p5m
@@ -25,6 +25,8 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
 
 depend fmri=service/opengl/ogl-select type=require
+depend fmri=x11/keyboard/xkbcomp type=require
+depend fmri=x11/keyboard/data-xkb type=require
 
 link path=usr/X11/bin/Xvfb target=../../bin/Xvfb
 file usr/bin/Xvfb path=usr/bin/$(MACH32)/Xvfb


### PR DESCRIPTION
If I install 'xvfb' it wont run without installing xkbcomp and data-xkb as well.
