### PR TITLE
libgee: Remove lib/libgee and update lib/desktop/libgee to 0.20.1

### DIFF
--- a/components/library/libgee/Makefile
+++ b/components/library/libgee/Makefile
@@ -27,14 +27,14 @@ COMPONENT_NAME=     libgee
 COMPONENT_VERSION=  0.20.1
 COMPONENT_SUMMARY=  GObject based collection and utility library
 COMPONENT_LICENSE = LGPLv2.1
-COMPONENT_PROJECT_URL=  https://wiki.gnome.org/Projects/Libgee
+COMPONENT_PROJECT_URL=	https://wiki.gnome.org/Projects/Libgee
 COMPONENT_SRC=      $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=  $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
     sha256:bb2802d29a518e8c6d2992884691f06ccfcc25792a5686178575c7111fea4630
-COMPONENT_ARCHIVE_URL=  https://download.gnome.org/sources/libgee/0.20/$(COMPONENT_ARCHIVE)
-COMPONENT_FMRI=     library/libgee
-COMPONENT_CLASSIFICATION=   Development/C
+COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/libgee/0.20/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=			library/desktop/libgee
+COMPONENT_CLASSIFICATION=	Development/GNOME and GTK+
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
@@ -49,5 +49,6 @@ install:    $(INSTALL_32_and_64)
 
 test:       $(TEST_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += system/library

--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -819,6 +819,7 @@ library/java/libgtk-java@2.10.2,5.11-2017.0.0.0
 library/java/manual/locale/ja@0.5.11,5.11-2015.0.1.0
 library/java/manual@0.5.11,5.11-2015.0.1.0
 library/java/wiseman@1.0,5.11-2018.0.0.0
+library/libgee@0.20.1,5.11-2018.0.0.1
 library/libinfinity@0.5.5,5.11-2017.0.0.2
 library/libproxy/libproxy-mozjs@0.3.1,5.11-2014.0.1.1
 library/libunique@1.1.6,5.11-2017.0.0.1


### PR DESCRIPTION
lib/libgee had been introduced and conflicted with lib/desktop/libgee.