### PR TITLE
Update GTK+3 to 3.24.5

### DIFF
--- a/components/library/gtk+3/Makefile
+++ b/components/library/gtk+3/Makefile
@@ -17,12 +17,12 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gtk+
-COMPONENT_VERSION=	3.24.4
+COMPONENT_VERSION=	3.24.5
 COMPONENT_SUMMARY=	GTK+ - GIMP Toolkit Library for creation of graphical user interfaces
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:d84f59ff02a87cc90c9df4a572a13eca4e3506e2bf511e2b9cbdb4526fa0cb9c
+	sha256:0be5fb0d302bc3de26ab58c32990d895831e2b7c7418d0ffea1206d6a3ddb02f
 COMPONENT_ARCHIVE_URL= \
 	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/3.24/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://www.gtk.org/

--- a/components/library/gtk+3/gtk3.p5m
+++ b/components/library/gtk+3/gtk3.p5m
@@ -467,12 +467,12 @@ file path=usr/lib/$(MACH64)/gtk-3.0/3.0.0/printbackends/libprintbackend-file.so
 link path=usr/lib/$(MACH64)/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/$(MACH64)/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/$(MACH64)/libgailutil-3.so.0.0.0
-link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.0
-link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.0
-file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.0
-link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.0
-link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.0
-file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.0
+link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.1
+link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.1
+file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.1
+link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.1
+link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.1
+file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.1
 file path=usr/lib/$(MACH64)/pkgconfig/gail-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-x11-3.0.pc
@@ -500,12 +500,12 @@ file path=usr/lib/gtk-3.0/3.0.0/printbackends/libprintbackend-file.so
 link path=usr/lib/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/libgailutil-3.so.0.0.0
-link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.0
-link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.0
-file path=usr/lib/libgdk-3.so.0.2404.0
-link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.0
-link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.0
-file path=usr/lib/libgtk-3.so.0.2404.0
+link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.1
+link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.1
+file path=usr/lib/libgdk-3.so.0.2404.1
+link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.1
+link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.1
+file path=usr/lib/libgtk-3.so.0.2404.1
 file path=usr/lib/pkgconfig/gail-3.0.pc
 file path=usr/lib/pkgconfig/gdk-3.0.pc
 file path=usr/lib/pkgconfig/gdk-x11-3.0.pc

--- a/components/library/gtk+3/manifests/sample-manifest.p5m
+++ b/components/library/gtk+3/manifests/sample-manifest.p5m
@@ -456,12 +456,12 @@ file path=usr/lib/$(MACH64)/gtk-3.0/3.0.0/printbackends/libprintbackend-lpr.so
 link path=usr/lib/$(MACH64)/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/$(MACH64)/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/$(MACH64)/libgailutil-3.so.0.0.0
-link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.0
-link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.0
-file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.0
-link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.0
-link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.0
-file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.0
+link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.1
+link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.1
+file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.1
+link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.1
+link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.1
+file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.1
 file path=usr/lib/$(MACH64)/pkgconfig/gail-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-x11-3.0.pc
@@ -489,12 +489,12 @@ file path=usr/lib/gtk-3.0/3.0.0/printbackends/libprintbackend-lpr.so
 link path=usr/lib/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/libgailutil-3.so.0.0.0
-link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.0
-link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.0
-file path=usr/lib/libgdk-3.so.0.2404.0
-link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.0
-link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.0
-file path=usr/lib/libgtk-3.so.0.2404.0
+link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.1
+link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.1
+file path=usr/lib/libgdk-3.so.0.2404.1
+link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.1
+link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.1
+file path=usr/lib/libgtk-3.so.0.2404.1
 file path=usr/lib/pkgconfig/gail-3.0.pc
 file path=usr/lib/pkgconfig/gdk-3.0.pc
 file path=usr/lib/pkgconfig/gdk-x11-3.0.pc


### PR DESCRIPTION
Overview of Changes in GTK+ 3.24.5

* Adwaita: Refresh the theme
* HighContrast: Refresh the theme
* GtkSwitch: Use icons instead of glyphs