### PR TITLE
libsodium: update to 1.0.16

### DIFF
--- a/components/library/libsodium/Makefile
+++ b/components/library/libsodium/Makefile
@@ -10,18 +10,18 @@
 #
 
 #
-# Copyright 2016 Alexander Pyhalov
+# Copyright 2018 Alexander Pyhalov
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libsodium
-COMPONENT_VERSION= 1.0.13
+COMPONENT_VERSION= 1.0.16
 COMPONENT_SUMMARY= Sodium crypto library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:9c13accb1a9e59ab3affde0e60ef9a2149ed4d6e8f99c93c7a5b97499ee323fd
+  sha256:eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533
 COMPONENT_ARCHIVE_URL= \
   https://github.com/jedisct1/libsodium/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://download.libsodium.org/doc/
@@ -33,6 +33,9 @@ COMPONENT_LICENSE_FILE = LICENSE
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
+
+# pynacl tests dump core with -O3
+gcc_OPT = -O2
 
 # For tests to pass
 unexport SHELLOPTS

--- a/components/library/libsodium/libsodium.p5m
+++ b/components/library/libsodium/libsodium.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 Alexander Pyhalov
+# Copyright 2018 Alexander Pyhalov
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -34,6 +34,7 @@ file path=usr/include/sodium/crypto_auth_hmacsha512256.h
 file path=usr/include/sodium/crypto_box.h
 file path=usr/include/sodium/crypto_box_curve25519xchacha20poly1305.h
 file path=usr/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
+file path=usr/include/sodium/crypto_core_ed25519.h
 file path=usr/include/sodium/crypto_core_hchacha20.h
 file path=usr/include/sodium/crypto_core_hsalsa20.h
 file path=usr/include/sodium/crypto_core_salsa20.h
@@ -55,16 +56,17 @@ file path=usr/include/sodium/crypto_pwhash_argon2id.h
 file path=usr/include/sodium/crypto_pwhash_scryptsalsa208sha256.h
 file path=usr/include/sodium/crypto_scalarmult.h
 file path=usr/include/sodium/crypto_scalarmult_curve25519.h
+file path=usr/include/sodium/crypto_scalarmult_ed25519.h
 file path=usr/include/sodium/crypto_secretbox.h
 file path=usr/include/sodium/crypto_secretbox_xchacha20poly1305.h
 file path=usr/include/sodium/crypto_secretbox_xsalsa20poly1305.h
+file path=usr/include/sodium/crypto_secretstream_xchacha20poly1305.h
 file path=usr/include/sodium/crypto_shorthash.h
 file path=usr/include/sodium/crypto_shorthash_siphash24.h
 file path=usr/include/sodium/crypto_sign.h
 file path=usr/include/sodium/crypto_sign_ed25519.h
 file path=usr/include/sodium/crypto_sign_edwards25519sha512batch.h
 file path=usr/include/sodium/crypto_stream.h
-file path=usr/include/sodium/crypto_stream_aes128ctr.h
 file path=usr/include/sodium/crypto_stream_chacha20.h
 file path=usr/include/sodium/crypto_stream_salsa20.h
 file path=usr/include/sodium/crypto_stream_salsa2012.h
@@ -81,11 +83,11 @@ file path=usr/include/sodium/randombytes_sysrandom.h
 file path=usr/include/sodium/runtime.h
 file path=usr/include/sodium/utils.h
 file path=usr/include/sodium/version.h
-link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.18.3.0
-link path=usr/lib/$(MACH64)/libsodium.so.18 target=libsodium.so.18.3.0
-file path=usr/lib/$(MACH64)/libsodium.so.18.3.0
+link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.23.1.0
+link path=usr/lib/$(MACH64)/libsodium.so.23 target=libsodium.so.23.1.0
+file path=usr/lib/$(MACH64)/libsodium.so.23.1.0
 file path=usr/lib/$(MACH64)/pkgconfig/libsodium.pc
-link path=usr/lib/libsodium.so target=libsodium.so.18.3.0
-link path=usr/lib/libsodium.so.18 target=libsodium.so.18.3.0
-file path=usr/lib/libsodium.so.18.3.0
+link path=usr/lib/libsodium.so target=libsodium.so.23.1.0
+link path=usr/lib/libsodium.so.23 target=libsodium.so.23.1.0
+file path=usr/lib/libsodium.so.23.1.0
 file path=usr/lib/pkgconfig/libsodium.pc

--- a/components/library/libsodium/manifests/sample-manifest.p5m
+++ b/components/library/libsodium/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -34,6 +34,7 @@ file path=usr/include/sodium/crypto_auth_hmacsha512256.h
 file path=usr/include/sodium/crypto_box.h
 file path=usr/include/sodium/crypto_box_curve25519xchacha20poly1305.h
 file path=usr/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
+file path=usr/include/sodium/crypto_core_ed25519.h
 file path=usr/include/sodium/crypto_core_hchacha20.h
 file path=usr/include/sodium/crypto_core_hsalsa20.h
 file path=usr/include/sodium/crypto_core_salsa20.h
@@ -55,16 +56,17 @@ file path=usr/include/sodium/crypto_pwhash_argon2id.h
 file path=usr/include/sodium/crypto_pwhash_scryptsalsa208sha256.h
 file path=usr/include/sodium/crypto_scalarmult.h
 file path=usr/include/sodium/crypto_scalarmult_curve25519.h
+file path=usr/include/sodium/crypto_scalarmult_ed25519.h
 file path=usr/include/sodium/crypto_secretbox.h
 file path=usr/include/sodium/crypto_secretbox_xchacha20poly1305.h
 file path=usr/include/sodium/crypto_secretbox_xsalsa20poly1305.h
+file path=usr/include/sodium/crypto_secretstream_xchacha20poly1305.h
 file path=usr/include/sodium/crypto_shorthash.h
 file path=usr/include/sodium/crypto_shorthash_siphash24.h
 file path=usr/include/sodium/crypto_sign.h
 file path=usr/include/sodium/crypto_sign_ed25519.h
 file path=usr/include/sodium/crypto_sign_edwards25519sha512batch.h
 file path=usr/include/sodium/crypto_stream.h
-file path=usr/include/sodium/crypto_stream_aes128ctr.h
 file path=usr/include/sodium/crypto_stream_chacha20.h
 file path=usr/include/sodium/crypto_stream_salsa20.h
 file path=usr/include/sodium/crypto_stream_salsa2012.h
@@ -81,11 +83,11 @@ file path=usr/include/sodium/randombytes_sysrandom.h
 file path=usr/include/sodium/runtime.h
 file path=usr/include/sodium/utils.h
 file path=usr/include/sodium/version.h
-link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.18.3.0
-link path=usr/lib/$(MACH64)/libsodium.so.18 target=libsodium.so.18.3.0
-file path=usr/lib/$(MACH64)/libsodium.so.18.3.0
+link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.23.1.0
+link path=usr/lib/$(MACH64)/libsodium.so.23 target=libsodium.so.23.1.0
+file path=usr/lib/$(MACH64)/libsodium.so.23.1.0
 file path=usr/lib/$(MACH64)/pkgconfig/libsodium.pc
-link path=usr/lib/libsodium.so target=libsodium.so.18.3.0
-link path=usr/lib/libsodium.so.18 target=libsodium.so.18.3.0
-file path=usr/lib/libsodium.so.18.3.0
+link path=usr/lib/libsodium.so target=libsodium.so.23.1.0
+link path=usr/lib/libsodium.so.23 target=libsodium.so.23.1.0
+file path=usr/lib/libsodium.so.23.1.0
 file path=usr/lib/pkgconfig/libsodium.pc

--- a/components/library/libsodium/test/results-32.master
+++ b/components/library/libsodium/test/results-32.master
@@ -16,6 +16,7 @@ PASS: box_easy2
 PASS: box_seal
 PASS: box_seed
 PASS: chacha20
+PASS: codecs
 PASS: core1
 PASS: core2
 PASS: core3
@@ -31,6 +32,8 @@ PASS: hash3
 PASS: kdf
 PASS: keygen
 PASS: kx
+PASS: metamorphic
+PASS: misuse
 PASS: onetimeauth
 PASS: onetimeauth2
 PASS: onetimeauth7
@@ -48,6 +51,7 @@ PASS: secretbox7
 PASS: secretbox8
 PASS: secretbox_easy
 PASS: secretbox_easy2
+PASS: secretstream
 PASS: shorthash
 PASS: sign
 PASS: sodium_core
@@ -65,10 +69,10 @@ PASS: pwhash_scrypt_ll
 PASS: siphashx24
 PASS: xchacha20
 ============================================================================
-Testsuite summary for libsodium 1.0.13
+Testsuite summary for libsodium 1.0.14
 ============================================================================
-# TOTAL: 66
-# PASS:  66
+# TOTAL: 70
+# PASS:  70
 # SKIP:  0
 # XFAIL: 0
 # FAIL:  0

--- a/components/library/libsodium/test/results-64.master
+++ b/components/library/libsodium/test/results-64.master
@@ -16,6 +16,7 @@ PASS: box_easy2
 PASS: box_seal
 PASS: box_seed
 PASS: chacha20
+PASS: codecs
 PASS: core1
 PASS: core2
 PASS: core3
@@ -31,6 +32,8 @@ PASS: hash3
 PASS: kdf
 PASS: keygen
 PASS: kx
+PASS: metamorphic
+PASS: misuse
 PASS: onetimeauth
 PASS: onetimeauth2
 PASS: onetimeauth7
@@ -48,6 +51,7 @@ PASS: secretbox7
 PASS: secretbox8
 PASS: secretbox_easy
 PASS: secretbox_easy2
+PASS: secretstream
 PASS: shorthash
 PASS: sign
 PASS: sodium_core
@@ -65,10 +69,10 @@ PASS: pwhash_scrypt_ll
 PASS: siphashx24
 PASS: xchacha20
 ============================================================================
-Testsuite summary for libsodium 1.0.13
+Testsuite summary for libsodium 1.0.14
 ============================================================================
-# TOTAL: 66
-# PASS:  66
+# TOTAL: 70
+# PASS:  70
 # SKIP:  0
 # XFAIL: 0
 # FAIL:  0


### PR DESCRIPTION
ABI-incompatible update, the only dependency dnscrypt-proxy should be rebuilt.