### PR TITLE
open-vm-tools: bump to 10.2.5

### DIFF
--- a/components/sysutils/open-vm-tools/Makefile
+++ b/components/sysutils/open-vm-tools/Makefile
@@ -16,8 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		open-vm-tools
-COMPONENT_VERSION=	10.1.15
-COMPONENT_REVISION= 1
+COMPONENT_VERSION=	10.2.5
 COMPONENT_SUMMARY=	open-vm-tools is a set of services and modules that enable several features in VMware products for better management of, and seamless user interactions with, guests.
 COMPONENT_PROJECT_URL=	https://github.com/vmware/open-vm-tools
 COMPONENT_FMRI=		system/virtualization/open-vm-tools
@@ -25,7 +24,7 @@ COMPONENT_CLASSIFICATION= Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-stable-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/vmware/$(COMPONENT_NAME)/archive/stable-$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:2257122f5fee37bf1da1a764708a098b2e8d2847b5ba23dbffe97fd9c4b4214f
+COMPONENT_ARCHIVE_HASH=	sha256:c0f182c0c422fca8f8b3e5c21802f724256dfe5907383db28ec7e4d5b6d52b0f
 COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 

--- a/components/sysutils/open-vm-tools/patches/02-ucontext.patch
+++ b/components/sysutils/open-vm-tools/patches/02-ucontext.patch
@@ -1,11 +1,11 @@
---- open-vm-tools-stable-9.4.6/lib/include/sigPosixRegs.h.orig	Tue Dec  8 07:30:06 2015
-+++ open-vm-tools-stable-9.4.6/lib/include/sigPosixRegs.h	Tue Dec  8 07:30:15 2015
-@@ -70,7 +70,7 @@
-
+--- open-vm-tools-stable-10.2.5/lib/include/sigPosixRegs.h.orig	2018-04-30 12:19:21.563492316 +0000
++++ open-vm-tools-stable-10.2.5/lib/include/sigPosixRegs.h	2018-04-30 12:19:34.829574329 +0000
+@@ -72,7 +72,7 @@
+ #endif
+ 
  #include <signal.h>
- #ifndef __ANDROID__
 -#include <sys/ucontext.h>
 +#include <ucontext.h>
- #endif
-
- #if __linux__
+ 
+ #if __linux__ && !defined __ANDROID__
+ #  if defined(__x86_64__)

--- a/components/sysutils/open-vm-tools/patches/03-lock.patch
+++ b/components/sysutils/open-vm-tools/patches/03-lock.patch
@@ -9,8 +9,8 @@ diff -pruN '--exclude=*.orig' open-vm-tools-10.1.15~/lib/file/fileLockPrimitive.
 -#define LOCK_EXCLUSIVE  "X"
 +#define __LOCK_SHARED     "S"
 +#define __LOCK_EXCLUSIVE  "X"
- #define FILELOCK_PROGRESS_DEARTH 8000 // Dearth of progress time in msec
- #define FILELOCK_PROGRESS_SAMPLE 200  // Progress sampling time in msec
+ #define FILELOCK_PROGRESS_DEARTH 8000 // Dearth of progress time in milliseconds
+ #define FILELOCK_PROGRESS_SAMPLE 200  // Progress sampling time in milliseconds
  
 @@ -472,8 +472,8 @@ fixedUp:
        goto corrupt;

--- a/components/sysutils/open-vm-tools/patches/11-hgfsmounter-c.patch
+++ b/components/sysutils/open-vm-tools/patches/11-hgfsmounter-c.patch
@@ -1,0 +1,11 @@
+--- open-vm-tools-stable-10.2.5/hgfsmounter/hgfsmounter.c.orig	2018-04-30 16:23:56.361064863 +0000
++++ open-vm-tools-stable-10.2.5/hgfsmounter/hgfsmounter.c	2018-04-30 16:24:28.813729272 +0000
+@@ -103,7 +103,7 @@
+ #include "hgfsmounter_version.h"
+ 
+ /* XXX embed_version.h does not currently support Mach-O binaries (OS X). */
+-#if defined(__linux__) || defined(__FreeBSD__)
++#if defined(__linux__) || defined(__FreeBSD__) || defined(sun)
+ #  include "vm_version.h"
+ #  include "embed_version.h"
+    VM_EMBED_VERSION(HGFSMOUNTER_VERSION_STRING);

--- a/components/sysutils/open-vm-tools/patches/70-dilos.patch
+++ b/components/sysutils/open-vm-tools/patches/70-dilos.patch
@@ -51,26 +51,23 @@ Index: open-vm-tools-2013.04.16-1098359/open-vm-tools/lib/procMgr/procMgrSolaris
        return FALSE;
     }
 
-Index: open-vm-tools-2013.04.16-1098359/open-vm-tools/lib/include/vmci_sockets.h
-===================================================================
---- open-vm-tools-2013.04.16-1098359/lib/include/vmci_sockets.h.orig
-+++ open-vm-tools-2013.04.16-1098359/lib/include/vmci_sockets.h
-@@ -487,7 +487,7 @@ struct uuid_2_cid {
+--- open-vm-tools-stable-10.2.5/lib/include/vmci_sockets.h.orig	2018-04-30 12:10:50.994448776 +0000
++++ open-vm-tools-stable-10.2.5/lib/include/vmci_sockets.h	2018-04-30 12:12:27.824324960 +0000
+@@ -524,7 +524,7 @@
        }
  #  endif // !NT_INCLUDED
  #else // _WIN32
--#if (defined(linux) && !defined(VMKERNEL)) || (defined(__APPLE__))
-+#if (defined(linux) && !defined(VMKERNEL)) || (defined(__APPLE__)) || (defined(__sun))
- #  if defined(linux) && defined(__KERNEL__)
+-#if (defined(__linux__) && !defined(VMKERNEL)) || (defined(__APPLE__))
++#if (defined(__linux__) && !defined(VMKERNEL)) || (defined(__APPLE__)) || (defined(__sun))
+ #  if defined(__linux__) && defined(__KERNEL__)
     void VMCISock_KernelRegister(void);
     void VMCISock_KernelDeregister(void);
-@@ -507,7 +507,7 @@ struct uuid_2_cid {
+@@ -544,7 +544,7 @@
  /** \cond PRIVATE */
  #  define VMCI_SOCKETS_DEFAULT_DEVICE      "/dev/vsock"
  #  define VMCI_SOCKETS_CLASSIC_ESX_DEVICE  "/vmfs/devices/char/vsock/vsock"
--#  if defined(linux)
-+#  if defined(linux) || defined(__sun)
+-#  if defined(__linux__)
++#  if defined(__linux__) || (defined(__sun))
  #     define VMCI_SOCKETS_VERSION       1972
  #     define VMCI_SOCKETS_GET_AF_VALUE  1976
  #     define VMCI_SOCKETS_GET_LOCAL_CID 1977
-


### PR DESCRIPTION
Tested with 
- VMWare Workstation 14.1.1
- VMWare ESX 6.5 
The version of the tools shown in VCenter is 10309.