### PR TITLE
Rebuild gfile after build server is clean

### DIFF
--- a/components/library/libmagic/Makefile
+++ b/components/library/libmagic/Makefile
@@ -23,6 +23,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		file
 COMPONENT_FMRI=		library/magic
 COMPONENT_VERSION=	5.35
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	http://www.darwinsys.com/file/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz


### PR DESCRIPTION
I get following with official gfile builds:
```
$ gfile Xorg.0.log.old
gfile: compiled magic version [524] does not match with shared library magic version [535]
Xorg.0.log.old: JSON data
```
I think the build environment on the build server is polluted as my
build are OK. Clean the build environment on the build server before
merge, please.