### PR TITLE
Jenkins weekly 2.154 and lts 2.138.4

### DIFF
--- a/components/developer/jenkins-core-lts/Makefile
+++ b/components/developer/jenkins-core-lts/Makefile
@@ -28,9 +28,9 @@ COMPONENT_NAME=		jenkins
 JENKINS_RELEASE=lts
 COMPONENT_MAJOR_VERSION=	2
 COMPONENT_MINOR_VERSION=	138
-COMPONENT_PATCH_VERSION=	2
+COMPONENT_PATCH_VERSION=	4
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:d8ed5a7033be57aa9a84a5342b355ef9f2ba6cdb490db042a6d03efb23ca1e83
+	sha256:053d2941d558092c934a0f95798ff2177170eecfffab27a46e30744cf12bc3da
 # See $(COMPONENT_ARCHIVE_URL).sha256 e.g. for current weekly release, run
 #   wget -O - http://mirrors.jenkins-ci.org/war/latest/jenkins.war.sha256
 # or for LTS

--- a/components/developer/jenkins-core-weekly/Makefile
+++ b/components/developer/jenkins-core-weekly/Makefile
@@ -27,9 +27,9 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		jenkins
 JENKINS_RELEASE=weekly
 COMPONENT_MAJOR_VERSION=	2
-COMPONENT_MINOR_VERSION=	150
+COMPONENT_MINOR_VERSION=	154
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:90e827e570d013551157e78249b50806f5c3953f9845b634f5c0fc542bf54b9a
+	sha256:2d12418c2e482eaf2cf1d13ad2b25f58e801b80c46cbd6dd3bae4c6df308d98e
 # See $(COMPONENT_ARCHIVE_URL).sha256 e.g. for current weekly release, run
 #   wget -O - http://mirrors.jenkins-ci.org/war/latest/jenkins.war.sha256
 # or for LTS


### PR DESCRIPTION
Security updates, per https://jenkins.io/security/advisory/2018-12-05/

Note: Current "latest" stable is 2.150.1, I am clarifying with Jenkins IRC whether it is as safe as 2.138.4 which is recommended in the doc.