### PR TITLE
Hack font 3.003

### DIFF
--- a/components/fonts/hack-ttf/Makefile
+++ b/components/fonts/hack-ttf/Makefile
@@ -11,28 +11,27 @@
 
 #
 # Copyright 2016 Tim Mooney <Timothy.V.Mooney@gmail.com>
+# Copyright 2018 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=	Hack
 # Both COMPONENT_VERSION and IPS_COMPONENT_VERSION are derived from this
-COMPONENT_FILE_VERSION= 2_020
-# transform _ in upstream version to .
-COMPONENT_VERSION=$(shell echo $(COMPONENT_FILE_VERSION) | sed -e 's/_/./g')
+COMPONENT_VERSION= 3.003
 # remove leading 0s in any part of the version.
 IPS_COMPONENT_VERSION= $(shell echo $(COMPONENT_VERSION) | sed -e 's/\.0*\([1-9]\)/.\1/')
 COMPONENT_SUMMARY= Hack, a typeface designed for source code
-COMPONENT_PROJECT_URL= http://sourcefoundry.org/hack/
+COMPONENT_PROJECT_URL= https://sourcefoundry.org/hack/
 COMPONENT_FMRI=		system/font/truetype/hack
 COMPONENT_CLASSIFICATION=	System/Fonts
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(IPS_COMPONENT_VERSION)
-COMPONENT_ARCHIVE=      $(COMPONENT_NAME)-v$(COMPONENT_FILE_VERSION)-ttf.zip
+COMPONENT_ARCHIVE=      $(COMPONENT_NAME)-v$(COMPONENT_VERSION)-ttf.tar.xz
 COMPONENT_ARCHIVE_URL=	\
 	https://github.com/chrissimpkins/Hack/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_HASH= \
-  sha256:048566ae79c580f725b68340d9d2a3b0fa125fb08c1d30cf0a7c327d07ab739a
-COMPONENT_LICENSE=	Hack Open Font License Version 2.0, BitStream Vera Font License
+  sha256:d9ed5d0a07525c7e7bd587b4364e4bc41021dd668658d09864453d9bb374a78d
+COMPONENT_LICENSE=	MIT, BitStream Vera Font License
 COMPONENT_LICENSE_FILE=	hack.license
 
 include $(WS_TOP)/make-rules/prep.mk

--- a/components/fonts/hack-ttf/hack.license
+++ b/components/fonts/hack-ttf/hack.license
@@ -1,49 +1,30 @@
-## License
+The work in the Hack project is Copyright 2018 Source Foundry Authors and licensed under the MIT License
 
-Hack Copyright 2015, Christopher Simpkins with Reserved Font Name "Hack".
+The work in the DejaVu project was committed to the public domain.
 
 Bitstream Vera Sans Mono Copyright 2003 Bitstream Inc. and licensed under the Bitstream Vera License with Reserved Font Names "Bitstream" and "Vera"
 
-DejaVu modifications of the original Bitstream Vera Sans Mono typeface have been committed to the public domain.
+### MIT License
 
+Copyright (c) 2018 Source Foundry Authors
 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This Font Software is licensed under the Hack Open Font License v2.0 and the Bitstream Vera License.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-These licenses are copied below.
-
-
-### Hack Open Font License v2.0
-
-(Version 1.0 - 06 September 2015)
-
-(Version 2.0 - 27 September 2015)
-
-Copyright 2015 by Christopher Simpkins. All Rights Reserved.
-
-DEFINITIONS
-
-"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
-
-PERMISSION AND CONDITIONS
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated source code, documentation, and binary files (the "Font Software"), to reproduce and distribute the modifications to the Bitstream Vera Font Software, including without limitation the rights to use, study, copy, merge, embed, modify, redistribute, and/or sell modified or unmodified copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
-
-(1) The above copyright notice and this permission notice shall be included in all modified and unmodified copies of the Font Software typefaces. These notices can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
-
-(2) The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or characters may be added to the Fonts, only if the fonts are renamed to names not containing the word "Hack".
-
-(3) Neither the Font Software nor any of its individual components, in original or modified versions, may be sold by itself.
-
-TERMINATION
-
-This license becomes null and void if any of the above conditions are not met.
-
-THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
-
-Except as contained in this notice, the names of Christopher Simpkins and the Author(s) of the Font Software shall not be used to promote, endorse or advertise any modified version, except to acknowledge the contribution(s) of Christopher Simpkins and the Author(s) or with their explicit written permission.  For further information, contact: chris at sourcefoundry dot org.
-
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ### BITSTREAM VERA LICENSE
 


### PR DESCRIPTION
* license changed from custom Hack license to MIT (Vera is kept)
* a bit saner versioning

@timmooney: Just FYI.