### PR TITLE
add lmdb version 0.9.23

### DIFF
--- a/components/database/lmdb/Makefile
+++ b/components/database/lmdb/Makefile
@@ -1,0 +1,58 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Rouven Weiler
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =			lmdb
+COMPONENT_VERSION =			0.9.23
+COMPONENT_SUMMARY =			Lightning memory-mapped database library
+COMPONENT_SRC =				lmdb-LMDB_$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE =			LMDB_$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH =		sha256:abf42e91f046787ed642d9eb21812a5c473f3ba5854124484d16eadbe0aa9c81
+COMPONENT_ARCHIVE_URL =			https://github.com/LMDB/lmdb/archive/LMDB_$(COMPONENT_VERSION).tar.gz
+COMPONENT_PROJECT_URL =			https://github.com/LMDB/lmdb
+COMPONENT_FMRI =			database/lmdb
+COMPONENT_CLASSIFICATION =		System/Databases
+COMPONENT_LICENSE =			OpenLDAP Public License
+COMPONENT_LICENSE_FILE =		$(COMPONENT_NAME).license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/justmake.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_COPY_ACTION = $(CP) -r $(SOURCE_DIR)/libraries/liblmdb/* $(@D)
+
+COMPONENT_BUILD_ARGS += CC="$(CC)"
+COMPONENT_BUILD_ARGS += CFLAGS="$(CFLAGS) -pthread"
+COMPONENT_BUILD_ARGS += LDFLAGS="$(LDFLAGS)"
+COMPONENT_BUILD_ARGS += SOVERSION="$(COMPONENT_VERSION)"
+
+COMPONENT_INSTALL_ARGS += bindir="$(USRBINDIR.$(BITS))"
+COMPONENT_INSTALL_ARGS += includedir="$(USRINCDIR)"
+COMPONENT_INSTALL_ARGS += libdir="$(USRLIBDIR.$(BITS))"
+COMPONENT_INSTALL_ARGS += mandir="$(USRSHAREMANDIR)"
+COMPONENT_INSTALL_ARGS += SOVERSION="$(COMPONENT_VERSION)"
+
+COMPONENT_TEST_TARGETS = test
+COMPONENT_TEST_ARGS += CC="$(CC)"
+COMPONENT_TEST_ARGS += CFLAGS="$(CFLAGS) -pthread"
+COMPONENT_TEST_ARGS += LDFLAGS="$(LDFLAGS)"
+COMPONENT_TEST_ARGS += SOVERSION="$(COMPONENT_VERSION)"
+
+build: $(BUILD_32_and_64)
+
+install: $(INSTALL_32_and_64)
+
+test: $(TEST_32_and_64)

--- a/components/database/lmdb/lmdb.license
+++ b/components/database/lmdb/lmdb.license
@@ -1,0 +1,47 @@
+The OpenLDAP Public License
+  Version 2.8, 17 August 2003
+
+Redistribution and use of this software and associated documentation
+("Software"), with or without modification, are permitted provided
+that the following conditions are met:
+
+1. Redistributions in source form must retain copyright statements
+   and notices,
+
+2. Redistributions in binary form must reproduce applicable copyright
+   statements and notices, this list of conditions, and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution, and
+
+3. Redistributions must contain a verbatim copy of this document.
+
+The OpenLDAP Foundation may revise this license from time to time.
+Each revision is distinguished by a version number.  You may use
+this Software under terms of this license revision or under the
+terms of any subsequent revision of the license.
+
+THIS SOFTWARE IS PROVIDED BY THE OPENLDAP FOUNDATION AND ITS
+CONTRIBUTORS ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT
+SHALL THE OPENLDAP FOUNDATION, ITS CONTRIBUTORS, OR THE AUTHOR(S)
+OR OWNER(S) OF THE SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+The names of the authors and copyright holders must not be used in
+advertising or otherwise to promote the sale, use or other dealing
+in this Software without specific, written prior permission.  Title
+to copyright in this Software shall at all times remain with copyright
+holders.
+
+OpenLDAP is a registered trademark of the OpenLDAP Foundation.
+
+Copyright 1999-2003 The OpenLDAP Foundation, Redwood City,
+California, USA.  All Rights Reserved.  Permission to copy and
+distribute verbatim copies of this document is granted.

--- a/components/database/lmdb/lmdb.p5m
+++ b/components/database/lmdb/lmdb.p5m
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 Rouven Weiler
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/mdb_copy
+file path=usr/bin/$(MACH64)/mdb_dump
+file path=usr/bin/$(MACH64)/mdb_load
+file path=usr/bin/$(MACH64)/mdb_stat
+file path=usr/bin/mdb_copy
+file path=usr/bin/mdb_dump
+file path=usr/bin/mdb_load
+file path=usr/bin/mdb_stat
+file path=usr/include/lmdb.h
+file path=usr/lib/$(MACH64)/liblmdb-$(COMPONENT_VERSION).so
+link path=usr/lib/$(MACH64)/liblmdb.so target=./liblmdb-$(COMPONENT_VERSION).so
+file path=usr/lib/liblmdb-$(COMPONENT_VERSION).so
+link path=usr/lib/liblmdb.so target=./liblmdb-$(COMPONENT_VERSION).so
+file path=usr/share/man/man1/mdb_copy.1
+file path=usr/share/man/man1/mdb_dump.1
+file path=usr/share/man/man1/mdb_load.1
+file path=usr/share/man/man1/mdb_stat.1

--- a/components/database/lmdb/manifests/sample-manifest.p5m
+++ b/components/database/lmdb/manifests/sample-manifest.p5m
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 Rouven Weiler
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/mdb_copy
+file path=usr/bin/$(MACH64)/mdb_dump
+file path=usr/bin/$(MACH64)/mdb_load
+file path=usr/bin/$(MACH64)/mdb_stat
+file path=usr/bin/mdb_copy
+file path=usr/bin/mdb_dump
+file path=usr/bin/mdb_load
+file path=usr/bin/mdb_stat
+file path=usr/include/lmdb.h
+file path=usr/lib/$(MACH64)/liblmdb-$(COMPONENT_VERSION).so
+link path=usr/lib/$(MACH64)/liblmdb.so target=./liblmdb-$(COMPONENT_VERSION).so
+file path=usr/lib/liblmdb-$(COMPONENT_VERSION).so
+link path=usr/lib/liblmdb.so target=./liblmdb-$(COMPONENT_VERSION).so
+file path=usr/share/man/man1/mdb_copy.1
+file path=usr/share/man/man1/mdb_dump.1
+file path=usr/share/man/man1/mdb_load.1
+file path=usr/share/man/man1/mdb_stat.1

--- a/components/database/lmdb/patches/01-Makefile.patch
+++ b/components/database/lmdb/patches/01-Makefile.patch
@@ -1,0 +1,90 @@
+--- lmdb-LMDB_0.9.23/libraries/liblmdb/Makefile	2019-01-24 06:48:44.393091156 +0000
++++ lmdb-LMDB_0.9.23/libraries/liblmdb/Makefile	2019-01-24 08:25:21.037887427 +0000
+@@ -18,7 +18,6 @@
+ # There may be other macros in mdb.c of interest. You should
+ # read mdb.c before changing any of them.
+ #
+-CC	= gcc
+ AR	= ar
+ W	= -W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized
+ THREADS = -pthread
+@@ -27,18 +26,11 @@
+ LDLIBS	=
+ SOLIBS	=
+ SOEXT	= .so
+-prefix	= /usr/local
+-exec_prefix = $(prefix)
+-bindir = $(exec_prefix)/bin
+-libdir = $(exec_prefix)/lib
+-includedir = $(prefix)/include
+-datarootdir = $(prefix)/share
+-mandir = $(datarootdir)/man
+ 
+ ########################################################################
+ 
+ IHDRS	= lmdb.h
+-ILIBS	= liblmdb.a liblmdb$(SOEXT)
++ILIBS	= liblmdb-$(SOVERSION)$(SOEXT)
+ IPROGS	= mdb_stat mdb_copy mdb_dump mdb_load
+ IDOCS	= mdb_stat.1 mdb_copy.1 mdb_dump.1 mdb_load.1
+ PROGS	= $(IPROGS) mtest mtest2 mtest3 mtest4 mtest5
+@@ -51,33 +43,34 @@
+ 	mkdir -p $(DESTDIR)$(mandir)/man1
+ 	for f in $(IPROGS); do cp $$f $(DESTDIR)$(bindir); done
+ 	for f in $(ILIBS); do cp $$f $(DESTDIR)$(libdir); done
++	ln -sf ./liblmdb-$(SOVERSION)$(SOEXT) $(DESTDIR)$(libdir)/liblmdb$(SOEXT)
+ 	for f in $(IHDRS); do cp $$f $(DESTDIR)$(includedir); done
+ 	for f in $(IDOCS); do cp $$f $(DESTDIR)$(mandir)/man1; done
+ 
+ clean:
+ 	rm -rf $(PROGS) *.[ao] *.[ls]o *~ testdb
+ 
+-test:	all
++test: all
+ 	rm -rf testdb && mkdir testdb
+-	./mtest && ./mdb_stat testdb
++	LD_LIBRARY_PATH=. ./mtest && LD_LIBRARY_PATH=. ./mdb_stat testdb
+ 
+ liblmdb.a:	mdb.o midl.o
+ 	$(AR) rs $@ mdb.o midl.o
+ 
+-liblmdb$(SOEXT):	mdb.lo midl.lo
++liblmdb-$(SOVERSION)$(SOEXT):	mdb.lo midl.lo
+ #	$(CC) $(LDFLAGS) -pthread -shared -Wl,-Bsymbolic -o $@ mdb.o midl.o $(SOLIBS)
+-	$(CC) $(LDFLAGS) -pthread -shared -o $@ mdb.lo midl.lo $(SOLIBS)
++	$(CC) $(LDFLAGS) -pthread -shared -o $@ mdb.lo midl.lo $(SOLIBS) -Wl,-soname -Wl,liblmdb-$(SOVERSION)$(SOEXT)
+ 
+-mdb_stat: mdb_stat.o liblmdb.a
+-mdb_copy: mdb_copy.o liblmdb.a
+-mdb_dump: mdb_dump.o liblmdb.a
+-mdb_load: mdb_load.o liblmdb.a
+-mtest:    mtest.o    liblmdb.a
+-mtest2:	mtest2.o liblmdb.a
+-mtest3:	mtest3.o liblmdb.a
+-mtest4:	mtest4.o liblmdb.a
+-mtest5:	mtest5.o liblmdb.a
+-mtest6:	mtest6.o liblmdb.a
++mdb_stat: mdb_stat.o 
++mdb_copy: mdb_copy.o 
++mdb_dump: mdb_dump.o 
++mdb_load: mdb_load.o 
++mtest:    mtest.o 
++mtest2:	mtest2.o 
++mtest3:	mtest3.o 
++mtest4:	mtest4.o 
++mtest5:	mtest5.o 
++mtest6:	mtest6.o 
+ 
+ mdb.o: mdb.c lmdb.h midl.h
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) -c mdb.c
+@@ -91,8 +84,8 @@
+ midl.lo: midl.c midl.h
+ 	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c midl.c -o $@
+ 
+-%:	%.o
+-	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@
++%:	%.o | liblmdb-$(SOVERSION)$(SOEXT)
++	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -L. -llmdb-$(SOVERSION) -o $@
+ 
+ %.o:	%.c lmdb.h
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $<


### PR DESCRIPTION
needed to build future builds with samba.
as of now, lmdb support has to be explicitly disabled for building samba.
having this will hopefully avoid that.

Please look a little bit deeper in this as it is my first completely written pkg.
The build routine for lmdb is also quite "special".

Thanks in advance. 