### PR TITLE
Rebuild p11-kit dependencies

### DIFF
--- a/components/library/gcr/Makefile
+++ b/components/library/gcr/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gcr
 COMPONENT_VERSION=	3.28.0
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	https://github.com/GNOME/gcr
 COMPONENT_SUMMARY=	A GNOME library for displaying certificates and crypto UI
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/library/glib-networking/Makefile
+++ b/components/library/glib-networking/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= glib-networking
 COMPONENT_VERSION= 2.42.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= Network-related giomodules for glib
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz

--- a/components/library/gnutls-3/Makefile
+++ b/components/library/gnutls-3/Makefile
@@ -26,7 +26,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnutls
 COMPONENT_VERSION=	3.5.14
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=  ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5
 COMPONENT_SUMMARY=	GNU transport layer security library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)


### PR DESCRIPTION
```
{global} newman@lenovo:~ $ pkg search -l depend::library/desktop/p11-kit
INDEX      ACTION VALUE                                          PACKAGE
require    depend pkg:/library/desktop/p11-kit@0.23.1-2018.0.0.0 pkg:/library/gnutls-3@3.5.14-2018.0.0.1
require    depend pkg:/library/desktop/p11-kit@0.23.1-2017.1.0.0 pkg:/library/glib-networking@2.42.0-2018.0.0.1
require    depend pkg:/library/desktop/p11-kit@0.23.1-2018.0.0.0 pkg:/library/gnome/gcr@3.28.0-2018.0.0.0
```
Rebuild after https://github.com/OpenIndiana/oi-userland/pull/4674 si merged.