### PR TITLE
9283 Chain build of openssl-0.9.8 fails due to missing target

### DIFF
--- a/components/library/openssl/openssl-1.0.2/Makefile
+++ b/components/library/openssl/openssl-1.0.2/Makefile
@@ -27,7 +27,7 @@ COMPONENT_NAME =	openssl
 # When new version of OpenSSL comes in, you must update both COMPONENT_VERSION
 # and IPS_COMPONENT_VERSION.
 COMPONENT_VERSION =	1.0.2o
-COMPONENT_REVISION =	1
+COMPONENT_REVISION =	2
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
 IPS_COMPONENT_VERSION = 1.0.2.15
@@ -213,4 +213,5 @@ $(BUILD_DIR_64)/llib-lssl.ln: LINT_FLAGS=$(LFLAGS_64)
 COMPONENT_TEST_TARGETS = test
 test:		$(TEST_32_and_64)
 
+REQUIRED_PACKAGES += developer/build/makedepend
 REQUIRED_PACKAGES += system/library


### PR DESCRIPTION
```
making all in crypto/rsa...
make[4]: Entering directory '/export/home/newman/ws/oi-userland/components/library/openssl/openssl-0.9.8/build/i86/crypto/rsa'
/usr/gcc/6/bin/gcc -I.. -I../.. -I../../include -fPIC -DOPENSSL_PIC -DOPENSSL_THREADS -D_REENTRANT -DDSO_DLFCN -DHAVE_DLFCN_H -DPK11_LIB_LOCATION=\"/usr/lib/libpkcs11.so.1\" -O3 -march=pentium -Wall -DL_ENDIAN -DOPENSSL_NO_INLINE_ASM -DOPENSSL_BN_ASM_PART_WORDS -DOPENSSL_IA32_SSE2 -DSHA1_ASM -DMD5_ASM -DRMD160_ASM -DAES_ASM   -c -o rsa_eay.o rsa_eay.c
/usr/gcc/6/bin/gcc -I.. -I../.. -I../../include -fPIC -DOPENSSL_PIC -DOPENSSL_THREADS -D_REENTRANT -DDSO_DLFCN -DHAVE_DLFCN_H -DPK11_LIB_LOCATION=\"/usr/lib/libpkcs11.so.1\" -O3 -march=pentium -Wall -DL_ENDIAN -DOPENSSL_NO_INLINE_ASM -DOPENSSL_BN_ASM_PART_WORDS -DOPENSSL_IA32_SSE2 -DSHA1_ASM -DMD5_ASM -DRMD160_ASM -DAES_ASM   -c -o rsa_gen.o rsa_gen.c
make[4]: *** No rule to make target '../../include/openssl/ec.h', needed by 'rsa_lib.o'.  Stop.
make[4]: Leaving directory '/export/home/newman/ws/oi-userland/components/library/openssl/openssl-0.9.8/build/i86/crypto/rsa'
make[3]: *** [Makefile:87: subdirs] Error 1
make[3]: Leaving directory '/export/home/newman/ws/oi-userland/components/library/openssl/openssl-0.9.8/build/i86/crypto'
make[2]: *** [Makefile:334: build_crypto] Error 1
make[2]: Leaving directory '/export/home/newman/ws/oi-userland/components/library/openssl/openssl-0.9.8/build/i86'
make[1]: *** [/export/home/newman/ws/oi-userland/make-rules/configure.mk:183: /export/home/newman/ws/oi-userland/components/library/openssl/openssl-0.9.8/build/i86/.built] Error 2
make[1]: Leaving directory '/export/home/newman/ws/oi-userland/components/library/openssl/openssl-0.9.8'
gmake: *** [Makefile:153: /export/home/newman/ws/oi-userland/components/library/openssl/openssl-1.0.2/../openssl-0.9.8/build/i86/.built] Error 2
```

Once `developer/build/makedepend` is installed openssl 1.0.2 & 0.9.8 build.