### PR TITLE
Update nghttp2 to 1.37.0

### DIFF
--- a/components/library/nghttp2/Makefile
+++ b/components/library/nghttp2/Makefile
@@ -11,24 +11,25 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME= nghttp2
-COMPONENT_VERSION= 1.27.0
-COMPONENT_SUMMARY= HTTP/2 C Library
-COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
+COMPONENT_NAME=		nghttp2
+COMPONENT_VERSION=	1.37.0
+COMPONENT_SUMMARY=	HTTP/2 C Library
+COMPONENT_FMRI=		library/nghttp2
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:d3c9542e26c3819c50963e02d285973b38ec1dd2816133c852a224f0bd911952
+	sha256:aa090b164b17f4b91fe32310a1c0edf3e97e02cd9d1524eef42d60dd1e8d47b7
 COMPONENT_ARCHIVE_URL= \
-  https://github.com/tatsuhiro-t/nghttp2/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = https://nghttp2.org/
-COMPONENT_LICENSE_FILE = COPYING
-COMPONENT_LICENSE = MIT
-COMPONENT_CLASSIFICATION = System/Libraries
-COMPONENT_FMRI = library/nghttp2
+	https://github.com/nghttp2/nghttp2/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://nghttp2.org/
+COMPONENT_LICENSE_FILE=	COPYING
+COMPONENT_LICENSE=	MIT
+COMPONENT_CLASSIFICATION= System/Libraries
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
@@ -49,11 +50,11 @@ COMPONENT_TEST_TRANSFORMS += \
         '-e "/FAIL:/p" ' \
         '-e "/ERROR:/p" '
 
-build: $(BUILD_32_and_64)
+build:		$(BUILD_32_and_64)
 
-install: $(INSTALL_32_and_64)
+install:	$(INSTALL_32_and_64)
 
-test: $(TEST_32_and_64)
+test:		$(TEST_32_and_64)
 
 # Build dependencies
 REQUIRED_PACKAGES += developer/cunit

--- a/components/library/nghttp2/manifests/sample-manifest.p5m
+++ b/components/library/nghttp2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,13 +24,13 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/nghttp2/nghttp2.h
 file path=usr/include/nghttp2/nghttp2ver.h
-link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.14.0
-link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.14.0
-file path=usr/lib/$(MACH64)/libnghttp2.so.14.14.0
+link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.17.2
+link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.17.2
+file path=usr/lib/$(MACH64)/libnghttp2.so.14.17.2
 file path=usr/lib/$(MACH64)/pkgconfig/libnghttp2.pc
-link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.14.0
-link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.14.0
-file path=usr/lib/libnghttp2.so.14.14.0
+link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.17.2
+link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.17.2
+file path=usr/lib/libnghttp2.so.14.17.2
 file path=usr/lib/pkgconfig/libnghttp2.pc
 file path=usr/share/doc/nghttp2/README.rst
 file path=usr/share/man/man1/h2load.1

--- a/components/library/nghttp2/nghttp2.p5m
+++ b/components/library/nghttp2/nghttp2.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2015 <contributor>
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,13 +24,13 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/nghttp2/nghttp2.h
 file path=usr/include/nghttp2/nghttp2ver.h
-link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.14.0
-link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.14.0
-file path=usr/lib/$(MACH64)/libnghttp2.so.14.14.0
+link path=usr/lib/$(MACH64)/libnghttp2.so target=libnghttp2.so.14.17.2
+link path=usr/lib/$(MACH64)/libnghttp2.so.14 target=libnghttp2.so.14.17.2
+file path=usr/lib/$(MACH64)/libnghttp2.so.14.17.2
 file path=usr/lib/$(MACH64)/pkgconfig/libnghttp2.pc
-link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.14.0
-link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.14.0
-file path=usr/lib/libnghttp2.so.14.14.0
+link path=usr/lib/libnghttp2.so target=libnghttp2.so.14.17.2
+link path=usr/lib/libnghttp2.so.14 target=libnghttp2.so.14.17.2
+file path=usr/lib/libnghttp2.so.14.17.2
 file path=usr/lib/pkgconfig/libnghttp2.pc
 file path=usr/share/doc/nghttp2/README.rst
 file path=usr/share/man/man1/h2load.1


### PR DESCRIPTION
**Testing**

* ABI Tracker: https://abi-laboratory.pro/index.php?view=timeline&l=nghttp2

* Test suite passed.

* `curl` with HTTP/2 works:
```
$ curl --http2 --head https://nghttp2.org
HTTP/2 200 
date: Sat, 16 Mar 2019 07:59:50 GMT
content-type: text/html
last-modified: Fri, 08 Mar 2019 12:33:02 GMT
etag: "5c8260fe-19d8"
accept-ranges: bytes
content-length: 6616
x-backend-header-rtt: 0.007242
strict-transport-security: max-age=31536000
server: nghttpx
via: 2 nghttpx
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
```

* Rebuild of following packages passed:

  - pkg:/network/asterisk
  - pkg:/web/curl
  - pkg:/web/server/apache-24