### PR TITLE
mate-system-monitor: do not throw if icon not found

### DIFF
--- a/components/desktop/mate/mate-system-monitor/Makefile
+++ b/components/desktop/mate/mate-system-monitor/Makefile
@@ -20,6 +20,7 @@ include ../../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		mate-system-monitor
 COMPONENT_MJR_VERSION=	1.20
 COMPONENT_MNR_VERSION=	1
+COMPONENT_REVISION= 1
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE system monitor

--- a/components/desktop/mate/mate-system-monitor/patches/03-default-icon.patch
+++ b/components/desktop/mate/mate-system-monitor/patches/03-default-icon.patch
@@ -1,0 +1,14 @@
+--- mate-system-monitor-1.20.1/src/iconthemewrapper.cpp.orig	2018-10-16 01:12:23.890830040 +0000
++++ mate-system-monitor-1.20.1/src/iconthemewrapper.cpp	2018-10-16 01:12:30.260851246 +0000
+@@ -12,7 +12,10 @@
+ {
+     try
+     {
+-      return Gtk::IconTheme::get_default()->load_icon(icon_name, size, flags);
++	  if (Gtk::IconTheme::get_default()->has_icon(icon_name))
++	    return Gtk::IconTheme::get_default()->load_icon(icon_name, size, flags);
++      else
++	    return Gtk::IconTheme::get_default()->load_icon("image-missing", size, flags);
+     }
+     catch (Gtk::IconThemeError &error)
+     {


### PR DESCRIPTION
A quick piggy workaround but should be better than dumping if the corresponding icon is not found.
It seems that load_icon() does not handle this.