### PR TITLE
Update CFFI to 1.12.2, alter Python cryptography

### DIFF
--- a/components/python/cffi/Makefile
+++ b/components/python/cffi/Makefile
@@ -21,21 +21,19 @@
 
 #
 # Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cffi
-COMPONENT_VERSION=	1.11.4
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	1.12.2
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:df9083a992b17a28cd4251a3f5c879e0198bb26c9e808c4647e0a18739f1d11d
+	sha256:e113878a446c6228669144ae8a56e268c91b7f1fafae927adc4879d9849e0ea7
 COMPONENT_ARCHIVE_URL=	$(call pypi_url)
 COMPONENT_PROJECT_URL=	http://cffi.readthedocs.org/
-COMPONENT_BUGDB=	python-mod/cffi
-COMPONENT_ANITYA_ID=	5536
 
 PYTHON_VERSIONS=	2.7 3.4 3.5
 
@@ -46,12 +44,11 @@ include $(WS_MAKE_RULES)/ips.mk
 CFLAGS = -DXOPEN_SOURCE=700
 CFLAGS += $(CC_BITS)
 
-# We get spurious test failures with python 3.4
 COMPONENT_TEST_DIR =	$(@D)/tests
 COMPONENT_TEST_ENV =	PYTHON_VERSIONS="2.7 3.4 3.5"
 COMPONENT_TEST_ENV +=	$(PYTHON_ENV)
 COMPONENT_TEST_ENV +=	PYTHONPATH=$(PROTO_DIR)/$(PYTHON_LIB)
-COMPONENT_TEST_ENV +=	TESTOWNLIB_CC="$(CC) $(CC_PIC) %s $(CC_BITS) -shared -o %s"
+COMPONENT_TEST_ENV +=	TESTOWNLIB_CC="$(CC) $(CC_PIC) %s $(CC_BITS) -shared -o '%s.so'"
 COMPONENT_TEST_CMD =	$(PYTHON.$(BITS)) /usr/bin/py.test-$(PYTHON_VERSION)
 COMPONENT_TEST_ARGS =	--resultlog $(@D)/testresults
 COMPONENT_TEST_ARGS +=	-p no:codechecker
@@ -70,19 +67,18 @@ COMPONENT_PRE_TEST_ACTION = \
 	    $(SOURCE_DIR)/doc/source/installation.rst \
 	    $(@D)/tests/doc/source
 
-# common targets
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
 
-
-REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += library/python/pycparser-27
 REQUIRED_PACKAGES += library/python/pycparser-34
 REQUIRED_PACKAGES += library/python/pycparser-35
-REQUIRED_PACKAGES += runtime/python-27
 REQUIRED_PACKAGES += runtime/python-34
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/libffi
+REQUIRED_PACKAGES += runtime/python-27
 REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += system/library

--- a/components/python/cffi/patches/setup.py.patch
+++ b/components/python/cffi/patches/setup.py.patch
@@ -1,19 +1,14 @@
 We don't have __sync_synchronize, so don't bother testing for it.
 Not contributed upstream, but may be in future.
 
-
---- cffi-1.11.4/setup.py.orig	2018-01-13 11:28:57.000000000 -0800
-+++ cffi-1.11.4/setup.py	2018-02-15 17:32:38.870952346 -0800
-@@ -73,11 +73,11 @@
-             no_working_compiler_found()
-         sys.stderr.write("Note: will not use '__thread' in the C code\n")
-         _safe_to_ignore()
+--- cffi-1.12.2/setup.py	2019-02-26 16:01:22.000000000 +0000
++++ cffi-1.12.2/setup.py.new	2019-03-17 10:44:25.408667954 +0000
+@@ -86,7 +86,7 @@ def ask_supports_thread():
+             _safe_to_ignore()
  
  def ask_supports_sync_synchronize():
--    if sys.platform == 'win32':
-+    if sys.platform == 'win32' or sys.platform == 'sunos5':
+-    if sys.platform == 'win32' or no_compiler_found:
++    if sys.platform == 'win32' or sys.platform == 'sunos5' or no_compiler_found:
          return
      config = get_config()
      ok = config.try_link('int main(void) { __sync_synchronize(); return 0; }')
-     if ok:
-         define_macros.append(('HAVE_SYNC_SYNCHRONIZE', None))

--- a/components/python/cffi/patches/test.patch
+++ b/components/python/cffi/patches/test.patch
@@ -160,31 +160,17 @@ The testsuite makes some incorrect assumptions:
              continue     # enums may always be signed with MSVC
          ffi = FFI()
          ffi.cdef("enum foo_e { AA };")
---- cffi-1.11.4/testing/cffi0/test_ownlib.py	2015-06-09 03:04:07.000000000 -0700
-+++ cffi-1.11.4/testing/cffi0/test_ownlib.py	2015-08-12 13:55:21.239982926 -0700
-@@ -1,4 +1,4 @@
--import py, sys
-+import os, py, sys
- import subprocess, weakref
- from cffi import FFI
- from cffi.backend_ctypes import CTypesBackend
-@@ -102,7 +102,6 @@
-         from testing.udir import udir
-         udir.join('testownlib.c').write(SOURCE)
-         if sys.platform == 'win32':
--            import os
-             # did we already build it?
-             if os.path.exists(str(udir.join('testownlib.dll'))):
-                 cls.module = str(udir.join('testownlib.dll'))
-@@ -129,7 +128,7 @@
-                 cls.module = str(udir.join('testownlib.dll'))
-         else:
+--- cffi-1.12.2/testing/cffi0/test_ownlib.py	2019-02-16 16:28:51.000000000 +0000
++++ cffi-1.12.2/testing/cffi0/test_ownlib.py.new	2019-03-17 10:49:40.260213627 +0000
+@@ -160,7 +160,7 @@ class TestOwnLib(object):
+                 unicode_name = u+'testownlib'
+                 encoded = str(unicode_name)
              subprocess.check_call(
--                'cc testownlib.c -shared -fPIC -o testownlib.so',
-+                os.getenv('TESTOWNLIB_CC') % ('testownlib.c', 'testownlib.so'),
+-                "cc testownlib.c -shared -fPIC -o '%s.so'" % (encoded,),
++                os.getenv('TESTOWNLIB_CC') % ('testownlib.c', encoded),
                  cwd=str(udir), shell=True)
-             cls.module = str(udir.join('testownlib.so'))
-
+             cls.module = os.path.join(str(udir), unicode_name + (u+'.so'))
+         print(repr(cls.module))
 --- cffi-1.11.4/testing/cffi0/test_verify.py    2015-06-09 03:04:07.000000000 -0700
 +++ cffi-1.11.4/testing/cffi0/test_verify.py    2015-08-12 14:17:18.300215250 -0700
 @@ -17,12 +17,16 @@

--- a/components/python/cryptography/Makefile
+++ b/components/python/cryptography/Makefile
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
 
 # Component uses ABI3 naming.
@@ -30,7 +31,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cryptography
 COMPONENT_VERSION=	2.1.4
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
@@ -46,24 +47,35 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/setup.py.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-# common targets
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)
 
 #
-# tests require cryptography_vectors, iso8601, pretend, pytest>= 2.8.7,
-# hypothesis>=1.11.4 and pyasn1_modules, some of which have not yet integrated.
-# On a i386 kernel zone with the test dependencies installed, test results are:
-# Python2.7: 74000 passed, 6136 skipped
-# Python3.4: 74000 passed, 6136 skipped
-# Python3.5: 74000 passed, 6136 skipped
+# The test suite requires several PyPI packages not in our distribution.
+# Install them for all Pythons in $(PYTHON_VERSION) like this (replace
+# Makefile variables, where appropriate; X and Y stand for Python minor
+# and, respectively, major version):
 #
-test:		$(NO_TESTS)
+#   pipX.Y install --user cryptography-vectors==$(COMPONENT_VERSION) iso8601 pretend pytest hypothesis pyasn1-modules
+#
+# Results for Python 2.7.16, 3.4.9, and 3.5.6 for 32-bit and 64-bit:
+#
+#   93184 passed, 4352 skipped in 308.30 seconds
+#
+COMPONENT_TEST_DIR=	$(COMPONENT_SRC)
+COMPONENT_TEST_CMD=	py.test-$(PYTHON_VERSION)
+COMPONENT_TEST_ARGS=	tests
 
+test:		$(TEST_32_and_64)
+
+REQUIRED_PACKAGES += library/python/pytest-27
+REQUIRED_PACKAGES += library/python/pytest-34
+REQUIRED_PACKAGES += library/python/pytest-35
 REQUIRED_PACKAGES += library/python/cffi
+REQUIRED_PACKAGES += runtime/python-34
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += runtime/python-27
-REQUIRED_PACKAGES += runtime/python-34
 REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += system/library

--- a/components/python/cryptography/cryptography-PYVER.p5m
+++ b/components/python/cryptography/cryptography-PYVER.p5m
@@ -124,7 +124,7 @@ file path=usr/lib/python$(PYVER)/vendor-packages/cryptography/x509/oid.py
 license cryptography.license license=BSD-like
 
 # Dependencies on cffi must be incorporated.
-depend type=incorporate fmri=library/python/cffi-$(PYV)@1.11.4
+depend type=incorporate fmri=library/python/cffi-$(PYV)@1.12.2
 
 # force a dependency on asn1crypto; pkgdepend work is needed to flush this out.
 depend type=require fmri=library/python/asn1crypto-$(PYV)


### PR DESCRIPTION
CFFI changelog: https://cffi.readthedocs.io/en/latest/whatsnew.html

Python cryptography needs to be installed with CFFI in one batch because of the `depend type=incorporate fmri=library/python/cffi-$(PYV)@1.12.2`.

**Testing**

`pkg` works.

_pkg_

I run the pkg test suite and there appear no regression, though I find the test suite a bit unstable in it's results:

[py27.new.txt](https://github.com/OpenIndiana/oi-userland/files/2976704/py27.new.txt)
[py27.old.txt](https://github.com/OpenIndiana/oi-userland/files/2976705/py27.old.txt)
[py35.new.txt](https://github.com/OpenIndiana/oi-userland/files/2976706/py35.new.txt)
[py35.old.txt](https://github.com/OpenIndiana/oi-userland/files/2976707/py35.old.txt)

_CFFI_
Test suite did not regress. There are but three types of failures, the last one seems to be OI-specific thing:

1) https://bitbucket.org/cffi/cffi/issues/406/testing-cffi0-test_vgen2py

2) [dont_call_me_any_more.txt](https://github.com/OpenIndiana/oi-userland/files/2976688/dont_call_me_any_more.txt)

```
>   ffiplatform.compile = lambda *args: dont_call_me_any_more
E   NameError: global name 'dont_call_me_any_more' is not defined
```

3) [found_unexpected_file.txt](https://github.com/OpenIndiana/oi-userland/files/2976689/found_unexpected_file.txt)

```
E           AssertionError: found unexpected file '/tmp/ffi-2/test_setuptools_api_2/src1/pack3/64'
E           assert '64' in {'mymod.SO': None}
```

_Python cryptography_

Test suite passed.