### PR TITLE
Update terminus font to 4.47

### DIFF
--- a/components/fonts/terminus/Makefile
+++ b/components/fonts/terminus/Makefile
@@ -11,26 +11,26 @@
 
 #
 # Copyright 2016 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		terminus-font
-COMPONENT_VERSION=	4.46
+COMPONENT_VERSION=	4.47
 COMPONENT_PROJECT_URL=	https://terminus-font.sourceforge.net/
 COMPONENT_SUMMARY=	Terminus Font
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-    sha256:16d58f25fde6705549a95c9b89e132ea5d94045fb89be2d177cb7a98f5b54a06
+	sha256:0f1b205888e4e26a94878f746b8566a65c3e3742b33cf9a4e6517646d5651297
 COMPONENT_ARCHIVE_URL=	http://sourceforge.net/projects/terminus-font/files/$(COMPONENT_SRC)/$(COMPONENT_ARCHIVE)/download
 COMPONENT_FMRI=		system/font/terminus
 COMPONENT_LICENSE_FILE=	terminus.license
 COMPONENT_LICENSE=	OFL
 COMPONENT_CLASSIFICATION=	System/Fonts
 
-CONFIGURE_DEFAULT_DIRS=no
+CONFIGURE_DEFAULT_DIRS=	no
 
 include $(WS_TOP)/make-rules/prep.mk
 include $(WS_TOP)/make-rules/configure.mk
@@ -44,11 +44,11 @@ COMPONENT_INSTALL_TARGETS = install-pcf
 
 COMPONENT_PRE_CONFIGURE_ACTION=$(CLONEY) $(SOURCE_DIR) $(@D)
 
-build: $(BUILD_32)
+build:		$(BUILD_32)
 
-install: $(INSTALL_32)
+install:	$(INSTALL_32)
 
-test: $(NO_TESTS)
+test:		$(NO_TESTS)
 
 # Build dependencies
 REQUIRED_PACKAGES+= x11/bdftopcf


### PR DESCRIPTION
*    Added 35 new characters (33 glyphs).
*    Replaced ao2-variant "ae" with ao1 "ae", it was too similar to "oe".
*    Some fixes and improvements (17 characters in various sizes/styles).
*    Significantly improved the font build scripts. Python 3.5.0 or node 6.9.0 are now required to build the font.