### PR TITLE
git: Use gawk for completion

### DIFF
--- a/components/developer/git/Makefile
+++ b/components/developer/git/Makefile
@@ -25,6 +25,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		git
 COMPONENT_VERSION=	2.19.1
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	git - Fast Version Control System
 COMPONENT_PROJECT_URL=	https://git-scm.com/
 COMPONENT_FMRI=		developer/versioning/git

--- a/components/developer/git/git.p5m
+++ b/components/developer/git/git.p5m
@@ -37,6 +37,8 @@ license $(COMPONENT_LICENSE_FILE) license=$(COMPONENT_LICENSE)
 
 # Needed at runtime for localization in shell scripts
 depend fmri=text/gnu-gettext type=require
+# BASH completion uses gawk
+depend fmri=pkg:/text/gawk type=require
 
 file path=usr/bin/diff-highlight
 file path=usr/bin/gitk

--- a/components/developer/git/patches/0010-use-gawk-for-completion.patch
+++ b/components/developer/git/patches/0010-use-gawk-for-completion.patch
@@ -1,0 +1,20 @@
+--- git-2.19.1/contrib/completion/git-completion.bash	2018-09-27 22:46:40.000000000 +0000
++++ git-2.19.1/contrib/completion/git-completion.bash.new	2018-10-10 08:41:42.946342292 +0000
+@@ -503,7 +503,7 @@ __git_index_files ()
+ 	local root="$2" match="$3"
+ 
+ 	__git_ls_files_helper "$root" "$1" "$match" |
+-	awk -F / -v pfx="${2//\\/\\\\}" '{
++	gawk -F / -v pfx="${2//\\/\\\\}" '{
+ 		paths[$1] = 1
+ 	}
+ 	END {
+@@ -1578,7 +1578,7 @@ _git_gitk ()
+ # 3: A prefix to be added to each listed symbol name (optional).
+ # 4: A suffix to be appended to each listed symbol name (optional).
+ __git_match_ctag () {
+-	awk -v pfx="${3-}" -v sfx="${4-}" "
++	gawk -v pfx="${3-}" -v sfx="${4-}" "
+ 		/^${1//\//\\/}/ { print pfx \$1 sfx }
+ 		" "$2"
+ }


### PR DESCRIPTION
`git add ` bash completion fails since git 2.19 with:
```
$ git add awk: syntax error near line 1
awk: bailing out near line 1
```

As for the rest of the bash-completion we should use `gawk` instead of
`awk`.

Tested.