### PR TITLE
Bring back OpenIndiana-specific colors to the loader

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -583,7 +583,6 @@ $(BUILD_DIR)/$(MACH)/.published: $(BUILD_DIR)/$(MACH)/publish.transforms
 	$(RM) -r $(@D)/pkgrecv.dir
 	$(MKDIR) $(@D)/pkgrecv.dir
 
-
 ifeq ($(DEBUG),yes)
 	$(RM) -r $(@D)/pkgrepo-merged.dir
 	$(MKDIR) $(@D)/pkgrepo-merged.dir
@@ -621,4 +620,7 @@ clean::
 clobber::       clean
 	$(RM) -r $(CLOBBER_PATHS)
 
-REQUIRED_PACKAGES+= developer/illumos-closed
+REQUIRED_PACKAGES += developer/gcc-7
+REQUIRED_PACKAGES += developer/illumos-closed
+REQUIRED_PACKAGES += runtime/python-27
+REQUIRED_PACKAGES += runtime/python-35

--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -71,11 +71,12 @@ PATCHES =       $(shell find $(PATCH_DIR) $(PARFAIT_PATCH_DIR) -type f -name '$(
 $(SOURCE_DIR)/.patched:	$(SOURCE_DIR)/.downloaded $(PATCHES)
 	$(MKDIR) $(@D)
 	cd $(SOURCE_DIR) && \
-        $(GIT) checkout -f && \
-              $(GIT) clean -f
+	$(GIT) checkout -f && \
+	$(GIT) clean -f
 	for p in $(PATCHES); do \
-          $(GPATCH) -d $(@D) $(GPATCH_FLAGS) < $$p; \
-        done
+	  echo "\nPatch: $$p:"; \
+	  $(GPATCH) -d $(@D) $(GPATCH_FLAGS) < $$p; \
+	done
 	@cd $(SOURCE_DIR); $(GIT) log -1 --format=%H > .downloaded
 	$(TOUCH) $@
 

--- a/components/openindiana/illumos-gate/patches/0003-XXXX-OpenIndiana-specific-color-theme.patch
+++ b/components/openindiana/illumos-gate/patches/0003-XXXX-OpenIndiana-specific-color-theme.patch
@@ -1,0 +1,14 @@
+OpenIndiana-specific loader color theme
+
+--- a/usr/src/boot/sys/boot/i386/loader/loader.rc	2019-01-09 20:10:49.035948755 +0000
++++ b/usr/src/boot/sys/boot/i386/loader/loader.rc	2019-01-09 20:17:16.353335005 +0000
+@@ -2,6 +2,9 @@
+ \
+ \ Includes additional commands
+ include /boot/forth/loader.4th
++\ OpenIndiana-specific loader color theme
++set tem.fg_color=white
++set tem.bg_color=black
+ try-include /boot/loader.rc.local
+ 
+ \ Reads and processes loader.conf variables


### PR DESCRIPTION
Recent update of loader with framebuffer sets colors to black on white, though traditional OpenIndiana colors are vice versa. This change brings `boot/loader.rc.oi` with OI-custom/former colors.

Tested in QEMU VM.