### PR TITLE
Update freetype to 2.10.0

### DIFF
--- a/components/library/freetype/Makefile
+++ b/components/library/freetype/Makefile
@@ -12,22 +12,22 @@
 #
 # Copyright 2015 Alexander Pyhalov
 # Copyright 2016 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           freetype
-COMPONENT_VERSION=        2.9.1
-COMPONENT_REVISION=	  1
+COMPONENT_VERSION=        2.10.1
 COMPONENT_FMRI=           system/library/freetype-2
 COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_SUMMARY=  	FreeType 2 font engine
 COMPONENT_SRC=      	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d
+	sha256:16dbfa488a21fe827dc27eaf708f42f7aa3bb997d745d31a19781628c36ba26f
 COMPONENT_ARCHIVE_URL= \
-  http://download.savannah.gnu.org/releases/freetype/$(COMPONENT_ARCHIVE)
+	http://download.savannah.gnu.org/releases/freetype/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://freetype.org/
 COMPONENT_LICENSE=      The FreeType Project License
 COMPONENT_LICENSE_FILE= freetype-2.license
@@ -61,8 +61,10 @@ install: $(INSTALL_32_and_64)
 
 test: $(NO_TESTS)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += compress/bzip2
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/library/freetype/freetype-2.p5m
+++ b/components/library/freetype/freetype-2.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2016 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,6 +39,7 @@ file path=usr/include/freetype2/freetype/ftbzip2.h
 file path=usr/include/freetype2/freetype/ftcache.h
 file path=usr/include/freetype2/freetype/ftchapters.h
 file path=usr/include/freetype2/freetype/ftcid.h
+file path=usr/include/freetype2/freetype/ftcolor.h
 file path=usr/include/freetype2/freetype/ftdriver.h
 file path=usr/include/freetype2/freetype/fterrdef.h
 file path=usr/include/freetype2/freetype/fterrors.h
@@ -73,13 +75,13 @@ file path=usr/include/freetype2/freetype/ttnameid.h
 file path=usr/include/freetype2/freetype/tttables.h
 file path=usr/include/freetype2/freetype/tttags.h
 file path=usr/include/freetype2/ft2build.h
-link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.16.1
-link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.16.1
-file path=usr/lib/$(MACH64)/libfreetype.so.6.16.1
+link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.17.1
+link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.17.1
+file path=usr/lib/$(MACH64)/libfreetype.so.6.17.1
 file path=usr/lib/$(MACH64)/pkgconfig/freetype2.pc
-link path=usr/lib/libfreetype.so target=libfreetype.so.6.16.1
-link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.16.1
-file path=usr/lib/libfreetype.so.6.16.1
+link path=usr/lib/libfreetype.so target=libfreetype.so.6.17.1
+link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.17.1
+file path=usr/lib/libfreetype.so.6.17.1
 file path=usr/lib/pkgconfig/freetype2.pc
 file path=usr/share/aclocal/freetype2.m4
 file path=usr/share/man/man1/freetype-config.1

--- a/components/library/freetype/manifests/sample-manifest.p5m
+++ b/components/library/freetype/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,6 +38,7 @@ file path=usr/include/freetype2/freetype/ftbzip2.h
 file path=usr/include/freetype2/freetype/ftcache.h
 file path=usr/include/freetype2/freetype/ftchapters.h
 file path=usr/include/freetype2/freetype/ftcid.h
+file path=usr/include/freetype2/freetype/ftcolor.h
 file path=usr/include/freetype2/freetype/ftdriver.h
 file path=usr/include/freetype2/freetype/fterrdef.h
 file path=usr/include/freetype2/freetype/fterrors.h
@@ -73,13 +74,13 @@ file path=usr/include/freetype2/freetype/ttnameid.h
 file path=usr/include/freetype2/freetype/tttables.h
 file path=usr/include/freetype2/freetype/tttags.h
 file path=usr/include/freetype2/ft2build.h
-link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.16.1
-link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.16.1
-file path=usr/lib/$(MACH64)/libfreetype.so.6.16.1
+link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.17.1
+link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.17.1
+file path=usr/lib/$(MACH64)/libfreetype.so.6.17.1
 file path=usr/lib/$(MACH64)/pkgconfig/freetype2.pc
-link path=usr/lib/libfreetype.so target=libfreetype.so.6.16.1
-link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.16.1
-file path=usr/lib/libfreetype.so.6.16.1
+link path=usr/lib/libfreetype.so target=libfreetype.so.6.17.1
+link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.17.1
+file path=usr/lib/libfreetype.so.6.17.1
 file path=usr/lib/pkgconfig/freetype2.pc
 file path=usr/share/aclocal/freetype2.m4
 file path=usr/share/man/man1/freetype-config.1


### PR DESCRIPTION
Changes between 2.9.1 and 2.10.0: https://sourceforge.net/projects/freetype/files/freetype2/2.10.0/

**Testing:**

- [x] pkg:/desktop/librecad
- [x] pkg:/desktop/mate/control-center
- [x] pkg:/desktop/window-manager/openbox
- [x] pkg:/editor/diagram/dia
- [x] pkg:/editor/gnu-emacs/gnu-emacs-gtk
- [x] pkg:/games/openttd/openttd-core
- [x] pkg:/image/editor/gimp
- [x] pkg:/image/editor/inkscape
- [x] pkg:/library/c++/harfbuzz (test suite)
- [x] pkg:/library/desktop/gtk3 (test suite)
- [x] pkg:/library/desktop/pango (test suite)
- [x] pkg:/library/desktop/webkitgtk2
- [x] pkg:/library/qt4
- [x] pkg:/library/qt5
- [x] pkg:/mail/thunderbird
- [x] pkg:/media/vlc
- [x] pkg:/terminal/xterm
- [x] pkg:/web/browser/firefox