### PR TITLE
top: fix crash on window resize in batch mode, man page references

### DIFF
--- a/components/sysutils/top/Makefile
+++ b/components/sysutils/top/Makefile
@@ -19,18 +19,21 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, Michal Nowak
 #
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		top
 COMPONENT_VERSION=	3.8beta1
-COMPONENT_REVISION=	2
-COMPONENT_PROJECT_URL=	http://www.unixtop.org/
+COMPONENT_REVISION=	3
+COMPONENT_PROJECT_URL=	https://sourceforge.net/projects/unixtop/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:6c683e9cb092078cbc1b2233b15fa8bd3d35a00874e6ba27cf54370d1d64fa4d
 COMPONENT_ARCHIVE_URL=	https://sourceforge.net/projects/unixtop/files/unixtop/$(COMPONENT_SRC)/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=		diagnostic/top
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk

--- a/components/sysutils/top/manifests/sample-manifest.p5m
+++ b/components/sysutils/top/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/sysutils/top/patches/08-winch-segfault-fix.patch
+++ b/components/sysutils/top/patches/08-winch-segfault-fix.patch
@@ -1,0 +1,31 @@
+https://sourceforge.net/p/unixtop/patches/22/
+
+diff -u top-3.8beta1/top.c top-3.8beta1/top.c
+--- top-3.8beta1/top.c	2008-05-07 11:41:39.000000000 +0800
++++ top-3.8beta1/top.c	2017-01-15 18:32:50.000000000 +0800
+@@ -257,14 +258,14 @@
+ }
+ 
+ void
+-set_signals()
++set_signals(int set_winch)
+ 
+ {
+     (void) set_signal(SIGINT, sig_leave);
+     (void) set_signal(SIGQUIT, sig_leave);
+     (void) set_signal(SIGTSTP, sig_tstop);
+ #ifdef SIGWINCH
+-    (void) set_signal(SIGWINCH, sig_winch);
++    if(set_winch) set_signal(SIGWINCH, sig_winch);
+ #endif
+ }
+ 
+@@ -905,7 +906,7 @@
+     screen_init();
+ 
+     /* set the signal handlers */
+-    set_signals();
++    set_signals(gstate->interactive);
+ 
+     /* longjmp re-entry point */
+     /* set the jump buffer for long jumps out of signal handlers */

--- a/components/sysutils/top/patches/09-man-page-references.patch
+++ b/components/sysutils/top/patches/09-man-page-references.patch
@@ -1,0 +1,22 @@
+--- top-3.8beta1/top.1.in	2008-05-07 05:41:39.000000000 +0000
++++ top-3.8beta1/top.1.in.new	2018-08-04 20:21:45.922721699 +0000
+@@ -298,7 +298,7 @@ Quit
+ .B r
+ Change the priority (the \*(lqnice\*(rq) of a list of processes.
+ This acts similarly to the command
+-.IR renice (8)).
++.IR renice (1)).
+ .\}
+ .TP
+ .B s
+@@ -456,8 +456,8 @@ close approximation to reality.
+ kill(1),
+ ps(1),
+ stty(1),
+-mem(4),
+-renice(8)
++mem(7D),
++renice(1)
+ @MAN_SUPPLEMENT@
+ .SH COPYRIGHT
+ Copyright (C) 1984-2007 William LeFebvre. For additional licensing

--- a/components/sysutils/top/top.p5m
+++ b/components/sysutils/top/top.p5m
@@ -19,23 +19,19 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, Michal Nowak
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
-set name=pkg.fmri \
-    value=pkg:/diagnostic/top@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(COMPONENT_VERSION)
 set name=pkg.summary \
     value="provides a rolling display of top cpu using processes"
-set name=com.oracle.info.description value="the top utility"
 set name=info.classification \
     value="org.opensolaris.category.2008:Applications/System Utilities"
-set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
-set name=org.opensolaris.arc-caseid \
-    value=PSARC/2008/533
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
+license top.license license="BSD, Apachev2.0"
 file usr/bin/$(MACH64)/top path=usr/bin/top
 file path=usr/share/man/man1/top.1
-license top.license license="BSD, Apachev2.0"


### PR DESCRIPTION
Tested that `top -b -d 10` won't crash on window resize with
`checkwinsize` on in the environment.

Some man page references (mem, renice) were wrong.