### PR TITLE
Update irssi to 1.2.0, CVE-2019-5882 fix

### DIFF
--- a/components/network/irssi/Makefile
+++ b/components/network/irssi/Makefile
@@ -12,19 +12,20 @@
 # Copyright 2011 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
 # Copyright 2016 Adam Stevko
 # Copyright 2017 Gary Mills
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		irssi
-COMPONENT_VERSION=	1.1.1
+COMPONENT_VERSION=	1.2.0
 COMPONENT_SUMMARY=	irssi - a terminal based IRC client
 COMPONENT_CLASSIFICATION= Applications/Internet
 COMPONENT_FMRI=		network/chat/irssi
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:784807e7a1ba25212347f03e4287cff9d0659f076edfb2c6b20928021d75a1bf
+  sha256:1643fca1d8b35e5a5d7b715c9c889e1e9cdb7e578e06487901ea959e6ab3ebe5
 COMPONENT_ARCHIVE_URL= \
   https://github.com/irssi/irssi/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	http://irssi.org/
@@ -56,9 +57,10 @@ install:	$(INSTALL_32)
 
 test:		$(TEST_32)
 
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/ncurses
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/network/irssi/irssi.p5m
+++ b/components/network/irssi/irssi.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright 2011 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
 # Copyright 2016 Adam Stevko
+# Copyright 2019 Michal Nowak
 #
 
 <transform file path=usr/share/man/.+ -> default mangler.man.stability uncommitted>
@@ -115,8 +116,16 @@ file path=usr/include/irssi/src/fe-common/irc/module-formats.h
 file path=usr/include/irssi/src/fe-common/irc/module.h
 file path=usr/include/irssi/src/fe-common/irc/notifylist/module-formats.h
 file path=usr/include/irssi/src/fe-common/irc/notifylist/module.h
+file path=usr/include/irssi/src/fe-text/gui-printtext.h
+file path=usr/include/irssi/src/fe-text/gui-windows.h
+file path=usr/include/irssi/src/fe-text/mainwindows.h
 file path=usr/include/irssi/src/fe-text/statusbar-item.h
+file path=usr/include/irssi/src/fe-text/statusbar.h
+file path=usr/include/irssi/src/fe-text/term.h
+file path=usr/include/irssi/src/fe-text/textbuffer-view.h
+file path=usr/include/irssi/src/fe-text/textbuffer.h
 file path=usr/include/irssi/src/irc/core/bans.h
+file path=usr/include/irssi/src/irc/core/channel-events.h
 file path=usr/include/irssi/src/irc/core/channel-rejoin.h
 file path=usr/include/irssi/src/irc/core/ctcp.h
 file path=usr/include/irssi/src/irc/core/irc-cap.h
@@ -166,6 +175,7 @@ file path=usr/share/doc/irssi/AUTHORS
 file path=usr/share/doc/irssi/COPYING
 file path=usr/share/doc/irssi/ChangeLog
 file path=usr/share/doc/irssi/capsicum.txt
+file path=usr/share/doc/irssi/design.html
 file path=usr/share/doc/irssi/design.txt
 file path=usr/share/doc/irssi/faq.html
 file path=usr/share/doc/irssi/faq.txt
@@ -240,6 +250,7 @@ file path=usr/share/irssi/help/notice
 file path=usr/share/irssi/help/notify
 file path=usr/share/irssi/help/op
 file path=usr/share/irssi/help/oper
+file path=usr/share/irssi/help/otr
 file path=usr/share/irssi/help/part
 file path=usr/share/irssi/help/ping
 file path=usr/share/irssi/help/query

--- a/components/network/irssi/manifests/sample-manifest.p5m
+++ b/components/network/irssi/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -110,8 +110,16 @@ file path=usr/include/irssi/src/fe-common/irc/module-formats.h
 file path=usr/include/irssi/src/fe-common/irc/module.h
 file path=usr/include/irssi/src/fe-common/irc/notifylist/module-formats.h
 file path=usr/include/irssi/src/fe-common/irc/notifylist/module.h
+file path=usr/include/irssi/src/fe-text/gui-printtext.h
+file path=usr/include/irssi/src/fe-text/gui-windows.h
+file path=usr/include/irssi/src/fe-text/mainwindows.h
 file path=usr/include/irssi/src/fe-text/statusbar-item.h
+file path=usr/include/irssi/src/fe-text/statusbar.h
+file path=usr/include/irssi/src/fe-text/term.h
+file path=usr/include/irssi/src/fe-text/textbuffer-view.h
+file path=usr/include/irssi/src/fe-text/textbuffer.h
 file path=usr/include/irssi/src/irc/core/bans.h
+file path=usr/include/irssi/src/irc/core/channel-events.h
 file path=usr/include/irssi/src/irc/core/channel-rejoin.h
 file path=usr/include/irssi/src/irc/core/ctcp.h
 file path=usr/include/irssi/src/irc/core/irc-cap.h
@@ -161,6 +169,7 @@ file path=usr/share/doc/irssi/AUTHORS
 file path=usr/share/doc/irssi/COPYING
 file path=usr/share/doc/irssi/ChangeLog
 file path=usr/share/doc/irssi/capsicum.txt
+file path=usr/share/doc/irssi/design.html
 file path=usr/share/doc/irssi/design.txt
 file path=usr/share/doc/irssi/faq.html
 file path=usr/share/doc/irssi/faq.txt
@@ -235,6 +244,7 @@ file path=usr/share/irssi/help/notice
 file path=usr/share/irssi/help/notify
 file path=usr/share/irssi/help/op
 file path=usr/share/irssi/help/oper
+file path=usr/share/irssi/help/otr
 file path=usr/share/irssi/help/part
 file path=usr/share/irssi/help/ping
 file path=usr/share/irssi/help/query


### PR DESCRIPTION
Test suite passed. Manually tested network connection and channel join.