### PR TITLE
bzip2: Update project URL

### DIFF
--- a/components/archiver/bzip2/Makefile
+++ b/components/archiver/bzip2/Makefile
@@ -21,20 +21,21 @@
 
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		bzip2
 COMPONENT_VERSION=	1.0.6
-COMPONENT_REVISION=	4
-COMPONENT_PROJECT_URL=	http://www.bzip.org/
+COMPONENT_REVISION=	5
+COMPONENT_PROJECT_URL=	https://sourceware.org/bzip2/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
-COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	utility/bzip
+	sha256:a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
+COMPONENT_ARCHIVE_URL=	https://sourceforge.net/projects/bzip2/files/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=		compress/bzip2
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/justmake.mk
@@ -77,5 +78,6 @@ BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
 
 include $(WS_MAKE_RULES)/depend.mk
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/archiver/bzip2/bzip2.p5m
+++ b/components/archiver/bzip2/bzip2.p5m
@@ -21,24 +21,20 @@
 
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
-set name=pkg.fmri \
-    value=pkg:/compress/bzip2@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.description \
     value="bzip2 is a freely available, patent free, high-quality data compressor."
 set name=pkg.summary \
     value="high-quality block-sorting file compressor - utilities"
-set name=com.oracle.info.description value="the bzip2 data compression utility"
-set name=com.oracle.info.tpno value=5547
 set name=info.classification \
     value="org.opensolaris.category.2008:Applications/System Utilities"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
-set name=org.opensolaris.arc-caseid \
-    value=PSARC/1999/555
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+<transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
 file path=usr/bin/bunzip2
 file path=usr/bin/bzcat
 file path=usr/bin/bzdiff
@@ -48,10 +44,7 @@ file path=usr/bin/bzip2recover
 file path=usr/bin/bzmore
 file path=usr/include/bzlib.h
 file path=usr/lib/$(MACH64)/libbz2.so.1
-#file path=usr/lib/$(MACH64)/llib-lbz2.ln
 file path=usr/lib/libbz2.so.1
-#file path=usr/lib/llib-lbz2
-#file path=usr/lib/llib-lbz2.ln
 file manpages/bunzip2.1 path=usr/share/man/man1/bunzip2.1
 file manpages/bzcat.1 path=usr/share/man/man1/bzcat.1
 file path=usr/share/man/man1/bzcmp.1


### PR DESCRIPTION
The former bzip2.org domain is gone (https://sourceforge.net/p/valgrind/mailman/message/36403427/), replace with actual project page and SF.net as download site.