### PR TITLE
Update Python 3.4 and 3.5 to 3.4.10 and, respectively, 3.5.7

### DIFF
--- a/components/python/python34/Makefile
+++ b/components/python/python34/Makefile
@@ -21,19 +21,18 @@
 
 #
 # Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2019, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Python
-COMPONENT_VERSION=	3.4.9
-COMPONENT_REVISION=	3
+COMPONENT_VERSION=	3.4.10
 COMPONENT_PROJECT_URL=	https://www.python.org
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:59629676ba2b01a798f5211d8f63c26ee52f1d5133cf37583e0bf1bad50c2bd9
+	sha256:d46a8f6fe91679e199c671b1b0a30aaf172d2acb5bcab25beb35f16c3d195b4e
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/ftp/python/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).asc
 COMPONENT_BUGDB=	utility/python
@@ -129,9 +128,10 @@ COMPONENT_POST_INSTALL_ACTION= \
 	(cd $(PROTOUSRDIR) ;  \
 		$(MV) include/python3.4m/pyconfig.h include/python3.4m/pyconfig-$(BITS).h )
 
-# common targets
 $(INSTALL_32):	$(INSTALL_64)
+
 build:		$(BUILD_32_and_64)
+
 install:	$(INSTALL_32_and_64)
 
 # Using "-uall,-network" ensures all tests are run except the network tests.
@@ -154,7 +154,7 @@ COMPONENT_TEST_TARGETS = test < /dev/null
 COMPONENT_TEST_TRANSFORMER =	$(NAWK)
 COMPONENT_TEST_TRANSFORMS = "'/tests OK/ { results = 1 }; /^Re-running failed tests in verbose mode/ { results = 0 } { if (results) print }'"
 
-test:				$(TEST_32_and_64)
+test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += compress/bzip2
@@ -173,3 +173,4 @@ REQUIRED_PACKAGES += runtime/tcl-8
 REQUIRED_PACKAGES += runtime/tk-8
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/python/python34/Makefile
+++ b/components/python/python34/Makefile
@@ -147,6 +147,13 @@ COMPONENT_TEST_ENV = EXTRATESTOPTS="-v -uall,-network $(TESTOPTS_PYTHON_TEST)"
 # Prevent the tests from getting stuck waiting for input.
 COMPONENT_TEST_TARGETS = test < /dev/null
 
+# The test output contains details from each test, in whatever order they
+# complete.  The default _TRANSFORMER is not powerful enough to deal with
+# this; we need heavier artillery.  Extract just the sections that start
+# with "tests OK." and end with "Re-running failed tests..." for comparison.
+COMPONENT_TEST_TRANSFORMER =	$(NAWK)
+COMPONENT_TEST_TRANSFORMS = "'/tests OK/ { results = 1 }; /^Re-running failed tests in verbose mode/ { results = 0 } { if (results) print }'"
+
 test:				$(TEST_32_and_64)
 
 # Auto-generated dependencies

--- a/components/python/python34/manifests/sample-manifest.p5m
+++ b/components/python/python34/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,9 +30,9 @@ link path=usr/bin/$(MACH64)/pydoc3 target=pydoc3.4
 file path=usr/bin/$(MACH64)/pydoc3.4
 link path=usr/bin/$(MACH64)/python3 target=python3.4
 link path=usr/bin/$(MACH64)/python3-config target=python3.4-config
-hardlink path=usr/bin/$(MACH64)/python3.4 target=python3.4m
+file path=usr/bin/$(MACH64)/python3.4
 link path=usr/bin/$(MACH64)/python3.4-config target=python3.4m-config
-file path=usr/bin/$(MACH64)/python3.4m
+hardlink path=usr/bin/$(MACH64)/python3.4m target=python3.4
 file path=usr/bin/$(MACH64)/python3.4m-config
 link path=usr/bin/$(MACH64)/pyvenv target=pyvenv-3.4
 file path=usr/bin/$(MACH64)/pyvenv-3.4
@@ -1190,7 +1190,23 @@ file path=usr/lib/python3.4/test/cjkencodings/shift_jisx0213.txt
 file path=usr/lib/python3.4/test/cmath_testcases.txt
 file path=usr/lib/python3.4/test/coding20731.py
 file path=usr/lib/python3.4/test/curses_tests.py
+file path=usr/lib/python3.4/test/data/BIG5.TXT
+file path=usr/lib/python3.4/test/data/BIG5HKSCS-2004.TXT
+file path=usr/lib/python3.4/test/data/CP932.TXT
+file path=usr/lib/python3.4/test/data/CP936.TXT
+file path=usr/lib/python3.4/test/data/CP949.TXT
+file path=usr/lib/python3.4/test/data/CP950.TXT
+file path=usr/lib/python3.4/test/data/EUC-CN.TXT
+file path=usr/lib/python3.4/test/data/EUC-JISX0213.TXT
+file path=usr/lib/python3.4/test/data/EUC-JP.TXT
+file path=usr/lib/python3.4/test/data/EUC-KR.TXT
+file path=usr/lib/python3.4/test/data/JOHAB.TXT
+file path=usr/lib/python3.4/test/data/NamedSequences.txt
+file path=usr/lib/python3.4/test/data/NormalizationTest.txt
 file path=usr/lib/python3.4/test/data/README
+file path=usr/lib/python3.4/test/data/SHIFTJIS.TXT
+file path=usr/lib/python3.4/test/data/SHIFT_JISX0213.TXT
+file path=usr/lib/python3.4/test/data/gb-18030-2000.xml
 file path=usr/lib/python3.4/test/datetimetester.py
 file path=usr/lib/python3.4/test/decimaltestdata/abs.decTest
 file path=usr/lib/python3.4/test/decimaltestdata/add.decTest
@@ -1436,6 +1452,7 @@ file path=usr/lib/python3.4/test/subprocessdata/qcat.py
 file path=usr/lib/python3.4/test/subprocessdata/qgrep.py
 file path=usr/lib/python3.4/test/subprocessdata/sigchild_ignore.py
 file path=usr/lib/python3.4/test/support/__init__.py
+file path=usr/lib/python3.4/test/talos-2019-0758.pem
 file path=usr/lib/python3.4/test/test___all__.py
 file path=usr/lib/python3.4/test/test___future__.py
 file path=usr/lib/python3.4/test/test__locale.py

--- a/components/python/python34/python-34.p5m
+++ b/components/python/python34/python-34.p5m
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
 
 # bootstrap: pkgdepend doesn't like python 3.4 yet;
@@ -1260,7 +1261,23 @@ file path=usr/lib/python3.4/test/cjkencodings/shift_jisx0213.txt
 file path=usr/lib/python3.4/test/cmath_testcases.txt
 file path=usr/lib/python3.4/test/coding20731.py
 file path=usr/lib/python3.4/test/curses_tests.py
+file path=usr/lib/python3.4/test/data/BIG5.TXT
+file path=usr/lib/python3.4/test/data/BIG5HKSCS-2004.TXT
+file path=usr/lib/python3.4/test/data/CP932.TXT
+file path=usr/lib/python3.4/test/data/CP936.TXT
+file path=usr/lib/python3.4/test/data/CP949.TXT
+file path=usr/lib/python3.4/test/data/CP950.TXT
+file path=usr/lib/python3.4/test/data/EUC-CN.TXT
+file path=usr/lib/python3.4/test/data/EUC-JISX0213.TXT
+file path=usr/lib/python3.4/test/data/EUC-JP.TXT
+file path=usr/lib/python3.4/test/data/EUC-KR.TXT
+file path=usr/lib/python3.4/test/data/JOHAB.TXT
+file path=usr/lib/python3.4/test/data/NamedSequences.txt
+file path=usr/lib/python3.4/test/data/NormalizationTest.txt
 file path=usr/lib/python3.4/test/data/README
+file path=usr/lib/python3.4/test/data/SHIFTJIS.TXT
+file path=usr/lib/python3.4/test/data/SHIFT_JISX0213.TXT
+file path=usr/lib/python3.4/test/data/gb-18030-2000.xml
 file path=usr/lib/python3.4/test/datetimetester.py
 file path=usr/lib/python3.4/test/decimaltestdata/abs.decTest
 file path=usr/lib/python3.4/test/decimaltestdata/add.decTest

--- a/components/python/python34/test/results-32.master
+++ b/components/python/python34/test/results-32.master
@@ -1,0 +1,11 @@
+366 tests OK.
+7 tests failed:
+    test_capi test_cmd_line_script test_import test_selectors
+    test_socket test_strftime test_uuid
+2 tests altered the execution environment:
+    test___all__ test_warnings
+17 tests skipped:
+    test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
+    test_smtpnet test_socketserver test_startfile test_timeout test_tk
+    test_ttk_guionly test_urllib2net test_urllibnet test_winreg
+    test_winsound test_xmlrpc_net test_zipfile64

--- a/components/python/python34/test/results-32.master
+++ b/components/python/python34/test/results-32.master
@@ -1,9 +1,9 @@
-366 tests OK.
+364 tests OK.
 7 tests failed:
     test_capi test_cmd_line_script test_import test_selectors
     test_socket test_strftime test_uuid
-2 tests altered the execution environment:
-    test___all__ test_warnings
+4 tests altered the execution environment:
+    test___all__ test_logging test_ssl test_warnings
 17 tests skipped:
     test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
     test_smtpnet test_socketserver test_startfile test_timeout test_tk

--- a/components/python/python34/test/results-64.master
+++ b/components/python/python34/test/results-64.master
@@ -1,9 +1,9 @@
-365 tests OK.
+367 tests OK.
 6 tests failed:
     test_cmd_line_script test_import test_selectors test_socket
     test_strftime test_uuid
-4 tests altered the execution environment:
-    test___all__ test_io test_logging test_warnings
+2 tests altered the execution environment:
+    test___all__ test_warnings
 17 tests skipped:
     test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
     test_smtpnet test_socketserver test_startfile test_timeout test_tk

--- a/components/python/python34/test/results-64.master
+++ b/components/python/python34/test/results-64.master
@@ -1,0 +1,11 @@
+365 tests OK.
+6 tests failed:
+    test_cmd_line_script test_import test_selectors test_socket
+    test_strftime test_uuid
+4 tests altered the execution environment:
+    test___all__ test_io test_logging test_warnings
+17 tests skipped:
+    test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
+    test_smtpnet test_socketserver test_startfile test_timeout test_tk
+    test_ttk_guionly test_urllib2net test_urllibnet test_winreg
+    test_winsound test_xmlrpc_net test_zipfile64

--- a/components/python/python35/Makefile
+++ b/components/python/python35/Makefile
@@ -21,7 +21,7 @@
 
 #
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2019, Michal Nowak
 #
 
 PREFERRED_BITS=	64
@@ -29,13 +29,12 @@ PREFERRED_BITS=	64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Python
-COMPONENT_VERSION=	3.5.6
-COMPONENT_REVISION=	2
+COMPONENT_VERSION=	3.5.7
 COMPONENT_PROJECT_URL=	https://www.python.org
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:f55cde04f521f273c7cba08912921cc5642cfc15ca7b22d5829f0aff4371155f
+	sha256:285892899bf4d5737fd08482aa6171c6b2564a45b9102dfacfb72826aebdc7dc
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/ftp/python/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).asc
 
@@ -114,8 +113,8 @@ COMPONENT_BUILD_ARGS =
 # 64-bit shared objects need to go to 64-bit directory
 COMPONENT_INSTALL_ARGS += DESTSHARED=$(CONFIGURE_PREFIX)/lib/python3.5/lib-dynload
 
-# common targets
 build:		$(BUILD_64)
+
 install:	$(INSTALL_64)
 
 # Using "-uall,-network" ensures all tests are run except the network tests.
@@ -138,7 +137,7 @@ COMPONENT_TEST_TARGETS = test < /dev/null
 COMPONENT_TEST_TRANSFORMER =	$(NAWK)
 COMPONENT_TEST_TRANSFORMS = "'/tests OK/ { results = 1 }; /^Re-running failed tests in verbose mode/ { results = 0 } { if (results) print }'"
 
-test:				$(TEST_64)
+test:		$(TEST_64)
 
 # Required for dump(1)
 REQUIRED_PACKAGES += developer/object-file

--- a/components/python/python35/manifests/sample-manifest.p5m
+++ b/components/python/python35/manifests/sample-manifest.p5m
@@ -1378,6 +1378,7 @@ file path=usr/lib/python3.5/test/subprocessdata/qgrep.py
 file path=usr/lib/python3.5/test/subprocessdata/sigchild_ignore.py
 file path=usr/lib/python3.5/test/support/__init__.py
 file path=usr/lib/python3.5/test/support/script_helper.py
+file path=usr/lib/python3.5/test/talos-2019-0758.pem
 file path=usr/lib/python3.5/test/test___all__.py
 file path=usr/lib/python3.5/test/test___future__.py
 file path=usr/lib/python3.5/test/test__locale.py

--- a/components/python/python35/test/results-64.master
+++ b/components/python/python35/test/results-64.master
@@ -1,7 +1,7 @@
-374 tests OK.
-7 tests failed:
-    test_cmd_line_script test_eintr test_import test_mmap
-    test_selectors test_socket test_zipimport
+373 tests OK.
+8 tests failed:
+    test_cmd_line_script test_concurrent_futures test_import test_mmap
+    test_selectors test_socket test_strftime test_zipimport
 18 tests skipped:
     test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
     test_smtpnet test_socketserver test_startfile test_timeout


### PR DESCRIPTION
**Testing**

Run-tested.

Run test suite. There are some discrepancies (as seen in test master files), but the test suite is not stable enough for me to constitute regression. For Python 3.5 full test suite log, see: [test-64-results.txt](https://github.com/OpenIndiana/oi-userland/files/3095708/test-64-results.txt).