### PR TITLE
unzip 64-bit only + CVE-2014-9913 & CVE-2018-1000035

### DIFF
--- a/components/archiver/unzip/Makefile
+++ b/components/archiver/unzip/Makefile
@@ -26,20 +26,21 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		unzip
 COMPONENT_VERSION=	6.0
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_SRC=		$(COMPONENT_NAME)60
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tgz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37
 COMPONENT_ARCHIVE_URL=	ftp://ftp.info-zip.org/pub/infozip/src/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=http://www.info-zip.org/UnZip.html
+COMPONENT_PROJECT_URL=	http://www.info-zip.org/UnZip.html
 COMPONENT_BUGDB=	utility/zip
+COMPONENT_FMRI=		compress/unzip
 
 LD_OPTIONS=
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/justmake.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/justmake.mk
+include $(WS_MAKE_RULES)/ips.mk
 
 # remove the unwanted file.
 COMPONENT_PREP_ACTION = $(RM) $(SOURCE_DIR)/crc_i386.S
@@ -48,9 +49,10 @@ COMPONENT_BUILD_ENV += \
  "LOCAL_UNZIP=-DUNICODE_SUPPORT -DNO_WORKING_ISPRINT -DUNICODE_WCHAR -DNO_LCHMOD"
 
 # The Makefile we want is under unix/Makefile
-COMPONENT_BUILD_ARGS += -f unix/Makefile
-COMPONENT_BUILD_TARGETS += generic CC="$(CC)"
-COMPONENT_INSTALL_ARGS += -f unix/Makefile
+COMPONENT_BUILD_ARGS    += -f unix/Makefile
+COMPONENT_BUILD_TARGETS += generic CC="$(CC) $(CC_BITS)"
+COMPONENT_INSTALL_ARGS  += -f unix/Makefile
+COMPONENT_TEST_ARGS     += -f unix/Makefile
 
 # This doesn't respect DESTDIR, so overload BINDIR and MANDIR when we install.
 COMPONENT_INSTALL_ARGS += BINDIR=$(PROTOUSRBINDIR)
@@ -58,15 +60,13 @@ COMPONENT_INSTALL_ARGS += MANDIR=$(PROTOUSRSHAREMAN1DIR)
 
 # common targets
 
-build:		$(BUILD_32)
+build:		$(BUILD_64)
 
-install:	$(INSTALL_32)
+install:	$(INSTALL_64)
 
-test:		$(NO_TESTS)
+test:		$(TEST_64)
 
 BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
-
-include $(WS_TOP)/make-rules/depend.mk
 
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/archiver/unzip/patches/CVE-2014-8141.patch
+++ b/components/archiver/unzip/patches/CVE-2014-8141.patch
@@ -13,7 +13,7 @@ Bug-Debian: http://bugs.debian.org/773722
  
  #ifdef WINDLL
     static ZCONST char Far DiskFullQuery[] =
-@@ -2295,7 +2297,12 @@
+@@ -2307,7 +2307,12 @@
              if (readbuf(__G__ (char *)G.extra_field, length) == 0)
                  return PK_EOF;
              /* Looks like here is where extra fields are read */
@@ -36,7 +36,7 @@ Bug-Debian: http://bugs.debian.org/773722
  
    See the accompanying file LICENSE, version 2009-Jan-02 or later
    (the contents of which are also included in unzip.h) for terms of use.
-@@ -1901,48 +1901,82 @@
+@@ -1888,48 +1888,82 @@
      and a 4-byte version of disk start number.
      Sets both local header and central header fields.  Not terribly clever,
      but it means that this procedure is only called in one place.

--- a/components/archiver/unzip/patches/CVE-2014-9913.patch
+++ b/components/archiver/unzip/patches/CVE-2014-9913.patch
@@ -1,0 +1,26 @@
+https://build.opensuse.org/package/view_file/Archiving/unzip/CVE-2014-9913.patch?expand=1
+
+Index: unzip60/list.c
+===================================================================
+--- unzip60.orig/list.c
++++ unzip60/list.c
+@@ -339,7 +339,18 @@ int list_files(__G)    /* return PK-type
+                 G.crec.compression_method == ENHDEFLATED) {
+                 methbuf[5] = dtype[(G.crec.general_purpose_bit_flag>>1) & 3];
+             } else if (methnum >= NUM_METHODS) {
+-                sprintf(&methbuf[4], "%03u", G.crec.compression_method);
++		/* 2013-02-26 SMS.
++		 * http://sourceforge.net/p/infozip/bugs/27/  CVE-2014-9913.
++		 * Unexpectedly large compression methods overflow
++		 * &methbuf[].  Use the old, three-digit decimal format
++		 * for values which fit.  Otherwise, sacrifice the
++		 * colon, and use four-digit hexadecimal.
++		 */
++		if (G.crec.compression_method <= 999) {
++		    sprintf( &methbuf[ 4], "%03u", G.crec.compression_method);
++		} else {
++		    sprintf( &methbuf[ 3], "%04X", G.crec.compression_method);
++		}
+             }
+ 
+ #if 0       /* GRR/Euro:  add this? */

--- a/components/archiver/unzip/patches/CVE-2018-1000035.patch
+++ b/components/archiver/unzip/patches/CVE-2018-1000035.patch
@@ -1,0 +1,41 @@
+https://build.opensuse.org/package/view_file/Archiving/unzip/CVE-2018-1000035.patch?expand=1
+
+From: <kbabioch@suse.com>
+Date: Thu Feb  8 15:10:03 CET 2018
+Upstream: merged
+References: http://www.info-zip.org/phpBB3/viewtopic.php?f=7&t=548
+
+Index: fileio.c
+===================================================================
+--- a/fileio.c.orig
++++ b/fileio.c
+@@ -1582,7 +1582,11 @@ int UZ_EXP UzpPassword (pG, rcnt, pwbuf,
+     int r = IZ_PW_ENTERED;
+     char *m;
+     char *prompt;
+-
++    char *zfnf;
++    char *efnf;
++    size_t zfnfl;
++    int isOverflow;
++    
+ #ifndef REENTRANT
+     /* tell picky compilers to shut up about "unused variable" warnings */
+     pG = pG;
+@@ -1590,7 +1590,15 @@ int UZ_EXP UzpPassword (pG, rcnt, pwbuf,
+ 
+     if (*rcnt == 0) {           /* First call for current entry */
+         *rcnt = 2;
+-        if ((prompt = (char *)malloc(2*FILNAMSIZ + 15)) != (char *)NULL) {
++        zfnf = FnFilter1(zfn);
++        efnf = FnFilter2(efn);
++        zfnfl = strlen(zfnf);
++        isOverflow = TRUE;
++        if (2*FILNAMSIZ >= zfnfl && (2*FILNAMSIZ - zfnfl) >= strlen(efnf))
++        {
++		isOverflow = FALSE;
++        }
++        if ((isOverflow == FALSE) && ((prompt = (char *)malloc(2*FILNAMSIZ + 15)) != (char *)NULL)) {
+             sprintf(prompt, LoadFarString(PasswPrompt),
+                     FnFilter1(zfn), FnFilter2(efn));
+             m = prompt;

--- a/components/archiver/unzip/unzip.p5m
+++ b/components/archiver/unzip/unzip.p5m
@@ -1,30 +1,17 @@
 #
-# CDDL HEADER START
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
-# The contents of this file are subject to the terms of the
-# Common Development and Distribution License (the "License").
-# You may not use this file except in compliance with the License.
-#
-# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
-# or http://www.opensolaris.org/os/licensing.
-# See the License for the specific language governing permissions
-# and limitations under the License.
-#
-# When distributing Covered Code, include this CDDL HEADER in each
-# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
-# If applicable, add the following below this CDDL HEADER, with the
-# fields enclosed by brackets "[]" replaced with your own identifying
-# information: Portions Copyright [yyyy] [name of copyright owner]
-#
-# CDDL HEADER END
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
-
-set name=pkg.fmri \
-    value=pkg:/compress/unzip@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.description value="The Info-Zip (unzip) decompression utility"
 set name=pkg.summary value="Info-Zip (unzip)"
 set name=com.oracle.info.description value="the unzip decompression utility"
@@ -47,5 +34,5 @@ link path=usr/bin/zipinfo target=unzip
 file path=usr/share/man/man1/funzip.1
 file path=usr/share/man/man1/unzip.1
 file path=usr/share/man/man1/unzipsfx.1
-file path=usr/share/man/man1/zipinfo.1
 file path=usr/share/man/man1/zipgrep.1
+file path=usr/share/man/man1/zipinfo.1


### PR DESCRIPTION
Runtested.

The trick to make it 64-bit in `COMPONENT_BUILD_TARGETS` is really cheap, but the only way I was able to persuade the build system to build in 64-bits.