### PR TITLE
10840 Add gSOAP 2.8.83

### DIFF
--- a/components/library/gsoap/Makefile
+++ b/components/library/gsoap/Makefile
@@ -1,0 +1,90 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Michal Nowak
+#
+
+PREFERRED_BITS=		64
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		gsoap
+COMPONENT_VERSION=	2.8.83
+COMPONENT_SUMMARY=	Toolkit for SOAP/REST-based C/C++ server and client web service applications
+COMPONENT_PROJECT_URL=	https://www.genivia.com/products.html
+COMPONENT_FMRI=		library/gsoap
+COMPONENT_CLASSIFICATION=	System/Libraries
+COMPONENT_SRC=		$(COMPONENT_NAME)-2.8
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)_$(COMPONENT_VERSION).zip
+COMPONENT_ARCHIVE_URL=	http://downloads.sourceforge.net/project/gsoap2/gsoap-2.8/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:879ab40d40e379add9d3526c0592f891eaea16f7487be160157dbc40216e1633
+COMPONENT_LICENSE=	GPLv2+ with exceptions
+COMPONENT_LICENSE_FILE=	gsoap.license
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+# Some samples need extra libraries, which are not autodetected
+LDFLAGS += -lsocket -lxnet -lnsl
+
+# gsoap zip file contain a lot of enexpected files (binaries, non-GPL-licensed
+# files, etc), files we don't want, don't need, or perhaps can't even ship.
+#
+# What follows is a list of files to be removed according to Fedora gsoap.spec
+# (openSUSE does a simmilar thing):
+#
+# * XML files non-executable
+# * Documentation fonts non-executable
+# * we want all txt files to have unix end-of-line encoding
+# * remove stuff with gsoap license only - not GPL
+# * remove pre-compiled binaries
+# * Remove .DS_Store files
+COMPONENT_PRE_CONFIGURE_ACTION += \
+	cd $(SOURCE_DIR) ; \
+	find gsoap/samples/autotest/databinding/examples -name '*.xml' -exec chmod a-x {} ';' ; \
+	chmod a-x gsoap/doc/fonts/* ; \
+	for txt in `find . -name '*.txt'`; do \
+		dos2unix $$txt $$txt ; \
+	done ; \
+	rm -rf gsoap/extras gsoap/mod_gsoap gsoap/Symbian ; \
+	sed 's!$$(top_srcdir)/gsoap/extras/\*!!' -i gsoap/Makefile.am ; \
+	rm -rf gsoap/bin rm gsoap/samples/calc_vs2005/calc_vs2005/soapcpp2.exe \
+		gsoap/samples/rest/person gsoap/samples/wcf/Basic/TransportSecurity/calculator \
+		rm gsoap/VisualStudio2005/wsdl2h/wsdl2h/soapcpp2.exe ; \
+	find . -name .DS_Store -exec rm {} ';' ; \
+	autoreconf --install --force ; \
+	cp -a $(SOURCE_DIR)/* $(@D) ;
+
+CONFIGURE_SCRIPT = $(@D)/configure
+
+CONFIGURE_OPTIONS +=	--enable-ipv6
+# Build and runs tests
+CONFIGURE_OPTIONS +=	--enable-samples
+
+# Parallel build fails. We either disable it, or build soapcpp2_yacc.c first.
+# We opt for the former.
+COMPONENT_BUILD_ARGS=
+
+build:		$(BUILD_64)
+
+install:	$(INSTALL_64)
+
+test:		$(TEST_64)
+
+# dos2unix
+REQUIRED_PACKAGES += system/extended-system-utilities
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += library/security/openssl
+REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += system/library

--- a/components/library/gsoap/files/soapcpp2.1
+++ b/components/library/gsoap/files/soapcpp2.1
@@ -1,0 +1,158 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH SOAPCPP2 1 "Juni 27, 2003"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+soapcpp2 \- the gSOAP Stub and Skeleton Compiler for C and C++
+.SH SYNOPSIS
+\fBsoapcpp2\fR [\fIOPTIONS\fR] \fIINPUT\fR
+.SH DESCRIPTION
+Please see /usr/share/doc/gsoap-doc/soapdoc2.html for details.
+.PP
+Create stubs and client and server code from input \fIINPUT\fR or
+standard input if \fIINPUT\fR is not specified.
+.SH OPTIONS
+.TP
+\fB\-0\fR
+No SOAP, generate REST source code.
+.TP
+\fB\-1\fR
+Generate SOAP 1.1 source code.
+.TP
+\fB\-2\fR
+Generate SOAP 1.2 source code.
+.TP
+\fB\-A\fR
+Require HTTP SOAPAction headers to invoke server-side operations.
+.TP
+\fB\-a\fR
+Use HTTP SOAPAction with WS-Addressing to invoke server-side operations.
+.TP
+\fB\-b\fR
+Serialize byte arrays char[N] as string.
+.TP
+\fB\-C\fR
+Generate client-side source code only.
+.TP
+\fB\-c\fR
+Generate C source code.
+.TP
+\fB\-c++\fR
+Generate C++ source code (default).
+.TP
+\fB\-c++11\fR
+Generate C++ source code optimized for C++11 (compile with -std=c++11).
+.TP
+\fB\-d\fIpath\fR
+Use \fIpath\fR to save files.
+.TP
+\fB\-Ec\fR
+Generate extra functions for deep copying.
+.TP
+\fB\-Ed\fR
+Generate extra functions for deep deletion.
+.TP
+\fB\-Et\fR
+Generate extra functions for data traversals with callback functions.
+.TP
+\fB\-e\fR
+Generate SOAP RPC encoding style bindings (also use \fB-1\fR or \fB-2\fR).
+.TP
+\fB\-f\fIN\fR
+Multiple soapC files, with \fIN\fR serializer definitions per file (N>=10).
+.TP
+\fB\-g\fR
+Generate XML sample messages in template format for testmsgr.
+.TP
+\fB\-h\fR
+Display help info and exit.
+.TP
+\fB\-I\fIpath\fR
+Use \fIpath\fR(s) for \fB#import\fR (paths separated with ':').
+.TP
+\fB\-i\fR
+Generate C++ service proxies and objects inherited from \fBsoap\fR struct.
+.TP
+\fB\-j\fR
+Generate C++ service proxies and objects that share a \fBsoap\fR struct.
+.TP
+\fB\-L\fR
+Do not generate \fBsoapClientLib\fR/\fBsoapServerLib\fR.
+.TP
+\fB\-l\fR
+Generate linkable modules (experimental).
+.TP
+\fB\-m\fR
+Generate source code for the Matlab(tm) MEX compiler (deprecated).
+.TP
+\fB\-n\fR
+Use service name to rename service functions and namespace table.
+.TP
+\fB\-p\fIname\fR
+Save files with new prefix \fIname\fR instead of \fBsoap\fR.
+.TP
+\fB\-Q\fIname\fR
+Use \fIname\fR as the C++ namespace, including custom serializers.
+.TP
+\fB\-q\fIname\fR
+Use \fIname\fR as the C++ namespace, excluding custom serializers.
+.TP
+\fB\-r\fR
+Generate soapReadme.md report.
+.TP
+\fB\-S\fR
+Generate server-side source code only.
+.TP
+\fB\-s\fR
+Generate stub and skeleton functions with strict XML validation checks.
+.TP
+\fB\-T\fR
+Generate server auto-test source code.
+.TP
+\fB\-t\fR
+Generate source code for fully \fBxsi:type\fR typed SOAP/XML messages.
+.TP
+\fB\-u\fR
+Uncomment WSDL/schema output by suppressing XML comments.
+.TP
+\fB\-V\fR
+Display the current version and exit.
+.TP
+\fB\-v\fR
+Verbose output.
+.TP
+\fB\-w\fR
+Do not generate WSDL and schema files.
+.TP
+\fB\-x\fR
+Do not generate sample XML message files.
+.TP
+\fB\-y\fR
+Include C/C++ type access information in sample XML messages.
+.TP
+\fB\-z1\fR
+Compatibility: Generate old-style C++ service proxies and objects.
+.TP
+\fB\-z2\fR
+Compatibility with 2.7.x: Omit XML output for NULL pointers.
+.TP
+\fB\-z3\fR
+Compatibility up to 2.8.30: \fB_param_N\fR indexing; nillable pointers.
+.SH SEE ALSO
+.BR wsdl2h (1).
+.SH AUTHOR
+This manual page was written by Thomas Wana <greuff@debian.org>,
+for the Debian project (but may be used by others).

--- a/components/library/gsoap/files/wsdl2h.1
+++ b/components/library/gsoap/files/wsdl2h.1
@@ -1,0 +1,191 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH WSDL2H 1 "December 23, 2004"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+wsdl2h \- the gSOAP WSDL/WADL/XSD processor for C and C++
+.SH SYNOPSIS
+\fBwsdl2h\fR [\fIOPTIONS\fR] \fISOURCE\fR ...
+.SH DESCRIPTION
+Please see /usr/share/doc/gsoap-doc/soapdoc2.html for details.
+.PP
+Converts a \fBWSDL\fR or \fBXSD\fR input file, or from an HTTP address,
+\fISOURCE\fR to a declaration file that can be parsed by
+\fBsoapcpp2\fR(1). If no \fISOURCE\fR argument is specified, read
+from standard input.
+.SH OPTIONS
+.TP
+\fB\-a\fR
+Generate indexed struct names for local elements with anonymous types.
+.TP
+\fB\-b\fR
+Bi-directional operations (duplex ops) added to serve one-way responses.
+.TP
+\fB\-c\fR
+Generate C source code.
+.TP
+\fB\-c++\fR
+Generate C++ source code (default).
+.TP
+\fB\-c++11\fR
+Generate C++11 source code.
+.TP
+\fB\-D\fR
+Make attribute members with default/fixed values optional with pointers.
+.TP
+\fB\-d\fR
+Use DOM to populate \fBxs\fR:\fIany\fR, \fBxs\fR:\fIanyType\fR and
+\fBxs\fR:\fIanyAttribute\fR.
+.TP
+\fB\-e\fR
+Do not qualify enum names.
+.TP
+\fB\-F\fR
+Add transient members to structs to simulate struct-type derivation in C.
+.TP
+\fB\-f\fR
+Generate flat C++ class hierarchy by removing inheritance.
+.TP
+\fB\-g\fR
+Generate global top-level element and attribute declarations.
+.TP
+\fB\-h\fR
+Display help info and exit.
+.TP
+\fB\-I\fIpath\fR
+Use \fIpath\fR to locate WSDL and XSD files.
+.TP
+\fB\-i\fR
+Do not import (advanced option).
+.TP
+\fB\-j\fR
+Do not generate \fBSOAP_ENV__Header\fR and \fBSOAP_ENV__Detail\fR definitions.
+.TP
+\fB\-k\fR
+Do not generate \fBSOAP_ENV__Header\fR mustUnderstand qualifiers.
+.TP
+\fB\-L\fR
+Generate less documentation by removing generic @note comments.
+.TP
+\fB\-l\fR
+Display license information.
+.TP
+\fB\-M\fR
+Suppress error "must understand element with \fBwsdl\fR:\fIrequired\fR='true'".
+.TP
+\fB\-m\fR
+Use \fBxsd.h\fR module to import primitive types.
+.TP
+\fB\-N\fIname\fR
+Use \fIname\fR for service prefixes to produce a service for each binding.
+.TP
+\fB\-n\fIname\fR
+Use \fIname\fR as the base namespace prefix instead of \fBns\fR.
+.TP
+\fB\-O1\fR
+Optimize by omitting duplicate choice/sequence members.
+.TP
+\fB\-O2\fR
+Optimize -O1 and omit unused schema types (unreachable from roots).
+.TP
+\fB\-O3\fR
+Optimize -O2 and omit unused schema root attributes.
+.TP
+\fB\-O4\fR
+Optimize -O3 and omit unused schema root elements (use only with WSDLs).
+.TP
+\fB\-o\fIfile\fR
+Output to file \fIfile\fR.
+.TP
+\fB\-P\fR
+Do not create polymorphic types inherited from \fBxsd__anyType\fR.
+.TP
+\fB\-p\fR
+Create polymorphic types inherited from base \fBxsd__anyType\fR.
+.TP
+\fB\-q\fIname\fR
+Use \fIname\fR for the C++ namespace of all declarations.
+.TP
+\fB\-R\fR
+Generate REST operations for REST bindings specified in a WSDL.
+.TP
+\fB\-r\fIhost\fR[:\fIport\fR[:\fIuid\fR:\fIpwd\fR]]
+Connect via proxy \fIhost\fR, \fIport\fR and proxy credentials \fIuid\fR and \fIpwd\fR.
+.TP
+\fB\-r\fR:\fIuid\fR:\fIpwd\fR
+Connect with authentication credentials \fIuid\fR and \fIpwd\fR.
+.TP
+\fB\-S\fIname\fR
+Use \fIname\fR instead of \fBsoap\fR for the C++ class members with soap contexts.
+.TP
+\fB\-s\fR
+Do not generate STL code (no \fBstd::string\fR and no \fBstd::vector\fR).
+.TP
+\fB\-t\fIfile\fR
+Use type map file \fIfile\fR instead of the default file \fBtypemap.dat\fR.
+.TP
+\fB\-U\fR
+Allow UTF-8-encoded Unicode C/C++ identifiers when mapping XML tag names.
+.TP
+\fB\-u\fR
+Do not generate unions.
+.TP
+\fB\-V\fR
+Display the current version and exit.
+.TP
+\fB\-v\fR
+Verbose output.
+.TP
+\fB\-W\fR
+Suppress warnings.
+.TP
+\fB\-w\fR
+Always wrap response parameters in a response struct (<=1.1.4 behavior).
+.TP
+\fB\-x\fR
+Do not generate \fB_XML\fR \fIany\fR/\fIanyAttribute\fR extensibility elements.
+.TP
+\fB\-y\fR
+Generate typedef synonyms for structs and enums.
+.TP
+\fB\-z1\fR
+Compatibility with 2.7.6e: Generate pointer-based arrays.
+.TP
+\fB\-z2\fR
+Compatibility with 2.7.7 to 2.7.15: Qualify element/attribute references.
+.TP
+\fB\-z3\fR
+Compatibility with 2.7.16 to 2.8.7: Qualify element/attribute references.
+.TP
+\fB\-z4\fR
+Compatibility up to 2.8.11: Do not generate union structs in \fBstd::vector\fR.
+.TP
+\fB\-z5\fR
+Compatibility up to 2.8.15: Do not include minor improvements.
+.TP
+\fB\-z6\fR
+Compatibility up to 2.8.17: Do not include minor improvements.
+.TP
+\fB\-z7\fR
+Compatibility up to 2.8.59: Do not generate \fBstd::vector\fR of class of union.
+.TP
+\fB\-_\fR
+Do not generate _USCORE (replace with Unicode code point _x005f).
+.SH SEE ALSO
+.BR soapcpp2 (1).
+.SH AUTHOR
+This manual page was written by Thomas Wana <greuff@debian.org>,
+for the Debian project (but may be used by others).

--- a/components/library/gsoap/gsoap.license
+++ b/components/library/gsoap/gsoap.license
@@ -1,0 +1,150 @@
+
+LICENSE
+
+The gSOAP 2.8 releases, including all 2.8.x updates, are distributed under:
+
+1) The gSOAP Public License 1.3 (which is based on the Mozilla public license
+   1.1).
+   
+   Components NOT covered by the gSOAP Public License are:
+   - wsdl2h tool AND its source code output, 
+   - soapcpp2 tool AND its source code output,
+   - UDDI code,
+   - the webserver example code in gsoap/samples/webserver,
+   - several example applications in the gsoap/samples directory.
+
+   For details, see the note down below. The gSOAP public license is included
+   in the package as license.pdf
+
+2) GPL v2 (GNU Public License, a common open-source software license) covers
+   all of the gSOAP software, see GPLv2_license.txt
+
+   If you use gSOAP under the GPL v2 to integrate parts of it or code generated
+   by it with your own code, then you are allowed to sell copies of the
+   modified program commercially, but only under the terms of the GNU GPL v2.
+   Thus, for instance, you must make the source code of your programs available
+   to the users of your programs as described in the GPL, and they must be
+   allowed to redistribute and modify it as described in the GPL. These
+   requirements are the condition for including the GPL-covered code you
+   received in a program of your own.
+ 
+   If you do not wish for your program to be released under a GPL-compatible
+   open source license, then an alternate proprietary software license for
+   gSOAP which will remove the aforementioned requirement is available from
+   Genivia Inc, see 3) below.
+
+   For more information on the GNU Public License 2.0, please visit:
+   http://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html
+
+   We do not accept third-party GPL contributions to avoid having to fork the
+   code base in GPL and non-GPL.
+
+3) Proprietary commercial software development licenses for the standard
+   commercial edition and for enterprise-level licensing. The standard edition
+   is functionally identical to the open source version of gSOAP and includes
+   all software components, but without the open source GPL licensing
+   requirements for your project.
+
+IMPORTANT NOTE
+
+Please check the suitability of GPL v2 for your project. Requirements imposed
+by the GPL v2 may affect the release of your software.
+
+If you use gSOAP under the GPL v2 to integrate parts of it or code generated
+by it with your own code, then you are allowed to sell copies of the modified
+program commercially, but only under the terms of the GNU GPL v2. Thus, for
+instance, you must make the source code available to the users of the program
+as described in the GPL, and they must be allowed to redistribute and modify
+it as described in the GPL. These requirements are the condition for including
+the GPL-covered code you received in a program of your own. These
+restrictions may hamper certain proprietary software development scenarios.
+If you do not wish for your program to be released under a GPL-compatible open
+source license, then an alternate proprietary software license for gSOAP which
+will remove the aforementioned requirement is available from Genivia Inc.
+
+The gSOAP software does not include any third-party GPL code. All software was
+written from the ground up since 2003 and is owned and copyrighted by Genivia
+Inc. This allows Genivia to dual license the gSOAP software under GPLv2 and
+under the Genivia commercial-use licenses.
+
+The Ohloh site by Black Duck includes an analysis of the gSOAP GPLv2 open
+source repository:
+
+	https://www.ohloh.net/p/gsoap
+
+Please note that "Black Duck Scans" will detect the use of GPL gSOAP software
+in your project builds when you are using the gSOAP source code. The
+commercial-use licenses by Genivia explicitly grant the use of the gSOAP
+software for non-GPL use and inclusion.
+
+Note that the GNU Bison and Flex tools are used to generate source code for the
+gSOAP soapcpp2 compiler. The Bison/Flex-generated source code is not restricted
+by the GPL or LGPL terms for this particular use.
+
+Non-GPL third-party contributions are included in the 'extras' directory in the
+package and you are free to use these contributions. Suggested changes and
+improvements by vendors were accepted under the public gSOAP license (not
+GPL), which includes support for VxWorks and Apache and IIS modules for gSOAP.
+
+For commercial-use licensing please visit:
+
+	http://www.genivia.com/Products/gsoap/contract.html
+
+or contact us at Genivia Inc:
+
+	contact@genivia.com
+
+GPL and OpenSSL
+
+This program is released under the GPL with the additional exemption that
+compiling, linking, and/or using OpenSSL is allowed.
+
+GPL and the gSOAP public license
+
+This program is released under the GPL with the additional exemption that
+compiling, linking, and/or using software released under the gSOAP public
+license is allowed.
+
+COPYRIGHT
+
+gSOAP is copyrighted by Robert A. van Engelen, Genivia, Inc.
+Copyright (C) 2000-2015 Robert A. van Engelen, Genivia, Inc.
+All Rights Reserved.
+
+USE RESTRICTIONS
+
+You may not: (i) transfer rights to gSOAP or claim authorship; or (ii) remove
+any product identification, copyright, proprietary notices or labels from gSOAP.
+
+WARRANTY 
+
+GENIVIA INC. EXPRESSLY DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED OR
+STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, OF FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT OF THIRD
+PARTY INTELLECTUAL PROPERTY RIGHTS, AND ANY WARRANTY THAT MAY ARISE BY REASON
+OF TRADE USAGE, CUSTOM, OR COURSE OF DEALING.  WITHOUT LIMITING THE
+FOREGOING, YOU ACKNOWLEDGE THAT THE SOFTWARE IS PROVIDED "AS IS" AND THAT
+GENIVIA INC. DO NOT WARRANT THE SOFTWARE WILL RUN UNINTERRUPTED OR ERROR FREE.
+LIMITED LIABILITY: THE ENTIRE RISK AS TO RESULTS AND PERFORMANCE OF THE
+SOFTWARE IS ASSUMED BY YOU.  UNDER NO CIRCUMSTANCES WILL GENIVIA INC. BE LIABLE
+FOR ANY SPECIAL, INDIRECT, INCIDENTAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES OF
+ANY KIND OR NATURE WHATSOEVER, WHETHER BASED ON CONTRACT, WARRANTY, TORT
+(INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, ARISING OUT OF OR IN
+ANY WAY RELATED TO THE SOFTWARE, EVEN IF GENIVIA INC. HAS BEEN ADVISED ON THE
+POSSIBILITY OF SUCH DAMAGE OR IF SUCH DAMAGE COULD HAVE BEEN REASONABLY
+FORESEEN, AND NOTWITHSTANDING ANY FAILURE OF ESSENTIAL PURPOSE OF ANY
+EXCLUSIVE REMEDY PROVIDED.  SUCH LIMITATION ON DAMAGES INCLUDES, BUT IS NOT
+LIMITED TO, DAMAGES FOR LOSS OF GOODWILL, LOST PROFITS, LOSS OF DATA OR
+SOFTWARE, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION OR IMPAIRMENT OF
+OTHER GOODS.  IN NO EVENT WILL GENIVIA INC. BE LIABLE FOR THE COSTS OF
+PROCUREMENT OF SUBSTITUTE SOFTWARE OR SERVICES.  YOU ACKNOWLEDGE THAT THIS
+SOFTWARE IS NOT DESIGNED FOR USE IN ON-LINE EQUIPMENT IN HAZARDOUS
+ENVIRONMENTS SUCH AS OPERATION OF NUCLEAR FACILITIES, AIRCRAFT NAVIGATION OR
+CONTROL, OR LIFE-CRITICAL APPLICATIONS.  GENIVIA INC. EXPRESSLY DISCLAIM ANY
+LIABILITY RESULTING FROM USE OF THE SOFTWARE IN ANY SUCH ON-LINE EQUIPMENT IN
+HAZARDOUS ENVIRONMENTS AND ACCEPTS NO LIABILITY IN RESPECT OF ANY ACTIONS OR
+CLAIMS BASED ON THE USE OF THE SOFTWARE IN ANY SUCH ON-LINE EQUIPMENT IN
+HAZARDOUS ENVIRONMENTS BY YOU.  FOR PURPOSES OF THIS PARAGRAPH, THE TERM
+"LIFE-CRITICAL APPLICATION" MEANS AN APPLICATION IN WHICH THE FUNCTIONING OR
+MALFUNCTIONING OF THE SOFTWARE MAY RESULT DIRECTLY OR INDIRECTLY IN PHYSICAL
+INJURY OR LOSS OF HUMAN LIFE.

--- a/components/library/gsoap/gsoap.p5m
+++ b/components/library/gsoap/gsoap.p5m
@@ -1,0 +1,242 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Michal Nowak
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# From https://src.fedoraproject.org/rpms/gsoap/tree/master
+file files/soapcpp2.1 path=usr/share/man/man1/soapcpp2.1
+file files/wsdl2h.1 path=usr/share/man/man1/wsdl2h.1
+
+file path=usr/bin/soapcpp2
+file path=usr/bin/wsdl2h
+file path=usr/include/stdsoap2.h
+file path=usr/lib/$(MACH64)/libgsoap++-$(COMPONENT_VERSION).so
+#file path=usr/lib/$(MACH64)/libgsoap++.a
+link path=usr/lib/$(MACH64)/libgsoap++.so \
+    target=libgsoap++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoap-$(COMPONENT_VERSION).so
+#file path=usr/lib/$(MACH64)/libgsoap.a
+link path=usr/lib/$(MACH64)/libgsoap.so target=libgsoap-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapck++-$(COMPONENT_VERSION).so
+#file path=usr/lib/$(MACH64)/libgsoapck++.a
+link path=usr/lib/$(MACH64)/libgsoapck++.so \
+    target=libgsoapck++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapck-$(COMPONENT_VERSION).so
+#file path=usr/lib/$(MACH64)/libgsoapck.a
+link path=usr/lib/$(MACH64)/libgsoapck.so \
+    target=libgsoapck-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapssl++-$(COMPONENT_VERSION).so
+#file path=usr/lib/$(MACH64)/libgsoapssl++.a
+link path=usr/lib/$(MACH64)/libgsoapssl++.so \
+    target=libgsoapssl++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapssl-$(COMPONENT_VERSION).so
+#file path=usr/lib/$(MACH64)/libgsoapssl.a
+link path=usr/lib/$(MACH64)/libgsoapssl.so \
+    target=libgsoapssl-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/pkgconfig/gsoap++.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoap.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapck++.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapck.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapssl++.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapssl.pc
+file path=usr/share/gsoap/WS/LEGAL.txt
+file path=usr/share/gsoap/WS/README.txt
+file path=usr/share/gsoap/WS/WS-Addressing.xsd
+file path=usr/share/gsoap/WS/WS-Addressing03.xsd
+file path=usr/share/gsoap/WS/WS-Addressing04.xsd
+file path=usr/share/gsoap/WS/WS-Addressing05.xsd
+file path=usr/share/gsoap/WS/WS-Discovery.wsdl
+file path=usr/share/gsoap/WS/WS-Enumeration.wsdl
+file path=usr/share/gsoap/WS/WS-Policy.xsd
+file path=usr/share/gsoap/WS/WS-Policy12.xsd
+file path=usr/share/gsoap/WS/WS-ReliableMessaging.wsdl
+file path=usr/share/gsoap/WS/WS-ReliableMessaging.xsd
+file path=usr/share/gsoap/WS/WS-Routing.xsd
+file path=usr/share/gsoap/WS/WS-SecureConversation.xsd
+file path=usr/share/gsoap/WS/WS-SecurityPolicy.xsd
+file path=usr/share/gsoap/WS/WS-Trust.wsdl
+file path=usr/share/gsoap/WS/WS-Trust.xsd
+file path=usr/share/gsoap/WS/WS-typemap.dat
+file path=usr/share/gsoap/WS/discovery.xsd
+file path=usr/share/gsoap/WS/ds.xsd
+file path=usr/share/gsoap/WS/enumeration.xsd
+file path=usr/share/gsoap/WS/oasis-sstc-saml-schema-assertion-1.1.xsd
+file path=usr/share/gsoap/WS/reference-1.1.xsd
+file path=usr/share/gsoap/WS/saml-schema-assertion-2.0.xsd
+file path=usr/share/gsoap/WS/typemap.dat
+file path=usr/share/gsoap/WS/ws-bpel_abstract_common_base.xsd
+file path=usr/share/gsoap/WS/ws-bpel_executable.xsd
+file path=usr/share/gsoap/WS/ws-bpel_plnktype.xsd
+file path=usr/share/gsoap/WS/ws-bpel_serviceref.xsd
+file path=usr/share/gsoap/WS/ws-bpel_varprop.xsd
+file path=usr/share/gsoap/WS/ws-reliability-1.1.xsd
+file path=usr/share/gsoap/WS/wsse.xsd
+file path=usr/share/gsoap/WS/wsu.xsd
+file path=usr/share/gsoap/WS/xenc.xsd
+file path=usr/share/gsoap/custom/README.txt
+file path=usr/share/gsoap/custom/chrono_duration.cpp
+file path=usr/share/gsoap/custom/chrono_duration.h
+file path=usr/share/gsoap/custom/chrono_time_point.cpp
+file path=usr/share/gsoap/custom/chrono_time_point.h
+file path=usr/share/gsoap/custom/duration.c
+file path=usr/share/gsoap/custom/duration.h
+file path=usr/share/gsoap/custom/float128.c
+file path=usr/share/gsoap/custom/float128.h
+file path=usr/share/gsoap/custom/int128.c
+file path=usr/share/gsoap/custom/int128.h
+file path=usr/share/gsoap/custom/long_double.c
+file path=usr/share/gsoap/custom/long_double.h
+file path=usr/share/gsoap/custom/long_time.c
+file path=usr/share/gsoap/custom/long_time.h
+file path=usr/share/gsoap/custom/qbytearray_base64.cpp
+file path=usr/share/gsoap/custom/qbytearray_base64.h
+file path=usr/share/gsoap/custom/qbytearray_hex.cpp
+file path=usr/share/gsoap/custom/qbytearray_hex.h
+file path=usr/share/gsoap/custom/qdate.cpp
+file path=usr/share/gsoap/custom/qdate.h
+file path=usr/share/gsoap/custom/qdatetime.cpp
+file path=usr/share/gsoap/custom/qdatetime.h
+file path=usr/share/gsoap/custom/qstring.cpp
+file path=usr/share/gsoap/custom/qstring.h
+file path=usr/share/gsoap/custom/qtime.cpp
+file path=usr/share/gsoap/custom/qtime.h
+file path=usr/share/gsoap/custom/struct_timeval.c
+file path=usr/share/gsoap/custom/struct_timeval.h
+file path=usr/share/gsoap/custom/struct_tm.c
+file path=usr/share/gsoap/custom/struct_tm.h
+file path=usr/share/gsoap/custom/struct_tm_date.c
+file path=usr/share/gsoap/custom/struct_tm_date.h
+file path=usr/share/gsoap/import/README.txt
+file path=usr/share/gsoap/import/WS-Header.h
+file path=usr/share/gsoap/import/WS-example.c
+file path=usr/share/gsoap/import/WS-example.h
+file path=usr/share/gsoap/import/c14n.h
+file path=usr/share/gsoap/import/dom.h
+file path=usr/share/gsoap/import/ds.h
+file path=usr/share/gsoap/import/ds2.h
+file path=usr/share/gsoap/import/plnk.h
+file path=usr/share/gsoap/import/ref.h
+file path=usr/share/gsoap/import/saml1.h
+file path=usr/share/gsoap/import/saml2.h
+file path=usr/share/gsoap/import/ser.h
+file path=usr/share/gsoap/import/soap12.h
+file path=usr/share/gsoap/import/stdstring.h
+file path=usr/share/gsoap/import/stl.h
+file path=usr/share/gsoap/import/stldeque.h
+file path=usr/share/gsoap/import/stllist.h
+file path=usr/share/gsoap/import/stlset.h
+file path=usr/share/gsoap/import/stlvector.h
+file path=usr/share/gsoap/import/vprop.h
+file path=usr/share/gsoap/import/wsa.h
+file path=usr/share/gsoap/import/wsa3.h
+file path=usr/share/gsoap/import/wsa4.h
+file path=usr/share/gsoap/import/wsa5.h
+file path=usr/share/gsoap/import/wsc.h
+file path=usr/share/gsoap/import/wsc2.h
+file path=usr/share/gsoap/import/wsdd.h
+file path=usr/share/gsoap/import/wsdd10.h
+file path=usr/share/gsoap/import/wsdd5.h
+file path=usr/share/gsoap/import/wsdx.h
+file path=usr/share/gsoap/import/wsp.h
+file path=usr/share/gsoap/import/wsp_appliesto.h
+file path=usr/share/gsoap/import/wsrm.h
+file path=usr/share/gsoap/import/wsrm4.h
+file path=usr/share/gsoap/import/wsrm5.h
+file path=usr/share/gsoap/import/wsrp.h
+file path=usr/share/gsoap/import/wsrx.h
+file path=usr/share/gsoap/import/wsrx5.h
+file path=usr/share/gsoap/import/wsse.h
+file path=usr/share/gsoap/import/wsse11.h
+file path=usr/share/gsoap/import/wsse2.h
+file path=usr/share/gsoap/import/wst.h
+file path=usr/share/gsoap/import/wst2.h
+file path=usr/share/gsoap/import/wstx.h
+file path=usr/share/gsoap/import/wstx2.h
+file path=usr/share/gsoap/import/wsu.h
+file path=usr/share/gsoap/import/xenc.h
+file path=usr/share/gsoap/import/xenc2.h
+file path=usr/share/gsoap/import/xlink.h
+file path=usr/share/gsoap/import/xmime.h
+file path=usr/share/gsoap/import/xmime4.h
+file path=usr/share/gsoap/import/xmime5.h
+file path=usr/share/gsoap/import/xml.h
+file path=usr/share/gsoap/import/xmlmime.h
+file path=usr/share/gsoap/import/xmlmime5.h
+file path=usr/share/gsoap/import/xop.h
+file path=usr/share/gsoap/import/xsd.h
+file path=usr/share/gsoap/plugin/README.txt
+file path=usr/share/gsoap/plugin/cacerts.c
+file path=usr/share/gsoap/plugin/cacerts.h
+file path=usr/share/gsoap/plugin/calcrest.h
+file path=usr/share/gsoap/plugin/curlapi.c
+file path=usr/share/gsoap/plugin/curlapi.h
+file path=usr/share/gsoap/plugin/httpda.c
+file path=usr/share/gsoap/plugin/httpda.h
+file path=usr/share/gsoap/plugin/httpdatest.c
+file path=usr/share/gsoap/plugin/httpdatest.h
+file path=usr/share/gsoap/plugin/httpform.c
+file path=usr/share/gsoap/plugin/httpform.h
+file path=usr/share/gsoap/plugin/httpget.c
+file path=usr/share/gsoap/plugin/httpget.h
+file path=usr/share/gsoap/plugin/httpgettest.c
+file path=usr/share/gsoap/plugin/httpgettest.h
+file path=usr/share/gsoap/plugin/httpmd5.c
+file path=usr/share/gsoap/plugin/httpmd5.h
+file path=usr/share/gsoap/plugin/httpmd5test.c
+file path=usr/share/gsoap/plugin/httpmd5test.h
+file path=usr/share/gsoap/plugin/httppipe.c
+file path=usr/share/gsoap/plugin/httppipe.h
+file path=usr/share/gsoap/plugin/httppost.c
+file path=usr/share/gsoap/plugin/httppost.h
+file path=usr/share/gsoap/plugin/httpposttest.c
+file path=usr/share/gsoap/plugin/httpposttest.h
+file path=usr/share/gsoap/plugin/logging.c
+file path=usr/share/gsoap/plugin/logging.h
+file path=usr/share/gsoap/plugin/md5evp.c
+file path=usr/share/gsoap/plugin/md5evp.h
+file path=usr/share/gsoap/plugin/mecevp.c
+file path=usr/share/gsoap/plugin/mecevp.h
+file path=usr/share/gsoap/plugin/mq.c
+file path=usr/share/gsoap/plugin/mq.h
+file path=usr/share/gsoap/plugin/plugin.c
+file path=usr/share/gsoap/plugin/plugin.h
+file path=usr/share/gsoap/plugin/sessions.c
+file path=usr/share/gsoap/plugin/sessions.h
+file path=usr/share/gsoap/plugin/smdevp.c
+file path=usr/share/gsoap/plugin/smdevp.h
+file path=usr/share/gsoap/plugin/threads.c
+file path=usr/share/gsoap/plugin/threads.h
+file path=usr/share/gsoap/plugin/wsaapi.c
+file path=usr/share/gsoap/plugin/wsaapi.h
+file path=usr/share/gsoap/plugin/wsddapi.c
+file path=usr/share/gsoap/plugin/wsddapi.h
+file path=usr/share/gsoap/plugin/wsrmapi.c
+file path=usr/share/gsoap/plugin/wsrmapi.h
+file path=usr/share/gsoap/plugin/wsse2api.c
+file path=usr/share/gsoap/plugin/wsse2api.h
+file path=usr/share/gsoap/plugin/wsseapi-lite.c
+file path=usr/share/gsoap/plugin/wsseapi-lite.h
+file path=usr/share/gsoap/plugin/wsseapi.c
+file path=usr/share/gsoap/plugin/wsseapi.cpp
+file path=usr/share/gsoap/plugin/wsseapi.h
+file path=usr/share/gsoap/plugin/wstapi.c
+file path=usr/share/gsoap/plugin/wstapi.h

--- a/components/library/gsoap/manifests/sample-manifest.p5m
+++ b/components/library/gsoap/manifests/sample-manifest.p5m
@@ -1,0 +1,238 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/soapcpp2
+file path=usr/bin/wsdl2h
+file path=usr/include/stdsoap2.h
+file path=usr/lib/$(MACH64)/libgsoap++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoap++.a
+link path=usr/lib/$(MACH64)/libgsoap++.so \
+    target=libgsoap++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoap-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoap.a
+link path=usr/lib/$(MACH64)/libgsoap.so target=libgsoap-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapck++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapck++.a
+link path=usr/lib/$(MACH64)/libgsoapck++.so \
+    target=libgsoapck++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapck-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapck.a
+link path=usr/lib/$(MACH64)/libgsoapck.so \
+    target=libgsoapck-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapssl++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapssl++.a
+link path=usr/lib/$(MACH64)/libgsoapssl++.so \
+    target=libgsoapssl++-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapssl-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/libgsoapssl.a
+link path=usr/lib/$(MACH64)/libgsoapssl.so \
+    target=libgsoapssl-$(COMPONENT_VERSION).so
+file path=usr/lib/$(MACH64)/pkgconfig/gsoap++.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoap.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapck++.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapck.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapssl++.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gsoapssl.pc
+file path=usr/share/gsoap/WS/LEGAL.txt
+file path=usr/share/gsoap/WS/README.txt
+file path=usr/share/gsoap/WS/WS-Addressing.xsd
+file path=usr/share/gsoap/WS/WS-Addressing03.xsd
+file path=usr/share/gsoap/WS/WS-Addressing04.xsd
+file path=usr/share/gsoap/WS/WS-Addressing05.xsd
+file path=usr/share/gsoap/WS/WS-Discovery.wsdl
+file path=usr/share/gsoap/WS/WS-Enumeration.wsdl
+file path=usr/share/gsoap/WS/WS-Policy.xsd
+file path=usr/share/gsoap/WS/WS-Policy12.xsd
+file path=usr/share/gsoap/WS/WS-ReliableMessaging.wsdl
+file path=usr/share/gsoap/WS/WS-ReliableMessaging.xsd
+file path=usr/share/gsoap/WS/WS-Routing.xsd
+file path=usr/share/gsoap/WS/WS-SecureConversation.xsd
+file path=usr/share/gsoap/WS/WS-SecurityPolicy.xsd
+file path=usr/share/gsoap/WS/WS-Trust.wsdl
+file path=usr/share/gsoap/WS/WS-Trust.xsd
+file path=usr/share/gsoap/WS/WS-typemap.dat
+file path=usr/share/gsoap/WS/discovery.xsd
+file path=usr/share/gsoap/WS/ds.xsd
+file path=usr/share/gsoap/WS/enumeration.xsd
+file path=usr/share/gsoap/WS/oasis-sstc-saml-schema-assertion-1.1.xsd
+file path=usr/share/gsoap/WS/reference-1.1.xsd
+file path=usr/share/gsoap/WS/saml-schema-assertion-2.0.xsd
+file path=usr/share/gsoap/WS/typemap.dat
+file path=usr/share/gsoap/WS/ws-bpel_abstract_common_base.xsd
+file path=usr/share/gsoap/WS/ws-bpel_executable.xsd
+file path=usr/share/gsoap/WS/ws-bpel_plnktype.xsd
+file path=usr/share/gsoap/WS/ws-bpel_serviceref.xsd
+file path=usr/share/gsoap/WS/ws-bpel_varprop.xsd
+file path=usr/share/gsoap/WS/ws-reliability-1.1.xsd
+file path=usr/share/gsoap/WS/wsse.xsd
+file path=usr/share/gsoap/WS/wsu.xsd
+file path=usr/share/gsoap/WS/xenc.xsd
+file path=usr/share/gsoap/custom/README.txt
+file path=usr/share/gsoap/custom/chrono_duration.cpp
+file path=usr/share/gsoap/custom/chrono_duration.h
+file path=usr/share/gsoap/custom/chrono_time_point.cpp
+file path=usr/share/gsoap/custom/chrono_time_point.h
+file path=usr/share/gsoap/custom/duration.c
+file path=usr/share/gsoap/custom/duration.h
+file path=usr/share/gsoap/custom/float128.c
+file path=usr/share/gsoap/custom/float128.h
+file path=usr/share/gsoap/custom/int128.c
+file path=usr/share/gsoap/custom/int128.h
+file path=usr/share/gsoap/custom/long_double.c
+file path=usr/share/gsoap/custom/long_double.h
+file path=usr/share/gsoap/custom/long_time.c
+file path=usr/share/gsoap/custom/long_time.h
+file path=usr/share/gsoap/custom/qbytearray_base64.cpp
+file path=usr/share/gsoap/custom/qbytearray_base64.h
+file path=usr/share/gsoap/custom/qbytearray_hex.cpp
+file path=usr/share/gsoap/custom/qbytearray_hex.h
+file path=usr/share/gsoap/custom/qdate.cpp
+file path=usr/share/gsoap/custom/qdate.h
+file path=usr/share/gsoap/custom/qdatetime.cpp
+file path=usr/share/gsoap/custom/qdatetime.h
+file path=usr/share/gsoap/custom/qstring.cpp
+file path=usr/share/gsoap/custom/qstring.h
+file path=usr/share/gsoap/custom/qtime.cpp
+file path=usr/share/gsoap/custom/qtime.h
+file path=usr/share/gsoap/custom/struct_timeval.c
+file path=usr/share/gsoap/custom/struct_timeval.h
+file path=usr/share/gsoap/custom/struct_tm.c
+file path=usr/share/gsoap/custom/struct_tm.h
+file path=usr/share/gsoap/custom/struct_tm_date.c
+file path=usr/share/gsoap/custom/struct_tm_date.h
+file path=usr/share/gsoap/import/README.txt
+file path=usr/share/gsoap/import/WS-Header.h
+file path=usr/share/gsoap/import/WS-example.c
+file path=usr/share/gsoap/import/WS-example.h
+file path=usr/share/gsoap/import/c14n.h
+file path=usr/share/gsoap/import/dom.h
+file path=usr/share/gsoap/import/ds.h
+file path=usr/share/gsoap/import/ds2.h
+file path=usr/share/gsoap/import/plnk.h
+file path=usr/share/gsoap/import/ref.h
+file path=usr/share/gsoap/import/saml1.h
+file path=usr/share/gsoap/import/saml2.h
+file path=usr/share/gsoap/import/ser.h
+file path=usr/share/gsoap/import/soap12.h
+file path=usr/share/gsoap/import/stdstring.h
+file path=usr/share/gsoap/import/stl.h
+file path=usr/share/gsoap/import/stldeque.h
+file path=usr/share/gsoap/import/stllist.h
+file path=usr/share/gsoap/import/stlset.h
+file path=usr/share/gsoap/import/stlvector.h
+file path=usr/share/gsoap/import/vprop.h
+file path=usr/share/gsoap/import/wsa.h
+file path=usr/share/gsoap/import/wsa3.h
+file path=usr/share/gsoap/import/wsa4.h
+file path=usr/share/gsoap/import/wsa5.h
+file path=usr/share/gsoap/import/wsc.h
+file path=usr/share/gsoap/import/wsc2.h
+file path=usr/share/gsoap/import/wsdd.h
+file path=usr/share/gsoap/import/wsdd10.h
+file path=usr/share/gsoap/import/wsdd5.h
+file path=usr/share/gsoap/import/wsdx.h
+file path=usr/share/gsoap/import/wsp.h
+file path=usr/share/gsoap/import/wsp_appliesto.h
+file path=usr/share/gsoap/import/wsrm.h
+file path=usr/share/gsoap/import/wsrm4.h
+file path=usr/share/gsoap/import/wsrm5.h
+file path=usr/share/gsoap/import/wsrp.h
+file path=usr/share/gsoap/import/wsrx.h
+file path=usr/share/gsoap/import/wsrx5.h
+file path=usr/share/gsoap/import/wsse.h
+file path=usr/share/gsoap/import/wsse11.h
+file path=usr/share/gsoap/import/wsse2.h
+file path=usr/share/gsoap/import/wst.h
+file path=usr/share/gsoap/import/wst2.h
+file path=usr/share/gsoap/import/wstx.h
+file path=usr/share/gsoap/import/wstx2.h
+file path=usr/share/gsoap/import/wsu.h
+file path=usr/share/gsoap/import/xenc.h
+file path=usr/share/gsoap/import/xenc2.h
+file path=usr/share/gsoap/import/xlink.h
+file path=usr/share/gsoap/import/xmime.h
+file path=usr/share/gsoap/import/xmime4.h
+file path=usr/share/gsoap/import/xmime5.h
+file path=usr/share/gsoap/import/xml.h
+file path=usr/share/gsoap/import/xmlmime.h
+file path=usr/share/gsoap/import/xmlmime5.h
+file path=usr/share/gsoap/import/xop.h
+file path=usr/share/gsoap/import/xsd.h
+file path=usr/share/gsoap/plugin/README.txt
+file path=usr/share/gsoap/plugin/cacerts.c
+file path=usr/share/gsoap/plugin/cacerts.h
+file path=usr/share/gsoap/plugin/calcrest.h
+file path=usr/share/gsoap/plugin/curlapi.c
+file path=usr/share/gsoap/plugin/curlapi.h
+file path=usr/share/gsoap/plugin/httpda.c
+file path=usr/share/gsoap/plugin/httpda.h
+file path=usr/share/gsoap/plugin/httpdatest.c
+file path=usr/share/gsoap/plugin/httpdatest.h
+file path=usr/share/gsoap/plugin/httpform.c
+file path=usr/share/gsoap/plugin/httpform.h
+file path=usr/share/gsoap/plugin/httpget.c
+file path=usr/share/gsoap/plugin/httpget.h
+file path=usr/share/gsoap/plugin/httpgettest.c
+file path=usr/share/gsoap/plugin/httpgettest.h
+file path=usr/share/gsoap/plugin/httpmd5.c
+file path=usr/share/gsoap/plugin/httpmd5.h
+file path=usr/share/gsoap/plugin/httpmd5test.c
+file path=usr/share/gsoap/plugin/httpmd5test.h
+file path=usr/share/gsoap/plugin/httppipe.c
+file path=usr/share/gsoap/plugin/httppipe.h
+file path=usr/share/gsoap/plugin/httppost.c
+file path=usr/share/gsoap/plugin/httppost.h
+file path=usr/share/gsoap/plugin/httpposttest.c
+file path=usr/share/gsoap/plugin/httpposttest.h
+file path=usr/share/gsoap/plugin/logging.c
+file path=usr/share/gsoap/plugin/logging.h
+file path=usr/share/gsoap/plugin/md5evp.c
+file path=usr/share/gsoap/plugin/md5evp.h
+file path=usr/share/gsoap/plugin/mecevp.c
+file path=usr/share/gsoap/plugin/mecevp.h
+file path=usr/share/gsoap/plugin/mq.c
+file path=usr/share/gsoap/plugin/mq.h
+file path=usr/share/gsoap/plugin/plugin.c
+file path=usr/share/gsoap/plugin/plugin.h
+file path=usr/share/gsoap/plugin/sessions.c
+file path=usr/share/gsoap/plugin/sessions.h
+file path=usr/share/gsoap/plugin/smdevp.c
+file path=usr/share/gsoap/plugin/smdevp.h
+file path=usr/share/gsoap/plugin/threads.c
+file path=usr/share/gsoap/plugin/threads.h
+file path=usr/share/gsoap/plugin/wsaapi.c
+file path=usr/share/gsoap/plugin/wsaapi.h
+file path=usr/share/gsoap/plugin/wsddapi.c
+file path=usr/share/gsoap/plugin/wsddapi.h
+file path=usr/share/gsoap/plugin/wsrmapi.c
+file path=usr/share/gsoap/plugin/wsrmapi.h
+file path=usr/share/gsoap/plugin/wsse2api.c
+file path=usr/share/gsoap/plugin/wsse2api.h
+file path=usr/share/gsoap/plugin/wsseapi-lite.c
+file path=usr/share/gsoap/plugin/wsseapi-lite.h
+file path=usr/share/gsoap/plugin/wsseapi.c
+file path=usr/share/gsoap/plugin/wsseapi.cpp
+file path=usr/share/gsoap/plugin/wsseapi.h
+file path=usr/share/gsoap/plugin/wstapi.c
+file path=usr/share/gsoap/plugin/wstapi.h

--- a/components/library/gsoap/patches/01-fedora-libtool.patch
+++ b/components/library/gsoap/patches/01-fedora-libtool.patch
@@ -1,0 +1,137 @@
+https://src.fedoraproject.org/rpms/gsoap/blob/master/f/gsoap-libtool.patch
+
+diff -ur gsoap-2.8.orig/configure.ac gsoap-2.8/configure.ac
+--- gsoap-2.8.orig/configure.ac	2019-01-14 18:17:20.000000000 +0100
++++ gsoap-2.8/configure.ac	2019-01-17 15:48:00.000982088 +0100
+@@ -16,8 +16,7 @@
+ AM_PROG_LEX
+ AC_PROG_YACC
+ AC_PROG_CPP
+-AC_PROG_RANLIB
+-#AM_PROG_LIBTOOL
++AM_PROG_LIBTOOL
+ AC_PROG_LN_S
+ AC_PROG_AWK
+ AC_PROG_INSTALL
+@@ -295,15 +294,15 @@
+     WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lgnutls -lgcrypt -lgpg-error -lz"
+     SAMPLE_INCLUDES=
+     SAMPLE_SSL_LIBS="-lgnutls -lgcrypt -lgpg-error -lz"
+-    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.a"
++    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.la"
+   else
+     AC_MSG_RESULT(no)
+     WSDL2H_EXTRA_FLAGS="-DWITH_OPENSSL -DWITH_GZIP"
+     # compile with wsdl2h when OPENSSL is available
+-    WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lssl -lcrypto -lz"
++    WSDL2H_EXTRA_LIBS="${WSDL2H_EXTRA_LIBS} -lcrypto"
+     SAMPLE_INCLUDES=
+     SAMPLE_SSL_LIBS="-lssl -lcrypto -lz"
+-    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.a"
++    WSDL2H_SOAP_CPP_LIB="libgsoapssl++.la"
+   fi
+   if test -n "$ZLIB"; then
+     WSDL2H_EXTRA_FLAGS="-I${ZLIB}/include ${WSDL2H_EXTRA_FLAGS}"
+@@ -322,7 +321,7 @@
+   WSDL2H_EXTRA_FLAGS=
+   SAMPLE_SSL_LIBS=
+   SAMPLE_INCLUDES=
+-  WSDL2H_SOAP_CPP_LIB="libgsoap++.a"
++  WSDL2H_SOAP_CPP_LIB="libgsoap++.la"
+ fi
+ AM_CONDITIONAL(WITH_OPENSSL, test "x$with_openssl" = "xyes" -a "x$with_gnutls" != "xyes")
+ AC_SUBST(WITH_OPENSSL)
+diff -ur gsoap-2.8.orig/gsoap/Makefile.am gsoap-2.8/gsoap/Makefile.am
+--- gsoap-2.8.orig/gsoap/Makefile.am	2019-01-14 18:17:21.000000000 +0100
++++ gsoap-2.8/gsoap/Makefile.am	2019-01-17 15:58:13.041317567 +0100
+@@ -34,20 +34,30 @@
+ dom_cpp.cpp: dom.cpp
+ 	$(LN_S) -f $(top_srcdir)/gsoap/dom.cpp dom_cpp.cpp
+ 
+-lib_LIBRARIES = libgsoap.a libgsoap++.a libgsoapck.a libgsoapck++.a libgsoapssl.a libgsoapssl++.a
++lib_LTLIBRARIES = libgsoap.la libgsoap++.la libgsoapck.la libgsoapck++.la libgsoapssl.la libgsoapssl++.la
+ 
+-libgsoap_a_SOURCES = stdsoap2.c dom.c
+-libgsoap_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
+-libgsoap___a_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp
+-libgsoap___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
+-libgsoapck_a_SOURCES = stdsoap2_ck.c dom.c
+-libgsoapck_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
+-libgsoapck___a_SOURCES = stdsoap2_ck_cpp.cpp dom_cpp.cpp
+-libgsoapck___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
+-libgsoapssl_a_SOURCES = stdsoap2_ssl.c dom.c
+-libgsoapssl_a_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
+-libgsoapssl___a_SOURCES = stdsoap2_ssl_cpp.cpp dom_cpp.cpp
+-libgsoapssl___a_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++SOVERSION = $(shell grep 'define VERSION' $(srcdir)/src/soapcpp2.h | cut -d '"' -f 2)
++
++libgsoap_la_SOURCES = stdsoap2.c dom.c
++libgsoap_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
++libgsoap_la_LDFLAGS = -release $(SOVERSION)
++libgsoap___la_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp
++libgsoap___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform)
++libgsoap___la_LDFLAGS = -release $(SOVERSION)
++libgsoapck_la_SOURCES = stdsoap2_ck.c dom.c
++libgsoapck_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
++libgsoapck_la_LDFLAGS = -release $(SOVERSION)
++libgsoapck___la_SOURCES = stdsoap2_ck_cpp.cpp dom_cpp.cpp
++libgsoapck___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) -DWITH_COOKIES
++libgsoapck___la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl_la_SOURCES = stdsoap2_ssl.c dom.c
++libgsoapssl_la_CFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++libgsoapssl_la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl_la_LIBADD = -lssl -lcrypto -lz
++libgsoapssl___la_SOURCES = stdsoap2_ssl_cpp.cpp dom_cpp.cpp
++libgsoapssl___la_CXXFLAGS = $(SOAPCPP2_DEBUG) $(SOAPCPP2_NONAMESPACES) $(SOAPCPP2_NO_C_LOCALE) $(SOAPCPP2_IPV6) $(SOAPCPP2_IPV6_V6ONLY) -D$(platform) $(WSDL2H_EXTRA_FLAGS) -DWITH_DOM -DWITH_COOKIES
++libgsoapssl___la_LDFLAGS = -release $(SOVERSION)
++libgsoapssl___la_LIBADD = -lssl -lcrypto -lz
+ 
+ BUILT_SOURCES = stdsoap2_cpp.cpp dom_cpp.cpp stdsoap2_ck.c stdsoap2_ck_cpp.cpp stdsoap2_ssl.c stdsoap2_ssl_cpp.cpp
+ 
+diff -ur gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am gsoap-2.8/gsoap/samples/autotest/Makefile.am
+--- gsoap-2.8.orig/gsoap/samples/autotest/Makefile.am	2019-01-14 18:17:22.000000000 +0100
++++ gsoap-2.8/gsoap/samples/autotest/Makefile.am	2019-01-17 15:48:00.008982002 +0100
+@@ -14,7 +14,7 @@
+ WSDLINPUT=$(top_srcdir)/gsoap/samples/autotest/examples.wsdl
+ SOAPHEADER=$(top_srcdir)/gsoap/samples/autotest/examples.h
+ SOAP_CPP_SRC=soapC.cpp soapServer.cpp
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
+ 
+ $(SOAP_CPP_SRC) : $(WSDLINPUT)
+ 	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
+diff -ur gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am gsoap-2.8/gsoap/samples/databinding/Makefile.am
+--- gsoap-2.8.orig/gsoap/samples/databinding/Makefile.am	2019-01-14 18:17:22.000000000 +0100
++++ gsoap-2.8/gsoap/samples/databinding/Makefile.am	2019-01-17 15:48:00.008982002 +0100
+@@ -14,7 +14,7 @@
+ WSDLINPUT=$(top_srcdir)/gsoap/samples/databinding/address.xsd
+ SOAPHEADER=$(top_srcdir)/gsoap/samples/databinding/address.h
+ SOAP_CPP_SRC=addressC.cpp
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
+ 
+ $(SOAP_CPP_SRC) : $(WSDLINPUT)
+ 	$(WSDL) $(WSDL_FLAGS) $(WSDLINPUT)
+diff -ur gsoap-2.8.orig/gsoap/samples/Makefile.defines gsoap-2.8/gsoap/samples/Makefile.defines
+--- gsoap-2.8.orig/gsoap/samples/Makefile.defines	2019-01-14 18:17:22.000000000 +0100
++++ gsoap-2.8/gsoap/samples/Makefile.defines	2019-01-17 15:48:00.008982002 +0100
+@@ -13,13 +13,13 @@
+ SOAP_C_CORE=soapC.c
+ SOAP_C_CLIENT=soapClient.c $(SOAP_C_CORE)
+ SOAP_C_SERVER=soapServer.c $(SOAP_C_CORE)
+-SOAP_C_LIB=$(top_builddir)/gsoap/libgsoap.a
+-SOAP_C_LIB_CK=$(top_builddir)/gsoap/libgsoapck.a
+-SOAP_C_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl.a
++SOAP_C_LIB=$(top_builddir)/gsoap/libgsoap.la
++SOAP_C_LIB_CK=$(top_builddir)/gsoap/libgsoapck.la
++SOAP_C_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl.la
+ 
+ SOAP_CPP_CORE=soapC.cpp
+ SOAP_CPP_CLIENT=soapClient.cpp $(SOAP_CPP_CORE)
+ SOAP_CPP_SERVER=soapServer.cpp $(SOAP_CPP_CORE)
+-SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.a
+-SOAP_CPP_LIB_CK=$(top_builddir)/gsoap/libgsoapck++.a
+-SOAP_CPP_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl++.a
++SOAP_CPP_LIB=$(top_builddir)/gsoap/libgsoap++.la
++SOAP_CPP_LIB_CK=$(top_builddir)/gsoap/libgsoapck++.la
++SOAP_CPP_LIB_SSL=$(top_builddir)/gsoap/libgsoapssl++.la

--- a/components/library/gsoap/patches/02-automake1.13-fix.patch
+++ b/components/library/gsoap/patches/02-automake1.13-fix.patch
@@ -1,0 +1,25 @@
+https://build.opensuse.org/package/view_file/devel:libraries:c_c++/gsoap/gsoap-automake1_13.diff?expand=1
+
+From: Jan Engelhardt <jengelh@inai.de>
+Date: 2013-02-28 23:21:08.137905619 +0100
+
+automake-1.13 has finally removed AM_CONFIG_HEADER.
+
+---
+ configure.ac |    3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+Index: gsoap-2.8.57/configure.ac
+===================================================================
+--- gsoap-2.8.57.orig/configure.ac
++++ gsoap-2.8.57/configure.ac
+@@ -4,8 +4,7 @@ AM_INIT_AUTOMAKE([foreign])
+ AC_CONFIG_SRCDIR([gsoap/stdsoap2.cpp])
+ AC_CANONICAL_HOST
+ 
+-# AC_CONFIG_HEADERS([config.h])
+-AM_CONFIG_HEADER(config.h)
++AC_CONFIG_HEADERS([config.h])
+ 
+ # we use subdirs.
+ AC_PROG_MAKE_SET 

--- a/components/library/gsoap/patches/03-fix-gethostbyname_r.patch
+++ b/components/library/gsoap/patches/03-fix-gethostbyname_r.patch
@@ -1,0 +1,30 @@
+Patch by Philip Kime <Philip@kime.org.uk> (https://www.illumos.org/attachments/1768).
+
+Reported as https://sourceforge.net/p/gsoap2/bugs/1247/.
+
+--- gsoap-2.8/gsoap/stdsoap2.cpp	Thu Apr 18 22:09:34 2019
++++ gsoap-2.8/gsoap/stdsoap2.cpp	Wed Apr 24 21:43:51 2019
+@@ -5066,7 +5066,10 @@
+ static int
+ tcp_gethostbyname(struct soap *soap, const char *addr, struct hostent *hostent, struct in_addr *inaddr)
+ {
+-#if defined(__GLIBC__) && (!_GNU_SOURCE && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE) && defined(HAVE_GETHOSTBYNAME_R)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || (defined(HAVE_GETHOSTBYNAME_R) && (defined(FREEBSD) || defined(__FreeBSD__)))
++#if defined(SUN_OS)
++  char *tmpbuf = soap->tmpbuf;
++  size_t tmplen = sizeof(soap->tmpbuf);
++#elif (defined(__GLIBC__) && (!_GNU_SOURCE && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE) && defined(HAVE_GETHOSTBYNAME_R)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || (defined(HAVE_GETHOSTBYNAME_R) && (defined(FREEBSD) || defined(__FreeBSD__))))
+   int r;
+   char *tmpbuf = soap->tmpbuf;
+   size_t tmplen = sizeof(soap->tmpbuf);
+@@ -5094,7 +5097,10 @@
+       return SOAP_OK;
+     }
+   }
+-#if defined(__GLIBC__) && (!_GNU_SOURCE && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE) && defined(HAVE_GETHOSTBYNAME_R)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || (defined(HAVE_GETHOSTBYNAME_R) && (defined(FREEBSD) || defined(__FreeBSD__)))
++
++#if defined(SUN_OS)
++  hostent = gethostbyname_r(addr, hostent, tmpbuf, tmplen, &soap->errnum);
++#elif (defined(__GLIBC__) && (!_GNU_SOURCE && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE) && defined(HAVE_GETHOSTBYNAME_R)) || _Posix_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || (defined(HAVE_GETHOSTBYNAME_R) && (defined(FREEBSD) || defined(__FreeBSD__))))
+   while ((r = gethostbyname_r(addr, hostent, tmpbuf, tmplen, &hostent, &soap->errnum)) < 0)
+   {
+     if (tmpbuf != soap->tmpbuf)

--- a/components/library/gsoap/patches/04-fix-HAVE_ISNAN-definition.patch
+++ b/components/library/gsoap/patches/04-fix-HAVE_ISNAN-definition.patch
@@ -1,0 +1,13 @@
+--- gsoap-2.8/gsoap/stdsoap2.h	2019-04-18 22:09:34.000000000 +0000
++++ gsoap-2.8/gsoap/stdsoap2.h.new	2019-04-24 22:58:49.520176598 +0000
+@@ -1395,7 +1395,9 @@ extern "C" {
+ #endif
+ 
+ #ifdef SUN_OS
+-# define HAVE_ISNAN
++# ifndef HAVE_ISNAN
++#  define HAVE_ISNAN
++# endif
+ #endif
+ 
+ #ifdef __APPLE__


### PR DESCRIPTION
This component is required to build webservice support to VirtualBox (illumos#10840).

Portions of the source package are unexpected (binaries et al.), others should be made sure they are not delivered as they are not GPL (Fedora & openSUSE are removing this stuff), hence the extensive `COMPONENT_PRE_CONFIGURE_ACTION` section.