### PR TITLE
GNU sed 4.5

### DIFF
--- a/components/text/sed/Makefile
+++ b/components/text/sed/Makefile
@@ -22,12 +22,13 @@
 #
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2017, Aurelien Larcher.
+# Copyright (c) 2018, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		sed
-COMPONENT_VERSION=	4.4
+COMPONENT_VERSION=	4.5
 COMPONENT_FMRI=	text/gnu-sed
 COMPONENT_SUMMARY=	GNU implementation of sed, the Unix stream editor
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
@@ -35,7 +36,7 @@ COMPONENT_PROJECT_URL=	http://www.gnu.org/software/sed/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:cbd6ebc5aaf080ed60d0162d7f6aeae58211a1ee9ba9bb25623daa6cd942683b
+  sha256:7aad73c8839c2bdadca9476f884d2953cdace9567ecd0d90f9959f229d146b40
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/pub/gnu/sed/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3, FDLv1.3
 

--- a/components/text/sed/test/results-64.master
+++ b/components/text/sed/test/results-64.master
@@ -1,73 +1,4 @@
-SKIP: testsuite/get-mb-cur-max
-SKIP: testsuite/test-mbrtowc
-PASS: testsuite/appquit
-PASS: testsuite/enable
-PASS: testsuite/sep
-PASS: testsuite/inclib
-PASS: testsuite/8bit
-PASS: testsuite/newjis
-PASS: testsuite/xabcx
-PASS: testsuite/dollar
-PASS: testsuite/noeol
-PASS: testsuite/noeolw
-PASS: testsuite/modulo
-PASS: testsuite/numsub
-PASS: testsuite/numsub2
-PASS: testsuite/numsub3
-PASS: testsuite/numsub4
-PASS: testsuite/numsub5
-PASS: testsuite/0range
-PASS: testsuite/bkslashes
-PASS: testsuite/head
-PASS: testsuite/madding
-PASS: testsuite/mac-mf
-PASS: testsuite/empty
-PASS: testsuite/xbxcx
-PASS: testsuite/xbxcx3
-PASS: testsuite/recall
-PASS: testsuite/recall2
-PASS: testsuite/xemacs
-PASS: testsuite/fasts
-PASS: testsuite/uniq
-PASS: testsuite/manis
-PASS: testsuite/khadafy
-PASS: testsuite/linecnt
-PASS: testsuite/eval
-PASS: testsuite/distrib
-PASS: testsuite/8to7
-PASS: testsuite/y-bracket
-PASS: testsuite/y-newline
-PASS: testsuite/y-zero
-PASS: testsuite/allsub
-PASS: testsuite/cv-vars
-PASS: testsuite/classes
-PASS: testsuite/middle
-PASS: testsuite/bsd
-PASS: testsuite/stdin
-PASS: testsuite/flipcase
-PASS: testsuite/insens
-PASS: testsuite/subwrite
-PASS: testsuite/writeout
-PASS: testsuite/readin
-PASS: testsuite/insert
-PASS: testsuite/utf8-1
-PASS: testsuite/utf8-2
-PASS: testsuite/utf8-3
-PASS: testsuite/utf8-4
-PASS: testsuite/badenc
-PASS: testsuite/inplace-hold
-PASS: testsuite/brackets
-PASS: testsuite/amp-escape
-PASS: testsuite/help
-PASS: testsuite/file
-PASS: testsuite/quiet
-PASS: testsuite/factor
-PASS: testsuite/binary3
-PASS: testsuite/binary2
-PASS: testsuite/binary
-PASS: testsuite/dc
-PASS: testsuite/newline-anchor
-PASS: testsuite/zero-anchor
+PASS: testsuite/misc.pl
 PASS: testsuite/cmd-l.sh
 PASS: testsuite/cmd-R.sh
 PASS: testsuite/colon-with-no-label.sh
@@ -75,10 +6,12 @@ PASS: testsuite/comment-n.sh
 PASS: testsuite/compile-errors.sh
 PASS: testsuite/compile-tests.sh
 PASS: testsuite/convert-number.sh
+PASS: testsuite/command-endings.sh
 PASS: testsuite/execute-tests.sh
 PASS: testsuite/help-version.sh
 PASS: testsuite/in-place-hyphen.sh
 PASS: testsuite/in-place-suffix-backup.sh
+SKIP: testsuite/inplace-selinux.sh
 SKIP: testsuite/invalid-mb-seq-UMR.sh
 PASS: testsuite/mb-bad-delim.sh
 SKIP: testsuite/mb-charclass-non-utf8.sh
@@ -91,11 +24,13 @@ PASS: testsuite/panic-tests.sh
 PASS: testsuite/posix-char-class.sh
 PASS: testsuite/posix-mode-addr.sh
 PASS: testsuite/posix-mode-bad-ref.sh
+PASS: testsuite/posix-mode-ERE.sh
 PASS: testsuite/posix-mode-s.sh
 PASS: testsuite/posix-mode-N.sh
 PASS: testsuite/range-overlap.sh
 PASS: testsuite/recursive-escape-c.sh
 PASS: testsuite/regex-errors.sh
+SKIP: testsuite/regex-max-int.sh
 PASS: testsuite/sandbox.sh
 PASS: testsuite/stdin-prog.sh
 PASS: testsuite/subst-options.sh
@@ -106,13 +41,31 @@ SKIP: testsuite/title-case.sh
 PASS: testsuite/unbuffered.sh
 PASS: testsuite/follow-symlinks.sh
 PASS: testsuite/follow-symlinks-stdin.sh
-# TOTAL: 108
-# PASS:  103
+PASS: testsuite/8bit.sh
+PASS: testsuite/8to7.sh
+PASS: testsuite/badenc.sh
+PASS: testsuite/binary.sh
+PASS: testsuite/bsd-wrapper.sh
+PASS: testsuite/dc.sh
+PASS: testsuite/distrib.sh
+PASS: testsuite/eval.sh
+PASS: testsuite/help.sh
+PASS: testsuite/inplace-hold.sh
+PASS: testsuite/mac-mf.sh
+PASS: testsuite/madding.sh
+PASS: testsuite/newjis.sh
+PASS: testsuite/stdin.sh
+PASS: testsuite/utf8-ru.sh
+PASS: testsuite/uniq.sh
+PASS: testsuite/xemacs.sh
+# TOTAL: 60
+# PASS:  55
 # SKIP:  5
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0
 # ERROR: 0
+PASS: test-accept
 PASS: test-set-mode-acl.sh
 PASS: test-set-mode-acl-1.sh
 PASS: test-set-mode-acl-2.sh
@@ -121,14 +74,18 @@ PASS: test-copy-acl-1.sh
 PASS: test-copy-acl-2.sh
 PASS: test-alignof
 PASS: test-alloca-opt
+PASS: test-arpa_inet
 PASS: test-binary-io.sh
+PASS: test-bind
 PASS: test-btowc1.sh
 PASS: test-btowc2.sh
 PASS: test-c-ctype
 PASS: test-c-strcase.sh
 PASS: test-canonicalize-lgpl
 PASS: test-chdir
+PASS: test-cloexec
 PASS: test-close
+PASS: test-connect
 PASS: test-ctype
 PASS: dfa-invalid-char-class.sh
 PASS: dfa-match.sh
@@ -137,6 +94,7 @@ PASS: test-dup2
 PASS: test-environ
 PASS: test-errno
 PASS: test-fcntl-h
+PASS: test-fcntl
 PASS: test-fdopen
 PASS: test-fflush
 PASS: test-fflush2.sh
@@ -163,6 +121,7 @@ PASS: test-ftello.sh
 PASS: test-ftello2.sh
 PASS: test-ftello3
 PASS: test-ftello4.sh
+PASS: test-ftruncate.sh
 PASS: test-fwrite
 PASS: test-fwriting
 PASS: test-getcwd-lgpl
@@ -173,15 +132,18 @@ PASS: test-getopt-posix
 PASS: test-getprogname
 PASS: test-gettimeofday
 PASS: test-ignore-value
+PASS: test-inet_pton
 PASS: test-intprops
 PASS: test-inttypes
+PASS: test-ioctl
 PASS: test-isblank
 PASS: test-langinfo
 PASS: test-limits-h
 PASS: test-link
+PASS: test-listen
 PASS: test-locale
 PASS: test-localeconv
-FAIL: test-localename
+PASS: test-localename
 PASS: test-lseek.sh
 PASS: test-lstat
 PASS: test-malloca
@@ -198,19 +160,35 @@ SKIP: test-mbrtowc-w32-5.sh
 PASS: test-mbsinit.sh
 PASS: test-memchr
 PASS: test-memrchr
+PASS: test-nanosleep
+PASS: test-netinet_in
 PASS: test-nl_langinfo.sh
 PASS: test-open
 PASS: test-pathmax
+PASS: test-perror.sh
+PASS: test-perror2
+PASS: test-pipe
 PASS: test-quotearg-simple
+PASS: test-raise
 PASS: test-read-file
 PASS: test-readlink
 PASS: test-regex
 PASS: test-rename
 PASS: test-rmdir
+PASS: test-select
+PASS: test-select-in.sh
+PASS: test-select-out.sh
 PASS: test-setenv
 PASS: test-setlocale1.sh
 PASS: test-setlocale2.sh
+PASS: test-setsockopt
+PASS: test-sigaction
+PASS: test-signal-h
+PASS: test-sigprocmask
+PASS: test-sleep
+PASS: test-sockets
 PASS: test-stat
+PASS: test-stat-time
 PASS: test-stdalign
 PASS: test-stdbool
 PASS: test-stddef
@@ -218,12 +196,17 @@ PASS: test-stdint
 PASS: test-stdio
 PASS: test-stdlib
 PASS: test-strerror
+PASS: test-strerror_r
 PASS: test-string
 PASS: test-strverscmp
 PASS: test-symlink
+PASS: test-sys_ioctl
+PASS: test-sys_select
+PASS: test-sys_socket
 PASS: test-sys_stat
 PASS: test-sys_time
 PASS: test-sys_types
+PASS: test-sys_uio
 PASS: test-init.sh
 PASS: test-time
 PASS: test-unistd
@@ -243,10 +226,10 @@ SKIP: test-wcrtomb-w32-4.sh
 SKIP: test-wcrtomb-w32-5.sh
 PASS: test-wctype-h
 PASS: test-xalloc-die.sh
-# TOTAL: 130
-# PASS:  118
+# TOTAL: 161
+# PASS:  150
 # SKIP:  11
 # XFAIL: 0
-# FAIL:  1
+# FAIL:  0
 # XPASS: 0
 # ERROR: 0


### PR DESCRIPTION
Changes:
```
* Noteworthy changes in release 4.5 (2018-03-31) [stable]

** Bug fixes

  sed now fails when matching very long input lines (>2GB).
  Before, sed would silently ignore the regex without indicating an
  error. [Bug present at least since sed-3.02]

  sed no longer rejects comments and closing braces after y/// commands.
  [Bug existed at least since sed-3.02]

  sed -E --posix no longer ignores special meaning of '+','?','|' .
  [Bug introduced in the original implementation of --posix option in
  v4.1a-5-gba68fb4]

  sed -i now creates selinux context based on the context of the symlink
  instead of the symlink target. [Bug present since at least sed-4.2]
  sed -i --follow-symlinks remains unchanged.

  sed now treats the sequence '\x5c' (ASCII 92, backslash) as literal
  backslash character, not as an escape prefix character.
  [Bug present since sed-3.02.80]
  Old behavior:
     $ echo z | sed -E 's/(z)/\x5c1/' # identical to 's/(z)/\1/'
     z
  New behavior:
     $ echo z | sed -E 's/(z)/\x5c1/'
     \1
```