### PR TITLE
rustc: fix build

### DIFF
--- a/components/developer/rust/Makefile
+++ b/components/developer/rust/Makefile
@@ -30,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		rustc
 COMPONENT_VERSION=	1.29.1
+COMPONENT_REVISION=     1
 COMPONENT_FMRI=		developer/lang/rustc
 COMPONENT_SUMMARY=	Rust - Safe, concurrent, practical language
 COMPONENT_CLASSIFICATION=	Development/Other Languages
@@ -140,6 +141,7 @@ COMPONENT_PRE_INSTALL_ACTION = \
 	mkdir -p $(PROTO_DIR)
 
 RUSTC_BIN_POST = cargo
+RUSTC_BIN_POST+= clippy-driver
 RUSTC_BIN_POST+= rls
 RUSTC_BIN_POST+= rustc
 RUSTC_BIN_POST+= rustdoc


### PR DESCRIPTION
```
/usr/bin/touch /scratch/alarcher/oi-userland/components/developer/rust/build/.linted-i386
/bin/cp -f /scratch/alarcher/oi-userland/components/developer/rust/build/manifest-i386-rustc.depend.res /scratch/alarcher/oi-userland/components/developer/rust/build/manifest-i386-rustc.pre-published
NEW PACKAGE CONTENTS ARE LOCALLY VALIDATED AND READY TO GO
/usr/bin/touch /scratch/alarcher/oi-userland/components/developer/rust/build/.pre-published-i386
/usr/bin/pkgsend -s /scratch/alarcher/oi-userland/i386/repo publish --fmri-in-manifest -d /scratch/alarcher/oi-userland/components/developer/rust/build/prototype/i386/mangled -d /scratch/alarcher/oi-userland/components/developer/rust/build/prototype/i386 -d /scratch/alarcher/oi-userland/components/developer/rust/build -d /scratch/alarcher/oi-userland/components/developer/rust -d rustc-1.29.1-src -T \*.py /scratch/alarcher/oi-userland/components/developer/rust/build/manifest-i386-rustc.pre-published
pkg://userland/developer/lang/rustc@1.29.1,5.11-2018.0.0.1:20181010T042634Z
PUBLISHED
/usr/bin/pkgfmt </scratch/alarcher/oi-userland/components/developer/rust/build/manifest-i386-rustc.pre-published >/scratch/alarcher/oi-userland/components/developer/rust/build/manifest-i386-rustc.published
/usr/bin/touch /scratch/alarcher/oi-userland/components/developer/rust/build/.published-i386

```