### PR TITLE
Update libedit to 3.1.20181209

### DIFF
--- a/components/library/libedit/Makefile
+++ b/components/library/libedit/Makefile
@@ -18,38 +18,40 @@
 #
 # CDDL HEADER END
 #
-# Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+
 #
+# Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
+#
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libedit
-COMPONENT_VERSION=	20170329-3.1
-IPS_COMPONENT_VERSION=  3.1
+COMPONENT_VERSION_DATE=	20181209
+COMPONENT_VERSION=	3.1.$(COMPONENT_VERSION_DATE)
 COMPONENT_SUMMARY=	Libedit - Command line editor library
 COMPONENT_PROJECT_URL=	http://www.thrysoee.dk/editline/
-COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION_DATE)-3.1
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:91f2d90fbd2a048ff6dad7131d9a39e690fd8a8fd982a353f1333dd4017dd4be
+	sha256:2811d70c0b000f2ca91b7cb1a37203134441743c4fcc9c37b0b687f328611064
 COMPONENT_ARCHIVE_URL=	http://www.thrysoee.dk/editline/$(COMPONENT_ARCHIVE)
 COMPONENT_CLASSIFICATION=	System/Libraries
-COMPONENT_FMRI=	library/libedit
+COMPONENT_FMRI=		library/libedit
 COMPONENT_LICENSE_FILE=	COPYING
 COMPONENT_LICENSE=	BSD
-
-# Uses GNU awk
-PATH=$(PATH.gnu)
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
+# Uses GNU awk
+PATH=$(PATH.gnu)
+
 COMPONENT_PREP_ACTION = (cd $(@D) && autoreconf -f)
 
-CONFIGURE_OPTIONS +=   --enable-shared
+CONFIGURE_OPTIONS +=   --disable-silent-rules
 CONFIGURE_OPTIONS +=   --disable-static
-CONFIGURE_OPTIONS +=   --enable-widec
-
 
 # common targets
 build:		$(BUILD_32_and_64)
@@ -57,7 +59,6 @@ build:		$(BUILD_32_and_64)
 install:	$(INSTALL_32_and_64)
 
 test:		$(NO_TESTS)
-
 
 # Build dependencies
 REQUIRED_PACKAGES += text/gawk

--- a/components/library/libedit/libedit.p5m
+++ b/components/library/libedit/libedit.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2018 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -19,19 +20,18 @@ set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-set name=pkg.human-version value=$(COMPONENT_VERSION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/editline/readline.h
 file path=usr/include/histedit.h
-link path=usr/lib/$(MACH64)/libedit.so target=libedit.so.0.0.56
-link path=usr/lib/$(MACH64)/libedit.so.0 target=libedit.so.0.0.56
-file path=usr/lib/$(MACH64)/libedit.so.0.0.56
+link path=usr/lib/$(MACH64)/libedit.so target=libedit.so.0.0.59
+link path=usr/lib/$(MACH64)/libedit.so.0 target=libedit.so.0.0.59
+file path=usr/lib/$(MACH64)/libedit.so.0.0.59
 file path=usr/lib/$(MACH64)/pkgconfig/libedit.pc
-link path=usr/lib/libedit.so target=libedit.so.0.0.56
-link path=usr/lib/libedit.so.0 target=libedit.so.0.0.56
-file path=usr/lib/libedit.so.0.0.56
+link path=usr/lib/libedit.so target=libedit.so.0.0.59
+link path=usr/lib/libedit.so.0 target=libedit.so.0.0.59
+file path=usr/lib/libedit.so.0.0.59
 file path=usr/lib/pkgconfig/libedit.pc
 file path=usr/share/man/man3/editline.3
 link path=usr/share/man/man3/el_deletestr.3 target=editline.3
@@ -39,6 +39,12 @@ link path=usr/share/man/man3/el_end.3 target=editline.3
 link path=usr/share/man/man3/el_get.3 target=editline.3
 link path=usr/share/man/man3/el_getc.3 target=editline.3
 link path=usr/share/man/man3/el_gets.3 target=editline.3
+link path=usr/share/man/man3/el_history.3 target=editline.3
+link path=usr/share/man/man3/el_history_end.3 target=editline.3
+link path=usr/share/man/man3/el_history_init.3 target=editline.3
+link path=usr/share/man/man3/el_history_w.3 target=editline.3
+link path=usr/share/man/man3/el_history_wend.3 target=editline.3
+link path=usr/share/man/man3/el_history_winit.3 target=editline.3
 link path=usr/share/man/man3/el_init.3 target=editline.3
 link path=usr/share/man/man3/el_init_fd.3 target=editline.3
 link path=usr/share/man/man3/el_insertstr.3 target=editline.3
@@ -49,6 +55,16 @@ link path=usr/share/man/man3/el_reset.3 target=editline.3
 link path=usr/share/man/man3/el_resize.3 target=editline.3
 link path=usr/share/man/man3/el_set.3 target=editline.3
 link path=usr/share/man/man3/el_source.3 target=editline.3
+link path=usr/share/man/man3/el_tok_end.3 target=editline.3
+link path=usr/share/man/man3/el_tok_init.3 target=editline.3
+link path=usr/share/man/man3/el_tok_line.3 target=editline.3
+link path=usr/share/man/man3/el_tok_reset.3 target=editline.3
+link path=usr/share/man/man3/el_tok_str.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wend.3 target=editline.3
+link path=usr/share/man/man3/el_tok_winit.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wline.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wreset.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wstr.3 target=editline.3
 link path=usr/share/man/man3/el_wdeletestr.3 target=editline.3
 link path=usr/share/man/man3/el_wget.3 target=editline.3
 link path=usr/share/man/man3/el_wgetc.3 target=editline.3
@@ -58,22 +74,5 @@ link path=usr/share/man/man3/el_wline.3 target=editline.3
 link path=usr/share/man/man3/el_wparse.3 target=editline.3
 link path=usr/share/man/man3/el_wpush.3 target=editline.3
 link path=usr/share/man/man3/el_wset.3 target=editline.3
-# Conflict with readline
-#link path=usr/share/man/man3/history.3 target=editline.3
-link path=usr/share/man/man3/history_end.3 target=editline.3
-link path=usr/share/man/man3/history_init.3 target=editline.3
-link path=usr/share/man/man3/history_w.3 target=editline.3
-link path=usr/share/man/man3/history_wend.3 target=editline.3
-link path=usr/share/man/man3/history_winit.3 target=editline.3
-link path=usr/share/man/man3/tok_end.3 target=editline.3
-link path=usr/share/man/man3/tok_init.3 target=editline.3
-link path=usr/share/man/man3/tok_line.3 target=editline.3
-link path=usr/share/man/man3/tok_reset.3 target=editline.3
-link path=usr/share/man/man3/tok_str.3 target=editline.3
-link path=usr/share/man/man3/tok_wend.3 target=editline.3
-link path=usr/share/man/man3/tok_winit.3 target=editline.3
-link path=usr/share/man/man3/tok_wline.3 target=editline.3
-link path=usr/share/man/man3/tok_wreset.3 target=editline.3
-link path=usr/share/man/man3/tok_wstr.3 target=editline.3
 file path=usr/share/man/man5/editrc.5
 file path=usr/share/man/man7/editline.7

--- a/components/library/libedit/manifests/sample-manifest.p5m
+++ b/components/library/libedit/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,13 +24,13 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/editline/readline.h
 file path=usr/include/histedit.h
-link path=usr/lib/$(MACH64)/libedit.so target=libedit.so.0.0.56
-link path=usr/lib/$(MACH64)/libedit.so.0 target=libedit.so.0.0.56
-file path=usr/lib/$(MACH64)/libedit.so.0.0.56
+link path=usr/lib/$(MACH64)/libedit.so target=libedit.so.0.0.59
+link path=usr/lib/$(MACH64)/libedit.so.0 target=libedit.so.0.0.59
+file path=usr/lib/$(MACH64)/libedit.so.0.0.59
 file path=usr/lib/$(MACH64)/pkgconfig/libedit.pc
-link path=usr/lib/libedit.so target=libedit.so.0.0.56
-link path=usr/lib/libedit.so.0 target=libedit.so.0.0.56
-file path=usr/lib/libedit.so.0.0.56
+link path=usr/lib/libedit.so target=libedit.so.0.0.59
+link path=usr/lib/libedit.so.0 target=libedit.so.0.0.59
+file path=usr/lib/libedit.so.0.0.59
 file path=usr/lib/pkgconfig/libedit.pc
 file path=usr/share/man/man3/editline.3
 link path=usr/share/man/man3/el_deletestr.3 target=editline.3
@@ -38,6 +38,12 @@ link path=usr/share/man/man3/el_end.3 target=editline.3
 link path=usr/share/man/man3/el_get.3 target=editline.3
 link path=usr/share/man/man3/el_getc.3 target=editline.3
 link path=usr/share/man/man3/el_gets.3 target=editline.3
+link path=usr/share/man/man3/el_history.3 target=editline.3
+link path=usr/share/man/man3/el_history_end.3 target=editline.3
+link path=usr/share/man/man3/el_history_init.3 target=editline.3
+link path=usr/share/man/man3/el_history_w.3 target=editline.3
+link path=usr/share/man/man3/el_history_wend.3 target=editline.3
+link path=usr/share/man/man3/el_history_winit.3 target=editline.3
 link path=usr/share/man/man3/el_init.3 target=editline.3
 link path=usr/share/man/man3/el_init_fd.3 target=editline.3
 link path=usr/share/man/man3/el_insertstr.3 target=editline.3
@@ -48,6 +54,16 @@ link path=usr/share/man/man3/el_reset.3 target=editline.3
 link path=usr/share/man/man3/el_resize.3 target=editline.3
 link path=usr/share/man/man3/el_set.3 target=editline.3
 link path=usr/share/man/man3/el_source.3 target=editline.3
+link path=usr/share/man/man3/el_tok_end.3 target=editline.3
+link path=usr/share/man/man3/el_tok_init.3 target=editline.3
+link path=usr/share/man/man3/el_tok_line.3 target=editline.3
+link path=usr/share/man/man3/el_tok_reset.3 target=editline.3
+link path=usr/share/man/man3/el_tok_str.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wend.3 target=editline.3
+link path=usr/share/man/man3/el_tok_winit.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wline.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wreset.3 target=editline.3
+link path=usr/share/man/man3/el_tok_wstr.3 target=editline.3
 link path=usr/share/man/man3/el_wdeletestr.3 target=editline.3
 link path=usr/share/man/man3/el_wget.3 target=editline.3
 link path=usr/share/man/man3/el_wgetc.3 target=editline.3
@@ -57,21 +73,5 @@ link path=usr/share/man/man3/el_wline.3 target=editline.3
 link path=usr/share/man/man3/el_wparse.3 target=editline.3
 link path=usr/share/man/man3/el_wpush.3 target=editline.3
 link path=usr/share/man/man3/el_wset.3 target=editline.3
-link path=usr/share/man/man3/history.3 target=editline.3
-link path=usr/share/man/man3/history_end.3 target=editline.3
-link path=usr/share/man/man3/history_init.3 target=editline.3
-link path=usr/share/man/man3/history_w.3 target=editline.3
-link path=usr/share/man/man3/history_wend.3 target=editline.3
-link path=usr/share/man/man3/history_winit.3 target=editline.3
-link path=usr/share/man/man3/tok_end.3 target=editline.3
-link path=usr/share/man/man3/tok_init.3 target=editline.3
-link path=usr/share/man/man3/tok_line.3 target=editline.3
-link path=usr/share/man/man3/tok_reset.3 target=editline.3
-link path=usr/share/man/man3/tok_str.3 target=editline.3
-link path=usr/share/man/man3/tok_wend.3 target=editline.3
-link path=usr/share/man/man3/tok_winit.3 target=editline.3
-link path=usr/share/man/man3/tok_wline.3 target=editline.3
-link path=usr/share/man/man3/tok_wreset.3 target=editline.3
-link path=usr/share/man/man3/tok_wstr.3 target=editline.3
 file path=usr/share/man/man5/editrc.5
 file path=usr/share/man/man7/editline.7

--- a/components/library/libedit/patches/03-manpage-conflicts.patch
+++ b/components/library/libedit/patches/03-manpage-conflicts.patch
@@ -1,0 +1,60 @@
+From: 1Antoine1 <antoine.belvire@opensuse.org>
+Date: 2018-08-06 11:47:22 +0200
+Subject: doc: File conlicts with readline-doc
+References: (none)
+Upstream: not submitted yet
+
+Make sure all manpages are prefixed with "el_" in order to avoid
+file conflicts with readline-doc.
+
+---
+diff -up libedit-20180525-3.1/doc/Makefile.am.orig libedit-20180525-3.1/doc/Makefile.am
+--- libedit-20180525-3.1/doc/Makefile.am.orig	2018-08-06 11:37:52.160085685 +0200
++++ libedit-20180525-3.1/doc/Makefile.am	2018-08-06 11:39:04.352082128 +0200
+@@ -20,14 +20,14 @@ EL_MAN_LINKS = \
+ 		el_resize.3 \
+ 		el_set.3 \
+ 		el_source.3 \
+-		history.3 \
+-		history_end.3 \
+-		history_init.3 \
+-		tok_end.3 \
+-		tok_init.3 \
+-		tok_line.3 \
+-		tok_reset.3 \
+-		tok_str.3
++		el_history.3 \
++		el_history_end.3 \
++		el_history_init.3 \
++		el_tok_end.3 \
++		el_tok_init.3 \
++		el_tok_line.3 \
++		el_tok_reset.3 \
++		el_tok_str.3
+ 
+ EL_MAN_LINKS += \
+ 		el_wdeletestr.3 \
+@@ -39,14 +39,14 @@ EL_MAN_LINKS += \
+ 		el_wparse.3 \
+ 		el_wpush.3 \
+ 		el_wset.3 \
+-		history_w.3 \
+-		history_wend.3 \
+-		history_winit.3 \
+-		tok_wend.3 \
+-		tok_winit.3 \
+-		tok_wline.3 \
+-		tok_wreset.3 \
+-		tok_wstr.3
++		el_history_w.3 \
++		el_history_wend.3 \
++		el_history_winit.3 \
++		el_tok_wend.3 \
++		el_tok_winit.3 \
++		el_tok_wline.3 \
++		el_tok_wreset.3 \
++		el_tok_wstr.3
+ 
+ 
+ install-data-hook: $(EL_MAN_LINKS)
+


### PR DESCRIPTION
Wide character are now enabled by default, specific configure option removed.

Changed version to include CVS date part.

Added openSUSE patch to deal with man page conflict with `library/readline` component.

Tested: `ntpq`, `sqlite3`, `nsupdate`, and `nslookup`.