### PR TITLE
Mate 1.22 part1

### DIFF
--- a/components/desktop/mate/libmatekbd/Makefile
+++ b/components/desktop/mate/libmatekbd/Makefile
@@ -11,34 +11,34 @@
 #
 # Copyright 2016 Till Wegmueller
 # Copyright 2016 Ken Mays
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmatekbd
-COMPONENT_MJR_VERSION=  1.20
-COMPONENT_MNR_VERSION=  2
+COMPONENT_MJR_VERSION=  1.22
+COMPONENT_MNR_VERSION=  0
 COMPONENT_VERSION=      $(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE keyboard shared library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:21c3e307af2caf7fb552cfb1ea615b84acaa9f9993e7b988e3da6aa2e15d3fd0
+	sha256:c88ff0606f0581579804e97cf1f34fcebe739dc6fd41be1487552486823959b7
 COMPONENT_ARCHIVE_URL=	http://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE= GPLv2, LGPLv2, FDLv1.1
-COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
-COMPONENT_CLASSIFICATION = System/Libraries
-COMPONENT_FMRI = library/desktop/mate/$(COMPONENT_NAME)
+COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_FMRI=		library/desktop/mate/$(COMPONENT_NAME)
 
 include $(WS_TOP)/make-rules/prep.mk
 include $(WS_TOP)/make-rules/configure.mk
 include $(WS_TOP)/make-rules/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
-COMPONENT_PREP_ACTION=	cd $(@D)  && NOCONFIGURE=1 ./autogen.sh
+COMPONENT_PREP_ACTION=	cd $(@D) && NOCONFIGURE=1 ./autogen.sh
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --disable-static
@@ -50,7 +50,6 @@ CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
-# common targets
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)

--- a/components/desktop/mate/libmatemixer/Makefile
+++ b/components/desktop/mate/libmatemixer/Makefile
@@ -11,34 +11,34 @@
 #
 # Copyright 2016 Till Wegmueller
 # Copyright 2016 Ken Mays
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmatemixer
-COMPONENT_MJR_VERSION=  1.20
-COMPONENT_MNR_VERSION=	1
+COMPONENT_MJR_VERSION=  1.22
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
 COMPONENT_SUMMARY=	Mixer library for MATE desktop
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:239106f666d79abf578eb02eaa63d12724f73330985f5c827d4b5307623de602
+	sha256:09e64d6f3c4ca7c1e5ceb16ad86d147a77056bfe0faefe219295c8574abe0fec
 COMPONENT_ARCHIVE_URL=	http://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE= GPLv2, LGPLv2, FDLv1.1
-COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
-COMPONENT_CLASSIFICATION = System/Libraries
-COMPONENT_FMRI = library/desktop/mate/$(COMPONENT_NAME)
+COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_FMRI=		library/desktop/mate/$(COMPONENT_NAME)
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
-COMPONENT_PREP_ACTION=	cd $(@D)  && NOCONFIGURE=1 ./autogen.sh
+COMPONENT_PREP_ACTION=	cd $(@D) && NOCONFIGURE=1 ./autogen.sh
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --disable-static
@@ -52,7 +52,6 @@ CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
-# common targets
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)

--- a/components/desktop/mate/libmatemixer/libmatemixer.p5m
+++ b/components/desktop/mate/libmatemixer/libmatemixer.p5m
@@ -11,7 +11,7 @@
 
 #
 # Copyright 2016 Till Wegmueller
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -161,3 +161,4 @@ file path=usr/share/locale/xh/LC_MESSAGES/libmatemixer.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/libmatemixer.mo
 file path=usr/share/locale/zh_HK/LC_MESSAGES/libmatemixer.mo
 file path=usr/share/locale/zh_TW/LC_MESSAGES/libmatemixer.mo
+file path=usr/share/locale/zu/LC_MESSAGES/libmatemixer.mo

--- a/components/desktop/mate/libmatemixer/manifests/sample-manifest.p5m
+++ b/components/desktop/mate/libmatemixer/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -160,3 +160,4 @@ file path=usr/share/locale/xh/LC_MESSAGES/libmatemixer.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/libmatemixer.mo
 file path=usr/share/locale/zh_HK/LC_MESSAGES/libmatemixer.mo
 file path=usr/share/locale/zh_TW/LC_MESSAGES/libmatemixer.mo
+file path=usr/share/locale/zu/LC_MESSAGES/libmatemixer.mo

--- a/components/desktop/mate/libmateweather/Makefile
+++ b/components/desktop/mate/libmateweather/Makefile
@@ -11,34 +11,34 @@
 #
 # Copyright 2016 Till Wegmueller
 # Copyright 2016 Ken Mays
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmateweather
-COMPONENT_MJR_VERSION=	1.20
-COMPONENT_MNR_VERSION=	2
+COMPONENT_MJR_VERSION=	1.22
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
 COMPONENT_SUMMARY=	Library to accessing online weather information
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:bb4363c64a81885c0656be71a8965df22d0acff64df46cadd424d5116c0f57cf
+	sha256:ca5cca359ed53fabef194884d76d93eafbc35eee8bcd951c5b8e5942397b2be6
 COMPONENT_ARCHIVE_URL=	http://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE= GPLv2, LGPLv2, FDLv1.1
-COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
-COMPONENT_CLASSIFICATION = System/Libraries
-COMPONENT_FMRI = library/desktop/mate/$(COMPONENT_NAME)
+COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_FMRI=		library/desktop/mate/$(COMPONENT_NAME)
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
-COMPONENT_PREP_ACTION = cd $(@D)  && NOCONFIGURE=1 ./autogen.sh 
+COMPONENT_PREP_ACTION = cd $(@D) && NOCONFIGURE=1 ./autogen.sh
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --disable-static
@@ -50,7 +50,6 @@ CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
-# common targets
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)

--- a/components/desktop/mate/mate-common/Makefile
+++ b/components/desktop/mate/mate-common/Makefile
@@ -12,7 +12,7 @@
 # Copyright 2017 Gary Mills
 # Copyright 2016 Till Wegmueller
 # Copyright 2016 Ken Mays
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 PREFERRED_BITS=64
@@ -20,7 +20,7 @@ PREFERRED_BITS=64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-common
-COMPONENT_MJR_VERSION=	1.20
+COMPONENT_MJR_VERSION=	1.22
 COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
@@ -28,12 +28,12 @@ COMPONENT_SUMMARY=	Common automake macros for MATE
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:616d9c319ee892f05494570fb0f7316c10f17a1f8d15d0a9a6ae38c320161a41
+	sha256:3f19973a26ccff12834615c4fcc7414cef542ea648f391125e5cfdd8ec649c86
 COMPONENT_ARCHIVE_URL=	http://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE= GPLv2, LGPLv2, FDLv1.1
-COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
-COMPONENT_CLASSIFICATION = System/Libraries
-COMPONENT_FMRI = library/desktop/mate/$(COMPONENT_NAME)
+COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
+COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_FMRI=		library/desktop/mate/$(COMPONENT_NAME)
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
@@ -42,7 +42,6 @@ include $(WS_MAKE_RULES)/ips.mk
 PATH = $(PATH.gnu)
 
 COMPONENT_PREP_ACTION = cd $(@D) && NOCONFIGURE=1 ./autogen.sh
-
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --libexecdir=/usr/lib/mate
@@ -53,7 +52,6 @@ CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
-# common targets
 build:		$(BUILD_64)
 
 install:	$(INSTALL_64)


### PR DESCRIPTION
I started every GUI application visible from the MATE menu and basic functionality is ensured.

However, there seems to be some problems with icons in the default Nimbus theme. Some icons may be missing (Rhythmbox, gThumb, gtkam), "Help" icon is too big so that buttons in the row are too big ("Add to panel"), odd theming on checkbox in context menu ("Lock icon"). See the screenshots.

![rhythmbox](https://user-images.githubusercontent.com/4632197/55938789-70192500-5c3c-11e9-81d0-fd8d6ea404bc.png)
![gthumb](https://user-images.githubusercontent.com/4632197/55938785-70192500-5c3c-11e9-948a-bd19ac45305a.png)
![gtkam](https://user-images.githubusercontent.com/4632197/55938786-70192500-5c3c-11e9-8b83-747c29758a8f.png)

![help-icon-nimbus](https://user-images.githubusercontent.com/4632197/55938787-70192500-5c3c-11e9-9ad7-d1609ce3444a.png)

![lock-to-panel](https://user-images.githubusercontent.com/4632197/55938788-70192500-5c3c-11e9-9b27-d0224abc5032.png)
