### PR TITLE
logilab-common should not deliver pytest

### DIFF
--- a/components/python/logilab-common/Makefile
+++ b/components/python/logilab-common/Makefile
@@ -27,6 +27,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		logilab-common
 COMPONENT_VERSION=	0.63.2
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	http://www.logilab.org/project/logilab-common/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -47,11 +48,8 @@ PYTHON_VERSIONS=2.7
 # compile all of the python .py files in the proto area since setup.py doesn't
 # seem to be doing it for this component.
 COMPONENT_POST_INSTALL_ACTION = \
-	(cd $(PROTO_DIR)/usr/bin ; $(MV) -f pytest pytest-$(PYTHON_VERSION)) ; \
+	(cd $(PROTO_DIR)/usr/bin ; $(MV) -f pytest logilab-pytest-$(PYTHON_VERSION)) ; \
 	($(PYTHON) -m compileall $(PROTO_DIR)$(PYTHON_VENDOR_PACKAGES))
-
-
-# common targets
 
 build:		$(BUILD_NO_ARCH)
 
@@ -63,15 +61,17 @@ install:	$(INSTALL_NO_ARCH)
 # Use the python 2.7 libraries (via PYTHONPATH setting) for testing.
 test: PYTHON_VERSION=2.7
 
-COMPONENT_TEST_CMD = $(PROTOUSRBINDIR)/pytest-2.7
+COMPONENT_TEST_CMD = $(PROTOUSRBINDIR)/logilab-pytest-2.7
 COMPONENT_TEST_ARGS =
 
 # Expected failures for test target:
-# 425 test cases, 1 errors, 23 skipped
-# 21 modules OK (1 failed)
-# failures: test_locked_for_one_hour
+# Ran 425 test cases 1 errors, 1 failures, 23 skipped
+# 20 modules OK (2 failed)
+# FAIL: test_site_packages (unittest_modutils.file_from_modpath_tc)
+# ERROR: test_locked_for_one_hour (unittest_shellutils.AcquireLockTC)
 
-test:	$(TEST_NO_ARCH)
+test:		$(TEST_NO_ARCH)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/python/pyorbit-27
 REQUIRED_PACKAGES += runtime/python-27

--- a/components/python/logilab-common/logilab-common-27.p5m
+++ b/components/python/logilab-common/logilab-common-27.p5m
@@ -51,7 +51,7 @@ file \
 file path=usr/lib/python2.7/vendor-packages/logilab_common-$(COMPONENT_VERSION)-py2.7.egg-info/requires.txt
 file \
     path=usr/lib/python2.7/vendor-packages/logilab_common-$(COMPONENT_VERSION)-py2.7.egg-info/top_level.txt
-file path=usr/bin/pytest-2.7
+file path=usr/bin/logilab-pytest-2.7
 file path=usr/lib/python2.7/vendor-packages/logilab/__init__.py
 file path=usr/lib/python2.7/vendor-packages/logilab/common/__init__.py
 file path=usr/lib/python2.7/vendor-packages/logilab/common/__pkginfo__.py
@@ -103,9 +103,6 @@ file path=usr/lib/python2.7/vendor-packages/logilab/common/vcgutils.py
 file path=usr/lib/python2.7/vendor-packages/logilab/common/visitor.py
 file path=usr/lib/python2.7/vendor-packages/logilab/common/xmlrpcutils.py
 file path=usr/lib/python2.7/vendor-packages/logilab/common/xmlutils.py
-
-link path=usr/bin/pytest target=pytest-2.7 \
-    mediator=python mediator-version=2.7
 
 license logilab-common.license license=LGPLv2.1,GPLv2
 

--- a/components/python/logilab-common/manifests/sample-manifest.p5m
+++ b/components/python/logilab-common/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,7 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/pytest-2.7
+file path=usr/bin/logilab-pytest-2.7
 file path=usr/lib/python2.7/vendor-packages/logilab/__init__.py
 file path=usr/lib/python2.7/vendor-packages/logilab/common/__init__.py
 file path=usr/lib/python2.7/vendor-packages/logilab/common/__pkginfo__.py


### PR DESCRIPTION
I guess the pytest package should deliver `usr/bin/pytest-2.7`.