### PR TITLE
pigz 2.4 (64-bit only)

### DIFF
--- a/components/archiver/pigz/Makefile
+++ b/components/archiver/pigz/Makefile
@@ -20,45 +20,40 @@
 #
 # Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2016, Jim Klimov
+# Copyright (c) 2018, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pigz
-COMPONENT_VERSION=	2.3.4
+COMPONENT_VERSION=	2.4
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	http://zlib.net/pigz/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:6f031fa40bc15b1d80d502ff91f83ba14f4b079e886bfb83221374f7bf5c8f9a
+  sha256:a4f816222a7b4269bd232680590b579ccc72591f1bb5adafcd7208ca77e14f73
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)$(COMPONENT_ARCHIVE)
 COMPONENT_BUGDB=	utility/pigz
 COMPONENT_TEST_TARGETS=	test
+COMPONENT_FMRI= 	compress/pigz
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/justmake.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-CFLAGS += -std=c99
-LDFLAGS += -lz
-
-CFLAGS += $(CPP_LARGEFILES)
-
-PKG_PROTO_DIRS += $(BUILD_DIR_32)
+CFLAGS += -std=c99 $(CPP_LARGEFILES)
 
 COMPONENT_BUILD_ARGS += CC="$(CC)"
 COMPONENT_BUILD_ARGS += CFLAGS="$(CFLAGS)"
 COMPONENT_BUILD_ARGS += LDFLAGS="$(LDFLAGS)"
 
-#ASLR_MODE = $(ASLR_ENABLE)
+build:		$(BUILD_64)
 
-# common targets
-build:		$(BUILD_32_and_64)
+install:	$(INSTALL_64)
 
-install:	$(BUILD_32_and_64)
+test:		$(TEST_64)
 
-test:		$(TEST_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/archiver/pigz/manifests/sample-manifest.p5m
+++ b/components/archiver/pigz/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,3 +22,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=usr/bin/pigz
+file path=usr/bin/unpigz
+file path=usr/share/man/man1/pigz.1

--- a/components/archiver/pigz/patches/01-Makefile-install-target.patch
+++ b/components/archiver/pigz/patches/01-Makefile-install-target.patch
@@ -1,0 +1,32 @@
+--- pigz-2.4/Makefile.orig	2018-06-06 19:38:13.206226284 +0000
++++ pigz-2.4/Makefile	2018-06-06 19:44:55.993031070 +0000
+@@ -5,11 +5,14 @@
+ ZOPFLI=zopfli/src/zopfli/
+ ZOP=deflate.o blocksplitter.o tree.o lz77.o cache.o hash.o util.o squeeze.o katajainen.o
+ 
++BINDIR?=/usr/bin
++MANDIR?=/usr/share/man
++
+ # use gcc and gmake on Solaris
+ 
+ pigz: pigz.o yarn.o try.o $(ZOP)
+ 	$(CC) $(LDFLAGS) -o pigz pigz.o yarn.o try.o $(ZOP) $(LIBS)
+-	ln -f pigz unpigz
++	ln -sf pigz unpigz
+ 
+ pigz.o: pigz.c yarn.h try.h $(ZOPFLI)deflate.h $(ZOPFLI)util.h
+ 
+@@ -98,6 +101,13 @@
+ pigz.pdf: pigz.1
+ 	groff -mandoc -f H -T ps pigz.1 | ps2pdf - pigz.pdf
+ 
++install:
++	@mkdir -p $(DESTDIR)$(BINDIR)
++	@install -m0755 pigz $(DESTDIR)$(BINDIR)
++	@install -m0755 unpigz $(DESTDIR)$(BINDIR)
++	@mkdir -p $(DESTDIR)$(MANDIR)/man1
++	@install -m0644 pigz.1 $(DESTDIR)$(MANDIR)/man1
++
+ all: pigz pigzj pigzt pigzn docs
+ 
+ clean:

--- a/components/archiver/pigz/pigz.p5m
+++ b/components/archiver/pigz/pigz.p5m
@@ -1,23 +1,21 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL"). You may
-# only use this file in accordance with the terms of the CDDL.
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-#
-
 #
 # Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013, Adam Stevko. All rights reserved.
 # Copyright (c) 2016, Jim Klimov
+# Copyright (c) 2018, Michal Nowak
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability Uncommitted>
-
-set name=pkg.fmri value=pkg:/compress/pigz@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="parallel implementation of gzip"
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="Parallel implementation of gzip"
 set name=info.classification value="org.opensolaris.category.2008:Applications/System Utilities"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -25,13 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license pigz.license license='BSD-like'
 
-file $(MACH32)/pigz path=usr/bin/$(MACH32)/pigz
-link path=usr/bin/$(MACH32)/unpigz target=./pigz
-
-file $(MACH64)/pigz path=usr/bin/$(MACH64)/pigz
-link path=usr/bin/$(MACH64)/unpigz target=./pigz
-
-hardlink path=usr/bin/pigz target=../lib/isaexec pkg.linted.userland.action002.0=true
-link path=usr/bin/unpigz target=./pigz
-
-file pigz.1 path=usr/share/man/man1/pigz.1
+file path=usr/bin/pigz
+link path=usr/bin/unpigz target=pigz
+file path=usr/share/man/man1/pigz.1
+link path=usr/share/man/man1/unpigz.1 target=pigz.1


### PR DESCRIPTION
Thanks Aurélien for proper for of the 'install' target.

Tested `pigz` and `unpigz` binaries to compress and decompress a file.

Man pages for both binaries work.
