### PR TITLE
expat 2.2.6

### DIFF
--- a/components/library/libexpat/Makefile
+++ b/components/library/libexpat/Makefile
@@ -22,24 +22,26 @@
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2017, Aurelien Larcher
+# Copyright (c) 2018, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libexpat
-COMPONENT_VERSION=	2.2.2
-COMPONENT_FMRI=	library/expat
+COMPONENT_VERSION=	2.2.6
+COMPONENT_VERSION_U=	$(shell echo $(COMPONENT_VERSION) | tr . _)
+COMPONENT_FMRI=		library/expat
 COMPONENT_SUMMARY=	libexpat - XML parser library
 COMPONENT_DESCRIPTION=	A fast, non-validating, stream-oriented XML parsing library	
 COMPONENT_CLASSIFICATION=	System/Libraries
-COMPONENT_PROJECT_URL=	http://expat.sourceforge.net/
+COMPONENT_PROJECT_URL=	https://libexpat.github.io
 COMPONENT_SRC_NAME=	expat
 COMPONENT_SRC=		$(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:4f01ba52400fd1d5f370abf40d213220b0b079b311b2da96f5b236b8a3be4917
+    sha256:17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
 COMPONENT_ARCHIVE_URL= \
-    http://downloads.sourceforge.net/project/expat/expat/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+    https://github.com/libexpat/libexpat/releases/download/R_$(COMPONENT_VERSION_U)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	expat license
 
 include $(WS_MAKE_RULES)/prep.mk
@@ -52,9 +54,16 @@ CONFIGURE_OPTIONS+= --disable-static
 
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-COMPONENT_TEST_TRANSFORMS = \
-	'-n' \
-	'-e "/Checks/p" '
+COMPONENT_TEST_TRANSFORMS= \
+	'-e "s/^\# //" ' \
+	'-n ' \
+	'-e "/TOTAL/p" ' \
+	'-e "/PASS/p" '  \
+	'-e "/SKIP/p" '  \
+	'-e "/XFAIL/p" ' \
+	'-e "/FAIL/p" '  \
+	'-e "/XPASS/p" ' \
+	'-e "/ERROR/p" ' \
 
 # common targets
 build:		$(BUILD_32_and_64)
@@ -63,4 +72,5 @@ install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/library/libexpat/expat.p5m
+++ b/components/library/libexpat/expat.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Aurelien Larcher
+# Copyright 2018 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,13 +28,13 @@ file usr/bin/$(MACH64)/xmlwf path=usr/bin/xmlwf
 file path=usr/include/expat.h
 file path=usr/include/expat_config.h
 file path=usr/include/expat_external.h
-link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.4
-link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.4
-file path=usr/lib/$(MACH64)/libexpat.so.1.6.4
+link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.8
+link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.8
+file path=usr/lib/$(MACH64)/libexpat.so.1.6.8
 file path=usr/lib/$(MACH64)/pkgconfig/expat.pc
-link path=usr/lib/libexpat.so target=libexpat.so.1.6.4
-link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.4
-file path=usr/lib/libexpat.so.1.6.4
+link path=usr/lib/libexpat.so target=libexpat.so.1.6.8
+link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.8
+file path=usr/lib/libexpat.so.1.6.8
 file path=usr/lib/pkgconfig/expat.pc
 file path=usr/share/man/man1/xmlwf.1
 

--- a/components/library/libexpat/manifests/sample-manifest.p5m
+++ b/components/library/libexpat/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,12 +27,14 @@ file path=usr/bin/xmlwf
 file path=usr/include/expat.h
 file path=usr/include/expat_config.h
 file path=usr/include/expat_external.h
-link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.4
-link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.4
-file path=usr/lib/$(MACH64)/libexpat.so.1.6.4
+link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.8
+link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.8
+file path=usr/lib/$(MACH64)/libexpat.so.1.6.8
 file path=usr/lib/$(MACH64)/pkgconfig/expat.pc
-link path=usr/lib/libexpat.so target=libexpat.so.1.6.4
-link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.4
-file path=usr/lib/libexpat.so.1.6.4
+link path=usr/lib/libexpat.so target=libexpat.so.1.6.8
+link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.8
+file path=usr/lib/libexpat.so.1.6.8
 file path=usr/lib/pkgconfig/expat.pc
+file path=usr/share/doc/expat/AUTHORS
+file path=usr/share/doc/expat/changelog
 file path=usr/share/man/man1/xmlwf.1

--- a/components/library/libexpat/test/results-all.master
+++ b/components/library/libexpat/test/results-all.master
@@ -1,2 +1,11 @@
-100%: Checks: 98, Failed: 0
-100%: Checks: 98, Failed: 0
+PASS: runtests
+PASS: runtestspp
+TOTAL: 2
+PASS:  2
+SKIP:  0
+XFAIL: 0
+XFAIL: 0
+FAIL:  0
+XPASS: 0
+XPASS: 0
+ERROR: 0


### PR DESCRIPTION
Changes: https://github.com/libexpat/libexpat/blob/R_2_2_6/expat/Changes

Notably, fixes UTF-8 bug required for Python 2.7.15 (https://github.com/OpenIndiana/oi-userland/pull/4400) test suite to pass.

Test suite now seems to have a different output.