### PR TITLE
pgBadger 9.1

### DIFF
--- a/components/database/pgbadger/Makefile
+++ b/components/database/pgbadger/Makefile
@@ -11,27 +11,29 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2018 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= 	pgbadger
-COMPONENT_VERSION= 	7.1
-COMPONENT_SUMMARY= 	pgBadger PostgreSQL log analyzer
+COMPONENT_VERSION= 	9.2
+COMPONENT_SUMMARY= 	A fast PostgreSQL log analyzer
 COMPONENT_SRC= 		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= 	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:de7f36cb55d2c177fdf47115f3fb5c2e842b443432631212e408726baacbad7e
+  sha256:2107466309a409fb9e40f11bb77cac1f9ba7910d5328e7b2e08eb7a1c6d760ec
 COMPONENT_ARCHIVE_URL= \
   https://github.com/dalibo/pgbadger/archive/v$(COMPONENT_VERSION).tar.gz
-COMPONENT_PROJECT_URL = http://dalibo.github.io/pgbadger/
+COMPONENT_PROJECT_URL=	http://dalibo.github.io/pgbadger/
+COMPONENT_FMRI=	database/postgres/pgbadger
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/justmake.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 # Using makemaker.mk here is an overkill,
-# because we don't need versioned  pgbadger
+# because we don't need versioned pgbadger
 COMPONENT_PRE_BUILD_ACTION = ( cd $(BUILD_DIR_32) && $(PERL) Makefile.PL )
 
 PKG_PROTO_DIRS += $(BUILD_DIR_32)

--- a/components/database/pgbadger/manifests/sample-manifest.p5m
+++ b/components/database/pgbadger/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2017 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,12 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/perl5/5.16/bin/pgbadger
-file path=usr/perl5/5.16/lib/i86pc-solaris-64int/perllocal.pod
-file path=usr/perl5/5.16/man/man1/pgbadger.1
 file path=usr/perl5/5.22/bin/pgbadger
 file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
-file path=usr/perl5/5.22/man/man1/pgbadger.1
 file path=usr/perl5/5.22/man/man1/pgbadger.1p
-file path=usr/perl5/site_perl/5.16/i86pc-solaris-64int/auto/pgBadger/.packlist
 file path=usr/perl5/site_perl/5.22/i86pc-solaris-64int/auto/pgBadger/.packlist

--- a/components/database/pgbadger/pgbadger.p5m
+++ b/components/database/pgbadger/pgbadger.p5m
@@ -11,16 +11,17 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2018 Michal Nowak
 #
 
-set name=pkg.fmri value=pkg:/database/postgres/pgbadger@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="gBadger PostgreSQL log analyzer"
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value=org.opensolaris.category.2008:System/Databases
-set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license LICENSE license="BSD"
+license LICENSE license=PostgreSQL
 
-file pgbadger path=usr/bin/pgbadger mode=0555
-file blib/man1/pgbadger.1p path=usr/share/man/man1/pgbadger.1
+file usr/perl5/5.22/bin/pgbadger path=usr/bin/pgbadger mode=0555
+file usr/perl5/5.22/man/man1/pgbadger.1p path=usr/share/man/man1/pgbadger.1


### PR DESCRIPTION
There are problems with `JSON::XS` (which we don't ship) otherwise seems
to work:
```
 $ PATH=$PATH:/usr/perl5/5.22/bin:/usr/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin /usr/perl5/bin/prove --verbose
 t/basics.t .......
 1..4
 ok 1 Inline help
 ok 2 Light log report to stdout
 ok 3 Light log report to HTML
 not ok 4 From binary to JSON
 # (in test file t/basics.t, line 20)
 #   `./pgbadger --outdir $BATS_TMPDIR -o test-out.json \' failed with status 255
 # Long integer size is not compatible at /usr/perl5/5.22/lib/i86pc-solaris-64int/Storable.pm line 407, at ./pgbadger line 11433.
 Dubious, test returned 1 (wstat 256, 0x100)
 Failed 1/4 subtests
 t/consistency.t ..
 1..3
 ok 1 Consistent count
 ok 2 Consistent query_total
 ok 3 Consistent peak.write
 ok
 t/lint.t .........
 1..2
 ok 1 PERL syntax check
 ok 2 pod syntax check
 ok

 Test Summary Report
 -------------------
 t/basics.t     (Wstat: 256 Tests: 4 Failed: 1)
   Failed test:  4
   Non-zero exit status: 1
 Files=3, Tests=9,  5 wallclock secs ( 0.04 usr  0.01 sys +  4.28 cusr  0.28 csys =  4.61 CPU)
 Result: FAIL
```
Reported as: https://github.com/dalibo/pgbadger/issues/429