### PR TITLE
LightDM GTK Greeter 2.0.5

### DIFF
--- a/components/desktop/lightdm-gtk-greeter/Makefile
+++ b/components/desktop/lightdm-gtk-greeter/Makefile
@@ -16,13 +16,13 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= lightdm-gtk-greeter
-COMPONENT_VERSION= 2.0.2
+COMPONENT_VERSION= 2.0.5
 COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= GTK greeter for LDM
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:8ee6d93d1d6837b3590f64ac4d5bac5db888a8861dff1cb2ef10f7816ad36690
+  sha256:5dc608d58ff9d15117c9d99b55e5f038d39e2f1691f03ce1dc1c8881560387df
 COMPONENT_ARCHIVE_URL= \
   https://launchpad.net/lightdm-gtk-greeter/2.0/$(COMPONENT_VERSION)/+download/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://launchpad.net/lightdm-gtk-greeter/
@@ -46,6 +46,7 @@ CONFIGURE_OPTIONS += --localstatedir=/var
 CONFIGURE_OPTIONS += --libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
 CONFIGURE_OPTIONS += --disable-indicator-services-command
 CONFIGURE_OPTIONS += --disable-at-spi-command
+CONFIGURE_OPTIONS += --disable-maintainer-mode
 
 CONFIGURE_ENV += XGETTEXT=/usr/gnu/bin/xgettext
 

--- a/components/desktop/lightdm-gtk-greeter/patches/01-branding.patch
+++ b/components/desktop/lightdm-gtk-greeter/patches/01-branding.patch
@@ -3,7 +3,16 @@
 3) Use non-symbolic icons and nimbus icon theme. 
 --- lightdm-gtk-greeter-2.0.2/src/lightdm-gtk-greeter.c.~1~	2016-10-06 12:31:54.000000000 +0000
 +++ lightdm-gtk-greeter-2.0.2/src/lightdm-gtk-greeter.c	2017-08-29 18:17:48.381975286 +0000
-@@ -299,13 +299,14 @@
+@@ -100,7 +100,7 @@ static GtkLabel     *power_title, *power
+ static GtkImage     *power_icon;
+ 
+ static const gchar *DEFAULT_LAYOUT[] = {"~spacer", "~spacer", "~host", "~spacer",
+-                                        "~session", "~a11y", "~clock", "~power", NULL};
++                                        "~session", "~layout", "~a11y", "~clock", NULL};
+ 
+ static const gchar *POWER_WINDOW_DATA_LOOP = "power-window-loop";           /* <GMainLoop*> */
+ static const gchar *POWER_WINDOW_DATA_RESPONSE = "power-window-response";   /* <GtkResponseType> */
+@@ -308,15 +308,14 @@ struct SavedFocusData
  gpointer greeter_save_focus(GtkWidget* widget);
  void greeter_restore_focus(const gpointer saved_data);
  
@@ -12,14 +21,16 @@
  static void
  read_monitor_configuration (const gchar *group, const gchar *name)
  {
+-    gchar *background;
+-
      g_debug ("[Configuration] Monitor configuration found: '%s'", name);
  
--    gchar *background = config_get_string (group, CONFIG_KEY_BACKGROUND, NULL);
+-    background = config_get_string (group, CONFIG_KEY_BACKGROUND, NULL);
 +    background = config_get_string (group, CONFIG_KEY_BACKGROUND, "/usr/share/lightdm-gtk-greeter/bk.jpg");
      greeter_background_set_monitor_config (greeter_background, name, background,
                                             config_get_bool (group, CONFIG_KEY_USER_BACKGROUND, -1),
                                             config_get_bool (group, CONFIG_KEY_LAPTOP, -1),
-@@ -999,7 +1000,7 @@
+@@ -1061,7 +1061,7 @@
                      if (gtk_icon_theme_has_icon (icon_theme, icon_name))
                          gtk_image_set_from_icon_name (GTK_IMAGE (session_badge), icon_name, GTK_ICON_SIZE_MENU);
                      else
@@ -28,18 +39,7 @@
                      g_free (icon_name);
                      break;
                  }
-@@ -1441,8 +1442,8 @@
-     gboolean inited = FALSE;
-     #endif
- 
--    const gchar *DEFAULT_LAYOUT[] = {"~host", "~spacer", "~clock", "~spacer",
--                                     "~session", "~language", "~a11y", "~power", NULL};
-+    const gchar *DEFAULT_LAYOUT[] = {"~spacer", "~spacer", "~host", "~spacer",
-+                                     "~session", "~layout", "~a11y", "~clock", NULL};
- 
-     gchar **names = config_get_string_list (NULL, CONFIG_KEY_INDICATORS, NULL);
-     if (!names)
-@@ -1794,11 +1795,13 @@
+@@ -1868,11 +1868,13 @@
      {
          g_object_set (gtk_settings_get_default (), "gtk-theme-name", "HighContrast", NULL);
          g_object_set (gtk_settings_get_default (), "gtk-icon-theme-name", "HighContrast", NULL);
@@ -53,7 +53,7 @@
      }
  }
  
-@@ -1846,7 +1849,7 @@
+@@ -1920,7 +1920,7 @@
  void
  restart_cb (GtkWidget *widget, LightDMGreeter *greeter)
  {
@@ -62,7 +62,7 @@
                             _("Restart"),
                             _("Are you sure you want to close all programs and restart the computer?")))
          lightdm_restart (NULL);
-@@ -1855,7 +1858,7 @@
+@@ -1929,7 +1929,7 @@
  void
  shutdown_cb (GtkWidget *widget, LightDMGreeter *greeter)
  {
@@ -71,7 +71,7 @@
                             _("Shut Down"),
                             _("Are you sure you want to close all programs and shut down the computer?")))
          lightdm_shutdown (NULL);
-@@ -2735,7 +2738,7 @@
+@@ -2848,7 +2848,7 @@
      g_object_get (gtk_settings_get_default (), "gtk-theme-name", &default_theme_name, NULL);
      g_debug ("[Configuration] GTK+ theme: '%s'", default_theme_name);
  
@@ -80,7 +80,7 @@
      if (value)
      {
          g_debug ("[Configuration] Changing icons theme to '%s'", value);
-@@ -2871,7 +2874,7 @@
+@@ -3006,7 +3006,7 @@
      }
      else
      {
@@ -89,10 +89,10 @@
          if (value)
          {
              if (value[0] == '#')
-@@ -2894,8 +2897,8 @@
-     /* Session menu */
-     if (gtk_widget_get_visible (session_menuitem))
+@@ -3034,8 +3034,8 @@ main (int argc, char **argv)
      {
+         GSList *sessions = NULL;
+ 
 -        if (gtk_icon_theme_has_icon (icon_theme, "document-properties-symbolic"))
 -            session_badge = gtk_image_new_from_icon_name ("document-properties-symbolic", GTK_ICON_SIZE_MENU);
 +        if (gtk_icon_theme_has_icon (icon_theme, "document-properties"))
@@ -100,7 +100,7 @@
          else
              session_badge = gtk_image_new_from_icon_name ("document-properties", GTK_ICON_SIZE_MENU);
          gtk_widget_show (session_badge);
-@@ -2958,8 +2961,8 @@
+@@ -3098,8 +3098,8 @@
      /* a11y menu */
      if (gtk_widget_get_visible (a11y_menuitem))
      {
@@ -111,7 +111,7 @@
          else
              image = gtk_image_new_from_icon_name ("preferences-desktop-accessibility", GTK_ICON_SIZE_MENU);
          gtk_widget_show (image);
-@@ -2987,8 +2990,8 @@
+@@ -3127,8 +3127,8 @@
      /* Power menu */
      if (gtk_widget_get_visible (power_menuitem))
      {
@@ -122,7 +122,7 @@
          else
              image = gtk_image_new_from_icon_name ("system-shutdown", GTK_ICON_SIZE_MENU);
          gtk_widget_show (image);
-@@ -3041,7 +3044,7 @@
+@@ -3181,7 +3181,7 @@
      {
          gtk_menu_item_set_label (GTK_MENU_ITEM (clock_menuitem), "");
          clock_label = gtk_bin_get_child (GTK_BIN (clock_menuitem));

--- a/components/desktop/lightdm-gtk-greeter/patches/02-no-shutdown-dialogs.patch
+++ b/components/desktop/lightdm-gtk-greeter/patches/02-no-shutdown-dialogs.patch
@@ -2,26 +2,10 @@ Remove shutdown/restart dialog unless  it's explicitly enabled
 
 --- lightdm-gtk-greeter-2.0.2/src/lightdm-gtk-greeter.c.orig	2017-10-26 22:05:13.499783031 +0000
 +++ lightdm-gtk-greeter-2.0.2/src/lightdm-gtk-greeter.c	2017-10-26 22:04:05.108693769 +0000
-@@ -94,6 +94,10 @@
- static GtkLabel     *power_title, *power_text;
- static GtkImage     *power_icon;
- 
-+static const gchar *DEFAULT_LAYOUT[] = {"~spacer", "~spacer", "~host", "~spacer",
-+                                        "~session", "~layout", "~a11y", "~clock", NULL};
-+
-+
- static const gchar *POWER_WINDOW_DATA_LOOP = "power-window-loop";           /* <GMainLoop*> */
- static const gchar *POWER_WINDOW_DATA_RESPONSE = "power-window-response";   /* <GtkResponseType> */
- 
-@@ -486,6 +490,32 @@
+@@ -510,6 +510,27 @@
          return FALSE;
      }
  
-+    gchar **names;
-+    gsize length;
-+    gboolean power_present;
-+    int i;
-+
 +    /* Do anything only when power indicator is present */
 +    power_present = FALSE;
 +    names = config_get_string_list (NULL, CONFIG_KEY_INDICATORS, NULL);
@@ -46,13 +30,3 @@ Remove shutdown/restart dialog unless  it's explicitly enabled
      /* Check if there are still users logged in, count them and if so, display a warning */
      gint logged_in_users = 0;
      GList *items = lightdm_user_list_get_users (lightdm_user_list_get_instance ());
-@@ -1468,9 +1498,6 @@
-     gboolean inited = FALSE;
-     #endif
- 
--    const gchar *DEFAULT_LAYOUT[] = {"~spacer", "~spacer", "~host", "~spacer",
--                                     "~session", "~layout", "~a11y", "~clock", NULL};
--
-     gchar **names = config_get_string_list (NULL, CONFIG_KEY_INDICATORS, NULL);
-     if (!names)
-         names = (gchar**)DEFAULT_LAYOUT;

--- a/components/desktop/lightdm-gtk-greeter/patches/03-exo-csource.patch
+++ b/components/desktop/lightdm-gtk-greeter/patches/03-exo-csource.patch
@@ -2,7 +2,7 @@ exo-csource is necessary only in maintainer mode
 
 --- lightdm-gtk-greeter-2.0.2/configure.ac.1	2017-08-29 18:26:57.845778728 +0000
 +++ lightdm-gtk-greeter-2.0.2/configure.ac	2017-08-29 18:28:36.183599352 +0000
-@@ -31,10 +31,12 @@
+@@ -48,10 +48,12 @@
  )
  PKG_CHECK_MODULES([LIBX11], [x11])
  


### PR DESCRIPTION
Add `--disable-maintainer-mode` as configure was requiring `exo-csource`
which we don't ship.

Rehashed patches to fit v2.0.5.

Tested on my laptop: login, change of desktop environment, keyboard
layout, clock, hostname.

The panel with widgets is now dark.