### PR TITLE
First attempt at python virtualenv, needs work.

### DIFF
--- a/components/python/virtualenv/Makefile
+++ b/components/python/virtualenv/Makefile
@@ -1,0 +1,62 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2019 Tim Mooney
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		virtualenv
+COMPONENT_VERSION=	16.5.0
+COMPONENT_FMRI=		library/python/virtualenv
+COMPONENT_SUMMARY=	'A tool to create isolated Python environments'
+COMPONENT_PROJECT_URL=	https://virtualenv.pypa.io/en/latest/
+COMPONENT_CLASSIFICATION=Development/Python
+COMPONENT_SRC=		$(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:948df2d66849bdbf1207110b1bcc32f64e5e35257b76f8067392e3a2c08b3731
+COMPONENT_ARCHIVE_URL=	https://github.com/pypa/virtualenv/archive/$(COMPONENT_VERSION).tar.gz
+COMPONENT_LICENSE=	MIT
+COMPONENT_LICENSE_FILE=	virtualenv.license
+
+PYTHON_VERSIONS=        2.7 3.4 3.5
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/setup.py.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+COMPONENT_TEST_DIR =	$(SOURCE_DIR)
+COMPONENT_TEST_ARGS =	setup.py test
+
+# Replace "#!/usr/bin/env ..." shebang lines with properly versioned ones.
+COMPONENT_POST_INSTALL_ACTION += \
+    $(FIND) $(PROTOUSRLIBDIR)/python$(PYTHON_VERSION) -name *.py \
+        -exec $(GSED) -i -e 's|env python|python$(PYTHON_VERSION)|' "{}" \; ;
+
+COMPONENT_POST_INSTALL_ACTION += \
+        (cd $(PROTOUSRBINDIR); $(MV) virtualenv virtualenv-$(PYTHON_VERSION)) ;
+
+# this python module currently has no binary components, so all
+# targets are *_NO_ARCH
+build:		$(BUILD_NO_ARCH)
+
+install:	$(INSTALL_NO_ARCH)
+
+test:		$(TEST_NO_ARCH)
+
+REQUIRED_PACKAGES += runtime/python-27
+REQUIRED_PACKAGES += runtime/python-34
+REQUIRED_PACKAGES += runtime/python-35
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/python/setuptools-27
+REQUIRED_PACKAGES += library/python/setuptools-34
+REQUIRED_PACKAGES += library/python/setuptools-35

--- a/components/python/virtualenv/manifests/sample-manifest.p5m
+++ b/components/python/virtualenv/manifests/sample-manifest.p5m
@@ -1,0 +1,63 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/virtualenv-2.7
+file path=usr/bin/virtualenv-3.4
+file path=usr/bin/virtualenv-3.5
+file path=usr/lib/python2.7/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py2.7.egg-info/PKG-INFO
+file path=usr/lib/python2.7/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py2.7.egg-info/SOURCES.txt
+file path=usr/lib/python2.7/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py2.7.egg-info/dependency_links.txt
+file path=usr/lib/python2.7/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py2.7.egg-info/entry_points.txt
+file path=usr/lib/python2.7/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py2.7.egg-info/requires.txt
+file path=usr/lib/python2.7/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py2.7.egg-info/top_level.txt
+file path=usr/lib/python2.7/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py2.7.egg-info/zip-safe
+file path=usr/lib/python2.7/vendor-packages/virtualenv.py
+file path=usr/lib/python2.7/vendor-packages/virtualenv_support/__init__.py
+file path=usr/lib/python2.7/vendor-packages/virtualenv_support/pip-19.1-py2.py3-none-any.whl
+file path=usr/lib/python2.7/vendor-packages/virtualenv_support/setuptools-41.0.1-py2.py3-none-any.whl
+file path=usr/lib/python2.7/vendor-packages/virtualenv_support/wheel-0.33.1-py2.py3-none-any.whl
+file path=usr/lib/python3.4/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.4.egg-info/PKG-INFO
+file path=usr/lib/python3.4/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.4.egg-info/SOURCES.txt
+file path=usr/lib/python3.4/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.4.egg-info/dependency_links.txt
+file path=usr/lib/python3.4/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.4.egg-info/entry_points.txt
+file path=usr/lib/python3.4/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.4.egg-info/requires.txt
+file path=usr/lib/python3.4/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.4.egg-info/top_level.txt
+file path=usr/lib/python3.4/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.4.egg-info/zip-safe
+file path=usr/lib/python3.4/vendor-packages/virtualenv.py
+file path=usr/lib/python3.4/vendor-packages/virtualenv_support/__init__.py
+file path=usr/lib/python3.4/vendor-packages/virtualenv_support/pip-19.1-py2.py3-none-any.whl
+file path=usr/lib/python3.4/vendor-packages/virtualenv_support/setuptools-41.0.1-py2.py3-none-any.whl
+file path=usr/lib/python3.4/vendor-packages/virtualenv_support/wheel-0.33.1-py2.py3-none-any.whl
+file path=usr/lib/python3.5/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.5.egg-info/PKG-INFO
+file path=usr/lib/python3.5/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.5.egg-info/SOURCES.txt
+file path=usr/lib/python3.5/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.5.egg-info/dependency_links.txt
+file path=usr/lib/python3.5/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.5.egg-info/entry_points.txt
+file path=usr/lib/python3.5/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.5.egg-info/requires.txt
+file path=usr/lib/python3.5/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
+file path=usr/lib/python3.5/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py3.5.egg-info/zip-safe
+file path=usr/lib/python3.5/vendor-packages/virtualenv.py
+file path=usr/lib/python3.5/vendor-packages/virtualenv_support/__init__.py
+file path=usr/lib/python3.5/vendor-packages/virtualenv_support/pip-19.1-py2.py3-none-any.whl
+file path=usr/lib/python3.5/vendor-packages/virtualenv_support/setuptools-41.0.1-py2.py3-none-any.whl
+file path=usr/lib/python3.5/vendor-packages/virtualenv_support/wheel-0.33.1-py2.py3-none-any.whl

--- a/components/python/virtualenv/virtualenv-PYVER.p5m
+++ b/components/python/virtualenv/virtualenv-PYVER.p5m
@@ -1,0 +1,53 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Tim Mooney <Timothy.V.Mooney@gmail.com>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+# should come from COMPONENT_SUMMARY, but currently seems broken.
+set name=pkg.summary value="A tool to create isolated Python environments"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# manually force a dependency on the Python runtime
+depend fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+       pkg.debug.depend.path=usr/bin type=require
+
+# force a dependency on the meta-package
+depend fmri=library/python/virtualenv@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) \
+    type=require
+
+#
+# use pkg.depend.bypass-generate on virtualenv.py, to filter out
+# some auto-generated dependencies.  The winreg dependency is only needed
+# for Windows, and the configparser vs. ConfigParser and urllib vs urlparse
+# are Python standard library modules that have been renamed in Python 3,
+# so virtualenv tries both names.
+#
+file path=usr/bin/virtualenv-$(PYVER)
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py$(PYVER).egg-info/entry_points.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py$(PYVER).egg-info/requires.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv-$(COMPONENT_VERSION)-py$(PYVER).egg-info/zip-safe
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv.py pkg.depend.bypass-generate=.*(winreg|[Cc]onfig[Pp]arser|importlib|urllib|urlparse).*
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv_support/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv_support/pip-19.1-py2.py3-none-any.whl
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv_support/setuptools-41.0.1-py2.py3-none-any.whl
+file path=usr/lib/python$(PYVER)/vendor-packages/virtualenv_support/wheel-0.33.1-py2.py3-none-any.whl

--- a/components/python/virtualenv/virtualenv.license
+++ b/components/python/virtualenv/virtualenv.license
@@ -1,0 +1,22 @@
+Copyright (c) 2007 Ian Bicking and Contributors
+Copyright (c) 2009 Ian Bicking, The Open Planning Project
+Copyright (c) 2011-2016 The virtualenv developers
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This isn't ready for a commit, since there are problems with the publish stage.

I'm trying to package Python's virtualenv module, which is basically application isolation (containers) for python apps.  It's either required or strongly encouraged by a bunch of Python packages.

I only need virtualenv for one of the python environments (2.7, 3.4, or 3.5), I don't care which, but I'm trying to follow the example from other python mods and package for all 3 current environments.

The problem I'm running into is with package dependency generation for the publish target.  I'm getting errors like this, which I don't fully understand:

```
/export/home/mooney/oi-userland/tools/userland-mangler -D /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386/mangled -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386/mangled -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386 -d /export/home/mooney/oi-userland/components/python/virtualenv/build -d /export/home/mooney/oi-userland/components/python/virtualenv -d virtualenv-16.2.0 -m /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv.mogrified >/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv.mangled
/usr/bin/pkgdepend generate -m -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386/mangled -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386 -d /export/home/mooney/oi-userland/components/python/virtualenv/build -d /export/home/mooney/oi-userland/components/python/virtualenv -d virtualenv-16.2.0 /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-27.mangled >/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-27.depend
/usr/bin/pkgdepend generate -m -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386/mangled -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386 -d /export/home/mooney/oi-userland/components/python/virtualenv/build -d /export/home/mooney/oi-userland/components/python/virtualenv -d virtualenv-16.2.0 /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-34.mangled >/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-34.depend
/usr/bin/pkgdepend generate -m -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386/mangled -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386 -d /export/home/mooney/oi-userland/components/python/virtualenv/build -d /export/home/mooney/oi-userland/components/python/virtualenv -d virtualenv-16.2.0 /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-35.mangled >/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-35.depend
/usr/bin/pkgdepend generate -m -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386/mangled -d /export/home/mooney/oi-userland/components/python/virtualenv/build/prototype/i386 -d /export/home/mooney/oi-userland/components/python/virtualenv/build -d /export/home/mooney/oi-userland/components/python/virtualenv -d virtualenv-16.2.0 /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv.mangled >/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv.depend
/usr/bin/pkgdepend resolve -e /export/home/mooney/oi-userland/components/python/virtualenv/build/resolve.deps -m /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-27.depend /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-34.depend /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-35.depend /export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv.depend
/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-27.depend has unresolved dependency '
    depend type=require fmri=__TBD \
        pkg.debug.depend.reason=usr/lib/python2.7/vendor-packages/virtualenv.py \
        pkg.debug.depend.type=python \
        pkg.debug.depend.file=64/parse.so \
        pkg.debug.depend.file=64/parsemodule.so \
        pkg.debug.depend.file=parse.py \
        pkg.debug.depend.file=parse.pyc \
        pkg.debug.depend.file=parse.pyo \
        pkg.debug.depend.file=parse.so \
        pkg.debug.depend.file=parse/__init__.py \
        pkg.debug.depend.file=parsemodule.so \
        pkg.debug.depend.path=usr/lib/python2.7/lib-dynload/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/lib-old/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/lib-tk/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/plat-sunos5/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/site-packages/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/gtk-2.0/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/urllib \
        pkg.debug.depend.path=usr/lib/python27.zip/urllib'.
/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-27.depend has unresolved dependency '
    depend type=require fmri=__TBD \
        pkg.debug.depend.reason=usr/lib/python2.7/vendor-packages/virtualenv.py \
        pkg.debug.depend.type=python \
        pkg.debug.depend.file=64/winreg.so \
        pkg.debug.depend.file=64/winregmodule.so \
        pkg.debug.depend.file=winreg.py \
        pkg.debug.depend.file=winreg.pyc \
        pkg.debug.depend.file=winreg.pyo \
        pkg.debug.depend.file=winreg.so \
        pkg.debug.depend.file=winreg/__init__.py \
        pkg.debug.depend.file=winregmodule.so \
        pkg.debug.depend.path=usr/lib/python2.7 \
        pkg.debug.depend.path=usr/lib/python2.7/lib-dynload \
        pkg.debug.depend.path=usr/lib/python2.7/lib-old \
        pkg.debug.depend.path=usr/lib/python2.7/lib-tk \
        pkg.debug.depend.path=usr/lib/python2.7/plat-sunos5 \
        pkg.debug.depend.path=usr/lib/python2.7/site-packages \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/gtk-2.0 \
        pkg.debug.depend.path=usr/lib/python27.zip'.
/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-27.depend has unresolved dependency '
    depend type=require fmri=__TBD \
        pkg.debug.depend.reason=usr/lib/python2.7/vendor-packages/virtualenv.py \
        pkg.debug.depend.type=python \
        pkg.debug.depend.file=64/request.so \
        pkg.debug.depend.file=64/requestmodule.so \
        pkg.debug.depend.file=request.py \
        pkg.debug.depend.file=request.pyc \
        pkg.debug.depend.file=request.pyo \
        pkg.debug.depend.file=request.so \
        pkg.debug.depend.file=request/__init__.py \
        pkg.debug.depend.file=requestmodule.so \
        pkg.debug.depend.path=usr/lib/python2.7/lib-dynload/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/lib-old/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/lib-tk/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/plat-sunos5/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/site-packages/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/gtk-2.0/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/urllib \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/urllib \
        pkg.debug.depend.path=usr/lib/python27.zip/urllib'.
/export/home/mooney/oi-userland/components/python/virtualenv/build/manifest-i386-virtualenv-27.depend has unresolved dependency '
    depend type=require fmri=__TBD \
        pkg.debug.depend.reason=usr/lib/python2.7/vendor-packages/virtualenv.py \
        pkg.debug.depend.type=python \
        pkg.debug.depend.file=64/_winreg.so \
        pkg.debug.depend.file=64/_winregmodule.so \
        pkg.debug.depend.file=_winreg.py \
        pkg.debug.depend.file=_winreg.pyc \
        pkg.debug.depend.file=_winreg.pyo \
        pkg.debug.depend.file=_winreg.so \
        pkg.debug.depend.file=_winreg/__init__.py \
        pkg.debug.depend.file=_winregmodule.so \
        pkg.debug.depend.path=usr/lib/python2.7 \
        pkg.debug.depend.path=usr/lib/python2.7/lib-dynload \
        pkg.debug.depend.path=usr/lib/python2.7/lib-old \
        pkg.debug.depend.path=usr/lib/python2.7/lib-tk \
        pkg.debug.depend.path=usr/lib/python2.7/plat-sunos5 \
        pkg.debug.depend.path=usr/lib/python2.7/site-packages \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages \
        pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/gtk-2.0 \
        pkg.debug.depend.path=usr/lib/python27.zip'.
```

etc, with repeated dependency issues for python34 and python35.

Any suggestions for what the problem is?