### PR TITLE
aria2 1.34.0

### DIFF
--- a/components/web/aria2/Makefile
+++ b/components/web/aria2/Makefile
@@ -19,12 +19,15 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2016 Predrag Zečević
+# Copyright (c) 2018 Michal Nowak
 #
+
+PREFERRED_BITS=64
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           aria2
-COMPONENT_VERSION=        1.29.0
-COMPONENT_REVISION=       1
+COMPONENT_VERSION=        1.34.0
 COMPONENT_FMRI=           web/aria2
 COMPONENT_PROJECT_URL=    https://aria2.github.io/
 COMPONENT_CLASSIFICATION= Applications/Internet
@@ -33,7 +36,7 @@ COMPONENT_SUMMARY= \
 COMPONENT_SRC=         $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=     $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-    sha256:bbfc7e6b4c84b5063012edbe34c6d4258e64799cab4ac65709d970d649dcde23
+    sha256:aa8cbe4c8408229b9dbd62bf2d7cc38dd1ebe41e9614db17460e564f76f2f246
 COMPONENT_ARCHIVE_URL= \
     https://github.com/aria2/aria2/releases/download/release-$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE= GPLv3
@@ -57,19 +60,22 @@ CXXFLAGS += -I/usr/include/gmp
 
 LDFLAGS += -lsocket -lnsl
 
-CONFIGURE_OPTIONS+= --disable-static
+CONFIGURE_OPTIONS += --disable-static
+CONFIGURE_OPTIONS += --with-bashcompletiondir=/usr/share/bash-completion/completions/
 
 CONFIGURE_ENV += LD_OPTIONS="$(LD_OPTIONS)"
 
 COMPONENT_TEST_ENV += LD_OPTIONS="$(LD_OPTIONS)"
 
-build:		$(BUILD_32_and_64)
+build:		$(BUILD_64)
 
-install:	$(INSTALL_32_and_64)
+install:	$(INSTALL_64)
 
-test:		$(TEST_32_and_64)
+test:		$(TEST_64)
 
 REQUIRED_PACKAGES += database/sqlite-3
+# cppunit is for tests
+REQUIRED_PACKAGES += developer/cppunit
 REQUIRED_PACKAGES += library/gmp
 REQUIRED_PACKAGES += library/gnutls-3
 REQUIRED_PACKAGES += library/libssh2

--- a/components/web/aria2/aria2.p5m
+++ b/components/web/aria2/aria2.p5m
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2016 Predrag Zečević
+# Copyright (c) 2018 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,13 +31,12 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/aria2c
 file path=usr/bin/aria2c
+file path=usr/share/bash-completion/completions/aria2c
 file path=usr/share/doc/aria2/README
 file path=usr/share/doc/aria2/README.html
 file path=usr/share/doc/aria2/README.rst
 file path=usr/share/doc/aria2/bash_completion/README.txt
-file path=usr/share/doc/aria2/bash_completion/aria2c
 file path=usr/share/doc/aria2/xmlrpc/README.txt
 file path=usr/share/doc/aria2/xmlrpc/aria2mon
 file path=usr/share/doc/aria2/xmlrpc/aria2rpc

--- a/components/web/aria2/manifests/sample-manifest.p5m
+++ b/components/web/aria2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,13 +22,12 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/aria2c
 file path=usr/bin/aria2c
+file path=usr/share/bash-completion/completions/aria2c
 file path=usr/share/doc/aria2/README
 file path=usr/share/doc/aria2/README.html
 file path=usr/share/doc/aria2/README.rst
 file path=usr/share/doc/aria2/bash_completion/README.txt
-file path=usr/share/doc/aria2/bash_completion/aria2c
 file path=usr/share/doc/aria2/xmlrpc/README.txt
 file path=usr/share/doc/aria2/xmlrpc/aria2mon
 file path=usr/share/doc/aria2/xmlrpc/aria2rpc


### PR DESCRIPTION
Version bump, fixed `aria2c` bash completion, 64-bit-only.

Tested: file download, bash completion.

Internal tests fail: https://github.com/aria2/aria2/issues/1222