### PR TITLE
Update OpenVPN to 2.4.7, 64-bit-only

### DIFF
--- a/components/network/openvpn/Makefile
+++ b/components/network/openvpn/Makefile
@@ -11,20 +11,22 @@
 #
 # Copyright 2013 Adam Stevko. All rights reserved.
 # Copyright 2016 Jim Klimov
+# Copyright 2019 Michal Nowak
 #
+
+PREFERRED_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		openvpn
-COMPONENT_VERSION=	2.4.3
-COMPONENT_REVISION=	2
+COMPONENT_VERSION=	2.4.7
 COMPONENT_SUMMARY=	OpenVPN is a full-featured open source SSL VPN solution
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH=	sha256:15e15fc97f189b52aee7c90ec8355aa77469c773125110b4c2f089abecde36fb
+COMPONENT_ARCHIVE_HASH=	sha256:a42f53570f669eaf10af68e98d65b531015ff9e12be7a62d9269ea684652f648
 COMPONENT_PROJECT_URL=	http://openvpn.net
-COMPONENT_ARCHIVE_URL=	http://swupdate.openvpn.org/community/releases/$(COMPONENT_ARCHIVE)
-COMPONENT_FMRI=	network/openvpn
+COMPONENT_ARCHIVE_URL=	http://build.openvpn.net/downloads/releases/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=		network/openvpn
 COMPONENT_CLASSIFICATION=	Applications/Internet
 COMPONENT_LICENSE=	GPLv2
 COMPONENT_LICENSE_FILE=	COPYING
@@ -41,18 +43,22 @@ CONFIGURE_OPTIONS += GREP=/usr/gnu/bin/grep
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --enable-shared
 
-build:		$(BUILD_32)
+COMPONENT_POST_INSTALL_ACTION += \
+	$(MKDIR) $(PROTO_DIR)/$(USRSHAREDOCDIR)/openvpn/sample/ ; \
+	$(CP) -a $(SOURCE_DIR)/sample/sample-{config-files,keys,scripts} $(PROTO_DIR)/$(USRSHAREDOCDIR)/openvpn/sample/ ;
 
-install:	$(INSTALL_32)
+build:		$(BUILD_64)
 
-test:		$(TEST_32)
+install:	$(INSTALL_64)
+
+test:		$(TEST_64)
 
 # Build dependencies
 REQUIRED_PACKAGES += driver/network/header-tun
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/lz4
 REQUIRED_PACKAGES += library/lzo
 REQUIRED_PACKAGES += library/security/openssl
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/network/openvpn/manifests/sample-manifest.p5m
+++ b/components/network/openvpn/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,8 +24,8 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/openvpn-msg.h
 file path=usr/include/openvpn-plugin.h
-file path=usr/lib/openvpn/plugins/openvpn-plugin-auth-pam.so
-file path=usr/lib/openvpn/plugins/openvpn-plugin-down-root.so
+file path=usr/lib/$(MACH64)/openvpn/plugins/openvpn-plugin-auth-pam.so
+file path=usr/lib/$(MACH64)/openvpn/plugins/openvpn-plugin-down-root.so
 file path=usr/sbin/openvpn
 file path=usr/share/doc/openvpn/COPYING
 file path=usr/share/doc/openvpn/COPYRIGHT.GPL
@@ -34,6 +34,44 @@ file path=usr/share/doc/openvpn/README
 file path=usr/share/doc/openvpn/README.IPv6
 file path=usr/share/doc/openvpn/README.auth-pam
 file path=usr/share/doc/openvpn/README.down-root
-file path=usr/share/doc/openvpn/README.polarssl
+file path=usr/share/doc/openvpn/README.mbedtls
 file path=usr/share/doc/openvpn/management-notes.txt
+file path=usr/share/doc/openvpn/sample/sample-config-files/README
+file path=usr/share/doc/openvpn/sample/sample-config-files/client.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/firewall.sh
+file path=usr/share/doc/openvpn/sample/sample-config-files/home.up
+file path=usr/share/doc/openvpn/sample/sample-config-files/loopback-client
+file path=usr/share/doc/openvpn/sample/sample-config-files/loopback-server
+file path=usr/share/doc/openvpn/sample/sample-config-files/office.up
+file path=usr/share/doc/openvpn/sample/sample-config-files/openvpn-shutdown.sh
+file path=usr/share/doc/openvpn/sample/sample-config-files/openvpn-startup.sh
+file path=usr/share/doc/openvpn/sample/sample-config-files/server.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/static-home.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/static-office.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/tls-home.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/tls-office.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/xinetd-client-config
+file path=usr/share/doc/openvpn/sample/sample-config-files/xinetd-server-config
+file path=usr/share/doc/openvpn/sample/sample-keys/README
+file path=usr/share/doc/openvpn/sample/sample-keys/ca.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/ca.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client-ec.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/client-ec.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client-pass.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/client.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client.p12
+file path=usr/share/doc/openvpn/sample/sample-keys/dh2048.pem
+file path=usr/share/doc/openvpn/sample/sample-keys/gen-sample-keys.sh
+file path=usr/share/doc/openvpn/sample/sample-keys/openssl.cnf
+file path=usr/share/doc/openvpn/sample/sample-keys/server-ec.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/server-ec.key
+file path=usr/share/doc/openvpn/sample/sample-keys/server.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/server.key
+file path=usr/share/doc/openvpn/sample/sample-keys/ta.key
+file path=usr/share/doc/openvpn/sample/sample-scripts/auth-pam.pl
+file path=usr/share/doc/openvpn/sample/sample-scripts/bridge-start
+file path=usr/share/doc/openvpn/sample/sample-scripts/bridge-stop
+file path=usr/share/doc/openvpn/sample/sample-scripts/ucn.pl
+file path=usr/share/doc/openvpn/sample/sample-scripts/verify-cn
 file path=usr/share/man/man8/openvpn.8

--- a/components/network/openvpn/openvpn.p5m
+++ b/components/network/openvpn/openvpn.p5m
@@ -10,6 +10,7 @@
 
 #
 # Copyright 2013 Adam Stevko. All rights reserved.
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,8 +39,8 @@ depend type=require fmri=network/openvpn/easy-rsa
 
 file path=usr/include/openvpn-msg.h
 file path=usr/include/openvpn-plugin.h
-file path=usr/lib/openvpn/plugins/openvpn-plugin-auth-pam.so
-file path=usr/lib/openvpn/plugins/openvpn-plugin-down-root.so
+file path=usr/lib/$(MACH64)/openvpn/plugins/openvpn-plugin-auth-pam.so
+file path=usr/lib/$(MACH64)/openvpn/plugins/openvpn-plugin-down-root.so
 file path=usr/sbin/openvpn
 file path=usr/share/doc/openvpn/COPYING
 file path=usr/share/doc/openvpn/COPYRIGHT.GPL
@@ -48,5 +49,43 @@ file path=usr/share/doc/openvpn/README
 file path=usr/share/doc/openvpn/README.IPv6
 file path=usr/share/doc/openvpn/README.auth-pam
 file path=usr/share/doc/openvpn/README.down-root
-file path=usr/share/doc/openvpn/README.polarssl
+file path=usr/share/doc/openvpn/README.mbedtls
 file path=usr/share/doc/openvpn/management-notes.txt
+file path=usr/share/doc/openvpn/sample/sample-config-files/README
+file path=usr/share/doc/openvpn/sample/sample-config-files/client.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/firewall.sh
+file path=usr/share/doc/openvpn/sample/sample-config-files/home.up
+file path=usr/share/doc/openvpn/sample/sample-config-files/loopback-client
+file path=usr/share/doc/openvpn/sample/sample-config-files/loopback-server
+file path=usr/share/doc/openvpn/sample/sample-config-files/office.up
+file path=usr/share/doc/openvpn/sample/sample-config-files/openvpn-shutdown.sh
+file path=usr/share/doc/openvpn/sample/sample-config-files/openvpn-startup.sh
+file path=usr/share/doc/openvpn/sample/sample-config-files/server.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/static-home.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/static-office.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/tls-home.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/tls-office.conf
+file path=usr/share/doc/openvpn/sample/sample-config-files/xinetd-client-config
+file path=usr/share/doc/openvpn/sample/sample-config-files/xinetd-server-config
+file path=usr/share/doc/openvpn/sample/sample-keys/README
+file path=usr/share/doc/openvpn/sample/sample-keys/ca.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/ca.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client-ec.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/client-ec.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client-pass.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/client.key
+file path=usr/share/doc/openvpn/sample/sample-keys/client.p12
+file path=usr/share/doc/openvpn/sample/sample-keys/dh2048.pem
+file path=usr/share/doc/openvpn/sample/sample-keys/gen-sample-keys.sh
+file path=usr/share/doc/openvpn/sample/sample-keys/openssl.cnf
+file path=usr/share/doc/openvpn/sample/sample-keys/server-ec.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/server-ec.key
+file path=usr/share/doc/openvpn/sample/sample-keys/server.crt
+file path=usr/share/doc/openvpn/sample/sample-keys/server.key
+file path=usr/share/doc/openvpn/sample/sample-keys/ta.key
+file path=usr/share/doc/openvpn/sample/sample-scripts/auth-pam.pl
+file path=usr/share/doc/openvpn/sample/sample-scripts/bridge-start
+file path=usr/share/doc/openvpn/sample/sample-scripts/bridge-stop
+file path=usr/share/doc/openvpn/sample/sample-scripts/ucn.pl
+file path=usr/share/doc/openvpn/sample/sample-scripts/verify-cn

--- a/components/network/openvpn/patches/03-openvpn-man8.patch
+++ b/components/network/openvpn/patches/03-openvpn-man8.patch
@@ -1,15 +1,15 @@
---- openvpn-2.4.2/doc/openvpn.8.~1~	2017-05-11 03:50:04.000000000 +0300
-+++ openvpn-2.4.2/doc/openvpn.8	2017-05-11 21:59:17.993189472 +0300
-@@ -34,7 +34,7 @@
- .\" .ft -- normal face
- .\" .in +|-{n} -- indent
- .\"
--.TH openvpn 8 "25 August 2016"
-+.TH openvpn 1m "25 August 2016"
+--- openvpn-2.4.6/doc/openvpn.8	2018-04-24 09:12:55.000000000 +0000
++++ openvpn-2.4.6/doc/openvpn.8	2019-02-19 18:28:35.008492638 +0000
+@@ -41,7 +41,7 @@
+ .  TP \\$1\" no doublequotes around argument!
+ ..
+ .\" End of TQ macro
+-.TH openvpn 8 "28 February 2018"
++.TH openvpn 1m "28 February 2018"
  .\"*********************************************************
  .SH NAME
  openvpn \- secure IP tunnel daemon.
-@@ -640,7 +640,7 @@
+@@ -647,7 +647,7 @@ Similarly if
  .I our
  IP address changes due to DHCP, we should configure
  our IP address change script (see man page for
@@ -18,16 +18,16 @@
  ) to deliver a
  .B SIGHUP
  or
-@@ -785,7 +785,7 @@
+@@ -793,7 +793,7 @@ higher, or OpenVPN 2.0.x which has been
  directive code.  When used on Windows, requires version 8.2 or higher
- of the TAP-Win32 driver.  When used on *nix, requires that the tun
+ of the TAP\-Win32 driver.  When used on *nix, requires that the tun
  driver supports an
 -.BR ifconfig (8)
 +.BR ifconfig (1m)
  command which sets a subnet instead of a remote endpoint IP address.
  
  This option exists in OpenVPN 2.1 or higher.
-@@ -892,7 +892,7 @@
+@@ -900,7 +900,7 @@ also that DHCP can be used for the
  same purpose).
  
  This option, while primarily a proxy for the
@@ -36,7 +36,7 @@
  command, is designed to simplify TUN/TAP
  tunnel configuration by providing a
  standard interface to the different
-@@ -950,7 +950,7 @@
+@@ -958,7 +958,7 @@ TUN/TAP device close.
  
  This option is intended as
  a convenience proxy for the
@@ -45,7 +45,7 @@
  shell command,
  while at the same time providing portable semantics
  across OpenVPN's platform space.
-@@ -2234,7 +2234,7 @@
+@@ -2242,7 +2242,7 @@ Set the TOS field of the tunnel packet t
  .TP
  .B \-\-inetd [wait|nowait] [progname]
  Use this option when OpenVPN is being run from the inetd or
@@ -54,7 +54,7 @@
  server.
  
  The
-@@ -5572,9 +5572,9 @@
+@@ -5676,9 +5676,9 @@ need for separate
  and
  .B \-\-down
  scripts to run the appropriate
@@ -66,16 +66,16 @@
  commands.  These commands can be placed in the the same shell script
  which starts or terminates an OpenVPN session.
  
-@@ -5934,7 +5934,7 @@
- Show available TAP-Win32 adapters which can be selected using the
+@@ -6034,7 +6034,7 @@ to write these messages to a file.
+ Show available TAP\-Win32 adapters which can be selected using the
  .B \-\-dev\-node
- option.  On non-Windows systems, the
+ option.  On non\-Windows systems, the
 -.BR ifconfig (8)
 +.BR ifconfig (1m)
  command provides similar functionality.
  .\"*********************************************************
  .TP
-@@ -6960,7 +6960,7 @@
+@@ -7060,7 +7060,7 @@ On alice:
  The
  .B \-\-verb 9
  option will produce verbose output, similar to the
@@ -84,7 +84,7 @@
  program.  Omit the
  .B \-\-verb 9
  option to have OpenVPN run quietly.
-@@ -7175,10 +7175,10 @@
+@@ -7275,10 +7275,10 @@ archives, or browse the SVN repository.
  Report all bugs to the OpenVPN team <info@openvpn.net>.
  .\"*********************************************************
  .SH "SEE ALSO"

--- a/components/network/openvpn/patches/04-test-suite-replace-echo-n.patch
+++ b/components/network/openvpn/patches/04-test-suite-replace-echo-n.patch
@@ -1,0 +1,13 @@
+illumos `echo` does not support the '-n' option. Replace it with `printf`.
+
+--- openvpn-2.4.7/tests/t_lpback.sh	2019-02-20 13:28:23.000000000 +0000
++++ openvpn-2.4.7/tests/t_lpback.sh	2019-06-09 14:24:33.120063745 +0000
+@@ -44,7 +44,7 @@ set +e
+ e=0
+ for cipher in ${CIPHERS}
+ do
+-    echo -n "Testing cipher ${cipher}... "
++    printf "Testing cipher ${cipher}... "
+     ( "${top_builddir}/src/openvpn/openvpn" --test-crypto --secret key.$$ --cipher ${cipher} ) >log.$$ 2>&1
+     if [ $? != 0 ] ; then
+         echo "FAILED"


### PR DESCRIPTION
**Testing**
- Test suite passed
- Tested three examples in the `openvpn(1m)` man page against OpenVPN 2.4.6 on Linux