### PR TITLE
ncurses: Support 256 colors in sun-color console, underline

### DIFF
--- a/components/library/ncurses/Makefile
+++ b/components/library/ncurses/Makefile
@@ -29,7 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=	ncurses
 COMPONENT_VERSION=	5.9
-COMPONENT_REVISION=	5
+COMPONENT_REVISION=	6
 COMPONENT_SUMMARY=	A CRT screen handling and optimization package.
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/ncurses/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/library/ncurses/patches/07-sun-color.patch
+++ b/components/library/ncurses/patches/07-sun-color.patch
@@ -1,0 +1,20 @@
+Updates to illumos-gate in February 2019 added support for underline
+to sun-color, and upped the number of supported colours to 256.
+
+See: https://www.illumos.org/issues/10359
+     https://www.illumos.org/issues/10360
+
+--- ncurses-5.9/misc/terminfo.src	2011-02-20 21:46:53.000000000 +0000
++++ ncurses-5.9/misc/terminfo.src.new	2019-02-28 07:14:30.192672688 +0000
+@@ -5127,9 +5127,9 @@ sun-type4|Sun Workstation console with t
+ #	cbt=\E[Z
+ #	dim=\E[2m
+ #	blink=\E[5m
+-# It supports bold, but not underline -TD (2009-09-19)
++# It supports bold, -TD (2009-09-19)
+ sun-color|Sun Microsystems Workstation console with color support (IA systems),
+-	colors#8, ncv#3, pairs#64,
++	colors#256, ncv#3, pairs#32767
+ 	cub=\E[%p1%dD, cud=\E[%p1%dB, cuf=\E[%p1%dC,
+ 	cuu=\E[%p1%dA, home=\E[H, op=\E[0m, setab=\E[4%p1%dm,
+ 	setaf=\E[3%p1%dm,


### PR DESCRIPTION
Add https://github.com/omniosorg/omnios-build/blob/master/build/ncurses/patches/sun-color.patch. The second hunk is not included as `smul` and `rmul` are not used in v5.9 `sun-color` definition.

https://github.com/omniosorg/omnios-build/blob/master/build/ncurses/patches/xterm-no-rep.patch does not seem to be required at all as `use=ansi+rep` is not used in v5.9 `xterm` definition.

Test: underline works in man page. Not sure how to test those 256 colors.