### PR TITLE
9953 Update gnome-keyring to 3.28.2

### DIFF
--- a/components/desktop/gnome3/gnome-keyring/Makefile
+++ b/components/desktop/gnome3/gnome-keyring/Makefile
@@ -11,20 +11,21 @@
 #
 # Copyright (c) 2017 Alexander Pyhalov
 # Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018 Michal Nowak
 #
 
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnome-keyring
-COMPONENT_MJR_VERSION=	3.20
-COMPONENT_MNR_VERSION=	1
+COMPONENT_MJR_VERSION=	3.28
+COMPONENT_MNR_VERSION=	2
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.gnome.org
 COMPONENT_SUMMARY=	GNOME Keyring
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:97964e723f454be509c956ed5e38b5c2fd7363f43bd3f153b94a4a63eb888c8c
+	sha256:81171b7d07211b216b4c9bb79bf2deb3deca18fe8d56d46dda1c4549b4a2646a
 COMPONENT_ARCHIVE_URL=	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_CLASSIFICATION=	Desktop (GNOME)/Sessions
 COMPONENT_FMRI=		gnome/gnome-keyring
@@ -37,7 +38,7 @@ include $(WS_MAKE_RULES)/ips.mk
 
 PATH=$(PATH.gnu)
 
-COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -fi)
+COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -fi )
 
 PAM_MODULE_DIR.32 = $(USRLIBDIR)/security
 PAM_MODULE_DIR.64 = $(PAM_MODULE_DIR.32)/$(MACH64)
@@ -61,15 +62,14 @@ CONFIGURE_OPTIONS += --with-pic
 # Linux-specific capabilities support.
 CONFIGURE_OPTIONS += --without-libcap-ng
 
-
 # common targets
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
-test:		$(NO_TESTS)
+test:		$(TEST_32_and_64)
 
-# Auto-generated contents below.  Please manually verify and remove this comment
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/gnome/gcr
 REQUIRED_PACKAGES += system/library

--- a/components/desktop/gnome3/gnome-keyring/gnome-keyring.p5m
+++ b/components/desktop/gnome3/gnome-keyring/gnome-keyring.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
+# Copyright 2018 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -135,4 +136,3 @@ file path=usr/share/locale/zh_TW/LC_MESSAGES/gnome-keyring.mo
 file path=usr/share/man/man1/gnome-keyring-3.1
 file path=usr/share/man/man1/gnome-keyring-daemon.1
 file path=usr/share/man/man1/gnome-keyring.1
-file path=usr/share/p11-kit/modules/gnome-keyring.module

--- a/components/desktop/gnome3/gnome-keyring/manifests/sample-manifest.p5m
+++ b/components/desktop/gnome3/gnome-keyring/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -135,4 +135,3 @@ file path=usr/share/locale/zh_TW/LC_MESSAGES/gnome-keyring.mo
 file path=usr/share/man/man1/gnome-keyring-3.1
 file path=usr/share/man/man1/gnome-keyring-daemon.1
 file path=usr/share/man/man1/gnome-keyring.1
-file path=usr/share/p11-kit/modules/gnome-keyring.module


### PR DESCRIPTION
This finally fixes `agent key RSA SHA256:XXX returned incorrect signature type`.

Requires https://github.com/OpenIndiana/oi-userland/pull/4663.