### PR TITLE
Update OpenSSH to 7.9p1

### DIFF
--- a/components/network/openssh/Makefile
+++ b/components/network/openssh/Makefile
@@ -17,27 +17,29 @@
 # information: Portions Copyright [yyyy] [name of copyright owner]
 #
 # CDDL HEADER END
+
 #
 # Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2018 Till Wegmüller
 # Copyright 2018 Michal Nowak
 #
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		openssh
-COMPONENT_VERSION=	7.8p1
+COMPONENT_VERSION=	7.9p1
 HUMAN_VERSION=		$(COMPONENT_VERSION)
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 
 # Version for IPS.  The encoding rules are:
 #   OpenSSH <x>.<y>p<n>     => IPS <x>.<y>.0.<n>
 #   OpenSSH <x>.<y>.<z>p<n> => IPS <x>.<y>.<z>.<n>
-IPS_COMPONENT_VERSION=	7.8.0.1
+IPS_COMPONENT_VERSION=	7.9.0.1
 
 COMPONENT_PROJECT_URL=	https://www.openssh.org
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:1a484bb15152c183bb2514e112aa30dd34138c3cfb032eee5490a66c507144ca
-COMPONENT_ARCHIVE_URL=	http://mirror.yandex.ru/pub/OpenBSD/OpenSSH/portable/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:6b4b3ba2253d84ed3771c8050728d597c91cfce898713beb7b64a305b6f11aad
+COMPONENT_ARCHIVE_URL=	https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/$(COMPONENT_ARCHIVE)
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
@@ -109,6 +111,7 @@ install:	$(INSTALL_64)
 # the STC gate.
 test:		$(NO_TESTS)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/libedit
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += library/zlib

--- a/components/network/openssh/files/sshd_config
+++ b/components/network/openssh/files/sshd_config
@@ -80,15 +80,6 @@ LogLevel info
 # HostKey /etc/ssh/ssh_host_rsa_key
 # HostKey /etc/ssh/ssh_host_dsa_key
 
-# Length of the server key
-# Default 768, Minimum 512
-ServerKeyBits 768
-
-# sshd regenerates the key every KeyRegenerationInterval seconds.
-# The key is never stored anywhere except the memory of sshd.
-# The default is 1 hour (3600 seconds).
-KeyRegenerationInterval 3600
-
 # Ensure secure permissions on users .ssh directory.
 StrictModes yes
 
@@ -98,9 +89,7 @@ StrictModes yes
 LoginGraceTime 600
 
 # Maximum number of retries for authentication
-# Default is 6. Default (if unset) for MaxAuthTriesLog is MaxAuthTries / 2
 MaxAuthTries	6
-MaxAuthTriesLog	3
 
 # Are logins to accounts with empty passwords allowed.
 # If PermitEmptyPasswords is no, pass PAM_DISALLOW_NULL_AUTHTOK
@@ -129,17 +118,6 @@ Subsystem	sftp	internal-sftp
 
 # Should sshd use .rhosts and .shosts for password less authentication.
 IgnoreRhosts yes
-RhostsAuthentication no
 
-# Rhosts RSA Authentication
-# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts.
-# If the user on the client side is not root then this won't work on
-# Solaris since /usr/bin/ssh is not installed setuid.
-RhostsRSAAuthentication no
-
-# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication.
+# Uncomment if you don't trust ~/.ssh/known_hosts
 #IgnoreUserKnownHosts yes
-
-# Is pure RSA authentication allowed.
-# Default is yes
-RSAAuthentication yes

--- a/components/network/openssh/patches/0014-GSS-API-key-exchange-support.patch
+++ b/components/network/openssh/patches/0014-GSS-API-key-exchange-support.patch
@@ -2864,15 +2864,6 @@ diff -wpruN '--exclude=*.orig' a~/sshd.c a/sshd.c
  /* Re-exec fds */
  #define REEXEC_DEVCRYPTO_RESERVED_FD	(STDERR_FILENO + 1)
  #define REEXEC_STARTUP_PIPE_FD		(STDERR_FILENO + 2)
-@@ -536,7 +540,7 @@ privsep_preauth_child(void)
- 
- #ifdef GSSAPI
- 	/* Cache supported mechanism OIDs for later use */
--	if (options.gss_authentication)
-+	if (options.gss_authentication || options.gss_keyex)
- 		ssh_gssapi_prepare_supported_oids();
- #endif
- 
 @@ -1811,10 +1815,13 @@ main(int ac, char **av)
  		free(fp);
  	}

--- a/components/network/openssh/patches/0019-PubKeyPlugin-support.patch
+++ b/components/network/openssh/patches/0019-PubKeyPlugin-support.patch
@@ -207,14 +207,15 @@ diff -wpruN '--exclude=*.orig' a~/servconf.c a/servconf.c
  	sDeprecated, sIgnore, sUnsupported
  } ServerOpCodes;
  
-@@ -720,6 +722,7 @@
- 	{ "disableforwarding", sDisableForwarding, SSHCFG_ALL },
+@@ -694,6 +696,7 @@ static struct {
  	{ "exposeauthinfo", sExposeAuthInfo, SSHCFG_ALL },
  	{ "rdomain", sRDomain, SSHCFG_ALL },
+ 	{ "casignaturealgorithms", sCASignatureAlgorithms, SSHCFG_ALL },
 +	{ "pubkeyplugin", sPubKeyPlugin, SSHCFG_ALL },
  	{ NULL, sBadOption, 0 }
  };
- 
+
+
 @@ -2268,6 +2271,18 @@
  		}
  		break;

--- a/components/network/openssh/patches/0032-revert-dscp.patch
+++ b/components/network/openssh/patches/0032-revert-dscp.patch
@@ -1,0 +1,68 @@
+https://github.com/openssh/openssh-portable/commit/5ee8448ad7c306f05a9f56769f95
+is reverted in OmniOS as it causes problems for VMware guests where NAT mode
+is in use - see https://communities.vmware.com/thread/590825
+
+diff -wpruN '--exclude=*.orig' a~/readconf.c a/readconf.c
+--- a~/readconf.c	1970-01-01 00:00:00
++++ a/readconf.c	1970-01-01 00:00:00
+@@ -2149,9 +2149,9 @@ fill_default_options(Options * options)
+ 	if (options->visual_host_key == -1)
+ 		options->visual_host_key = 0;
+ 	if (options->ip_qos_interactive == -1)
+-		options->ip_qos_interactive = IPTOS_DSCP_AF21;
++		options->ip_qos_interactive = IPTOS_LOWDELAY;
+ 	if (options->ip_qos_bulk == -1)
+-		options->ip_qos_bulk = IPTOS_DSCP_CS1;
++		options->ip_qos_bulk = IPTOS_THROUGHPUT;
+ 	if (options->request_tty == -1)
+ 		options->request_tty = REQUEST_TTY_AUTO;
+ 	if (options->proxy_use_fdpass == -1)
+diff -wpruN '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
+@@ -508,9 +508,9 @@ fill_default_server_options(ServerOption
+ 	if (options->permit_tun == -1)
+ 		options->permit_tun = SSH_TUNMODE_NO;
+ 	if (options->ip_qos_interactive == -1)
+-		options->ip_qos_interactive = IPTOS_DSCP_AF21;
++		options->ip_qos_interactive = IPTOS_LOWDELAY;
+ 	if (options->ip_qos_bulk == -1)
+-		options->ip_qos_bulk = IPTOS_DSCP_CS1;
++		options->ip_qos_bulk = IPTOS_THROUGHPUT;
+ 	if (options->version_addendum == NULL)
+ 		options->version_addendum = xstrdup("");
+ 
+diff -wpruN '--exclude=*.orig' a~/ssh_config.4 a/ssh_config.4
+--- a~/ssh_config.4	1970-01-01 00:00:00
++++ a/ssh_config.4	1970-01-01 00:00:00
+@@ -1039,11 +1039,9 @@ If one argument is specified, it is used
+ If two values are specified, the first is automatically selected for
+ interactive sessions and the second for non-interactive sessions.
+ The default is
+-.Cm af21
+-(Low-Latency Data)
++.Cm lowdelay
+ for interactive sessions and
+-.Cm cs1
+-(Lower Effort)
++.Cm throughput
+ for non-interactive sessions.
+ .It Cm KbdInteractiveAuthentication
+ Specifies whether to use keyboard-interactive authentication.
+diff -wpruN '--exclude=*.orig' a~/sshd_config.4 a/sshd_config.4
+--- a~/sshd_config.4	1970-01-01 00:00:00
++++ a/sshd_config.4	1970-01-01 00:00:00
+@@ -851,11 +851,9 @@ If one argument is specified, it is used
+ If two values are specified, the first is automatically selected for
+ interactive sessions and the second for non-interactive sessions.
+ The default is
+-.Cm af21
+-(Low-Latency Data)
++.Cm lowdelay
+ for interactive sessions and
+-.Cm cs1
+-(Lower Effort)
++.Cm throughput
+ for non-interactive sessions.
+ .It Cm KbdInteractiveAuthentication
+ Specifies whether to allow keyboard-interactive authentication.


### PR DESCRIPTION
* Update OpenSSH to 7.9p1

Tested with key-based authentication against v7.9p1 (itself), v7.2p2 (openSUSE Leap 42.3), and v6.7p1 (Debian).

* 10156 Remove deprecated options from sshd_config

Deprecation warnings on `sshd` start are gone.

* Add OmniOs patch for VMware guests with NAT networking