### PR TITLE
curl: Fix CVE-2018-16839 and CVE-2018-16840

### DIFF
--- a/components/web/curl/Makefile
+++ b/components/web/curl/Makefile
@@ -25,6 +25,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =        curl
 COMPONENT_VERSION=      7.61.1
+COMPONENT_REVISION=	1
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  https://curl.haxx.se
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz

--- a/components/web/curl/patches/CVE-2018-16839.patch
+++ b/components/web/curl/patches/CVE-2018-16839.patch
@@ -1,0 +1,25 @@
+From f3a24d7916b9173c69a3e0ee790102993833d6c5 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Fri, 28 Sep 2018 16:08:16 +0200
+Subject: [PATCH] Curl_auth_create_plain_message: fix too-large-input-check
+
+CVE-2018-16839
+Reported-by: Harry Sintonen
+Bug: https://curl.haxx.se/docs/CVE-2018-16839.html
+---
+ lib/vauth/cleartext.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/vauth/cleartext.c b/lib/vauth/cleartext.c
+index a10edbdc74..be6d6111e2 100644
+--- a/lib/vauth/cleartext.c
++++ b/lib/vauth/cleartext.c
+@@ -74,7 +74,7 @@ CURLcode Curl_auth_create_plain_message(struct Curl_easy *data,
+   plen = strlen(passwdp);
+ 
+   /* Compute binary message length. Check for overflows. */
+-  if((ulen > SIZE_T_MAX/2) || (plen > (SIZE_T_MAX/2 - 2)))
++  if((ulen > SIZE_T_MAX/4) || (plen > (SIZE_T_MAX/2 - 2)))
+     return CURLE_OUT_OF_MEMORY;
+   plainlen = 2 * ulen + plen + 2;
+ 

--- a/components/web/curl/patches/CVE-2018-16840.patch
+++ b/components/web/curl/patches/CVE-2018-16840.patch
@@ -1,0 +1,33 @@
+From 81d135d67155c5295b1033679c606165d4e28f3f Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 18 Oct 2018 15:07:15 +0200
+Subject: [PATCH] Curl_close: clear data->multi_easy on free to avoid
+ use-after-free
+
+Regression from b46cfbc068 (7.59.0)
+CVE-2018-16840
+Reported-by: Brian Carpenter (Geeknik Labs)
+
+Bug: https://curl.haxx.se/docs/CVE-2018-16840.html
+---
+ lib/url.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/url.c b/lib/url.c
+index 723b898065..0d5a13f996 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -331,10 +331,12 @@ CURLcode Curl_close(struct Curl_easy *data)
+        and detach this handle from there. */
+     curl_multi_remove_handle(data->multi, data);
+ 
+-  if(data->multi_easy)
++  if(data->multi_easy) {
+     /* when curl_easy_perform() is used, it creates its own multi handle to
+        use and this is the one */
+     curl_multi_cleanup(data->multi_easy);
++    data->multi_easy = NULL;
++  }
+ 
+   /* Destroy the timeout list that is held in the easy handle. It is
+      /normally/ done by curl_multi_remove_handle() but this is "just in


### PR DESCRIPTION
`make test` in progress, as it runs in Valgrind it will take a while and I am not even sure the test suite is in good shape on our end. Sanity check `curl webpage.html` worker though.