### PR TITLE
gcc49: Remove elfedit-ing of libgfortran.so.3.0.0

### DIFF
--- a/components/developer/gcc49/Makefile
+++ b/components/developer/gcc49/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gcc
 COMPONENT_VERSION= 4.9.4
-COMPONENT_REVISION=5
+COMPONENT_REVISION=6
 MPFR_NAME= mpfr
 MPFR_VERSION=3.1.3
 MPC_NAME=mpc
@@ -117,12 +117,8 @@ CONFIGURE_OPTIONS+= $(CONFIGURE_OPTIONS.$(MACH))
 
 CONFIGURE_OPTIONS+= LDFLAGS="-R$(CONFIGURE_PREFIX)/lib"
 
-COMPONENT_POST_INSTALL_ACTION = \
-  for file in $(PROTO_DIR)$(CONFIGURE_PREFIX)/lib/libgfortran.so.3.0.0 $(PROTO_DIR)$(CONFIGURE_PREFIX)/lib/$(MACH64)/libgfortran.so.3.0.0; do \
-    elfedit -e 'dyn:delete RUNPATH' $$file ; \
-    elfedit -e 'dyn:delete RPATH' $$file ; \
-  done ; \
-  $(RM) -r $(PROTO_DIR)$(CONFIGURE_PREFIX)/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include-fixed
+COMPONENT_POST_INSTALL_ACTION += \
+  $(RM) -r $(PROTO_DIR)$(CONFIGURE_PREFIX)/lib/gcc/$(GNU_ARCH)/$(COMPONENT_VERSION)/include-fixed ;
 
 build: $(BUILD_32)
 


### PR DESCRIPTION
`COMPONENT_POST_INSTALL_ACTION` actually silently fails when `elfedit`-ing of `libgfortran.so.3.0.0` (see the end of https://hipster.openindiana.org/logs/oi-userland/latest/developer.gcc49.publish.log). It's because GNU elfedit is picked.

We can easily "fix" it by providing full path to `elfedit`, but it's not clear to me why we need it at all. What it does, when fixed, is that `libgfortran.so.3.0.0` can't find `/usr/gcc/4.9/lib/libquadmath.so.0` anymore.