### PR TITLE
Update VTE to 0.56.3

### DIFF
--- a/components/library/vte-291/Makefile
+++ b/components/library/vte-291/Makefile
@@ -10,7 +10,7 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
-# Copyright 2018-2019 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 PREFERRED_BITS=		64
@@ -18,7 +18,7 @@ PREFERRED_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		vte
-COMPONENT_MJR_VERSION=	0.54
+COMPONENT_MJR_VERSION=	0.56
 COMPONENT_MNR_VERSION=	3
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.gnome.org
@@ -28,7 +28,7 @@ COMPONENT_CLASSIFICATION=	Desktop (GNOME)/Libraries
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:693682145025c2af72d1070afaecba111351e747b4ba8f4a9d246b139f44ebfd
+	sha256:17a1d4bc8848f1d2acfa4c20aaa24b9bac49f057b8909c56d3dafec2e2332648
 COMPONENT_ARCHIVE_URL=	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	LGPLv2.1 LGPLv3 GPLv3
 COMPONENT_LICENSE_FILE=	COPYING.GPL3
@@ -38,6 +38,8 @@ include $(WS_TOP)/make-rules/configure.mk
 include $(WS_TOP)/make-rules/ips.mk
 
 PATH=$(PATH.gnu)
+
+GCC_VERSION = 7
 
 # Force use of gnutls-3 pkgconfig during 2.x->3.x transition
 GNUTLS_PKG_CONFIG_PATH_32 = /usr/lib/pkgconfig/gnutls-3
@@ -79,8 +81,6 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "/FAIL:/p" ' \
 	'-e "/ERROR:/p" '
 
-# common targets
-
 $(INSTALL_32):	$(INSTALL_64)
 
 build:		$(BUILD_32_and_64)
@@ -89,6 +89,9 @@ install:	$(INSTALL_32_and_64)
 
 test:		$(TEST_32_and_64)
 
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += library/desktop/atk
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += library/desktop/gtk3
@@ -98,6 +101,4 @@ REQUIRED_PACKAGES += library/gnutls-3
 REQUIRED_PACKAGES += library/pcre2
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += system/library/math

--- a/components/library/vte-291/manifests/sample-manifest.p5m
+++ b/components/library/vte-291/manifests/sample-manifest.p5m
@@ -36,14 +36,14 @@ file path=usr/include/vte-2.91/vte/vteterminal.h
 file path=usr/include/vte-2.91/vte/vtetypebuiltins.h
 file path=usr/include/vte-2.91/vte/vteversion.h
 file path=usr/lib/$(MACH64)/girepository-1.0/Vte-2.91.typelib
-link path=usr/lib/$(MACH64)/libvte-2.91.so target=libvte-2.91.so.0.5400.3
-link path=usr/lib/$(MACH64)/libvte-2.91.so.0 target=libvte-2.91.so.0.5400.3
-file path=usr/lib/$(MACH64)/libvte-2.91.so.0.5400.3
+link path=usr/lib/$(MACH64)/libvte-2.91.so target=libvte-2.91.so.0.5600.3
+link path=usr/lib/$(MACH64)/libvte-2.91.so.0 target=libvte-2.91.so.0.5600.3
+file path=usr/lib/$(MACH64)/libvte-2.91.so.0.5600.3
 file path=usr/lib/$(MACH64)/pkgconfig/vte-2.91.pc
 file path=usr/lib/girepository-1.0/Vte-2.91.typelib
-link path=usr/lib/libvte-2.91.so target=libvte-2.91.so.0.5400.3
-link path=usr/lib/libvte-2.91.so.0 target=libvte-2.91.so.0.5400.3
-file path=usr/lib/libvte-2.91.so.0.5400.3
+link path=usr/lib/libvte-2.91.so target=libvte-2.91.so.0.5600.3
+link path=usr/lib/libvte-2.91.so.0 target=libvte-2.91.so.0.5600.3
+file path=usr/lib/libvte-2.91.so.0.5600.3
 file path=usr/lib/pkgconfig/vte-2.91.pc
 file path=usr/share/gir-1.0/Vte-2.91.gir
 file path=usr/share/locale/am/LC_MESSAGES/vte-2.91.mo

--- a/components/library/vte-291/vte-291.p5m
+++ b/components/library/vte-291/vte-291.p5m
@@ -11,7 +11,7 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
-# Copyright 2018-2019 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -35,14 +35,14 @@ file path=usr/include/vte-2.91/vte/vteterminal.h
 file path=usr/include/vte-2.91/vte/vtetypebuiltins.h
 file path=usr/include/vte-2.91/vte/vteversion.h
 file path=usr/lib/$(MACH64)/girepository-1.0/Vte-2.91.typelib
-link path=usr/lib/$(MACH64)/libvte-2.91.so target=libvte-2.91.so.0.5400.3
-link path=usr/lib/$(MACH64)/libvte-2.91.so.0 target=libvte-2.91.so.0.5400.3
-file path=usr/lib/$(MACH64)/libvte-2.91.so.0.5400.3
+link path=usr/lib/$(MACH64)/libvte-2.91.so target=libvte-2.91.so.0.5600.3
+link path=usr/lib/$(MACH64)/libvte-2.91.so.0 target=libvte-2.91.so.0.5600.3
+file path=usr/lib/$(MACH64)/libvte-2.91.so.0.5600.3
 file path=usr/lib/$(MACH64)/pkgconfig/vte-2.91.pc
 file path=usr/lib/girepository-1.0/Vte-2.91.typelib
-link path=usr/lib/libvte-2.91.so target=libvte-2.91.so.0.5400.3
-link path=usr/lib/libvte-2.91.so.0 target=libvte-2.91.so.0.5400.3
-file path=usr/lib/libvte-2.91.so.0.5400.3
+link path=usr/lib/libvte-2.91.so target=libvte-2.91.so.0.5600.3
+link path=usr/lib/libvte-2.91.so.0 target=libvte-2.91.so.0.5600.3
+file path=usr/lib/libvte-2.91.so.0.5600.3
 file path=usr/lib/pkgconfig/vte-2.91.pc
 file path=usr/share/gir-1.0/Vte-2.91.gir
 file path=usr/share/locale/am/LC_MESSAGES/vte-2.91.mo


### PR DESCRIPTION
I am unable to build this with GCC 6 (even with `-std=gnu++1z`):

```
checking whether /usr/gcc/6/bin/g++ supports C++17 features by default... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with -std=gnu++17... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with -std=gnu++1z... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with -std=c++17... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with +std=c++17... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with -h std=c++17... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with -std=c++1z... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with +std=c++1z... no
checking whether /usr/gcc/6/bin/g++ supports C++17 features with -h std=c++1z... no
configure: error: *** A compiler with support for C++17 language features is required.
```

GCC 7 & 8 do fine.

Actually, what's the problem with having some stuff built with non-default GCC? Apart from pulling `g++-7-runtime` and `gcc-7-runtime`.