### PR TITLE
Add rename utility

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	31
+COMPONENT_REVISION=	32
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/server_desktop
+++ b/components/meta-packages/install-types/includes/server_desktop
@@ -16,6 +16,7 @@ depend type=require fmri=editor/vim
 depend type=require fmri=file/gnu-coreutils
 depend type=require fmri=file/gnu-findutils
 depend type=require fmri=file/slocate
+depend type=require fmri=file/rename
 depend type=require fmri=library/perl-5/authen-pam
 depend type=require fmri=library/perl-5/xml-parser
 depend type=require fmri=locale/af

--- a/components/sysutils/rename/Makefile
+++ b/components/sysutils/rename/Makefile
@@ -1,0 +1,51 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Michal Nowak
+#
+
+PREFERRED_BITS=		64
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		rename
+COMPONENT_MAJOR_VERSION=2.33
+COMPONENT_MINOR_VERSION=1
+COMPONENT_VERSION=	$(COMPONENT_MAJOR_VERSION).$(COMPONENT_MINOR_VERSION)
+COMPONENT_SUMMARY=	Various Linux utilities
+COMPONENT_PROJECT_URL=	https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
+COMPONENT_FMRI=		file/rename
+COMPONENT_CLASSIFICATION=Applications/System Utilities
+COMPONENT_SRC=		util-linux-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_URL=	https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:c14bd9f3b6e1792b90db87696e87ec643f9d63efa0a424f092a5a6b2f2dbef21
+COMPONENT_LICENSE_FILE=	README.licensing
+COMPONENT_LICENSE=	GPL-2.0-or-later, GPL-2.0, LGPL-2.1-or-later, BSD-3-Clause, BSD-4-Clause-UC, Public Domain
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+PATH = $(PATH.gnu)
+
+# Handpick stuff we want as most stuff won't build
+CONFIGURE_OPTIONS +=	--disable-all-programs
+CONFIGURE_OPTIONS +=	--enable-rename 
+
+build:		$(BUILD_64)
+
+install:	$(INSTALL_64)
+
+test:		$(NO_TESTS)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/sysutils/rename/manifests/sample-manifest.p5m
+++ b/components/sysutils/rename/manifests/sample-manifest.p5m
@@ -1,0 +1,54 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/rename
+file path=usr/share/bash-completion/completions/rename
+file path=usr/share/locale/ca/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/cs/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/da/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/de/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/es/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/et/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/eu/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/fi/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/fr/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/gl/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/hr/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/hu/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/id/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/it/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/ja/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/nl/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/pl/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/ru/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/sl/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/sv/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/tr/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/uk/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/vi/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/util-linux.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/util-linux.mo
+file path=usr/share/man/man1/rename.1
+file path=usr/share/man/man5/terminal-colors.d.5

--- a/components/sysutils/rename/util-linux.p5m
+++ b/components/sysutils/rename/util-linux.p5m
@@ -1,0 +1,54 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Michal Nowak
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/rename
+file path=usr/share/bash-completion/completions/rename
+#file path=usr/share/locale/ca/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/cs/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/da/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/de/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/es/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/et/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/eu/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/fi/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/fr/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/gl/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/hr/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/hu/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/id/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/it/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/ja/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/nl/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/pl/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/pt_BR/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/ru/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/sl/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/sv/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/tr/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/uk/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/vi/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/zh_CN/LC_MESSAGES/util-linux.mo
+#file path=usr/share/locale/zh_TW/LC_MESSAGES/util-linux.mo
+file path=usr/share/man/man1/rename.1
+#file path=usr/share/man/man5/terminal-colors.d.5


### PR DESCRIPTION
This brings the `rename` utility I missed from Linux. I am happy to add others, but most obviously won't build as are Linux-specific.

Not packaging locales as they are 6 MB, which I find too much for a 20 KB utility.