### PR TITLE
file/magic 5.33

### DIFF
--- a/components/library/libmagic/Makefile
+++ b/components/library/libmagic/Makefile
@@ -20,11 +20,11 @@ include ../../../make-rules/shared-macros.mk
 # we ALSO deliver a "gfile" built from darwinsys sources, as a bonus.
 COMPONENT_NAME=		file
 COMPONENT_FMRI=		library/magic
-COMPONENT_VERSION=	5.25
+COMPONENT_VERSION=	5.33
 COMPONENT_PROJECT_URL=	http://www.darwinsys.com/file/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:3735381563f69fb4239470b8c51b876a80425348b8285a7cded8b61d6b890eca
+COMPONENT_ARCHIVE_HASH=	sha256:1c52c8c3d271cd898d5511c36a68059cda94036111ab293f01f83c3525b737c6
 COMPONENT_ARCHIVE_URL=	ftp://ftp.astron.com/pub/file/$(COMPONENT_ARCHIVE)
 COMPONENT_SUMMARY=	libmagic for recognizing the type of data contained in a computer file using magic numbers
 COMPONENT_CLASSIFICATION=	System/Libraries

--- a/components/library/libmagic/manifests/sample-manifest.p5m
+++ b/components/library/libmagic/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)


### PR DESCRIPTION
`gfile` recognizes stuff. `nano` 2.9.7 can be builds with new magic:
```
checking magic.h usability... yes
checking magic.h presence... yes
checking for magic.h... yes
checking for magic_open in -lmagic... yes
```