### PR TITLE
Update VirtualBox to 6.0.4

### DIFF
--- a/components/sysutils/virtualbox/Makefile
+++ b/components/sysutils/virtualbox/Makefile
@@ -10,12 +10,13 @@
 
 #
 # Copyright 2017 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         VirtualBox
-COMPONENT_VERSION=      5.2.24
+COMPONENT_VERSION=      6.0.4
 COMPONENT_SUMMARY=      VirtualBox - general-purpose full virtualizer
 COMPONENT_PROJECT_URL=  http://www.virtualbox.org/
 COMPONENT_FMRI=         system/virtualbox
@@ -26,16 +27,16 @@ COMPONENT_DOWNLOAD_URL= \
   http://download.virtualbox.org/virtualbox/$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE_URL=  $(COMPONENT_DOWNLOAD_URL)/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_HASH= \
-  sha256:6c8672ff74f9fbe0a73522baab5f5600d2c65c5df4b0314d983a5d096e746457
+  sha256:f80b0c68182c946fb74ada8034960c38159ad91085b153da1277e4f191af6e1f
 COMPONENT_LICENSE=      GPLv2
 
 COMPONENT_NAME_1=       VirtualBoxSDK
-COMPONENT_VERSION_1=    $(COMPONENT_VERSION)-128163
+COMPONENT_VERSION_1=    $(COMPONENT_VERSION)-128413
 COMPONENT_SRC_1=        $(COMPONENT_NAME_1)-$(COMPONENT_VERSION_1)
 COMPONENT_ARCHIVE_1=    $(COMPONENT_SRC_1).zip
 COMPONENT_ARCHIVE_URL_1=$(COMPONENT_DOWNLOAD_URL)/$(COMPONENT_ARCHIVE_1)
 COMPONENT_ARCHIVE_HASH_1= \
-  sha256:40326138014027a9eb1830e32fb199da2f208185ec42e19af6f5d103731fb042
+  sha256:618ee3fd3eb64b4dd6f11bd80f1116cad7a5f9308a65536ce257cd2dbbb68dd7
 COMPONENT_LICENSE_1=      GPLv2
 UNPACK_ARGS_1= -r $(COMPONENT_SRC_1)
 
@@ -55,7 +56,7 @@ X11_SERVERDRV_DIR.64=/usr/lib/xorg/modules/drivers/$(MACH64)
 X11_SERVERDRV_DIR=$(X11_SERVERDRV_DIR.64)
 
 X11_SERVERINP_DIR.32=/usr/lib/xorg/modules/input
-X11_SERVERINP_DIR.64=/usr/lib/xorg/input/$(MACH64)
+X11_SERVERINP_DIR.64=/usr/lib/xorg/modules/input/$(MACH64)
 X11_SERVERINP_DIR=$(X11_SERVERMODS_DIR.64)
 
 VBOX_BINDIR= $(BUILD_DIR_64)/out/solaris.$(MACH64)/release/bin/additions/
@@ -136,7 +137,7 @@ CONFIGURE_OPTIONS += $(CONFIGURE_OPTIONS.$(BITS))
 
 VBOX_PREFIX   = /opt/VirtualBox
 VBOX_LIBDIR   = $(VBOX_PREFIX)/$(MACH64)
-VBOX_QT5_LIBS = VirtualBox.so VBoxDbg.so
+VBOX_QT5_LIBS = VirtualBoxVM.so VBoxDbg.so VBoxGlobal.so
 VBOX_QT5_RPATH= $(VBOX_LIBDIR):$(GCC_LIBDIR):$(QT5_ROOT)/lib/$(MACH64)
 
 COMPONENT_POST_INSTALL_ACTION = \
@@ -145,6 +146,8 @@ COMPONENT_POST_INSTALL_ACTION = \
 		/usr/bin/elfedit -e 'dyn:value -s RUNPATH "$(VBOX_QT5_RPATH)"' $(PROTO_DIR)$(VBOX_LIBDIR)/$$file; \
 		/usr/bin/elfedit -e 'dyn:value -s RPATH   "$(VBOX_QT5_RPATH)"' $(PROTO_DIR)$(VBOX_LIBDIR)/$$file; \
 	done; \
+	/usr/bin/elfedit -e 'dyn:value -s RUNPATH "$(VBOX_QT5_RPATH)"' $(PROTO_DIR)$(VBOX_PREFIX)/$(MACH64)/VirtualBox; \
+	/usr/bin/elfedit -e 'dyn:value -s RPATH   "$(VBOX_QT5_RPATH)"' $(PROTO_DIR)$(VBOX_PREFIX)/$(MACH64)/VirtualBox; \
 	echo "$(COMPONENT_VERSION)" > $(PROTO_DIR)$(VBOX_PREFIX)/VERSION
 
 $(INSTALL_ADDITIONS):	$(INSTALL_64)
@@ -186,6 +189,8 @@ $(INSTALL_ADDITIONS):	$(INSTALL_64)
 
 $(BUILD_32_and_64): GMAKE= cd $(@D)/src/VBox/HostDrivers && $(SHELL) -c ". $(@D)/env.sh && kmk KBUILD_VERBOSE=3"
 
+# Sometimes 32-bit build is skipped silently. Better build like this:
+#	gmake build install sample-manifest
 build:		$(BUILD_32_and_64) 
 
 $(INSTALL_64): GMAKE= cd $(@D)/src/VBox/Installer && $(SHELL) -c ". $(@D)/env.sh && kmk solaris-install VBOX_PATH_SI_SCRATCH_PKG=$(PROTO_DIR)"
@@ -195,10 +200,11 @@ install:	$(INSTALL_64) $(INSTALL_ADDITIONS)
 test:		$(NO_TESTS)
 
 # Build dependencies
+REQUIRED_PACKAGES += driver/usb
 REQUIRED_PACKAGES += system/header/header-audio
+REQUIRED_PACKAGES += x11/library/libxinerama
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += driver/usb
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/libxml2
 REQUIRED_PACKAGES += library/qt5
@@ -212,12 +218,11 @@ REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += web/curl
 REQUIRED_PACKAGES += x11/library/libx11
 REQUIRED_PACKAGES += x11/library/libxcb
-REQUIRED_PACKAGES += x11/library/libxcursor
 REQUIRED_PACKAGES += x11/library/libxcomposite
+REQUIRED_PACKAGES += x11/library/libxcursor
 REQUIRED_PACKAGES += x11/library/libxdamage
 REQUIRED_PACKAGES += x11/library/libxext
 REQUIRED_PACKAGES += x11/library/libxfixes
-REQUIRED_PACKAGES += x11/library/libxinerama
-REQUIRED_PACKAGES += x11/library/libxrandr
 REQUIRED_PACKAGES += x11/library/libxmu
+REQUIRED_PACKAGES += x11/library/libxrandr
 REQUIRED_PACKAGES += x11/library/toolkit/libxt

--- a/components/sysutils/virtualbox/manifests/sample-manifest.p5m
+++ b/components/sysutils/virtualbox/manifests/sample-manifest.p5m
@@ -46,6 +46,7 @@ file path=opt/VirtualBox/$(MACH64)/VBoxDragAndDropSvc.so
 link path=opt/VirtualBox/$(MACH64)/VBoxEFI32.fd target=../VBoxEFI32.fd
 link path=opt/VirtualBox/$(MACH64)/VBoxEFI64.fd target=../VBoxEFI64.fd
 file path=opt/VirtualBox/$(MACH64)/VBoxExtPackHelperApp
+file path=opt/VirtualBox/$(MACH64)/VBoxGlobal.so
 file path=opt/VirtualBox/$(MACH64)/VBoxGuestControlSvc.so
 file path=opt/VirtualBox/$(MACH64)/VBoxGuestPropSvc.so
 file path=opt/VirtualBox/$(MACH64)/VBoxHeadless
@@ -78,7 +79,8 @@ file path=opt/VirtualBox/$(MACH64)/VBoxZoneAccess
 file path=opt/VirtualBox/$(MACH64)/VMMR0.r0
 file path=opt/VirtualBox/$(MACH64)/VMMRC.rc
 file path=opt/VirtualBox/$(MACH64)/VirtualBox
-file path=opt/VirtualBox/$(MACH64)/VirtualBox.so
+file path=opt/VirtualBox/$(MACH64)/VirtualBoxVM
+file path=opt/VirtualBox/$(MACH64)/VirtualBoxVM.so
 file path=opt/VirtualBox/$(MACH64)/components/VBoxC.so
 file path=opt/VirtualBox/$(MACH64)/components/VBoxSVCM.so
 file path=opt/VirtualBox/$(MACH64)/components/VBoxXPCOMBase.xpt
@@ -141,6 +143,7 @@ link path=usr/bin/VBoxManage target=../../opt/VirtualBox/VBox.sh
 link path=usr/bin/VBoxSDL target=../../opt/VirtualBox/VBox.sh
 file path=usr/bin/VBoxService
 link path=usr/bin/VirtualBox target=../../opt/VirtualBox/VBox.sh
+link path=usr/bin/VirtualBoxVM target=../../opt/VirtualBox/VBox.sh
 file path=usr/kernel/drv/$(MACH64)/vboxguest
 file path=usr/kernel/drv/$(MACH64)/vboxms
 file path=usr/kernel/drv/$(MACH64)/vboxvideo

--- a/components/sysutils/virtualbox/patches/01-build-in-zone.patch
+++ b/components/sysutils/virtualbox/patches/01-build-in-zone.patch
@@ -1,6 +1,6 @@
---- VirtualBox-5.2.18/Config.kmk.~1~	2018-08-14 14:38:13.000000000 +0000
-+++ VirtualBox-5.2.18/Config.kmk	2018-09-21 16:58:33.317054655 +0000
-@@ -773,7 +773,7 @@
+--- VirtualBox-6.0.4/Config.kmk	2019-01-25 19:10:01.000000000 +0000
++++ VirtualBox-6.0.4/Config.kmk	2019-02-23 19:39:23.859546435 +0000
+@@ -793,7 +793,7 @@ VBOX_WITH_EXTPACK_VBOXDTRACE = 1
  ## @name Misc
  ## @{
  # Enable to compile with OpenSSL 1.0 (only relevant for Windows, see src/VBox/Runtime/Makefile.kmk)
@@ -9,10 +9,10 @@
  # Enables all the doxgen bits.
  VBOX_WITH_ALL_DOXYGEN_TARGETS = 1
  # Set this to skip installing the redistributable compiler runtime.
-@@ -2698,8 +2698,6 @@
- 		$(VBOX_GCC_PATH_CXX) \
+@@ -2794,8 +2794,6 @@ $(PATH_OUT)/DynamicConfig.kmk: \
  		$(VBOX_GCC32_PATH_CC) \
  		$(VBOX_GCC32_PATH_CXX) \
+                $(VBOX_GCC32_LIBGCC) \
 -		$(if-expr "$(KBUILD_HOST).$(KBUILD_HOST_ARCH)" == "solaris.amd64" && $(KBUILD_HOST_VERSION_MINOR) >= 11 \
 -			, /platform/i86pc/kernel/$(KBUILD_HOST_ARCH)/unix,) \
          	| $(PATH_OUT)/DynamicConfig.c $(PATH_OUT)/DynamicConfig.cpp

--- a/components/sysutils/virtualbox/patches/04-saner-minor_perm.patch
+++ b/components/sysutils/virtualbox/patches/04-saner-minor_perm.patch
@@ -1,0 +1,23 @@
+--- VirtualBox-6.0.4/src/VBox/Installer/solaris/vboxconfig.sh	2019-01-25 19:20:05.000000000 +0000
++++ VirtualBox-6.0.4/src/VBox/Installer/solaris/vboxconfig.sh.new	2019-02-27 06:55:46.286189698 +0000
+@@ -663,9 +663,9 @@ install_drivers()
+ {
+     if test -f "$DIR_CONF/vboxdrv.conf"; then
+         if test -n "_HARDENED_"; then
+-            add_driver "$MOD_VBOXDRV" "$DESC_VBOXDRV" "$FATALOP" "not-$NULLOP" "'* 0600 root sys','vboxdrvu 0666 root sys'"
++            add_driver "$MOD_VBOXDRV" "$DESC_VBOXDRV" "$FATALOP" "not-$NULLOP" "* 0600 root sys,vboxdrvu 0666 root sys"
+         else
+-            add_driver "$MOD_VBOXDRV" "$DESC_VBOXDRV" "$FATALOP" "not-$NULLOP" "'* 0666 root sys','vboxdrvu 0666 root sys'"
++            add_driver "$MOD_VBOXDRV" "$DESC_VBOXDRV" "$FATALOP" "not-$NULLOP" "* 0666 root sys,vboxdrvu 0666 root sys"
+         fi
+         load_module "drv/$MOD_VBOXDRV" "$DESC_VBOXDRV" "$FATALOP"
+     else
+@@ -746,7 +746,7 @@ install_drivers()
+         # All users which need host USB-passthrough support will have to be added to this group.
+         groupadd vboxuser >/dev/null 2>&1
+ 
+-        add_driver "$MOD_VBOXUSBMON" "$DESC_VBOXUSBMON" "$FATALOP" "not-$NULLOP" "'* 0666 root sys'"
++        add_driver "$MOD_VBOXUSBMON" "$DESC_VBOXUSBMON" "$FATALOP" "not-$NULLOP" "* 0666 root sys"
+         load_module "drv/$MOD_VBOXUSBMON" "$DESC_VBOXUSBMON" "$FATALOP"
+ 
+         chown root:vboxuser "/devices/pseudo/vboxusbmon@0:vboxusbmon"

--- a/components/sysutils/virtualbox/patches/14-no-freestanding.patch
+++ b/components/sysutils/virtualbox/patches/14-no-freestanding.patch
@@ -2,15 +2,15 @@ Use illumos headers as GCC headers fail to behave correctly in 32-bit environmen
 
 --- VirtualBox-5.2.22/Config.kmk.~1~	2018-11-08 22:35:51.000000000 +0000
 +++ VirtualBox-5.2.22/Config.kmk	2018-12-24 09:40:34.144696318 +0000
-@@ -4232,7 +4230,7 @@
+@@ -4394,7 +4394,7 @@ ifeq ($(VBOX_LDR_FMT),elf)
  TEMPLATE_VBoxR0_TOOL                = $(VBOX_GCC_TOOL)
  TEMPLATE_VBoxR0_CFLAGS              = -fno-pie -nostdinc -g $(VBOX_GCC_pipe) $(VBOX_GCC_WERR) $(VBOX_GCC_PEDANTIC_C)   $(VBOX_GCC_Wno-variadic-macros) $(VBOX_GCC_R0_OPT) $(VBOX_GCC_R0_FP) -fno-strict-aliasing -fno-exceptions $(VBOX_GCC_fno-stack-protector) -fno-common $(VBOX_GCC_fvisibility-hidden) -std=gnu99 $(VBOX_GCC_IPRT_FMT_CHECK)
  TEMPLATE_VBoxR0_CXXFLAGS            = -fno-pie -nostdinc -g $(VBOX_GCC_pipe) $(VBOX_GCC_WERR) $(VBOX_GCC_PEDANTIC_CXX) $(VBOX_GCC_Wno-variadic-macros) $(VBOX_GCC_R0_OPT) $(VBOX_GCC_R0_FP) -fno-strict-aliasing -fno-exceptions $(VBOX_GCC_fno-stack-protector) -fno-common $(VBOX_GCC_fvisibility-inlines-hidden) $(VBOX_GCC_fvisibility-hidden) -fno-rtti $(VBOX_GCC_IPRT_FMT_CHECK)
--TEMPLATE_VBoxR0_CFLAGS.amd64        = -m64 -mno-red-zone -mcmodel=kernel -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fno-asynchronous-unwind-tables -ffreestanding
-+TEMPLATE_VBoxR0_CFLAGS.amd64        = -m64 -mno-red-zone -mcmodel=kernel -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fno-asynchronous-unwind-tables
- TEMPLATE_VBoxR0_CXXFLAGS.amd64      = -m64 -mno-red-zone -mcmodel=kernel -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fno-asynchronous-unwind-tables
- ifeq ($(KBUILD_TARGET),solaris)
-  TEMPLATE_VBoxR0_LDFLAGS            = -r
+-TEMPLATE_VBoxR0_CFLAGS.amd64        = -m64 -mno-red-zone -mcmodel=kernel -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fasynchronous-unwind-tables -ffreestanding
++TEMPLATE_VBoxR0_CFLAGS.amd64        = -m64 -mno-red-zone -mcmodel=kernel -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fasynchronous-unwind-tables
+ TEMPLATE_VBoxR0_CXXFLAGS.amd64      = -m64 -mno-red-zone -mcmodel=kernel -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fasynchronous-unwind-tables
+  if $(VBOX_GCC_VERSION_CC) < 30400
+   TEMPLATE_VBoxR0_DEFS             += RT_WITHOUT_PRAGMA_ONCE
 @@ -4477,7 +4475,7 @@
  	-Wmissing-prototypes -Wstrict-prototypes $(VBOX_GCC_fdiagnostics-show-option) \
  	-Wshadow -Wuninitialized -Wunused-function -Wunused-label -Wunused-value -Wunused-variable \

--- a/components/sysutils/virtualbox/patches/16-display-svga-x11-uname-fix.patch
+++ b/components/sysutils/virtualbox/patches/16-display-svga-x11-uname-fix.patch
@@ -1,0 +1,11 @@
+--- VirtualBox-6.0.4/src/VBox/Additions/x11/VBoxClient/display-svga-x11.cpp	2019-03-15 10:53:19.491237602 +0000
++++ VirtualBox-6.0.4/src/VBox/Additions/x11/VBoxClient/display-svga-x11.cpp	2019-03-15 10:53:46.415980120 +0000
+@@ -61,7 +61,7 @@
+ {
+     struct utsname name;
+ 
+-    if (uname(&name))
++    if (uname(&name) == -1)
+         VBClFatalError(("Failed to get kernel name.\n"));
+     if (strcmp(name.sysname, "Linux"))
+         return false;

--- a/components/sysutils/virtualbox/virtualbox.p5m
+++ b/components/sysutils/virtualbox/virtualbox.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2018 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,6 +29,12 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=platform/i86pc/kernel/drv/.+ -> default variant.opensolaris.zone "global" >
 <transform file path=platform/i86pc/kernel/drv/.+ -> default restart_fmri svc:/application/virtualbox/run-once:defaul>
 
+driver name=vboxdrv
+driver name=vboxflt
+driver name=vboxnet
+driver name=vboxusb
+driver name=vboxusbmon
+
 file files/run-once.sh path=/opt/VirtualBox/run-once.sh owner=root group=sys mode=0555
 file files/virtualbox-run-once.xml \
   path=var/svc/manifest/application/virtualbox/virtualbox-run-once.xml \
@@ -39,6 +46,7 @@ link path=opt/VirtualBox/64 target=$(MACH64)
 
 #file path=autoresponse
 #file path=checkinstall.sh
+#file path=etc/fs/vboxfs/vboxfsmount
 file path=etc/hostname.vboxnet0
 #file path=makepackage.sh
 file path=opt/VirtualBox/$(MACH64)/DbgPlugInDiggers.so
@@ -58,6 +66,7 @@ file path=opt/VirtualBox/$(MACH64)/VBoxDragAndDropSvc.so
 link path=opt/VirtualBox/$(MACH64)/VBoxEFI32.fd target=../VBoxEFI32.fd
 link path=opt/VirtualBox/$(MACH64)/VBoxEFI64.fd target=../VBoxEFI64.fd
 file path=opt/VirtualBox/$(MACH64)/VBoxExtPackHelperApp mode=0555
+file path=opt/VirtualBox/$(MACH64)/VBoxGlobal.so
 file path=opt/VirtualBox/$(MACH64)/VBoxGuestControlSvc.so
 file path=opt/VirtualBox/$(MACH64)/VBoxGuestPropSvc.so
 file path=opt/VirtualBox/$(MACH64)/VBoxHeadless mode=4555
@@ -89,8 +98,9 @@ file path=opt/VirtualBox/$(MACH64)/VBoxXPCOMIPCD mode=0555
 file path=opt/VirtualBox/$(MACH64)/VBoxZoneAccess mode=4555
 file path=opt/VirtualBox/$(MACH64)/VMMR0.r0
 file path=opt/VirtualBox/$(MACH64)/VMMRC.rc pkg.linted.userland.action001.2=true
-file path=opt/VirtualBox/$(MACH64)/VirtualBox mode=4555
-file path=opt/VirtualBox/$(MACH64)/VirtualBox.so
+file path=opt/VirtualBox/$(MACH64)/VirtualBox mode=0555
+file path=opt/VirtualBox/$(MACH64)/VirtualBoxVM mode=4555
+file path=opt/VirtualBox/$(MACH64)/VirtualBoxVM.so
 file path=opt/VirtualBox/$(MACH64)/components/VBoxC.so
 file path=opt/VirtualBox/$(MACH64)/components/VBoxSVCM.so
 file path=opt/VirtualBox/$(MACH64)/components/VBoxXPCOMBase.xpt
@@ -241,9 +251,3 @@ file path=var/svc/manifest/application/virtualbox/virtualbox-balloonctrl.xml
 file path=var/svc/manifest/application/virtualbox/virtualbox-zoneaccess.xml
 #file path=vbox.pkginfo
 #file path=vbox.space
-
-driver name=vboxdrv 
-driver name=vboxflt 
-driver name=vboxnet 
-driver name=vboxusb 
-driver name=vboxusbmon


### PR DESCRIPTION
Sometimes 32-bit build is skipped silently for `sample-manifest` target. Left comment in the Makefile for instruction on how to generate sample-manifest.p5m.

***

VirtualBox changes to `/etc/minor_perm` look a bit weird:
```
vboxdrv:'* 0666 root sys'
vboxdrv:'vboxdrvu 0666 root sys'
vboxusbmon:'* 0666 root sys'
```
Removed those apostrophes in 04-saner-minor_perm.patch.

***

**Tested**
* Upgrade from v5.2
* Upgrade of Oracle Extension Pack
* Ubuntu Server VM works after upgrade
* xHCI from Oracle Extension Pack works in Ubuntu VM after upgrade