### PR TITLE
Update lsof to 4.91

### DIFF
--- a/components/sysutils/lsof/Makefile
+++ b/components/sysutils/lsof/Makefile
@@ -11,21 +11,22 @@
 #
 # Copyright 2017 Gary Mills
 # Copyright 2016 Jim Klimov. All rights reserved.
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		lsof
-COMPONENT_VERSION=	4.89
-COMPONENT_PROJECT_URL=	http://freecode.com/projects/util-linux
+COMPONENT_VERSION=	4.91
+COMPONENT_PROJECT_URL=	https://people.freebsd.org/~abe/
 COMPONENT_SUMMARY=	LSOF - lister of opened files
 COMPONENT_SRC=		$(COMPONENT_NAME)_$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 # Theoretical upstream is ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof
 # but it is not available at the time of this writing
 COMPONENT_ARCHIVE_URL=	https://fossies.org/linux/misc/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:5d08da7ebe049c9d9a6472d6afb81aa5af54c4733a3f8822cbc22b57867633c9
+	sha256:c9da946a525fbf82ff80090b6d1879c38df090556f3fe0e6d782cb44172450a3
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/justmake.mk
@@ -34,12 +35,8 @@ include $(WS_MAKE_RULES)/ips.mk
 # In oi_151a8, illumos version of yes ignores SIGPIPE, never exits
 PATH = $(PATH.gnu)
 
-# Snatched from espeak component
-BINDIR.32=/usr/bin
-BINDIR.64=/usr/bin/$(MACH64)
-
-LIBDIR.32=/usr/lib
-LIBDIR.64=/usr/lib/$(MACH64)
+BINDIR.64 =	/usr/bin
+LIBDIR.64 =	/usr/lib
 
 COMPONENT_COMMON_ARGS += -C $(BUILD_DIR_$(BITS))
 COMPONENT_COMMON_ARGS += BINDIR=$(BINDIR.$(BITS))
@@ -56,17 +53,17 @@ COMPONENT_INSTALL_ARGS += $(COMPONENT_COMMON_ARGS)
 COMPONENT_INSTALL_ENV += $(COMPONENT_COMMON_ENV)
 
 COMPONENT_PREP_ACTION = \
-    ( cd $(SOURCE_DIR) && tar xf - < $(COMPONENT_SRC)_src.tar )
+	( cd $(SOURCE_DIR) && tar xf - < $(COMPONENT_SRC)_src.tar )
 
 COMPONENT_PRE_BUILD_ACTION = \
-    ( cd $(@D) && cp -prf "$(SOURCE_DIR)/$(COMPONENT_SRC)_src"/./ ./ && \
-      yes '' | SOLARIS_KERNBITS=$(BITS) ./Configure solaris )
+	( cd $(@D) && cp -prf "$(SOURCE_DIR)/$(COMPONENT_SRC)_src"/./ ./ && \
+	  yes '' | SOLARIS_KERNBITS=$(BITS) ./Configure solaris )
 
-build:		$(BUILD_32_and_64)
+build:		$(BUILD_64)
 
 # The p5m manifest directly pulls from source dirs (the "make install" action
 # for Solaris in LSOF sources only prints hints what/how should be set up)
-install:	$(INSTALL_32_and_64)
+install:	$(INSTALL_64)
 
 test:		$(NO_TESTS)
 

--- a/components/sysutils/lsof/lsof.p5m
+++ b/components/sysutils/lsof/lsof.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2016 Jim Klimov. All rights reserved.
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/system/storage/$(COMPONENT_NAME)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,10 +24,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license lsof.license license="LSOF Copyright (no license)"
 
-file build/$(MACH32)/lsof.8 path=usr/share/man/man8/lsof.8
+file build/$(MACH64)/lsof.8 path=usr/share/man/man8/lsof.8
 
 # Executable must be setgid sys to read /dev/kmem
-file build/$(MACH64)/lsof path=usr/bin/$(MACH64)/lsof mode=2555 group=sys
-file build/$(MACH32)/lsof path=usr/bin/$(MACH32)/lsof mode=2555 group=sys
-# Must run the binary matching the kernel bitness
-hardlink path=usr/bin/lsof target=../lib/isaexec pkg.linted=true
+file build/$(MACH64)/lsof path=usr/bin/lsof mode=2555 group=sys


### PR DESCRIPTION
New version seems to fix bug (regression?) in `COMMAND` column.

**Changelog**

4.90		February 14, 2018

		Taught the Configure script to create a dummy opt_random.h
		for FreeBSD systems whose <sys/random.h> includes it.

		Added support for the FreeBSD ZFUSE file system.

		Corrected the quoting in a Darwin putchar() statement in the
		dfile.c source file.  Andrew Janke <floss@apjanke.net> reported
		my error.

		Added support for the FreeBSD DTYPE_PTS file descriptor and
		for unknown descriptors that reference the kernel's badfileops
		operation switch.  Enabled FreeBSD 12.0 support. Tested the
		changes on systems provided by Larry Rosenman <ler@lerctr.org>.

		Enhanced -K option with the form "-K i" to direct lsof to
		(i)gnore tasks.  A query from Rachel Kroll <rkroll@fb.com>
		suggested this option.  Linux task reports now include both
		process and task command names, making lsof's "-c <name>"
		option work correctly.

		Added a patch to prevent NFS blocking in Linux supplied by
		Kristna Streitov <kstreitova@suse.com>.

		Installed a FreeBSD patch that prevents examining a TCP state
		structure during a race condition.  The patch was supplied by
		Bryan Drewery <bdrewery@FreeBSD.org>.

		Updated FreeBSD for new UFS inode structure that lacks an i_dev
		member in the most recent 12.0-CURRENT.  Larry Rosenman
		<ler@lerctr.org> reported the problem and provided a test
		system.

		Added "#define KLD_MODULE" to dlsof.h and dnode2.c to prevent
		<machine/cpuconf.h> from generating an "ARM_NARCH is 0" error.
		This is needed so lsof can access kernel structures.  Larry
		Rosenman supplied the addition.

		Added recognition of the FreeBSD 11 file system name "nullfs".
		Jamie Landeg-Jones <jamie@catflap.org> supplied the fix.

		Added a patch from Larry Rosenman <ler@lerctr.org> that is
		needed on FreeBSD 12 so the lsof compilation can obtain the
		inpcb and tcpcb structures from their respective header files.

		Updated FreeBSD dmnt.c for the ino64 changes.

		Inserted a patch for Solaris 12.x to avoid compilation errors
		from <sys/aio_req.h>, based on information provided by Jorn
		Clausen <joern.clausen@uni-bielefeld.de>.  Jorn tested the
		patch.

		Added performance enhancement that uses the FreeBSD closefrom()
		and dup2() C library functions when available.  The enhancement
		was supplied by Conrad Meyer <cem@freebsd.org>.

		Corrected FreeBSD lsof's gathering of ZFS file device numbers.

		Updated lsof test library for FreeBSD.

		Updated socket optons information collection from the socket
		structure per changes supplied by Gleb Smirnoff
		<glebius@FreeBSD.org>.

		Added patch to dlsof.h that avoids a _KERNEL conflict with
		bzero.  Mateusz Guzik <mjguzik@gmail.com> supplied the patch.

		Corrected test library to handle 64 bit FreeBSD device numbers.

		Added #defines for FreeBSD 12, src r324225, from Gleb Smirnoff
		<glebius@FreeBSD.org>.

		Incorporated Linux pseudoterminal endpoint processing (+|-E)
		provided by Masatake YAMATO <yamato@redhat.com> with access to
		test systems provided by Peter Schiffer <pschiffe@redhat.com>.

		Corrected Linux command extraction for commands that include
		parentheses -- e.g., "(sd-pam)".
		
4.91		March 26, 2018

		A bug has been reported in the PTY endpoint processing of
		Linux lsof 4.90 by Peter Wu <peter@lekensteyn.nl>, making it
		necessary for me to release another revision of lsof.

		This revision applies two fixes that correct the Linux PTY
		endpoint processing bug. Masatake YAMATO <yamato@redhat.com>
		supplied the fixes.


**Testing**
v4.89:
```
$ sudo lsof -bw | head
COMMAND     PID     USER   FD   TYPE    DEVICE SIZE/OFF       NODE NAME
(unknown)     1     root  txt   VREG              58928     722411 /sbin/init
(unknown)     1     root  txt   VREG             255772     726087 /lib/libbsm.so.1
(unknown)     1     root  txt   VREG             238740     726251 /lib/libscf.so.1
(unknown)     1     root  txt   VREG              49328     726262 /lib/libuutil.so.1
(unknown)     1     root  txt   VREG             578064     726238 /lib/libnsl.so.1
(unknown)     1     root  txt   VREG             103796     726239 /lib/libnvpair.so.1
(unknown)     1     root  txt   VREG              55320     726259 /lib/libtsol.so.2
(unknown)     1     root  txt   VREG              34188     726091 /lib/libcontract.so.1
(unknown)     1     root  txt   VREG            1683332     726088 /lib/libc.so.1
```

v4.91:
```
$ sudo lsof -bw | head
COMMAND     PID     USER   FD   TYPE             DEVICE   SIZE/OFF       NODE NAME
sched         0     root  cwd   VDIR          304,65538         29          4 /
init          1     root  cwd   VDIR          304,65538         29          4 /
init          1     root  txt   VREG          304,65538      58928     722411 /sbin/init
init          1     root  txt   VREG          304,65538     255772     726087 /lib/libbsm.so.1
init          1     root  txt   VREG          304,65538     238740     726251 /lib/libscf.so.1
init          1     root  txt   VREG          304,65538      49328     726262 /lib/libuutil.so.1
init          1     root  txt   VREG          304,65538     578064     726238 /lib/libnsl.so.1
init          1     root  txt   VREG          304,65538     103796     726239 /lib/libnvpair.so.1
init          1     root  txt   VREG          304,65538      55320     726259 /lib/libtsol.so.2
```