### PR TITLE
Update nano to 4.0

### DIFF
--- a/components/editor/nano/Makefile
+++ b/components/editor/nano/Makefile
@@ -10,13 +10,13 @@
 
 #
 # Copyright (c) 2014 Rouven Wachhaus
-# Copyright (c) 2018 Michal Nowak
+# Copyright (c) 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		nano
-COMPONENT_VERSION=	3.2
+COMPONENT_VERSION=	4.0
 COMPONENT_FMRI=		editor/nano
 COMPONENT_SUMMARY=	GNU implementation of nano, a text editor emulating pico
 COMPONENT_CLASSIFICATION=System/Text Tools
@@ -24,7 +24,7 @@ COMPONENT_PROJECT_URL=	https://www.nano-editor.org/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:d12773af3589994b2e4982c5792b07c6240da5b86c5aef2103ab13b401fe6349
+	sha256:1e2fcfea35784624a7d86785768b772d58bb3995d1aec9176a27a113b1e9bac3
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/pub/gnu/nano/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3
 
@@ -36,15 +36,20 @@ COMPONENT_PREP_ACTION =        ( cd $(@D) && autoreconf -fiv )
 
 CONFIGURE_BINDIR.64 =	$(CONFIGURE_PREFIX)/bin
 
-CONFIGURE_OPTIONS  +=		--enable-color
-CONFIGURE_OPTIONS  +=		--enable-multibuffer
-CONFIGURE_OPTIONS  +=		--enable-utf8
-CONFIGURE_OPTIONS  +=		get_wch=getwch
+CONFIGURE_OPTIONS +=	--sysconfdir=/etc
+CONFIGURE_OPTIONS +=	--enable-color
+CONFIGURE_OPTIONS +=	--enable-multibuffer
+CONFIGURE_OPTIONS +=	--enable-utf8
+# magic does not identify files given their content
+CONFIGURE_OPTIONS +=	--disable-libmagic
+CONFIGURE_OPTIONS +=	get_wch=getwch
 
 CPPFLAGS += -I$(USRINCDIR)/ncurses
 CFLAGS += -I$(USRINCDIR)/ncurses
 
-# common targets
+COMPONENT_POST_INSTALL_ACTION = \
+	$(INSTALL) -D -m 0644 $(BUILD_DIR)/$(MACH64)/doc/sample.nanorc $(PROTO_DIR)$(ETCDIR)/nanorc
+
 build:		$(BUILD_64)
 
 install:	$(INSTALL_64)
@@ -52,6 +57,5 @@ install:	$(INSTALL_64)
 test:		$(NO_TESTS)
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += library/magic
 REQUIRED_PACKAGES += library/ncurses
 REQUIRED_PACKAGES += system/library

--- a/components/editor/nano/manifests/sample-manifest.p5m
+++ b/components/editor/nano/manifests/sample-manifest.p5m
@@ -22,6 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=etc/nanorc
 file path=usr/bin/nano
 link path=usr/bin/rnano target=nano
 file path=usr/share/doc/nano/faq.html
@@ -48,6 +49,7 @@ file path=usr/share/locale/hu/LC_MESSAGES/nano.mo
 file path=usr/share/locale/id/LC_MESSAGES/nano.mo
 file path=usr/share/locale/it/LC_MESSAGES/nano.mo
 file path=usr/share/locale/ja/LC_MESSAGES/nano.mo
+file path=usr/share/locale/ko/LC_MESSAGES/nano.mo
 file path=usr/share/locale/ms/LC_MESSAGES/nano.mo
 file path=usr/share/locale/nb/LC_MESSAGES/nano.mo
 file path=usr/share/locale/nl/LC_MESSAGES/nano.mo

--- a/components/editor/nano/nano.p5m
+++ b/components/editor/nano/nano.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Adam Stevko 
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,6 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=etc/nanorc preserve=true
 file path=usr/bin/nano
 link path=usr/bin/rnano target=nano
 file path=usr/share/doc/nano/faq.html
@@ -46,6 +48,7 @@ file path=usr/share/locale/hu/LC_MESSAGES/nano.mo
 file path=usr/share/locale/id/LC_MESSAGES/nano.mo
 file path=usr/share/locale/it/LC_MESSAGES/nano.mo
 file path=usr/share/locale/ja/LC_MESSAGES/nano.mo
+file path=usr/share/locale/ko/LC_MESSAGES/nano.mo
 file path=usr/share/locale/ms/LC_MESSAGES/nano.mo
 file path=usr/share/locale/nb/LC_MESSAGES/nano.mo
 file path=usr/share/locale/nl/LC_MESSAGES/nano.mo

--- a/components/editor/nano/patches/01-load-syntax-highlighting-files.patch
+++ b/components/editor/nano/patches/01-load-syntax-highlighting-files.patch
@@ -1,0 +1,11 @@
+--- nano-4.0/doc/sample.nanorc.in	2019-03-09 10:21:52.000000000 +0000
++++ nano-4.0/doc/sample.nanorc.in.new	2019-03-25 20:21:07.213862149 +0000
+@@ -259,7 +259,7 @@
+ ## them easier to remember and faster to type using nano's -Y option.
+ 
+ ## To include all existing syntax definitions, you can do:
+-# include "@PKGDATADIR@/*.nanorc"
++include "@PKGDATADIR@/*.nanorc"
+ 
+ 
+ ## Key bindings.


### PR DESCRIPTION
Update GNU nano to 4.0.

Add global `/etc/nanorc` with syntax highlighting on.

Highlighting according to file content (via libmagic) does not work, reported here: http://lists.gnu.org/archive/html/nano-devel/2019-03/msg00047.html.