### PR TITLE
cpuid 1.6.4 & man page

### DIFF
--- a/components/sysutils/cpuid/Makefile
+++ b/components/sysutils/cpuid/Makefile
@@ -10,12 +10,13 @@
 
 #
 # Copyright 2018 Aurelien Larcher
+# Copyright 2018 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cpuid
-COMPONENT_VERSION=	1.6.3
+COMPONENT_VERSION=	1.6.4
 COMPONENT_SUMMARY=	A simple CPUID decoder/dumper for x86/x86_64
 COMPONENT_PROJECT_URL=	https://github.com/tycho/cpuid
 COMPONENT_FMRI=		diagnostic/cpuid
@@ -25,7 +26,7 @@ COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL= \
   https://github.com/tycho/cpuid/archive/$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:4bf27e846dadefcab67ca5af3b6cbd86491b5a8a8795ab21ed7cd9aa52469760
+  sha256:027dcd9eaf07f80841243a7a0fca5db08e1824719663f6e4f2326b856adc7a55
 COMPONENT_LICENSE=	MIT
 
 include $(WS_MAKE_RULES)/prep.mk
@@ -36,6 +37,8 @@ COMPONENT_BUILD_ARGS+= CC="$(CC) $(CC_BITS) "
 COMPONENT_BUILD_ARGS+= prefix=$(USRDIR)
 COMPONENT_INSTALL_ARGS+= CC="$(CC) $(CC_BITS) "
 COMPONENT_INSTALL_ARGS+= prefix=$(USRDIR)
+
+COMPONENT_POST_INSTALL_ACTION = $(INSTALL) -D files/cpuid.1 $(PROTOUSRDIR)/share/man/man1/cpuid.1
 
 build:		$(BUILD_64)
 

--- a/components/sysutils/cpuid/cpuid.p5m
+++ b/components/sysutils/cpuid/cpuid.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2018 Aurelien Larcher
+# Copyright 2018 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,3 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/cpuid
+file path=usr/share/man/man1/cpuid.1

--- a/components/sysutils/cpuid/files/cpuid.1
+++ b/components/sysutils/cpuid/files/cpuid.1
@@ -1,0 +1,85 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "CPUID" "1" "July 2018" "" ""
+.
+.SH "NAME"
+\fBcpuid\fR \- dump and extract information from the x86 CPUID instruction
+.
+.SH "SYNOPSIS"
+\fBcpuid\fR [\-\-help] [\-\-dump] [\-\-vendor \fIname\fR] [\-\-ignore\-vendor] [\-\-parse \fIfilename\fR]
+.
+.SH "DESCRIPTION"
+\fBcpuid\fR is a very simple C program, designed to dump and extract information from the x86 CPUID instruction\.
+.
+.P
+\fBcpuid\fR is capable of dumping all CPUID leaves (except any unknown leaves which require special ECX values to dump all information)\. \fBcpuid\fR can only decode certain leaves, but this functionality will be expanded as the CPUID specifications provided by AMD and Intel change\.
+.
+.SH "OPTIONS"
+\fB\-c\fR, \fB\-\-cpu\fR Index (starting at 0) of CPU to get info from
+.
+.P
+\fB\-d\fR, \fB\-\-dump\fR Dump a raw CPUID table
+.
+.P
+\fB\-f\fR, \fB\-\-parse\fR Read and decode a raw CPUID table from the file specified
+.
+.P
+\fB\-h\fR, \fB\-\-help\fR Print list of options
+.
+.P
+\fB\-\-ignore\-vendor\fR Show feature flags from all vendors
+.
+.P
+\fB\-\-sanity\fR Do a sanity check of the CPUID data
+.
+.P
+\fB\-\-vendor\fR Override the processor vendor string
+.
+.P
+\fB\-\-version\fR Print \fBcpuid\fR version and license
+.
+.SH "STANDARDS"
+You can find current Intel and AMD CPUID specifications at these locations:
+.
+.P
+Intel Software Developer Manual volume 2A \fIhttps://www\.intel\.com/content/www/us/en/architecture\-and\-technology/64\-ia\-32\-architectures\-software\-developer\-vol\-2a\-manual\.html\fR
+.
+.P
+AMD Processor Programming Reference \fIhttp://developer\.amd\.com/resources/developer\-guides\-manuals/\fR
+.
+.P
+Please notify me if you notice any inconsistencies or if features you find relevant are not being decoded\.
+.
+.SH "BUGS"
+If you find a bug in \fBcpuid\fR, please submit details about it to the bug tracker on GitHub: https://github\.com/tycho/cpuid/issues
+.
+.P
+If the bug is regarding the decoding or dumping of CPUID details, then you should include the dump\.txt and decode\.txt generated with these commands:
+.
+.IP "" 4
+.
+.nf
+
+cpuid \-d \-c \-1 > dump\.txt
+cpuid \-c \-1 > decode\.txt
+.
+.fi
+.
+.IP "" 0
+.
+.P
+You should also specify what revision of \fBcpuid\fR you are running\. If you don\'t know, you can find out with:
+.
+.IP "" 4
+.
+.nf
+
+cpuid \-\-version
+.
+.fi
+.
+.IP "" 0
+.
+.SH "AUTHOR"
+Steven Noonan \fIsteven@uplinklabs\.net\fR

--- a/components/sysutils/cpuid/files/cpuid.ronn
+++ b/components/sysutils/cpuid/files/cpuid.ronn
@@ -1,0 +1,77 @@
+cpuid(1) -- dump and extract information from the x86 CPUID instruction
+=======================================================================
+
+## SYNOPSIS
+
+`cpuid` [--help] [--dump] [--vendor <name>] [--ignore-vendor] [--parse <filename>]
+
+## DESCRIPTION
+
+`cpuid` is a very simple C program, designed to dump and extract information
+from the x86 CPUID instruction.
+
+`cpuid` is capable of dumping all CPUID leaves (except any unknown leaves which
+require special ECX values to dump all information). `cpuid` can only decode
+certain leaves, but this functionality will be expanded as the CPUID
+specifications provided by AMD and Intel change.
+
+## OPTIONS
+
+  `-c`, `--cpu`
+  Index (starting at 0) of CPU to get info from
+
+  `-d`, `--dump`
+  Dump a raw CPUID table
+
+  `-f`, `--parse`
+  Read and decode a raw CPUID table from the file specified
+
+  `-h`, `--help`
+  Print list of options
+
+  `--ignore-vendor`
+  Show feature flags from all vendors
+
+  `--sanity`
+  Do a sanity check of the CPUID data
+
+  `--vendor`
+  Override the processor vendor string
+
+  `--version`
+  Print `cpuid` version and license
+
+## STANDARDS
+
+You can find current Intel and AMD CPUID specifications at these locations:
+
+[Intel Software Developer Manual volume 2A](https://www.intel.com/content/www/us/en/architecture-and-technology/64-ia-32-architectures-software-developer-vol-2a-manual.html)
+
+[AMD Processor Programming Reference](http://developer.amd.com/resources/developer-guides-manuals/)
+
+Please notify me if you notice any inconsistencies or if features you
+find relevant are not being decoded.
+
+## BUGS
+
+If you find a bug in `cpuid`, please submit details about it to the bug tracker
+on GitHub: https://github.com/tycho/cpuid/issues
+
+If the bug is regarding the decoding or dumping of CPUID details, then you
+should include the dump.txt and decode.txt generated with these commands:
+
+```
+cpuid -d -c -1 > dump.txt
+cpuid -c -1 > decode.txt
+```
+
+You should also specify what revision of `cpuid` you are running. If you don't
+know, you can find out with:
+
+```
+cpuid --version
+```
+
+## AUTHOR
+
+Steven Noonan <steven@uplinklabs.net>

--- a/components/sysutils/cpuid/manifests/sample-manifest.p5m
+++ b/components/sysutils/cpuid/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,3 +23,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/cpuid
+file path=usr/share/man/man1/cpuid.1


### PR DESCRIPTION
Created man page from modified upstream `README.md` file via `ronn` gem
(https://github.com/rtomayko/ronn). `man cpuid` seem OK with it. If
accepted, I'll send it upstream.