### PR TITLE
Update GNU libmicrohttpd to 0.9.63

### DIFF
--- a/components/library/libmicrohttpd/Makefile
+++ b/components/library/libmicrohttpd/Makefile
@@ -10,24 +10,24 @@
 
 #
 # Copyright 2014 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmicrohttpd
-COMPONENT_VERSION=	0.9.55
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	0.9.63
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/libmicrohttpd/
 COMPONENT_FMRI=		library/libmicrohttpd
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:0c1cab8dc9f2588bd3076a28f77a7f8de9560cbf2d80e53f9a8696ada80ed0f8
+	sha256:37c36f1be177f0e37ef181a645cd3baac1000bd322a01c2eff70f3cc8c91749c
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_SIG_URL=	http://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE).sig
 COMPONENT_LICENSE=	LGPL2.1+
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
-COMPONENT_SUMMARY=	GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application
+COMPONENT_SUMMARY=	GNU libmicrohttpd is a small HTTP server as a C library
 COMPONENT_CLASSIFICATION=System/Libraries
 
 include $(WS_MAKE_RULES)/prep.mk
@@ -49,6 +49,7 @@ CONFIGURE_ENV += LIBS="-lnsl -lsocket"
 
 CONFIGURE_OPTIONS += --enable-epoll=no
 CONFIGURE_OPTIONS += --enable-itc=socketpair
+CONFIGURE_OPTIONS += --disable-static
 
 # Needed for "gmake test" to work successfully.
 # If SHELLOPTS is exported (as it is by the userland makefiles),
@@ -63,9 +64,11 @@ build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
-# *ssl* tests fail sporadically
+# Tests work properly only for curl with GnuTLS SSL backend (we use OpenSSL only),
+# see https://gnunet.org/bugs/view.php?id=5564.
 test:		$(TEST_32_and_64)
 
+REQUIRED_PACKAGES += system/library/security/libgcrypt
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/gnutls-3
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += system/library/security/libgcrypt

--- a/components/library/libmicrohttpd/libmicrohttpd.p5m
+++ b/components/library/libmicrohttpd/libmicrohttpd.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,17 +24,16 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/microhttpd.h
-#file path=usr/lib/$(MACH64)/libmicrohttpd.a
-link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.43.0
-link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.43.0
-file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.43.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.50.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.50.0
+file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.50.0
 file path=usr/lib/$(MACH64)/pkgconfig/libmicrohttpd.pc
-#file path=usr/lib/libmicrohttpd.a
-link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.43.0
-link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.43.0
-file path=usr/lib/libmicrohttpd.so.12.43.0
+link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.50.0
+link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.50.0
+file path=usr/lib/libmicrohttpd.so.12.50.0
 file path=usr/lib/pkgconfig/libmicrohttpd.pc
 #file path=usr/share/info/dir
 file path=usr/share/info/libmicrohttpd-tutorial.info
 file path=usr/share/info/libmicrohttpd.info
+file path=usr/share/info/libmicrohttpd_performance_data.png
 file path=usr/share/man/man3/libmicrohttpd.3

--- a/components/library/libmicrohttpd/manifests/sample-manifest.p5m
+++ b/components/library/libmicrohttpd/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,17 +23,16 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/microhttpd.h
-file path=usr/lib/$(MACH64)/libmicrohttpd.a
-link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.43.0
-link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.43.0
-file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.43.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.50.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.50.0
+file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.50.0
 file path=usr/lib/$(MACH64)/pkgconfig/libmicrohttpd.pc
-file path=usr/lib/libmicrohttpd.a
-link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.43.0
-link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.43.0
-file path=usr/lib/libmicrohttpd.so.12.43.0
+link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.50.0
+link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.50.0
+file path=usr/lib/libmicrohttpd.so.12.50.0
 file path=usr/lib/pkgconfig/libmicrohttpd.pc
 file path=usr/share/info/dir
 file path=usr/share/info/libmicrohttpd-tutorial.info
 file path=usr/share/info/libmicrohttpd.info
+file path=usr/share/info/libmicrohttpd_performance_data.png
 file path=usr/share/man/man3/libmicrohttpd.3


### PR DESCRIPTION
There are test failures in testcurl/https test suite (see https://gnunet.org/bugs/view.php?id=5564), because our curl does not have GnuTLS SSL backend. Adding it results in broken pyculr, though:

```python
$ pkg list curl
Traceback (most recent call last):
  File "/usr/bin/pkg", line 67, in <module>
    import pycurl
ImportError: pycurl: libcurl link-time ssl backend (gnutls) is different from compile-time ssl backend (openssl)
```