### PR TITLE
Update backports.ssl_match_hostname to 3.7.0.1

### DIFF
--- a/components/python/backports.ssl_match_hostname/Makefile
+++ b/components/python/backports.ssl_match_hostname/Makefile
@@ -18,23 +18,26 @@
 #
 # CDDL HEADER END
 #
-# Copyright 2016, Aurelien Larcher.
+
 #
+# Copyright 2016, Aurelien Larcher.
+# Copyright 2019, Michal Nowak
+#
+
 include ../../../make-rules/shared-macros.mk
 
 
-COMPONENT_NAME= backports.ssl_match_hostname
-COMPONENT_VERSION= 3.5.0.1
-COMPONENT_REVISION= 1
-COMPONENT_SRC_VERSION= 29bca6a22953
-COMPONENT_FMRI= library/python/backports.ssl_match_hostname
-COMPONENT_PROJECT_URL= http://bitbucket.org/brandon/backports.ssl_match_hostname
-COMPONENT_SRC= brandon-$(COMPONENT_NAME)-$(COMPONENT_SRC_VERSION)
-COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+COMPONENT_NAME=		backports.ssl_match_hostname
+COMPONENT_VERSION=	3.7.0.1
+COMPONENT_SRC_VERSION=	312648aec6f0
+COMPONENT_FMRI=		library/python/backports.ssl_match_hostname
+COMPONENT_PROJECT_URL=	http://bitbucket.org/brandon/backports.ssl_match_hostname
+COMPONENT_SRC=		brandon-$(COMPONENT_NAME)-$(COMPONENT_SRC_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:bc3aee759eb480bda8c5c0e0521f62fd75afeca73395e3195e55f60644304a99
+	sha256:1aa15145177efe58811528663aeac20f8b0fc6009dc74411dfe2a7b5a695dba4
 COMPONENT_ARCHIVE_URL= \
-    https://bitbucket.org/brandon/backports.ssl_match_hostname/get/$(COMPONENT_SRC_VERSION).tar.gz
+	https://bitbucket.org/brandon/backports.ssl_match_hostname/get/$(COMPONENT_SRC_VERSION).tar.bz2
 
 PYTHON_VERSIONS=	2.7
 
@@ -46,6 +49,11 @@ build:		$(BUILD_NO_ARCH)
 
 install:	$(INSTALL_NO_ARCH)
 
+# Test ought to be run manually as `tox` is not in oi-userland:
+# 	pip install --user tox
+#	cd brandon-backports.ssl_match_hostname-$(COMPONENT_SRC_VERSION)
+#	PATH=$HOME/.local/bin:$PATH tox -e py27,py34,py35
 test:		$(NO_TESTS)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/python-27

--- a/components/python/backports.ssl_match_hostname/backports.backports-common-27.p5m
+++ b/components/python/backports.ssl_match_hostname/backports.backports-common-27.p5m
@@ -14,7 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/library/python/backports/backports-common-27@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="The ssl.match_hostname() function from Python 3.5"
+set name=pkg.summary value="The ssl.match_hostname() function from Python 3.7"
 set name=info.classification value="org.opensolaris.category.2008:Development/Python"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/python/backports.ssl_match_hostname/backports.ssl_match_hostname-PYVER.p5m
+++ b/components/python/backports.ssl_match_hostname/backports.ssl_match_hostname-PYVER.p5m
@@ -14,7 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/library/python/backports.ssl_match_hostname-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="The ssl.match_hostname() function from Python 3.5"
+set name=pkg.summary value="The ssl.match_hostname() function from Python 3.7"
 set name=info.classification value="org.opensolaris.category.2008:Development/Python"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)


### PR DESCRIPTION
Brings Python 3.7 changes to `ssl.match_hostname()` function.

**Testing**

Test suite passed in Python 2.7 virtual environment.

Rebuild of following packages passed:
- pkg:/library/python/backports.functools_lru_cache-27
- pkg:/library/python/backports.shutil_get_terminal_size-27