### PR TITLE
open-vm-tools: bump to 10.3.0

### DIFF
--- a/components/sysutils/open-vm-tools/Makefile
+++ b/components/sysutils/open-vm-tools/Makefile
@@ -16,7 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		open-vm-tools
-COMPONENT_VERSION=	10.2.5
+COMPONENT_VERSION=	10.3.0
 COMPONENT_SUMMARY=	open-vm-tools is a set of services and modules that enable several features in VMware products for better management of, and seamless user interactions with, guests.
 COMPONENT_PROJECT_URL=	https://github.com/vmware/open-vm-tools
 COMPONENT_FMRI=		system/virtualization/open-vm-tools
@@ -24,7 +24,7 @@ COMPONENT_CLASSIFICATION= Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-stable-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/vmware/$(COMPONENT_NAME)/archive/stable-$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:c0f182c0c422fca8f8b3e5c21802f724256dfe5907383db28ec7e4d5b6d52b0f
+COMPONENT_ARCHIVE_HASH=	sha256:b3d0b5fd272a8dc35cab1ddd732f9d436f72682925212a6cdeccdab283e2f5ec
 COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 
@@ -47,6 +47,7 @@ CFLAGS += -D__SOLARIS__=1
 CFLAGS += -D_FILE_OFFSET_BITS=64
 CFLAGS += -Wno-deprecated-declarations
 CFLAGS += -Wno-unused-local-typedefs
+CFLAGS += -Wno-unused-variable
 
 LDFLAGS += -lnsl
 

--- a/components/sysutils/open-vm-tools/patches/08-configure-ac.patch
+++ b/components/sysutils/open-vm-tools/patches/08-configure-ac.patch
@@ -1,0 +1,18 @@
+This patch will be obsolete when https://github.com/vmware/open-vm-tools/pull/268 will be
+accepted.
+
+--- open-vm-tools-stable-10.3.0/configure.ac.orig	2018-08-03 11:38:18.108521301 +0000
++++ open-vm-tools-stable-10.3.0/configure.ac	2018-08-03 11:38:37.038872822 +0000
+@@ -1526,7 +1526,11 @@
+ VMTOOLS_CPPFLAGS="-DVMTOOLS_USE_GLIB $GLIB2_CPPFLAGS"
+
+ PLUGIN_CPPFLAGS="$VMTOOLS_CPPFLAGS $PLUGIN_CPPFLAGS"
+-PLUGIN_LDFLAGS="-Wl,-z,defs -Wl,-lc -Wl,--as-needed -shared -module -avoid-version"
++if test "$have_gnu_ld" = "yes"; then
++    PLUGIN_LDFLAGS="-Wl,-z,defs -Wl,-lc -Wl,--as-needed -shared -module -avoid-version"
++else
++    PLUGIN_LDFLAGS="-Wl,-z,defs -Wl,-lc -shared -module -avoid-version"
++fi
+
+ # Installation directories for core services plugins.
+ TEST_PLUGIN_INSTALLDIR=$datadir/open-vm-tools/tests


### PR DESCRIPTION
CFLAGS += -Wno-unused-variable added
rpc_gen creates source code during the build process with an unused variable 'buf' and I found no way to prevent this.

patches/08-configure-ac.patch may be removed again with the next versions.