### PR TITLE
Minimal install: Add USB Ethernet driver

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	30
+COMPONENT_REVISION=	31
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -32,6 +32,7 @@ depend type=require fmri=driver/i86pc/platform
 depend type=require fmri=driver/network/afe
 depend type=require fmri=driver/network/amd8111s
 depend type=require fmri=driver/network/atge
+depend type=require fmri=driver/network/axf
 depend type=require fmri=driver/network/bfe
 depend type=require fmri=driver/network/bge
 depend type=require fmri=driver/network/bnx


### PR DESCRIPTION
Hi.
I'm using a USB dongle with one of my machines as it has no supported network devices (I'm hoping to fix that in the future).
To get it online I have to pull the driver onto a memory stick from a different OI machine and install from a local repo. Can we add the driver to the installer please?
Thanks.
