### PR TITLE
fetchmail 64-bit-only

### DIFF
--- a/components/mail/fetchmail/Makefile
+++ b/components/mail/fetchmail/Makefile
@@ -21,13 +21,16 @@
 
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2018, Michal Nowak
 #
+
+PREFERRED_BITS=64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		fetchmail
 COMPONENT_VERSION=	6.3.26
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
@@ -35,6 +38,7 @@ COMPONENT_ARCHIVE_HASH=	\
 COMPONENT_ARCHIVE_URL=	http://sourceforge.net/projects/$(COMPONENT_NAME).berlios/files/$(COMPONENT_ARCHIVE)/download
 COMPONENT_PROJECT_URL=	http://www.fetchmail.info/
 COMPONENT_BUGDB=	utility/fetchmail
+COMPONENT_FMRI=		mail/fetchmail
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
@@ -57,11 +61,11 @@ COMPONENT_POST_INSTALL_ACTION = \
     $(PYTHON) -m compileall $(PROTO_DIR)/$(PYTHON_VENDOR_PACKAGES)
 
 # common targets
-build:		$(BUILD_32_and_64)
+build:		$(BUILD_64)
 
-install:	$(INSTALL_32_and_64)
+install:	$(INSTALL_64)
 
-test:		$(TEST_32_and_64)
+test:		$(TEST_64)
 
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/python-2/tkinter-27

--- a/components/mail/fetchmail/fetchmail.p5m
+++ b/components/mail/fetchmail/fetchmail.p5m
@@ -19,11 +19,12 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2018, Michal Nowak
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
 set name=pkg.fmri \
-    value=pkg:/mail/fetchmail@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+    value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary \
     value="fetch mail from a POP, IMAP, ETRN, or ODMR-capable server"
 set name=pkg.description \
@@ -37,8 +38,6 @@ set name=org.opensolaris.arc-caseid value=PSARC/2008/135
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 file path=usr/bin/fetchmail
 file path=usr/bin/fetchmailconf
-file path=usr/bin/$(MACH64)/fetchmail
-file path=usr/bin/$(MACH64)/fetchmailconf
 file path=usr/lib/python2.7/vendor-packages/fetchmailconf.py \
     pkg.tmp.autopyc=false
 file path=usr/lib/python2.7/vendor-packages/fetchmailconf.pyc

--- a/components/mail/fetchmail/manifests/sample-manifest.p5m
+++ b/components/mail/fetchmail/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,11 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/fetchmail
-file path=usr/bin/$(MACH64)/fetchmailconf
 file path=usr/bin/fetchmail
 file path=usr/bin/fetchmailconf
-file path=usr/lib/python2.6/vendor-packages/fetchmailconf.py
 file path=usr/lib/python2.7/vendor-packages/fetchmailconf.py
 file path=usr/share/locale/ca/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/cs/LC_MESSAGES/fetchmail.mo


### PR DESCRIPTION
```
/usr/gnu/bin/make  check-TESTS
make[4]: Entering directory '/export/home/newman/ws/oi-userland/components/mail/fetchmail/build/amd64'
PASS: t.smoke
SKIP: t.validate-xhtml10
SKIP: t.validate-xhtml
PASS: t.x509_name_match
======================
All 2 tests passed
(2 tests were not run)
======================
```