### PR TITLE
Update Ansible to 2.7.14

### DIFF
--- a/components/python/ansible/Makefile
+++ b/components/python/ansible/Makefile
@@ -10,18 +10,22 @@
 
 #
 # Copyright 2018 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
+
+BUILD_BITS=		NO_ARCH
+BUILD_STYLE=		setup.py
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ansible
-COMPONENT_VERSION=	2.7.5
+COMPONENT_VERSION=	2.7.14
 COMPONENT_SUMMARY=	'Ansible is a radically simple IT automation system'
 COMPONENT_PROJECT_URL=	https://ansible.com/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:aaf9e1974bd12840ca055ac156f37601c08d73d726a3a6b98a2fe759a57051bb
+	sha256:6a52f43b5e4446aa04f3907a750010fbbf41eb050cb726065c6c877ed3a98d02
 COMPONENT_ARCHIVE_URL=	$(call pypi_url)
 COMPONENT_FMRI=	system/management/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	System/Administration and Configuration
@@ -30,20 +34,12 @@ COMPONENT_LICENSE_FILE=	COPYING
 
 PYTHON_VERSIONS=	2.7
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_DIR =    $(COMPONENT_SRC)/tests
-COMPONENT_TEST_CMD =    $(PYTHON) /usr/bin/py.test-$(PYTHON_VERSION)
-COMPONENT_TEST_ARGS =
-
-# common targets
-build:		$(BUILD_NO_ARCH)
-
-install:	$(INSTALL_NO_ARCH)
-
-test:           $(TEST_NO_ARCH)
+# https://docs.ansible.com/ansible/devel/dev_guide/testing_units.html
+COMPONENT_TEST_DIR=	$(COMPONENT_SRC)
+COMPONENT_TEST_CMD=	ln -sf /usr/bin/pytest-$(PYTHON_VERSION) bin/pytest && bin/ansible-test units -v --python $(PYTHON_VERSION)
+COMPONENT_TEST_ARGS=
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/python/setuptools-27


### PR DESCRIPTION
Changelog: https://github.com/ansible/ansible/blob/stable-2.7/changelogs/CHANGELOG-v2.7.rst

Test suite changed to accommodate pytest 4.4 (https://github.com/OpenIndiana/oi-userland/pull/4952), because it requires pytest > 4.4, which we don't ship yet.

**Testing**
- test suite did not regress: `17 failed, 4741 passed, 71 skipped, 4 warnings, 4 error`