### PR TITLE
Update LZO to 2.10

### DIFF
--- a/components/library/liblzo/Makefile
+++ b/components/library/liblzo/Makefile
@@ -12,21 +12,21 @@
 # Copyright 2012 EveryCity Ltd. All rights reserved.
 # Copyright 2013 Adam Stevko. All rights reserved.
 # Copyright 2016 Jim Klimov. All rights reserved.
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		lzo
-COMPONENT_VERSION=	2.09
-IPS_COMPONENT_VERSION=	2.0.9
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	2.10
+IPS_COMPONENT_VERSION=	2.0.10
 COMPONENT_FMRI=		library/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION =	System/Libraries
 COMPONENT_SUMMARY=	LZO is a portable lossless data compression library written in ANSI C
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:f294a7ced313063c057c504257f437c8335c41bfeed23531ee4e6a2b87bcb34c
+	sha256:c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072
 COMPONENT_PROJECT_URL=	http://www.oberhumer.com/opensource/$(COMPONENT_NAME)/
 COMPONENT_ARCHIVE_URL=	http://www.oberhumer.com/opensource/$(COMPONENT_NAME)/download/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE =	GPLv2
@@ -39,14 +39,13 @@ include $(WS_TOP)/make-rules/ips.mk
 CONFIGURE_OPTIONS+=	--enable-static=no
 CONFIGURE_OPTIONS+=	--enable-shared
 
+COMPONENT_TEST_TARGETS =	check test
+
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
 
-BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
-
-include $(WS_TOP)/make-rules/depend.mk
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/library/liblzo/lzo.p5m
+++ b/components/library/liblzo/lzo.p5m
@@ -12,30 +12,19 @@
 # Copyright 2012 EveryCity Ltd. All rights reserved.
 # Copyright 2013 Adam Stevko. All rights reserved.
 # Copyright 2016 Jim Klimov. All rights reserved.
+# Copyright 2019 Michal Nowak
 #
-
-<transform dir path=usr$ -> default group sys>
-<transform dir path=usr/share$ -> default group sys>
-<transform dir path=usr/share/doc$ -> default group other>
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
-set name=info.upstream-url value="$(COMPONENT_PROJECT_URL)"
-set name=info.source-url value="$(COMPONENT_ARCHIVE_URL)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-set name=info.classification value="org.opensolaris.category.2008:$(COMPONENT_CLASSIFICATION)"
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 license COPYING license="GPLv2"
 
-dir path=usr
-dir path=usr/include
-dir path=usr/include/lzo
-dir path=usr/lib
-dir path=usr/lib/$(MACH64)
-dir path=usr/share
-dir path=usr/share/doc
-dir path=usr/share/doc/lzo
 file path=usr/include/lzo/lzo1.h
 file path=usr/include/lzo/lzo1a.h
 file path=usr/include/lzo/lzo1b.h
@@ -49,8 +38,14 @@ file path=usr/include/lzo/lzo_asm.h
 file path=usr/include/lzo/lzoconf.h
 file path=usr/include/lzo/lzodefs.h
 file path=usr/include/lzo/lzoutil.h
+link path=usr/lib/$(MACH64)/liblzo2.so target=liblzo2.so.2.0.0
+link path=usr/lib/$(MACH64)/liblzo2.so.2 target=liblzo2.so.2.0.0
 file path=usr/lib/$(MACH64)/liblzo2.so.2.0.0
+file path=usr/lib/$(MACH64)/pkgconfig/lzo2.pc
+link path=usr/lib/liblzo2.so target=liblzo2.so.2.0.0
+link path=usr/lib/liblzo2.so.2 target=liblzo2.so.2.0.0
 file path=usr/lib/liblzo2.so.2.0.0
+file path=usr/lib/pkgconfig/lzo2.pc
 file path=usr/share/doc/lzo/AUTHORS
 file path=usr/share/doc/lzo/COPYING
 file path=usr/share/doc/lzo/LZO.FAQ
@@ -58,7 +53,3 @@ file path=usr/share/doc/lzo/LZO.TXT
 file path=usr/share/doc/lzo/LZOAPI.TXT
 file path=usr/share/doc/lzo/NEWS
 file path=usr/share/doc/lzo/THANKS
-link path=usr/lib/$(MACH64)/liblzo2.so target=liblzo2.so.2.0.0
-link path=usr/lib/$(MACH64)/liblzo2.so.2 target=liblzo2.so.2.0.0
-link path=usr/lib/liblzo2.so target=liblzo2.so.2.0.0
-link path=usr/lib/liblzo2.so.2 target=liblzo2.so.2.0.0

--- a/components/library/liblzo/manifests/sample-manifest.p5m
+++ b/components/library/liblzo/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,9 +38,11 @@ file path=usr/include/lzo/lzoutil.h
 link path=usr/lib/$(MACH64)/liblzo2.so target=liblzo2.so.2.0.0
 link path=usr/lib/$(MACH64)/liblzo2.so.2 target=liblzo2.so.2.0.0
 file path=usr/lib/$(MACH64)/liblzo2.so.2.0.0
+file path=usr/lib/$(MACH64)/pkgconfig/lzo2.pc
 link path=usr/lib/liblzo2.so target=liblzo2.so.2.0.0
 link path=usr/lib/liblzo2.so.2 target=liblzo2.so.2.0.0
 file path=usr/lib/liblzo2.so.2.0.0
+file path=usr/lib/pkgconfig/lzo2.pc
 file path=usr/share/doc/lzo/AUTHORS
 file path=usr/share/doc/lzo/COPYING
 file path=usr/share/doc/lzo/LZO.FAQ


### PR DESCRIPTION
**Testing**

ABI Tracker: https://abi-laboratory.pro/index.php?view=timeline&l=lzo

Changelog: https://abi-laboratory.pro/index.php?view=changelog&l=lzo&v=2.10

Test suite passed.

Following packages requiring LZO passed rebuild:

* pkg:/backup/bacula/bacula-fd
* pkg:/backup/bacula/bacula-sd
* pkg:/compress/lzop
* pkg:/database/mariadb-101
* pkg:/database/mariadb-103
* pkg:/games/openttd/openttd-core
* pkg:/library/desktop/cairo
* pkg:/network/openvpn