### PR TITLE
abook 0.6.1

### DIFF
--- a/components/mail/abook/Makefile
+++ b/components/mail/abook/Makefile
@@ -20,19 +20,21 @@
 
 #
 # Copyright (c) 2015 Matt Samudio
+# Copyright (c) 2018 Michal Nowak
 #
+
+PREFERRED_BITS=64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		abook
-COMPONENT_VERSION=	0.5.6
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	0.6.1
 COMPONENT_PROJECT_URL=	http://abook.sourceforge.net/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:0646f6311a94ad3341812a4de12a5a940a7a44d5cb6e9da5b0930aae9f44756e
-COMPONENT_ARCHIVE_URL=	http://prdownloads.sourceforge.net/abook/$(COMPONENT_ARCHIVE)
+    sha256:f0a90df8694fb34685ecdd45d97db28b88046c15c95e7b0700596028bd8bc0f9
+COMPONENT_ARCHIVE_URL=	http://abook.sourceforge.net/devel/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		mail/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	Applications/Internet
 COMPONENT_SUMMARY=	abook addressbook program
@@ -44,16 +46,17 @@ include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 CPPFLAGS += -I/usr/include/ncurses
-CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
+CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS) -fgnu89-inline"
 
 COMPONENT_PRE_CONFIGURE_ACTION = (cp -r $(SOURCE_DIR)/* $(BUILD_DIR_$(BITS))/) 
+COMPONENT_PREP_ACTION += ( cd $(@D) && autoreconf -fiv )
 COMPONENT_BUILD_ARGS=
 COMPONENT_BUILD_ENV += CC=$(CC)
 
 # common targets
-build:		$(BUILD_32_and_64)
+build:		$(BUILD_64)
 
-install:	$(INSTALL_32_and_64)
+install:	$(INSTALL_64)
 
 test:		$(NO_TESTS)
 

--- a/components/mail/abook/abook.p5m
+++ b/components/mail/abook/abook.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Matt Samudio
+# Copyright 2018 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,10 +23,10 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/abook
 file path=usr/bin/abook
 file path=usr/share/locale/de/LC_MESSAGES/abook.mo
 file path=usr/share/locale/fr/LC_MESSAGES/abook.mo
+file path=usr/share/locale/it/LC_MESSAGES/abook.mo
 file path=usr/share/locale/ja/LC_MESSAGES/abook.mo
 file path=usr/share/locale/sv/LC_MESSAGES/abook.mo
 file path=usr/share/man/man1/abook.1

--- a/components/mail/abook/manifests/sample-manifest.p5m
+++ b/components/mail/abook/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,11 +22,16 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/abook
 file path=usr/bin/abook
 file path=usr/share/locale/de/LC_MESSAGES/abook.mo
+link path=usr/share/locale/de/LC_TIME/abook.mo target=../LC_MESSAGES/abook.mo
 file path=usr/share/locale/fr/LC_MESSAGES/abook.mo
+link path=usr/share/locale/fr/LC_TIME/abook.mo target=../LC_MESSAGES/abook.mo
+file path=usr/share/locale/it/LC_MESSAGES/abook.mo
+link path=usr/share/locale/it/LC_TIME/abook.mo target=../LC_MESSAGES/abook.mo
 file path=usr/share/locale/ja/LC_MESSAGES/abook.mo
+link path=usr/share/locale/ja/LC_TIME/abook.mo target=../LC_MESSAGES/abook.mo
 file path=usr/share/locale/sv/LC_MESSAGES/abook.mo
+link path=usr/share/locale/sv/LC_TIME/abook.mo target=../LC_MESSAGES/abook.mo
 file path=usr/share/man/man1/abook.1
 file path=usr/share/man/man5/abookrc.5


### PR DESCRIPTION
Version bump, 64-bit only.

Version 0.6.1 is devel version, but it's what recent Linux distributions
are using for some time.