### PR TITLE
Update PCRE2 to 10.32, enable 32-bit character support

### DIFF
--- a/components/library/pcre2/Makefile
+++ b/components/library/pcre2/Makefile
@@ -28,11 +28,11 @@ PREFERRED_BITS=64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pcre2
-COMPONENT_VERSION=	10.31
+COMPONENT_VERSION=	10.32
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:e07d538704aa65e477b6a392b32ff9fc5edf75ab9a40ddfc876186c4ff4d68ac
+	sha256:f29e89cc5de813f45786580101aaee3984a65818631d4ddbda7b32f699b87c2e
 COMPONENT_ARCHIVE_URL=	ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/$(COMPONENT_ARCHIVE)
 COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).sig
 COMPONENT_PROJECT_URL=  http://pcre.org/
@@ -80,6 +80,7 @@ CONFIGURE_OPTIONS+=	--enable-rebuild-chartables
 CONFIGURE_OPTIONS+=	--enable-newline-is-any
 CONFIGURE_OPTIONS+=	--enable-pcre2grep-libz
 CONFIGURE_OPTIONS+=	--enable-pcre2grep-libbz2
+CONFIGURE_OPTIONS+=	--enable-pcre2-32
 CONFIGURE_OPTIONS+=	--with-link-size=4
 CONFIGURE_OPTIONS+=	--with-match-limit=10000000
 CONFIGURE_OPTIONS+=	--with-pic
@@ -120,14 +121,14 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "s|Testsuite summary for PCRE .*|Testsuite summary for PCRE|" '
 
 # common targets
-
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
 
-REQUIRED_PACKAGES += SUNWcs
+# Auto-generated dependencies
 REQUIRED_PACKAGES += compress/bzip2
 REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/library/pcre2/manifests/sample-manifest.p5m
+++ b/components/library/pcre2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,20 +30,28 @@ file path=usr/bin/pcre2grep
 file path=usr/bin/pcre2test
 file path=usr/include/pcre/pcre2.h
 file path=usr/include/pcre/pcre2posix.h
-link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.7.0
-link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.7.0
-file path=usr/lib/$(MACH64)/libpcre2-8.so.0.7.0
-link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.0
-link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.0
-file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.0
+link path=usr/lib/$(MACH64)/libpcre2-32.so target=libpcre2-32.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
+file path=usr/lib/$(MACH64)/libpcre2-32.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
+file path=usr/lib/$(MACH64)/libpcre2-8.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
+link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
+file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.1
+file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-32.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-8.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-posix.pc
-link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.7.0
-link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.7.0
-file path=usr/lib/libpcre2-8.so.0.7.0
-link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.0
-link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.0
-file path=usr/lib/libpcre2-posix.so.2.0.0
+link path=usr/lib/libpcre2-32.so target=libpcre2-32.so.0.7.1
+link path=usr/lib/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
+file path=usr/lib/libpcre2-32.so.0.7.1
+link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.7.1
+link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
+file path=usr/lib/libpcre2-8.so.0.7.1
+link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
+link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
+file path=usr/lib/libpcre2-posix.so.2.0.1
+file path=usr/lib/pkgconfig/libpcre2-32.pc
 file path=usr/lib/pkgconfig/libpcre2-8.pc
 file path=usr/lib/pkgconfig/libpcre2-posix.pc
 file path=usr/share/doc/pcre2/AUTHORS

--- a/components/library/pcre2/pcre2.p5m
+++ b/components/library/pcre2/pcre2.p5m
@@ -42,20 +42,28 @@ file path=usr/bin/pcre2grep
 file path=usr/bin/pcre2test
 file path=usr/include/pcre/pcre2.h
 file path=usr/include/pcre/pcre2posix.h
-link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.7.0
-link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.7.0
-file path=usr/lib/$(MACH64)/libpcre2-8.so.0.7.0
-link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.0
-link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.0
-file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.0
+link path=usr/lib/$(MACH64)/libpcre2-32.so target=libpcre2-32.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
+file path=usr/lib/$(MACH64)/libpcre2-32.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
+file path=usr/lib/$(MACH64)/libpcre2-8.so.0.7.1
+link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
+link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
+file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.1
+file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-32.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-8.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-posix.pc
-link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.7.0
-link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.7.0
-file path=usr/lib/libpcre2-8.so.0.7.0
-link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.0
-link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.0
-file path=usr/lib/libpcre2-posix.so.2.0.0
+link path=usr/lib/libpcre2-32.so target=libpcre2-32.so.0.7.1
+link path=usr/lib/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
+file path=usr/lib/libpcre2-32.so.0.7.1
+link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.7.1
+link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
+file path=usr/lib/libpcre2-8.so.0.7.1
+link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
+link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
+file path=usr/lib/libpcre2-posix.so.2.0.1
+file path=usr/lib/pkgconfig/libpcre2-32.pc
 file path=usr/lib/pkgconfig/libpcre2-8.pc
 file path=usr/lib/pkgconfig/libpcre2-posix.pc
 file path=usr/share/doc/pcre2/AUTHORS

--- a/components/library/pcre2/test/results-all.master
+++ b/components/library/pcre2/test/results-all.master
@@ -5,7 +5,7 @@
 PASS: RunTest
 PASS: RunGrepTest
 ============================================================================
-Testsuite summary for PCRE2 10.31
+Testsuite summary for PCRE2 10.32
 ============================================================================
 # TOTAL: 2
 # PASS:  2


### PR DESCRIPTION
https://www.pcre.org/news.txt

Updates Unicode to v11.

Clean: https://abi-laboratory.pro/index.php?view=timeline&l=pcre2.

Enables 32-bit character support for `shell/fish`: https://github.com/OpenIndiana/oi-userland/pull/4690.