### PR TITLE
Fix some zziplib man pages

### DIFF
--- a/components/archiver/zziplib/Makefile
+++ b/components/archiver/zziplib/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2013 Aurelien Larcher.  All rights reserved.
+# Copyright 2018 Michal Nowak
 #
 PREFERRED_BITS=64
 
@@ -18,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zziplib
 COMPONENT_VERSION=	0.13.69
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	Lightweight ZIP library
 COMPONENT_PROJECT_URL=	https://github.com/gdraheim/zziplib
 COMPONENT_FMRI=		compress/zziplib
@@ -36,6 +37,8 @@ include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 PATH=$(PATH.gnu)
+
+COMPONENT_PREP_ACTION=	( cd $(@D); autoreconf -i -f )
 
 CONFIGURE_OPTIONS+=	--enable-shared
 CONFIGURE_OPTIONS+=	--disable-static

--- a/components/archiver/zziplib/manifests/sample-manifest.p5m
+++ b/components/archiver/zziplib/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/archiver/zziplib/patches/03-disable-xmlto.patch
+++ b/components/archiver/zziplib/patches/03-disable-xmlto.patch
@@ -1,0 +1,11 @@
+--- zziplib-0.13.69/configure.ac	2018-03-17 13:46:45.000000000 +0000
++++ zziplib-0.13.69/configure.ac	2018-08-03 07:09:25.865903598 +0000
+@@ -90,7 +90,7 @@ AX_PAX_TAR_EXTRACT
+ AC_PATH_PROGS(PERL, perl5 perl, echo no perl found for)
+ AC_PATH_PROGS(PYTHON, python, echo no python found for)
+ AC_PATH_PROGS(MKZIP, zip pkzip, :)
+-AC_PATH_PROGS(XMLTO, xmlto, :)
++AC_PATH_PROGS(XMLTO, :, :)
+ 
+ AC_C_INLINE
+ AC_C_CONST

--- a/components/archiver/zziplib/patches/04-fix-man-pages.patch
+++ b/components/archiver/zziplib/patches/04-fix-man-pages.patch
@@ -1,0 +1,11 @@
+--- zziplib-0.13.69/docs/Makefile.am	2018-03-17 13:46:45.000000000 +0000
++++ zziplib-0.13.69/docs/Makefile.am	2018-08-03 08:44:03.111721716 +0000
+@@ -166,6 +166,8 @@ manpages.tar : zziplib.xml zzipmmapped.x
+ 	;   mv man3_/man3 man3; rm -r man3_; fi \
+ 	; echo 'chmod 664 man3/*.3' \
+ 	;       chmod 664 man3/*.3  \
++	; echo "sed -i -e 's@^.so @.so man3/@' man3/*.3" \
++	; sed -i -e 's@^.so @.so man3/@' man3/*.3 \
+ 	; echo '$(PAX_TAR_CREATE) "$@" man3/' \
+ 	;       $(PAX_TAR_CREATE) "$@" man3/  \
+ 	; echo '$(DELETE); rm man3/*.3 ; rmdir man3' \


### PR DESCRIPTION
There two ways to generate zziplib man pages and both have their
distinct problems. Man page generation via xmlto gets correct man pages
(with a docbook-xsl fix) but some man pages are not being generated,
plus xmlto way is to be deprecated in the future anyway. The other
method is via dbk2man.py but it generates correct amount of man pages
but they are broken in the same way xmlto-generated man pages are
without the docbook-xsl fix (filed
https://github.com/gdraheim/zziplib/issues/56).

So, disable `xmlto` and manually fix incorrect man pages via `sed`.

@AndWac Would be cool if you can test this.