### PR TITLE
Fix several desktop icons

### DIFF
--- a/components/desktop/xscreensaver/Makefile
+++ b/components/desktop/xscreensaver/Makefile
@@ -21,7 +21,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		xscreensaver
 COMPONENT_VERSION=	5.39
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	https://www.jwz.org/xscreensaver/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz

--- a/components/desktop/xscreensaver/patches/03-GNOME-desktop.patch
+++ b/components/desktop/xscreensaver/patches/03-GNOME-desktop.patch
@@ -28,13 +28,11 @@ Localized name & tooltips (Sun bug 5103358)
  1 files changed, 30 insertions(+), 4 deletions(-)
 
 diff --git driver/screensaver-properties.desktop.in driver/screensaver-properties.desktop.in
---- driver/screensaver-properties.desktop.in
-+++ driver/screensaver-properties.desktop.in
-@@ -1,8 +1,34 @@
- [Desktop Entry]
+--- driver/screensaver-properties.desktop.in	2009-10-07 04:26:41.000000000 +0000
++++ driver/screensaver-properties.desktop.in	2018-06-13 18:26:17.420717422 +0000
+@@ -2,7 +2,33 @@
  Exec=xscreensaver-demo
--Icon=xscreensaver
-+Icon=gnome-ccscreensaver.png
+ Icon=xscreensaver
  Terminal=false
 -_Name=Screensaver
 -_Comment=Change screensaver properties

--- a/components/print/system-config-printer/Makefile
+++ b/components/print/system-config-printer/Makefile
@@ -11,13 +11,14 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright 2018 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= system-config-printer
 COMPONENT_VERSION= 1.4.8
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 IPS_COMPONENT_VERSION= 2.30.0
 COMPONENT_SUMMARY= Print Manager for CUPS
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -56,3 +57,4 @@ REQUIRED_PACKAGES += library/python/pycups-27
 REQUIRED_PACKAGES += library/python/pygobject-3-27
 REQUIRED_PACKAGES += library/python/python-dbus-27
 REQUIRED_PACKAGES += runtime/python-27
+REQUIRED_PACKAGES += text/xmlto

--- a/components/print/system-config-printer/manifests/sample-manifest.p5m
+++ b/components/print/system-config-printer/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/print/system-config-printer/patches/system-config-printer-08-desktop-files.patch
+++ b/components/print/system-config-printer/patches/system-config-printer-08-desktop-files.patch
@@ -32,8 +32,8 @@ diff -urN system-config-printer-1.0.16/print-applet.desktop.in ../SUNWcups-manag
  Terminal=false
  Type=Application
  Icon=printer
---- system-config-printer-1.4.8/system-config-printer.desktop.in.~1~	2016-09-14 15:45:24.421829454 +0300
-+++ system-config-printer-1.4.8/system-config-printer.desktop.in	2016-09-14 15:46:46.200594632 +0300
+--- system-config-printer-1.4.8/system-config-printer.desktop.in.~1~	2015-03-17 13:32:23.000000000 +0000
++++ system-config-printer-1.4.8/system-config-printer.desktop.in	2018-06-13 18:44:44.934043844 +0000
 @@ -1,8 +1,9 @@
  [Desktop Entry]
 -_Name=Print Settings
@@ -43,7 +43,6 @@ diff -urN system-config-printer-1.0.16/print-applet.desktop.in ../SUNWcups-manag
  Exec=system-config-printer
  Terminal=false
  Type=Application
--Icon=printer
-+Icon=print-manager
+ Icon=printer
  StartupNotify=true
 +OnlyShowIn=MATE;

--- a/components/x11/xterm/Makefile
+++ b/components/x11/xterm/Makefile
@@ -11,11 +11,14 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2018 Michal Nowak
 #
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xterm
 COMPONENT_VERSION= 333
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= xterm - terminal emulator for X 
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tgz
@@ -49,12 +52,13 @@ build: $(BUILD_32)
 
 install: $(INSTALL_32)
 
-test: $(TEST_32)
+test: $(NO_TESTS)
 
 # Build dependencies
 REQUIRED_PACKAGES += terminal/luit
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/fontconfig
 REQUIRED_PACKAGES += system/library/freetype-2

--- a/components/x11/xterm/patches/01-desktop-icon.patch
+++ b/components/x11/xterm/patches/01-desktop-icon.patch
@@ -7,5 +7,5 @@ index ea23c9b..5485dd0 100644
  Type=Application
  Encoding=UTF-8
 -Icon=xterm-color_48x48
-+Icon=gnome-xterm
++Icon=terminal
  Categories=System;TerminalEmulator;


### PR DESCRIPTION
* XTerm

`Icon=terminal` seems to be a better match, which works for all icon
themes we ship (tested that), otherwise stub icon is used.

Disabled tests as I could not find any test target in Makefile.in.

* XScreensaver

We don't ship `Icon=gnome-ccscreensaver` outside Nimbus theme, replacing
with the same icon under a different name.

* system-config-printer

We don't ship `Icon=print-manager` outside Nimbus, replacing with
similar one.