### PR TITLE
pinentry: disable FLTK

### DIFF
--- a/components/sysutils/pinentry/Makefile
+++ b/components/sysutils/pinentry/Makefile
@@ -57,7 +57,8 @@ LIBS = -lsocket -lnsl -lpkcs11
 
 CONFIGURE_ENV +=	INSTALL="$(INSTALL)"
 CONFIGURE_ENV +=	LIBS="$(LIBS)"
-CONFIGURE_ENV +=	FLTK_CONFIG="$(USRBINDIR.$(BITS))/fltk-config"
+# Following line is required if FLTK pinentry is to be shipped
+# CONFIGURE_ENV +=	FLTK_CONFIG="$(USRBINDIR.$(BITS))/fltk-config"
 
 CONFIGURE_OPTIONS  +=		--localstatedir=/var
 CONFIGURE_OPTIONS  +=		--infodir=$(CONFIGURE_INFODIR)
@@ -65,6 +66,7 @@ CONFIGURE_OPTIONS  +=		--enable-pinentry-curses
 CONFIGURE_OPTIONS  +=		--enable-pinentry-gtk2
 CONFIGURE_OPTIONS  +=		--disable-pinentry-qt
 CONFIGURE_OPTIONS  +=		--disable-ncurses
+CONFIGURE_OPTIONS  +=		--disable-pinentry-fltk
 
 build: $(BUILD_64)
 


### PR DESCRIPTION
Follow-up to https://github.com/OpenIndiana/oi-userland/pull/4224/.
```
configure:

	Pinentry v1.1.0 has been configured as follows:

	Revision:  02df3d2  (735)
	Platform:  i386-pc-solaris2.11

	Curses Pinentry ..: yes
	TTY Pinentry .....: maybe
	Emacs Pinentry ...: no
	GTK+-2 Pinentry ..: yes
	GNOME 3 Pinentry .: no
	Qt Pinentry ......: no
	TQt Pinentry .....: no
	W32 Pinentry .....: no
	FLTK Pinentry ....: no

	Fallback to Curses: yes
	Emacs integration : yes

	libsecret ........: yes

	Default Pinentry .: pinentry-gtk-2
```