### PR TITLE
build-essential: add library/idnkit/header-idnkit for illumos build

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
 COMPONENT_VERSION=	1.0
-COMPONENT_REVISION=	12
+COMPONENT_REVISION=	13
 
 include ../../../make-rules/ips.mk
 

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -114,6 +114,7 @@ depend fmri=developer/astdev type=require
 depend fmri=developer/illumos-gcc type=require
 depend fmri=developer/opensolaris/osnet type=require
 depend fmri=library/glib2 type=require
+depend fmri=library/idnkit/header-idnkit type=require
 depend fmri=library/libxml2 type=require
 depend fmri=library/nspr/header-nspr type=require
 depend fmri=library/perl-5/xml-parser type=require


### PR DESCRIPTION
Since https://www.illumos.org/issues/9997 was integrated idnkit is required to build illumos-gate.

I hope this change is correct. I did a quick `gmake publish` to see if anything complains (looked ok). I have not done any further testing. I had previously installed library/idnkit/header-idnkit manually and could build illumos-gate again.