### PR TITLE
libgphoto2 2.5.18

### DIFF
--- a/components/library/libgphoto2/Makefile
+++ b/components/library/libgphoto2/Makefile
@@ -16,12 +16,12 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libgphoto2
-COMPONENT_VERSION= 2.5.14
+COMPONENT_VERSION= 2.5.18
 COMPONENT_SUMMARY= Digital camera library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-  sha256:d3ce70686fb87d6791b9adcbb6e5693bfbe1cfef9661c23c75eb8a699ec4e274
+  sha256:5b17b89d7ca0ec35c72c94ac3701e87d49e52371f9509b8e5c08c913ae57a7ec
 COMPONENT_ARCHIVE_URL= \
   http://sourceforge.net/projects/gphoto/files/libgphoto/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)/download
 COMPONENT_PROJECT_URL = http://www.gphoto.org
@@ -47,7 +47,7 @@ LD_Z_IGNORE=
 
 CFLAGS.32 += -D_FILE_OFFSET_BITS=64
 CFLAGS	  += $(CFLAGS.$(BITS))
-CFLAGS	  += -std=gnu89 $(CPP_XPG5MODE)
+CFLAGS	  += -std=gnu99 $(CPP_XPG6MODE)
 
 COMPONENT_PREP_ACTION += (cd $(@D) && autoreconf -fi)
 

--- a/components/library/libgphoto2/libgphoto2-2.p5m
+++ b/components/library/libgphoto2/libgphoto2-2.p5m
@@ -45,9 +45,9 @@ file path=usr/include/gphoto2/gphoto2-setting.h
 file path=usr/include/gphoto2/gphoto2-version.h
 file path=usr/include/gphoto2/gphoto2-widget.h
 file path=usr/include/gphoto2/gphoto2.h
-link path=usr/lib/$(MACH64)/libgphoto2.so target=libgphoto2.so.6.0.0
-link path=usr/lib/$(MACH64)/libgphoto2.so.6 target=libgphoto2.so.6.0.0
-file path=usr/lib/$(MACH64)/libgphoto2.so.6.0.0
+link path=usr/lib/$(MACH64)/libgphoto2.so target=libgphoto2.so.6.1.0
+link path=usr/lib/$(MACH64)/libgphoto2.so.6 target=libgphoto2.so.6.1.0
+file path=usr/lib/$(MACH64)/libgphoto2.so.6.1.0
 file path=usr/lib/$(MACH64)/libgphoto2/$(COMPONENT_VERSION)/adc65.so
 file path=usr/lib/$(MACH64)/libgphoto2/$(COMPONENT_VERSION)/agfa_cl20.so
 file path=usr/lib/$(MACH64)/libgphoto2/$(COMPONENT_VERSION)/aox.so
@@ -123,13 +123,12 @@ file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/serial.so
 file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/usb1.so
 file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/usbdiskdirect.so
 file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/usbscsi.so
-file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/vusb.so
 file path=usr/lib/$(MACH64)/pkgconfig/libgphoto2.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libgphoto2_port.pc
 file path=usr/lib/$(MACH64)/udev/check-ptp-camera
-link path=usr/lib/libgphoto2.so target=libgphoto2.so.6.0.0
-link path=usr/lib/libgphoto2.so.6 target=libgphoto2.so.6.0.0
-file path=usr/lib/libgphoto2.so.6.0.0
+link path=usr/lib/libgphoto2.so target=libgphoto2.so.6.1.0
+link path=usr/lib/libgphoto2.so.6 target=libgphoto2.so.6.1.0
+file path=usr/lib/libgphoto2.so.6.1.0
 file path=usr/lib/libgphoto2/$(COMPONENT_VERSION)/adc65.so
 file path=usr/lib/libgphoto2/$(COMPONENT_VERSION)/agfa_cl20.so
 file path=usr/lib/libgphoto2/$(COMPONENT_VERSION)/aox.so
@@ -204,7 +203,6 @@ file path=usr/lib/libgphoto2_port/0.12.0/serial.so
 file path=usr/lib/libgphoto2_port/0.12.0/usb1.so
 file path=usr/lib/libgphoto2_port/0.12.0/usbdiskdirect.so
 file path=usr/lib/libgphoto2_port/0.12.0/usbscsi.so
-file path=usr/lib/libgphoto2_port/0.12.0/vusb.so
 file path=usr/lib/pkgconfig/libgphoto2.pc
 file path=usr/lib/pkgconfig/libgphoto2_port.pc
 file path=usr/lib/udev/check-ptp-camera
@@ -215,6 +213,7 @@ file path=usr/share/doc/libgphoto2/ChangeLog
 file path=usr/share/doc/libgphoto2/NEWS
 file path=usr/share/doc/libgphoto2/README
 file path=usr/share/doc/libgphoto2/README.apidocs
+file path=usr/share/doc/libgphoto2/README.md
 file path=usr/share/doc/libgphoto2/README.packaging
 file path=usr/share/doc/libgphoto2/camlibs/ChangeLog
 file path=usr/share/doc/libgphoto2/camlibs/README.9050

--- a/components/library/libgphoto2/manifests/sample-manifest.p5m
+++ b/components/library/libgphoto2/manifests/sample-manifest.p5m
@@ -45,9 +45,9 @@ file path=usr/include/gphoto2/gphoto2-setting.h
 file path=usr/include/gphoto2/gphoto2-version.h
 file path=usr/include/gphoto2/gphoto2-widget.h
 file path=usr/include/gphoto2/gphoto2.h
-link path=usr/lib/$(MACH64)/libgphoto2.so target=libgphoto2.so.6.0.0
-link path=usr/lib/$(MACH64)/libgphoto2.so.6 target=libgphoto2.so.6.0.0
-file path=usr/lib/$(MACH64)/libgphoto2.so.6.0.0
+link path=usr/lib/$(MACH64)/libgphoto2.so target=libgphoto2.so.6.1.0
+link path=usr/lib/$(MACH64)/libgphoto2.so.6 target=libgphoto2.so.6.1.0
+file path=usr/lib/$(MACH64)/libgphoto2.so.6.1.0
 file path=usr/lib/$(MACH64)/libgphoto2/$(COMPONENT_VERSION)/adc65.so
 file path=usr/lib/$(MACH64)/libgphoto2/$(COMPONENT_VERSION)/agfa_cl20.so
 file path=usr/lib/$(MACH64)/libgphoto2/$(COMPONENT_VERSION)/aox.so
@@ -123,13 +123,12 @@ file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/serial.so
 file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/usb1.so
 file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/usbdiskdirect.so
 file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/usbscsi.so
-file path=usr/lib/$(MACH64)/libgphoto2_port/0.12.0/vusb.so
 file path=usr/lib/$(MACH64)/pkgconfig/libgphoto2.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libgphoto2_port.pc
 file path=usr/lib/$(MACH64)/udev/check-ptp-camera
-link path=usr/lib/libgphoto2.so target=libgphoto2.so.6.0.0
-link path=usr/lib/libgphoto2.so.6 target=libgphoto2.so.6.0.0
-file path=usr/lib/libgphoto2.so.6.0.0
+link path=usr/lib/libgphoto2.so target=libgphoto2.so.6.1.0
+link path=usr/lib/libgphoto2.so.6 target=libgphoto2.so.6.1.0
+file path=usr/lib/libgphoto2.so.6.1.0
 file path=usr/lib/libgphoto2/$(COMPONENT_VERSION)/adc65.so
 file path=usr/lib/libgphoto2/$(COMPONENT_VERSION)/agfa_cl20.so
 file path=usr/lib/libgphoto2/$(COMPONENT_VERSION)/aox.so
@@ -204,7 +203,6 @@ file path=usr/lib/libgphoto2_port/0.12.0/serial.so
 file path=usr/lib/libgphoto2_port/0.12.0/usb1.so
 file path=usr/lib/libgphoto2_port/0.12.0/usbdiskdirect.so
 file path=usr/lib/libgphoto2_port/0.12.0/usbscsi.so
-file path=usr/lib/libgphoto2_port/0.12.0/vusb.so
 file path=usr/lib/pkgconfig/libgphoto2.pc
 file path=usr/lib/pkgconfig/libgphoto2_port.pc
 file path=usr/lib/udev/check-ptp-camera
@@ -215,6 +213,7 @@ file path=usr/share/doc/libgphoto2/ChangeLog
 file path=usr/share/doc/libgphoto2/NEWS
 file path=usr/share/doc/libgphoto2/README
 file path=usr/share/doc/libgphoto2/README.apidocs
+file path=usr/share/doc/libgphoto2/README.md
 file path=usr/share/doc/libgphoto2/README.packaging
 file path=usr/share/doc/libgphoto2/camlibs/ChangeLog
 file path=usr/share/doc/libgphoto2/camlibs/README.9050


### PR DESCRIPTION
Run tested with gphoto2 2.5.17 and Canon Digital IXUS 100 IS: cam is
detected & list of images retrieved.

(`vusb.so` is now not delivered, I it's my understanding that it's used only for testing.)