### PR TITLE
KVM: Add OS-7174 (Windows 7 fix)

### DIFF
--- a/components/openindiana/kvm/Makefile
+++ b/components/openindiana/kvm/Makefile
@@ -14,6 +14,7 @@
 # Copyright 2011, Alasdair Lumsden <alasdairrr@gmail.com>
 # Copyright 2012, Piotr Jasiukajtis
 # Copyright 2012, Jon Tibble
+# Copyright 2018, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
@@ -21,7 +22,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		illumos-kvm
 COMPONENT_VERSION=	a8befd521c7e673749c64f118585814009fe4b73
 IPS_COMPONENT_VERSION=	0.0.1.20160303
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SRC=		illumos-kvm-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).zip
 COMPONENT_ARCHIVE_HASH=	sha256:47ac565293ff1c57c7bcfab9189ee998a85599e959640b6c1e364aab8a1a70eb

--- a/components/openindiana/kvm/patches/OS-7174-properly-restore-mxcsr-post-HMA.patch
+++ b/components/openindiana/kvm/patches/OS-7174-properly-restore-mxcsr-post-HMA.patch
@@ -1,0 +1,40 @@
+From 4149738a32ab6ac380a31c309d116e3dfef47a98 Mon Sep 17 00:00:00 2001
+From: Robert Mustacchi <rm@joyent.com>
+Date: Fri, 24 Aug 2018 23:07:43 +0000
+Subject: [PATCH] OS-7174 KVM doesn't properly restore mxcsr post-HMA Reviewed
+ by: Jerry Jelinek <jerry.jelinek@joyent.com> Reviewed by: Patrick Mooney
+ <patrick.mooney@joyent.com> Approved by: Jerry Jelinek
+ <jerry.jelinek@joyent.com>
+
+---
+ kvm_x86.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/kvm_x86.c b/kvm_x86.c
+index 233b484..622198a 100644
+--- a/kvm_x86.c
++++ b/kvm_x86.c
+@@ -4468,6 +4468,7 @@ kvm_arch_vcpu_ioctl_get_fpu(struct kvm_vcpu *vcpu, struct kvm_fpu *fpu)
+ 	fpu->last_ip = fxsave.fx_rip;
+ 	fpu->last_dp = fxsave.fx_rdp;
+ 	memcpy(fpu->xmm, fxsave.fx_xmm, sizeof (fxsave.fx_xmm));
++	fpu->mxcsr = fxsave.fx_mxcsr;
+ 
+ 	vcpu_put(vcpu);
+ 
+@@ -4491,6 +4492,7 @@ kvm_arch_vcpu_ioctl_set_fpu(struct kvm_vcpu *vcpu, struct kvm_fpu *fpu)
+ 	fxsave.fx_rip = fpu->last_ip;
+ 	fxsave.fx_rdp = fpu->last_dp;
+ 	memcpy(fxsave.fx_xmm, fpu->xmm, sizeof (fxsave.fx_xmm));
++	fxsave.fx_mxcsr = fpu->mxcsr;
+ 
+ 	ret = hma_fpu_set_fxsave_state(vcpu->arch.guest_fpu, &fxsave);
+ 
+@@ -4502,6 +4504,7 @@ kvm_arch_vcpu_ioctl_set_fpu(struct kvm_vcpu *vcpu, struct kvm_fpu *fpu)
+ void
+ fx_init(struct kvm_vcpu *vcpu)
+ {
++	vcpu->arch.cr0 |= X86_CR0_ET;
+ 	hma_fpu_init(vcpu->arch.guest_fpu);
+ }
+ 


### PR DESCRIPTION
There were problems with Windows 7 KVM VMs recently on SmartOS
(https://github.com/joyent/smartos-live/issues/792), OS-7174 is the fix,
though I was not able to reproduce the Win 7 boot failure. Win 7 boot
anyways.