### PR TITLE
Update libssh2 to 1.8.0

### DIFF
--- a/components/library/libssh2/Makefile
+++ b/components/library/libssh2/Makefile
@@ -18,18 +18,22 @@
 #
 # CDDL HEADER END
 #
-# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+
 #
+# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
+#
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libssh2
-COMPONENT_VERSION=	1.7.0
+COMPONENT_VERSION=	1.8.0
 COMPONENT_PROJECT_URL=	http://www.libssh2.org/
 COMPONENT_SUMMARY=	libssh2 - client-side C library implementing the SSH2 protocol
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:e4561fd43a50539a8c2ceb37841691baf03ecb7daf043766da1b112e4280d584
+	sha256:39f34e2f6835f4b992cafe8625073a88e5a28ba78f83e8099610a7b3af4676d4
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)download/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	library/libssh2
 COMPONENT_LICENSE=	BSD
@@ -42,13 +46,16 @@ include $(WS_MAKE_RULES)/ips.mk
 CONFIGURE_OPTIONS +=   --enable-shared
 CONFIGURE_OPTIONS +=   --disable-static
 
-# common targets
+# Test suite needs this
+unexport SHELLOPTS
+
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library


### PR DESCRIPTION
**Testing**

Passed rebuild:
- library/libgit2
- media/vlc
- web/curl

Test suite passed.

ABI Tracker clean: https://abi-laboratory.pro/index.php?view=timeline&l=libssh2