### PR TITLE
Update librsvg to 2.40.20

### DIFF
--- a/components/library/librsvg/Makefile
+++ b/components/library/librsvg/Makefile
@@ -11,22 +11,23 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright 2018 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME= librsvg
-COMPONENT_MAJOR_VERSION= 2.39
-COMPONENT_VERSION= $(COMPONENT_MAJOR_VERSION).0
-COMPONENT_FMRI= image/library/librsvg
-COMPONENT_CLASSIFICATION= System/Multimedia Libraries
-COMPONENT_SUMMARY= Library for SVG support for GNOME
-COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
+COMPONENT_NAME=		librsvg
+COMPONENT_MAJOR_VERSION=2.40
+COMPONENT_VERSION=	$(COMPONENT_MAJOR_VERSION).20
+COMPONENT_FMRI=		image/library/librsvg
+COMPONENT_CLASSIFICATION=System/Multimedia Libraries
+COMPONENT_SUMMARY=	Library for SVG support for GNOME
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:aa47dcde0128eee6e3595d203bc673d9c27389588842f401bf585f31fc65095f
+	sha256:cff4dd3c3b78bfe99d8fcfad3b8ba1eee3289a0823c0e118d78106be6b84c92b
 COMPONENT_ARCHIVE_URL= \
-  http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
+	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL= https://www.gnome.org/
 COMPONENT_LICENSE= LGPLv2
 
@@ -37,36 +38,39 @@ include $(WS_MAKE_RULES)/ips.mk
 PATH=$(PATH.gnu)
 
 # Cloning is required for gmake test to pass
-COMPONENT_PRE_CONFIGURE_ACTION = ($(CLONEY) $(SOURCE_DIR) $(@D))
-
-CONFIGURE_SCRIPT= $(@D)/configure
+COMPONENT_PRE_CONFIGURE_ACTION = ( $(CLONEY) $(SOURCE_DIR) $(@D) )
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && aclocal && \
-                          libtoolize --force --copy&&\
-                          gtkdocize &&\
-                          autoheader &&\
-                          automake -a -f -c --gnu &&\
-                          autoconf )
+			libtoolize --force --copy && \
+			gtkdocize && \
+			autoheader && \
+			automake -a -f -c --gnu && \
+			autoconf )
 
-CONFIGURE_OPTIONS.32 = --sysconfdir=/etc
-CONFIGURE_OPTIONS.64 = --sysconfdir=/etc/$(MACH64)
-CONFIGURE_OPTIONS += --with-html-dir=/usr/share/gtk-doc/html/librsvg
-CONFIGURE_OPTIONS += --disable-Bsymbolic
-CONFIGURE_OPTIONS += --disable-static
+CONFIGURE_OPTIONS.32 =	--sysconfdir=/etc
+CONFIGURE_OPTIONS.64 =	--sysconfdir=/etc/$(MACH64)
+CONFIGURE_OPTIONS +=	--with-html-dir=/usr/share/gtk-doc/html/librsvg
+CONFIGURE_OPTIONS +=	--disable-Bsymbolic
+CONFIGURE_OPTIONS +=	--disable-static
 
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
-build: $(BUILD_32_and_64)
+COMPONENT_TEST_TRANSFORMER = $(NAWK)
+COMPONENT_TEST_TRANSFORMS = "'/TOTAL|PASS|FAIL|XFAIL|SKIP|XPASS|ERROR/'"
 
-install: $(INSTALL_32_and_64)
+# To prevent "ERROR: loading - missing test plan"
+unexport SHELLOPTS
 
-test: $(TEST_32_and_64)
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
-REQUIRED_PACKAGES += library/desktop/gtk2
 REQUIRED_PACKAGES += library/desktop/gtk3
 REQUIRED_PACKAGES += library/desktop/pango
 REQUIRED_PACKAGES += library/glib2
@@ -74,4 +78,5 @@ REQUIRED_PACKAGES += library/libcroco
 REQUIRED_PACKAGES += library/libxml2
 REQUIRED_PACKAGES += service/gnome/desktop-cache
 REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/fontconfig
 REQUIRED_PACKAGES += system/library/math

--- a/components/library/librsvg/librsvg.p5m
+++ b/components/library/librsvg/librsvg.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2014 Alexander Pyhalov. All rights reserved.
+# Copyright 2018 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -36,7 +37,6 @@ file path=usr/include/librsvg-2.0/librsvg/rsvg-cairo.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg.h
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Rsvg-2.0.typelib
-file path=usr/lib/$(MACH64)/gtk-2.0/2.10.0/engines/libsvg.so
 link path=usr/lib/$(MACH64)/librsvg-2.so \
     target=librsvg-2.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/librsvg-2.so.$(COMPONENT_VERSION)
@@ -45,7 +45,6 @@ link path=usr/lib/$(MACH64)/librsvg-2.so.2 \
 file path=usr/lib/$(MACH64)/pkgconfig/librsvg-2.0.pc
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
 file path=usr/lib/girepository-1.0/Rsvg-2.0.typelib
-file path=usr/lib/gtk-2.0/2.10.0/engines/libsvg.so
 link path=usr/lib/librsvg-2.so target=librsvg-2.so.$(COMPONENT_VERSION)
 file path=usr/lib/librsvg-2.so.$(COMPONENT_VERSION)
 link path=usr/lib/librsvg-2.so.2 target=librsvg-2.so.$(COMPONENT_VERSION)
@@ -64,10 +63,11 @@ file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/api-index-deprecated.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/api-index-full.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/home.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/index.html
-file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/index.sgml
+file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/left-insensitive.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/left.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/licence.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/object-tree.html
+file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/right-insensitive.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/right.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-2.0.devhelp2
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-Using-RSVG-with-GIO.html
@@ -76,11 +76,7 @@ file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-Using-RSVG-with-cairo.htm
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-Version-check-and-feature-tests.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/style.css
+file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/up-insensitive.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/up.png
 file path=usr/share/man/man1/rsvg-convert.1
-file path=usr/share/themes/bubble/gtk-2.0/blue.svg
-file path=usr/share/themes/bubble/gtk-2.0/green.svg
-file path=usr/share/themes/bubble/gtk-2.0/gtkrc
-file path=usr/share/themes/bubble/gtk-2.0/orange.svg
-file path=usr/share/themes/bubble/gtk-2.0/purple.svg
-file path=usr/share/themes/bubble/gtk-2.0/red.svg
+file path=usr/share/thumbnailers/librsvg.thumbnailer

--- a/components/library/librsvg/manifests/sample-manifest.p5m
+++ b/components/library/librsvg/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -32,7 +32,6 @@ file path=usr/include/librsvg-2.0/librsvg/rsvg-cairo.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg.h
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Rsvg-2.0.typelib
-file path=usr/lib/$(MACH64)/gtk-2.0/2.10.0/engines/libsvg.so
 link path=usr/lib/$(MACH64)/librsvg-2.so \
     target=librsvg-2.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/librsvg-2.so.$(COMPONENT_VERSION)
@@ -41,7 +40,6 @@ link path=usr/lib/$(MACH64)/librsvg-2.so.2 \
 file path=usr/lib/$(MACH64)/pkgconfig/librsvg-2.0.pc
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-svg.so
 file path=usr/lib/girepository-1.0/Rsvg-2.0.typelib
-file path=usr/lib/gtk-2.0/2.10.0/engines/libsvg.so
 link path=usr/lib/librsvg-2.so target=librsvg-2.so.$(COMPONENT_VERSION)
 file path=usr/lib/librsvg-2.so.$(COMPONENT_VERSION)
 link path=usr/lib/librsvg-2.so.2 target=librsvg-2.so.$(COMPONENT_VERSION)
@@ -60,10 +58,11 @@ file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/api-index-deprecated.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/api-index-full.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/home.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/index.html
-file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/index.sgml
+file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/left-insensitive.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/left.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/licence.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/object-tree.html
+file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/right-insensitive.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/right.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-2.0.devhelp2
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-Using-RSVG-with-GIO.html
@@ -72,11 +71,7 @@ file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-Using-RSVG-with-cairo.htm
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg-Version-check-and-feature-tests.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/rsvg.html
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/style.css
+file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/up-insensitive.png
 file path=usr/share/gtk-doc/html/librsvg/rsvg-2.0/up.png
 file path=usr/share/man/man1/rsvg-convert.1
-file path=usr/share/themes/bubble/gtk-2.0/blue.svg
-file path=usr/share/themes/bubble/gtk-2.0/green.svg
-file path=usr/share/themes/bubble/gtk-2.0/gtkrc
-file path=usr/share/themes/bubble/gtk-2.0/orange.svg
-file path=usr/share/themes/bubble/gtk-2.0/purple.svg
-file path=usr/share/themes/bubble/gtk-2.0/red.svg
+file path=usr/share/thumbnailers/librsvg.thumbnailer

--- a/components/library/librsvg/test/results-32.master
+++ b/components/library/librsvg/test/results-32.master
@@ -1,0 +1,72 @@
+PASS: loading 1 /loading/one-byte-at-a-time
+PASS: loading 2 /loading/compressed-one-byte-at-a-time
+PASS: loading 3 /loading/compressed-two-bytes-at-a-time
+PASS: rsvg-test 1 /rsvg/reftest/duplicate-id.svg
+PASS: rsvg-test 2 /rsvg/reftest/gzip-compressed.svg
+PASS: rsvg-test 3 /rsvg/reftest/include-compressed.svg
+PASS: rsvg-test 4 /rsvg/reftest/nonexisting-filter.svg
+FAIL: rsvg-test 5 /rsvg/reftest/bugs/340047.svg
+PASS: rsvg-test 6 /rsvg/reftest/bugs/403357.svg
+PASS: rsvg-test 7 /rsvg/reftest/bugs/476507.svg
+PASS: rsvg-test 8 /rsvg/reftest/bugs/548494.svg
+PASS: rsvg-test 9 /rsvg/reftest/bugs/563933.svg
+FAIL: rsvg-test 10 /rsvg/reftest/bugs/587721-text-transform.svg
+PASS: rsvg-test 11 /rsvg/reftest/bugs/603550-mask-luminance.svg
+PASS: rsvg-test 12 /rsvg/reftest/bugs/738367.svg
+FAIL: rsvg-test 13 /rsvg/reftest/bugs/749415.svg
+PASS: rsvg-test 14 /rsvg/reftest/bugs/761175-recursive-masks.svg
+FAIL: rsvg-test 15 /rsvg/reftest/bugs/777834-empty-text-children.svg
+FAIL: rsvg-test 16 /rsvg/reftest/svg1.1/masking-intro-01-f.svg
+FAIL: rsvg-test 17 /rsvg/reftest/svg1.1/masking-mask-01-b.svg
+FAIL: rsvg-test 18 /rsvg/reftest/svg1.1/masking-mask-02-f.svg
+FAIL: rsvg-test 19 /rsvg/reftest/svg1.1/masking-opacity-01-b.svg
+FAIL: rsvg-test 20 /rsvg/reftest/svg1.1/masking-path-01-b.svg
+FAIL: rsvg-test 21 /rsvg/reftest/svg1.1/masking-path-02-b.svg
+FAIL: rsvg-test 22 /rsvg/reftest/svg1.1/masking-path-03-b.svg
+FAIL: rsvg-test 23 /rsvg/reftest/svg1.1/masking-path-04-b.svg
+FAIL: rsvg-test 24 /rsvg/reftest/svg1.1/struct-cond-03-t.svg
+ERROR: rsvg-test - exited with status 1
+PASS: crash 1 /crash/785276-empty.svg
+PASS: crash 2 /crash/785276-short-file.svg
+PASS: crash 3 /crash/bug620238.svg
+PASS: crash 4 /crash/bug759084.svg
+PASS: crash 5 /crash/marker-cycles.svg
+PASS: crash 6 /crash/mask-cycles.svg
+PASS: crash 7 /crash/pattern-fallback-cycles.svg
+PASS: styles 1 /styles/override presentation attribute
+PASS: styles 2 /styles/svg-element-style
+PASS: styles 3 /styles/presentation attribute in svg element
+PASS: styles 4 /styles/selectors/type
+PASS: styles 5 /styles/selectors/class
+PASS: styles 6 /styles/selectors/#id
+PASS: styles 7 /styles/selectors/style
+PASS: styles 8 /styles/selectors/style property prior than class
+PASS: styles 9 /styles/selectors/#id prior than class
+PASS: styles 10 /styles/selectors/type#id prior than class
+PASS: styles 11 /styles/selectors/class#id prior than class
+PASS: styles 12 /styles/selectors/type.class#id prior than class
+PASS: styles 13 /styles/selectors/#id prior than type
+PASS: styles 14 /styles/selectors/comma-separate (fill)
+PASS: styles 15 /styles/selectors/comma-separete (stroke)
+PASS: styles 16 /styles/selectors/2 or more selectors (fill)
+PASS: styles 17 /styles/selectors/2 or more selectors (stroke)
+PASS: styles 18 /styles/!important/stroke
+PASS: styles 19 /styles/!important/stroke-width
+PASS: styles 20 /styles/!important/class
+PASS: styles 21 /styles/!important/element
+PASS: styles 22 /styles/!important/#id prior than class
+PASS: styles 23 /styles/!important/class prior than type
+PASS: styles 24 /styles/!important/presentation attribute is invalid
+PASS: styles 25 /styles/!important/style prior than class
+PASS: render-crash 1 /render-crash/777155-zero-sized-pattern.svg
+PASS: dimensions 1 /dimensions/no viewbox, width and height
+PASS: dimensions 2 /dimensions/100% width and height
+PASS: dimensions 3 /dimensions/viewbox only
+PASS: dimensions 4 /dimensions/sub/rect no unit
+# TOTAL: 65
+# PASS:  51
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  13
+# XPASS: 0
+# ERROR: 1

--- a/components/library/librsvg/test/results-64.master
+++ b/components/library/librsvg/test/results-64.master
@@ -1,0 +1,72 @@
+PASS: loading 1 /loading/one-byte-at-a-time
+PASS: loading 2 /loading/compressed-one-byte-at-a-time
+PASS: loading 3 /loading/compressed-two-bytes-at-a-time
+PASS: rsvg-test 1 /rsvg/reftest/duplicate-id.svg
+PASS: rsvg-test 2 /rsvg/reftest/gzip-compressed.svg
+PASS: rsvg-test 3 /rsvg/reftest/include-compressed.svg
+PASS: rsvg-test 4 /rsvg/reftest/nonexisting-filter.svg
+FAIL: rsvg-test 5 /rsvg/reftest/bugs/340047.svg
+PASS: rsvg-test 6 /rsvg/reftest/bugs/403357.svg
+PASS: rsvg-test 7 /rsvg/reftest/bugs/476507.svg
+PASS: rsvg-test 8 /rsvg/reftest/bugs/548494.svg
+PASS: rsvg-test 9 /rsvg/reftest/bugs/563933.svg
+FAIL: rsvg-test 10 /rsvg/reftest/bugs/587721-text-transform.svg
+PASS: rsvg-test 11 /rsvg/reftest/bugs/603550-mask-luminance.svg
+PASS: rsvg-test 12 /rsvg/reftest/bugs/738367.svg
+FAIL: rsvg-test 13 /rsvg/reftest/bugs/749415.svg
+PASS: rsvg-test 14 /rsvg/reftest/bugs/761175-recursive-masks.svg
+FAIL: rsvg-test 15 /rsvg/reftest/bugs/777834-empty-text-children.svg
+FAIL: rsvg-test 16 /rsvg/reftest/svg1.1/masking-intro-01-f.svg
+FAIL: rsvg-test 17 /rsvg/reftest/svg1.1/masking-mask-01-b.svg
+FAIL: rsvg-test 18 /rsvg/reftest/svg1.1/masking-mask-02-f.svg
+FAIL: rsvg-test 19 /rsvg/reftest/svg1.1/masking-opacity-01-b.svg
+FAIL: rsvg-test 20 /rsvg/reftest/svg1.1/masking-path-01-b.svg
+FAIL: rsvg-test 21 /rsvg/reftest/svg1.1/masking-path-02-b.svg
+FAIL: rsvg-test 22 /rsvg/reftest/svg1.1/masking-path-03-b.svg
+FAIL: rsvg-test 23 /rsvg/reftest/svg1.1/masking-path-04-b.svg
+FAIL: rsvg-test 24 /rsvg/reftest/svg1.1/struct-cond-03-t.svg
+ERROR: rsvg-test - exited with status 1
+PASS: crash 1 /crash/785276-empty.svg
+PASS: crash 2 /crash/785276-short-file.svg
+PASS: crash 3 /crash/bug620238.svg
+PASS: crash 4 /crash/bug759084.svg
+PASS: crash 5 /crash/marker-cycles.svg
+PASS: crash 6 /crash/mask-cycles.svg
+PASS: crash 7 /crash/pattern-fallback-cycles.svg
+PASS: styles 1 /styles/override presentation attribute
+PASS: styles 2 /styles/svg-element-style
+PASS: styles 3 /styles/presentation attribute in svg element
+PASS: styles 4 /styles/selectors/type
+PASS: styles 5 /styles/selectors/class
+PASS: styles 6 /styles/selectors/#id
+PASS: styles 7 /styles/selectors/style
+PASS: styles 8 /styles/selectors/style property prior than class
+PASS: styles 9 /styles/selectors/#id prior than class
+PASS: styles 10 /styles/selectors/type#id prior than class
+PASS: styles 11 /styles/selectors/class#id prior than class
+PASS: styles 12 /styles/selectors/type.class#id prior than class
+PASS: styles 13 /styles/selectors/#id prior than type
+PASS: styles 14 /styles/selectors/comma-separate (fill)
+PASS: styles 15 /styles/selectors/comma-separete (stroke)
+PASS: styles 16 /styles/selectors/2 or more selectors (fill)
+PASS: styles 17 /styles/selectors/2 or more selectors (stroke)
+PASS: styles 18 /styles/!important/stroke
+PASS: styles 19 /styles/!important/stroke-width
+PASS: styles 20 /styles/!important/class
+PASS: styles 21 /styles/!important/element
+PASS: styles 22 /styles/!important/#id prior than class
+PASS: styles 23 /styles/!important/class prior than type
+PASS: styles 24 /styles/!important/presentation attribute is invalid
+PASS: styles 25 /styles/!important/style prior than class
+PASS: render-crash 1 /render-crash/777155-zero-sized-pattern.svg
+PASS: dimensions 1 /dimensions/no viewbox, width and height
+PASS: dimensions 2 /dimensions/100% width and height
+PASS: dimensions 3 /dimensions/viewbox only
+PASS: dimensions 4 /dimensions/sub/rect no unit
+# TOTAL: 65
+# PASS:  51
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  13
+# XPASS: 0
+# ERROR: 1


### PR DESCRIPTION
This is the last release without Rust code.

Test failures are odd ones like:
```
# Start of bugs tests
# Storing test result image at /var/tmp/340047-out.png
# 598 pixels differ (with maximum difference of 196) from reference image

# Storing test result image at /var/tmp/340047-diff.png
not ok 5 /rsvg/reftest/bugs/340047.svg
FAIL: rsvg-test 5 /rsvg/reftest/bugs/340047.svg
```

Dependencies to be rebuid: https://github.com/OpenIndiana/oi-userland/pull/4684