### PR TITLE
9516 Marco is compiled without Xinerama support, 1.18.3 bump

### DIFF
--- a/components/desktop/mate/marco/Makefile
+++ b/components/desktop/mate/marco/Makefile
@@ -17,15 +17,14 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		marco
 COMPONENT_MJR_VERSION=	1.18
-COMPONENT_MNR_VERSION=	1
-COMPONENT_REVISION=	2
+COMPONENT_MNR_VERSION=	3
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE Window Manager
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:65a276104745817208582e5da1894eeb86391ea2e288775aa1d098e679ba8b53
+    sha256:8494feb5e6fc06584ac3e91e98c601789adab62d6d64474300316fc2c35b8aa8
 COMPONENT_ARCHIVE_URL=	http://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE= GPLv2, LGPLv2, FDLv1.1
 COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
@@ -52,6 +51,7 @@ CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --disable-static
 CONFIGURE_OPTIONS+= --localstatedir=/var/lib
 CONFIGURE_OPTIONS+= --enable-maintainer-mode
+CONFIGURE_OPTIONS+= --enable-xinerama
 
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
@@ -66,6 +66,10 @@ test:		$(NO_TESTS)
 
 # Build dependencies
 REQUIRED_PACKAGES += gnome/zenity
+REQUIRED_PACKAGES += text/itstool
+# Needed for autogen.sh
+REQUIRED_PACKAGES += library/desktop/mate/mate-common
+REQUIRED_PACKAGES += library/gnome/yelp-tools
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/atk
@@ -87,5 +91,6 @@ REQUIRED_PACKAGES += x11/library/libxcursor
 REQUIRED_PACKAGES += x11/library/libxdamage
 REQUIRED_PACKAGES += x11/library/libxext
 REQUIRED_PACKAGES += x11/library/libxfixes
+REQUIRED_PACKAGES += x11/library/libxinerama
 REQUIRED_PACKAGES += x11/library/libxrandr
 REQUIRED_PACKAGES += x11/library/libxrender

--- a/components/desktop/mate/marco/patches/02-remove-Solaris-Xinerama-configure-check.patch
+++ b/components/desktop/mate/marco/patches/02-remove-Solaris-Xinerama-configure-check.patch
@@ -1,0 +1,30 @@
+Remove Solaris Xinerama check as we leverage XFree Xinerama.
+
+--- marco-1.18.3/configure.ac	2018-05-19 08:46:22.487960093 +0000
++++ marco-1.18.3/configure.ac	2018-05-19 08:46:57.904575972 +0000
+@@ -299,25 +299,6 @@ use_solaris_xinerama=no
+ use_xfree_xinerama=no
+ if test "${try_xinerama}" != no; then
+     case "$host" in
+-        *-*-solaris*)
+-            # Check for solaris
+-            use_solaris_xinerama=yes
+-            AC_CHECK_LIB(Xext, XineramaGetInfo,
+-                         use_solaris_xinerama=yes, use_solaris_xinerama=no,
+-                         $ALL_X_LIBS)
+-            if test "x$use_solaris_xinerama" = "xyes"; then
+-                AC_CHECK_HEADER(X11/extensions/xinerama.h,
+-                                if test -z "`echo $ALL_X_LIBS | grep "\-lXext" 2> /dev/null`"; then
+-                                    X_EXTRA_LIBS="-lXext $X_EXTRA_LIBS"
+-                                fi
+-                                AC_DEFINE(HAVE_SOLARIS_XINERAMA, , [Have Solaris-style Xinerama])
+-                                AC_DEFINE(HAVE_XINERAMA, , [Have some version of Xinerama]),
+-                                use_solaris_xinerama=no,
+-                                [#include <X11/Xlib.h>])
+-            fi
+-            AC_MSG_CHECKING(for Xinerama support on Solaris)
+-            AC_MSG_RESULT($use_solaris_xinerama);
+-            ;;
+         *)
+             # Check for XFree
+             use_xfree_xinerama=yes


### PR DESCRIPTION
MATE marco is build without XFree Xinerama support, so maximized windows are spread
over both screens. The reason seems to be that `configure` is looking for Solarix
Xinerama on `*-*-solaris*` hosts. As we ship only XFree Xinerama, `configure` won't
bother finding it. Removing the check.

Added couple of build deps which I had to install manually.

Bumped marco to 1.18.3.

Tested that maximized windows work as expected when two screens are on.

Should I move `x11/library/libxinerama` to the auto-generated dependencies section? Some script after `gmake publish` warned about this dependency.