### PR TITLE
mate-system-monitor fails to link with glibmm & gtkmm3

### DIFF
--- a/components/desktop/mate/mate-system-monitor/Makefile
+++ b/components/desktop/mate/mate-system-monitor/Makefile
@@ -56,6 +56,9 @@ install:	$(INSTALL_64)
 
 test:		$(NO_TESTS)
 
+# Build dependencies
+REQUIRED_PACKAGES += mate-common
+# Auto-generated dependencies
 REQUIRED_PACKAGES += image/library/librsvg
 REQUIRED_PACKAGES += library/c++/glibmm
 REQUIRED_PACKAGES += library/c++/sigcpp

--- a/components/library/glibmm/Makefile
+++ b/components/library/glibmm/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		glibmm
 COMPONENT_VERSION=	2.58.0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	glibmm - C++ Wrapper for the Glib2 Library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz

--- a/components/library/gtkmm3/Makefile
+++ b/components/library/gtkmm3/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gtkmm3
 COMPONENT_VERSION=	3.24.0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	gtkmm - C++ Wrapper for the Gtk+ Library
 COMPONENT_SRC=		gtkmm-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz


### PR DESCRIPTION
`mate-system-monitor` fails for me on "Processes" tab and won't rebuild. Rebuilt glibmm & gtkmm3 fixes both issues.