### PR TITLE
GTK3 should require desktop/shared-mime-info

### DIFF
--- a/components/library/gtk+3/Makefile
+++ b/components/library/gtk+3/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gtk+
 COMPONENT_VERSION= 3.18.9
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_SUMMARY= GTK+ - GIMP Toolkit Library for creation of graphical user interfaces
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz

--- a/components/library/gtk+3/gtk3.p5m
+++ b/components/library/gtk+3/gtk3.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
+# Copyright 2018 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -25,6 +26,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=usr/lib/(.*)gtk-3.0/3.0.0/immodules/(.*) ->  default restart_fmri svc:/application/desktop-cache/input-method-cache:default>
 
 depend type=require fmri=gnome/theme/gnome-icon-theme-symbolic@3.12.0,0.5.11
+depend type=require fmri=desktop/shared-mime-info
 
 file usr/bin/gtk3-demo path=usr/demo/jds/bin/gtk3-demo
 file usr/bin/gtk3-demo-application path=usr/demo/jds/bin/gtk3-demo-application


### PR DESCRIPTION
`/usr/bin/gtk-encode-symbolic-svg` fails to convert images if it's
unable to load MIME database on runtime:

```
Can't load file: Unrecognized image file format
```

GTK3 thus should require desktop/shared-mime-info.