### PR TITLE
Support lzip compressed archives in oi-userland

### DIFF
--- a/components/archiver/lzip/Makefile
+++ b/components/archiver/lzip/Makefile
@@ -19,12 +19,14 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		lzip
 COMPONENT_VERSION=	1.20
+COMPONENT_REVISION=	1
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	http://lzip.nongnu.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:c93b81a5a7788ef5812423d311345ba5d3bd4f5ebf1f693911e3a13553c1290c
 COMPONENT_ARCHIVE_URL=	http://download.savannah.gnu.org/releases/lzip/$(COMPONENT_ARCHIVE)
+COMPONENT_SIG_URL=	http://download.savannah.gnu.org/releases/lzip/$(COMPONENT_ARCHIVE).sig
 COMPONENT_FMRI=		compress/lzip
 COMPONENT_SUMMARY=	'Lzip - a lossless data compressor with a user interface similar to the one of gzip or bzip2'
 COMPONENT_LICENSE=	GPLv2+
@@ -34,7 +36,6 @@ COMPONENT_CLASSIFICATION= Applications/System Utilities
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
-
 
 COMPONENT_TEST_TRANSFORMER = $(NAWK)
 COMPONENT_TEST_TRANSFORMS = "'/testing|tests/'"

--- a/make-rules/prep-unpack.mk
+++ b/make-rules/prep-unpack.mk
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, Michal Nowak
 #
 
 UNPACK =		$(WS_TOOLS)/userland-unpack
@@ -56,6 +57,7 @@ REQUIRED_PACKAGES += compress/bzip2
 REQUIRED_PACKAGES += compress/gzip
 REQUIRED_PACKAGES += compress/p7zip
 REQUIRED_PACKAGES += compress/unzip
+REQUIRED_PACKAGES += compress/lzip
 REQUIRED_PACKAGES += compress/xz
 REQUIRED_PACKAGES += compress/zip
 REQUIRED_PACKAGES += developer/java/jdk

--- a/tools/userland-unpack
+++ b/tools/userland-unpack
@@ -20,6 +20,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2010, Oracle and/or it's affiliates.  All rights reserved.
+# Copyright (c) 2018, Michal Nowak
 #
 #
 # unpack.py - an archive unpack utility
@@ -44,6 +45,8 @@ def uncompress_unpack_commands(filename, verbose=False):
 		uncompress = "/usr/bin/uncompress -c"
 	elif (re.search("(\.7z)$", filename) != None):
 		uncompress = "/usr/bin/7z --s"
+	elif (re.search("(\.lz)$", filename) != None):
+		uncompress = "/usr/bin/lzip -dc"
 	elif (re.search("(\.xz)$", filename) != None):
 		uncompress = "/usr/bin/xz -dc"
 	elif (re.search("(\.zip)$", filename) != None):


### PR DESCRIPTION
* decompress archives via `lzip`
* install compressor/lzip by default for oi-userland development
* use sig & .lz archive for lzip component itself

Test:

```
/export/home/newman/ws/oi-userland/tools/userland-fetch  --file /export/home/newman/ws/oi-userland/archives/lzip-1.20.tar.lz --url http://download.savannah.gnu.org/releases/lzip/lzip-1.20.tar.lz --hash sha256:f719f64ab9c59fd4b8c8f88e824f9332b4ff53f2e50d1c36deb4ee2e790c5dfa --sigurl http://download.savannah.gnu.org/releases/lzip/lzip-1.20.tar.lz.sig
Source /export/home/newman/ws/oi-userland/archives/lzip-1.20.tar.lz...
    validating signature... Warning: using insecure memory!
gpg: Signature made February 14, 2018 at 07:44:34 PM CET using DSA key ID 132D7742
gpg: requesting key 132D7742 from hkp server keys.gnupg.net
gpgkeys: key 8FE99503132D7742 can't be retrieved
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
gpg: keyserver communications error: keyserver helper general error
gpg: keyserver communications error: Invalid public key algorithm
gpg: Can't check signature: No public key

failed
    validating hash... ok
/usr/bin/touch /export/home/newman/ws/oi-userland/archives/lzip-1.20.tar.lz
/bin/rm -f -r /export/home/newman/ws/oi-userland/components/archiver/lzip/lzip-1.20
/usr/bin/env RUBY_VERSION=2.3 /export/home/newman/ws/oi-userland/tools/userland-unpack  /export/home/newman/ws/oi-userland/archives/lzip-1.20.tar.lz
/usr/bin/touch /export/home/newman/ws/oi-userland/components/archiver/lzip/lzip-1.20/.unpacked
```