### PR TITLE
unrar 5.6.4

### DIFF
--- a/components/archiver/unrar/Makefile
+++ b/components/archiver/unrar/Makefile
@@ -28,13 +28,13 @@ include ../../../make-rules/shared-macros.mk
 PATH=$(SPRO_VROOT)/bin:/usr/bin:/usr/gnu/bin:/usr/sbin
 
 COMPONENT_NAME=		unrar
-COMPONENT_VERSION=	5.4.5
+COMPONENT_VERSION=	5.6.4
 COMPONENT_SRC=		$(COMPONENT_NAME)
 COMPONENT_SUMMARY=	Rar archives extractor utility
 COMPONENT_PROJECT_URL=	http://www.rarlabs.com/rar_add.htm
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)src-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:e470c584332422893fb52e049f2cbd99e24dc6c6da971008b4e2ae4284f8796c
+    sha256:9335d2201870f2034007c04be80e00f1dc23932cb88b329d55c76134e6ba49fe
 COMPONENT_ARCHIVE_URL=	http://www.rarlab.com/rar/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	archiver/unrar
 COMPONENT_CLASSIFICATION= Applications/System Utilities

--- a/components/archiver/unrar/patches/01-makefile.patch
+++ b/components/archiver/unrar/patches/01-makefile.patch
@@ -1,16 +1,17 @@
---- unrar/makefile.~1~	2016-05-10 12:51:35.000000000 +0300
-+++ unrar/makefile	2017-03-23 23:23:28.452337134 +0300
-@@ -2,12 +2,12 @@
+--- unrar/makefile	2017-11-21 22:53:39.000000000 +0000
++++ unrar/makefile.new	2018-05-26 15:19:08.862458981 +0000
+@@ -2,13 +2,13 @@
  # Makefile for UNIX - unrar
  
  # Linux using GCC
 -CXX=c++
--CXXFLAGS=-O2
+-CXXFLAGS=-O2 -Wno-logical-op-parentheses -Wno-switch -Wno-dangling-else
 +#CXX=c++
-+#CXXFLAGS=-O2
++#CXXFLAGS=-O2 -Wno-logical-op-parentheses -Wno-switch -Wno-dangling-else
  LIBFLAGS=-fPIC
  DEFINES=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP
  STRIP=strip
+ AR=ar
 -LDFLAGS=-pthread
 +#LDFLAGS=-pthread
  DESTDIR=/usr


### PR DESCRIPTION
Fixes following CVEs: CVE-2017-12942, CVE-2017-12941,CVE-2017-12940,
CVE-2017-12938 CVE-2012-6706 (source
http://metadata.ftp-master.debian.org/changelogs/non-free/u/unrar-nonfree/unrar-nonfree_5.5.8-1_changelog).