### PR TITLE
1/4: curl: disable brotli

### DIFF
--- a/components/web/curl/Makefile
+++ b/components/web/curl/Makefile
@@ -25,7 +25,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =        curl
 COMPONENT_VERSION=      7.61.1
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  https://curl.haxx.se
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
@@ -76,6 +76,7 @@ CONFIGURE_OPTIONS += --with-pic
 CONFIGURE_OPTIONS += --with-libssh2
 CONFIGURE_OPTIONS += --without-librtmp
 CONFIGURE_OPTIONS += "curl_disallow_getifaddrs=yes"
+CONFIGURE_OPTIONS += --without-brotli
 
 LINT_FLAGS += -I$(SOURCE_DIR)/include
 


### PR DESCRIPTION
**Update ABI-incompatible brotli from 0.6 to v1**

As brotli v1 breaks ABI and brings new soname (https://abi-laboratory.pro/index.php?view=timeline&l=brotli) and `curl` is built with brotli and is required to publish packages, brotli bump needs to be handled in steps:

1. https://github.com/OpenIndiana/oi-userland/pull/4820 Disable brotli in `curl` so brotli can be bumped safely (this PR)
2. https://github.com/OpenIndiana/oi-userland/pull/4821 update brotli to v1
3. https://github.com/OpenIndiana/oi-userland/pull/4822 build `curl` with brotli again
4. https://github.com/OpenIndiana/oi-userland/pull/4823 rebuild the rest of packages requiring brotli (links and apache24)