### PR TITLE
build-essential: add python runtime packages

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
 COMPONENT_VERSION=	1.0
-COMPONENT_REVISION=	12
+COMPONENT_REVISION=	13
 
 include ../../../make-rules/ips.mk
 

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -107,6 +107,8 @@ depend fmri=developer/java/junit type=require
 depend fmri=runtime/perl-522 type=require
 depend fmri=runtime/lua type=require
 depend fmri=library/apr-util type=require
+depend fmri=runtime/python-27 type=require
+depend fmri=runtime/python-35 type=require
 
 # illumos-gate build dependencies
 depend fmri=developer/as type=require


### PR DESCRIPTION
Required by illumos-gate as suggest by @jlevon