### PR TITLE
Update pixman to 0.38.0

### DIFF
--- a/components/library/pixman/Makefile
+++ b/components/library/pixman/Makefile
@@ -10,18 +10,19 @@
 
 #
 # Copyright (c) 2015 Alexander Pyhalov
+# Copyright (c) 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pixman
-COMPONENT_VERSION=	0.34.0
+COMPONENT_VERSION=	0.38.0
 COMPONENT_PROJECT_URL=	http://www.pixman.org/
 COMPONENT_SUMMARY=	Pixman: The pixel-manipulation library for X and Cairo
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:21b6b249b51c6800dc9553b65106e1e37d0e25df942c90531d4c3997aa20a88e
+	sha256:a7592bef0156d7c27545487a52245669b00cf7e70054505381cff2136d890ca8
 COMPONENT_ARCHIVE_URL=	http://cairographics.org/releases/$(COMPONENT_ARCHIVE)
 COMPONENT_CLASSIFICATION=	System/Libraries
 COMPONENT_FMRI=		library/graphics/pixman
@@ -36,12 +37,14 @@ PATH=$(PATH.gnu)
 
 CONFIGURE_OPTIONS += --disable-gtk
 
-# common targets
+# The test suite needs this
+unexport SHELLOPTS
+
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
-test:		$(NO_TESTS)
+test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library


### PR DESCRIPTION
**Testing**

ABI Tracker is clean: https://abi-laboratory.pro/index.php?view=timeline&l=pixman.

Test suite passed.

MATE, Firefox, Thunderbird still work.

Following packages passed rebuild:

- [x] pkg:/gnome/theme/gtk2-engines-murrine
- [x] pkg:/library/desktop/cairo
- [x] pkg:/mail/thunderbird
- [x] pkg:/web/browser/firefox 60esr
- [x] pkg:/x11/server/xephyr
- [x] pkg:/x11/server/xorg
- [x] pkg:/x11/server/xorg/driver/xorg-video-ati
- [x] pkg:/x11/server/xorg/driver/xorg-video-intel
- [x] pkg:/x11/server/xorg/driver/xorg-video-mga
- [x] pkg:/x11/server/xorg/driver/xorg-video-nv
- [x] pkg:/x11/server/xorg/driver/xorg-video-openchrome
- [x] pkg:/x11/server/xorg/driver/xorg-video-r128
- [x] pkg:/x11/server/xorg/driver/xorg-video-trident
- [x] pkg:/x11/server/xorg/driver/xorg-video-vmware
- [x] pkg:/x11/server/xvnc