### PR TITLE
Move vim.desktop back to gvim package

### DIFF
--- a/components/editor/vim/Makefile
+++ b/components/editor/vim/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		vim
 COMPONENT_VERSION=	8.1.0005
+COMPONENT_REVISION=	1
 # Remove leading zeros in the patch-level part of $COMPONENT_VERSION (IPS does not like them)
 IPS_COMPONENT_VERSION=  $(shell echo $(COMPONENT_VERSION) | sed -e 's/\.00*\([1-9]\)/.\1/')
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/editor/vim/gvim.p5m
+++ b/components/editor/vim/gvim.p5m
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2018, Michal Nowak
 #
 
 set name=pkg.fmri \
@@ -43,6 +44,7 @@ file path=usr/bin/gvim
 link path=usr/bin/gvimdiff target=gvim
 link path=usr/bin/rgview target=gvim
 link path=usr/bin/rgvim target=gvim
+file path=usr/share/applications/vim.desktop
 file path=usr/share/applications/gvim.desktop
 file path=usr/share/icons/hicolor/48x48/apps/gvim.png
 file path=usr/share/icons/locolor/16x16/apps/gvim.png

--- a/components/editor/vim/vim.p5m
+++ b/components/editor/vim/vim.p5m
@@ -45,7 +45,6 @@ link path=usr/bin/rvim target=vim
 link path=usr/bin/vimdiff target=vim
 file path=usr/bin/vimtutor
 file path=usr/bin/xxd
-file path=usr/share/applications/vim.desktop
 file path=usr/share/man/fr.ISO8859-1/man1/evim.1
 link path=usr/share/man/fr.ISO8859-1/man1/rview.1 target=vim.1
 link path=usr/share/man/fr.ISO8859-1/man1/rvim.1 target=vim.1


### PR DESCRIPTION
vim's `Icon` depends on gvim package content.