### PR TITLE
Deliver 64-bit only pixz

### DIFF
--- a/components/archiver/pixz/Makefile
+++ b/components/archiver/pixz/Makefile
@@ -20,12 +20,14 @@
 #
 # Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2016, Jim Klimov
+# Copyright (c) 2018, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pixz
 COMPONENT_VERSION=	1.0.6
+COMPONENT_REVISION=	1
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://github.com/vasi/$(COMPONENT_NAME)/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
@@ -39,9 +41,11 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
+CONFIGURE_BINDIR.64 = $(CONFIGURE_BINDIR.32)
+
 CFLAGS += $(CPP_LARGEFILES)
 
-PKG_PROTO_DIRS += $(BUILD_DIR_32)
+PKG_PROTO_DIRS += $(BUILD_DIR_64)
 PKG_PROTO_DIRS += $(COMPONENT_DIR)/files
 
 # Userland default includes -mt which links with libthread which we don't need.
@@ -52,11 +56,11 @@ COMPONENT_PREP_ACTION = (cd $(SOURCE_DIR) && $(AUTORECONF) -if)
 ASLR_MODE = $(ASLR_ENABLE)
 
 # common targets
-build:		$(BUILD_32_and_64)
+build:		$(BUILD_64)
 
-install:	$(INSTALL_32_and_64)
+install:	$(INSTALL_64)
 
-test:		$(NO_TESTS)
+test:		$(TEST_64)
 
 # Build dependencies added manually
 REQUIRED_PACKAGES += text/asciidoc

--- a/components/archiver/pixz/manifests/sample-manifest.p5m
+++ b/components/archiver/pixz/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,6 +22,5 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/pixz
 file path=usr/bin/pixz
 file path=usr/share/man/man1/pixz.1

--- a/components/archiver/pixz/pixz.p5m
+++ b/components/archiver/pixz/pixz.p5m
@@ -22,9 +22,9 @@
 #
 # Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2016, Jim Klimov
+# Copyright (c) 2018, Michal Nowak
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability Uncommitted>
 set name=pkg.fmri \
     value=pkg:/compress/pixz@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="parallel indexing version of XZ"
@@ -40,9 +40,7 @@ set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.arc-caseid value=PSARC/2012/358
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-file usr/bin/pixz path=usr/bin/$(MACH32)/pixz
-file path=usr/bin/$(MACH64)/pixz
-hardlink path=usr/bin/pixz target=../lib/isaexec pkg.linted.userland.action002.0=true
-
-file pixz.1 path=usr/share/man/man1/pixz.1
 license LICENSE license=BSD-like
+
+file path=usr/bin/pixz
+file path=usr/share/man/man1/pixz.1

--- a/components/archiver/pixz/test/results-64.master
+++ b/components/archiver/pixz/test/results-64.master
@@ -1,0 +1,31 @@
+make[1]: Entering directory '$(@D)'
+Making check in src
+make[2]: Entering directory '$(@D)/src'
+make[2]: Nothing to be done for 'check'.
+make[2]: Leaving directory '$(@D)/src'
+Making check in test
+make[2]: Entering directory '$(@D)/test'
+/usr/gnu/bin/make  check-TESTS
+make[3]: Entering directory '$(@D)/test'
+make[4]: Entering directory '$(@D)/test'
+PASS: compress-file-permissions.sh
+SKIP: cppcheck-src.sh
+PASS: single-file-round-trip.sh
+PASS: xz-compatibility-c-option.sh
+============================================================================
+Testsuite summary for pixz 1.0.6
+============================================================================
+# TOTAL: 4
+# PASS:  3
+# SKIP:  1
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+make[4]: Leaving directory '$(@D)/test'
+make[3]: Leaving directory '$(@D)/test'
+make[2]: Leaving directory '$(@D)/test'
+make[2]: Entering directory '$(@D)'
+make[2]: Leaving directory '$(@D)'
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
```
PASS: compress-file-permissions.sh
SKIP: cppcheck-src.sh
PASS: single-file-round-trip.sh
PASS: xz-compatibility-c-option.sh
============================================================================
Testsuite summary for pixz 1.0.6
============================================================================
 # TOTAL: 4
 # PASS:  3
 # SKIP:  1
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0
 # ERROR: 0
============================================================================
```