### PR TITLE
Update gzip to 1.10

### DIFF
--- a/components/archiver/gzip/Makefile
+++ b/components/archiver/gzip/Makefile
@@ -18,17 +18,20 @@
 #
 # CDDL HEADER END
 #
+
+#
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, Michal Nowak
 #
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gzip
-COMPONENT_VERSION=	1.9
+COMPONENT_VERSION=	1.10
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/gzip/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:ae506144fc198bd8f81f1f4ad19ce63d5a2d65e42333255977cf1dcf1479089a
+	sha256:8425ccac99872d544d4310305f915f5ea81e04d0f437ef1a230dc9d1c819d7c0
 COMPONENT_ARCHIVE_URL=	ftp://ftp.gnu.org/gnu/gzip/$(COMPONENT_ARCHIVE)
 
 include $(WS_MAKE_RULES)/prep.mk
@@ -98,6 +101,7 @@ install:	$(INSTALL_64) $(GZGREP_MAN_VARIANTS)
 
 test:		$(TEST_64)
 
-REQUIRED_PACKAGES += shell/bash
 REQUIRED_PACKAGES += SUNWcs
+# Auto-generated dependencies
+REQUIRED_PACKAGES += shell/bash
 REQUIRED_PACKAGES += system/library

--- a/components/archiver/gzip/test/results-64.master
+++ b/components/archiver/gzip/test/results-64.master
@@ -7,6 +7,7 @@ PASS: list
 PASS: memcpy-abuse
 PASS: mixed
 PASS: null-suffix-clobber
+PASS: reproducible
 PASS: stdin
 PASS: timestamp
 PASS: trailing-nul
@@ -19,8 +20,8 @@ PASS: zgrep-f
 PASS: zgrep-context
 PASS: zgrep-signal
 PASS: znew-k
-# TOTAL: 21
-# PASS:  21
+# TOTAL: 22
+# PASS:  22
 # SKIP:  0
 # XFAIL: 0
 # FAIL:  0


### PR DESCRIPTION
https://savannah.gnu.org/forum/forum.php?forum_id=9339

```
* Noteworthy changes in release 1.10 (2018-12-29) [stable]

** Changes in behavior

  Compressed gzip output no longer contains the current time as a
  timestamp when the input is not a regular file.  Instead, the output
  contains a null (zero) timestamp.  This makes gzip's behavior more
  reproducible when used as part of a pipeline.  (As a reminder, even
  regular files will use null timestamps after the year 2106, due to a
  limitation in the gzip format.)

** Bug fixes

  A use of uninitialized memory on some malformed inputs has been fixed.
  [bug present since the beginning]

  A few theoretical race conditions in signal handers have been fixed.
  These bugs most likely do not happen on practical platforms.
  [bugs present since the beginning]
```