### PR TITLE
Update libpng16 to 1.6.36

### DIFF
--- a/components/library/libpng16/Makefile
+++ b/components/library/libpng16/Makefile
@@ -11,15 +11,16 @@
 #
 # Copyright 2015 Alexander Pyhalov
 # Copyright 2016 Jim Klimov
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libpng
-COMPONENT_VERSION_SUP=1
-COMPONENT_VERSION_MAJ=6
-COMPONENT_VERSION_MIN=34
-COMPONENT_VERSION_PAT=0
+COMPONENT_VERSION_SUP=	1
+COMPONENT_VERSION_MAJ=	6
+COMPONENT_VERSION_MIN=	36
+COMPONENT_VERSION_PAT=	0
 COMPONENT_VERSION=	$(COMPONENT_VERSION_SUP).$(COMPONENT_VERSION_MAJ).$(COMPONENT_VERSION_MIN)
 # The XY in "libpngXY" file and directory names
 COMPONENT_VERSION_TAG=$(COMPONENT_VERSION_SUP)$(COMPONENT_VERSION_MAJ)
@@ -30,9 +31,9 @@ COMPONENT_SUMMARY=	Portable Network Graphics library version $(COMPONENT_VERSION
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6
+	sha256:eceb924c1fa6b79172fdfd008d335f0e59172a86a66481e09d4089df872aa319
 COMPONENT_ARCHIVE_URL=	http://sourceforge.net/projects/libpng/files/libpng16/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)/download
-COMPONENT_LICENSE=	libpng
+COMPONENT_LICENSE=	zlib
 COMPONENT_LICENSE_FILE=	LICENSE
 COMPONENT_CLASSIFICATION=	System/Multimedia Libraries
 COMPONENT_FMRI= 	image/library/libpng16
@@ -62,15 +63,14 @@ COMPONENT_TEST_TRANSFORMS= \
   '-e "/FAIL/p" '  \
   '-e "/XPASS/p" ' \
   '-e "/ERROR/p" ' 
- 
 
-# common targets
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/library/libpng16/libpng16.p5m
+++ b/components/library/libpng16/libpng16.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright 2015 Alexander Pyhalov
 # Copyright 2016 Jim Klimov
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/library/libpng16/manifests/sample-manifest.p5m
+++ b/components/library/libpng16/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -39,17 +39,17 @@ link path=usr/include/pnglibconf.h target=libpng16/pnglibconf.h
 link path=usr/lib/$(MACH64)/libpng.a target=libpng16.a
 link path=usr/lib/$(MACH64)/libpng.so target=libpng16.so
 file path=usr/lib/$(MACH64)/libpng16.a
-link path=usr/lib/$(MACH64)/libpng16.so target=libpng16.so.16.34.0
-link path=usr/lib/$(MACH64)/libpng16.so.16 target=libpng16.so.16.34.0
-file path=usr/lib/$(MACH64)/libpng16.so.16.34.0
+link path=usr/lib/$(MACH64)/libpng16.so target=libpng16.so.16.36.0
+link path=usr/lib/$(MACH64)/libpng16.so.16 target=libpng16.so.16.36.0
+file path=usr/lib/$(MACH64)/libpng16.so.16.36.0
 link path=usr/lib/$(MACH64)/pkgconfig/libpng.pc target=libpng16.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpng16.pc
 link path=usr/lib/libpng.a target=libpng16.a
 link path=usr/lib/libpng.so target=libpng16.so
 file path=usr/lib/libpng16.a
-link path=usr/lib/libpng16.so target=libpng16.so.16.34.0
-link path=usr/lib/libpng16.so.16 target=libpng16.so.16.34.0
-file path=usr/lib/libpng16.so.16.34.0
+link path=usr/lib/libpng16.so target=libpng16.so.16.36.0
+link path=usr/lib/libpng16.so.16 target=libpng16.so.16.36.0
+file path=usr/lib/libpng16.so.16.36.0
 link path=usr/lib/pkgconfig/libpng.pc target=libpng16.pc
 file path=usr/lib/pkgconfig/libpng16.pc
 file path=usr/share/man/man3/libpng.3


### PR DESCRIPTION
libpng16 license changed from "libpng" to "zlib + disclaimer from boost": https://sourceforge.net/projects/libpng/files/libpng16/1.6.36/.

ABI Tracker: https://abi-laboratory.pro/index.php?view=timeline&l=libpng.