### PR TITLE
mc: add shell scripts execution bit

### DIFF
--- a/components/sysutils/mc/Makefile
+++ b/components/sysutils/mc/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mc
 COMPONENT_VERSION=	4.8.22
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		file/mc
 COMPONENT_SUMMARY=	The GNU Midnight Commander file manager
 COMPONENT_DESCRIPTION=	GNU Midnight Commander is a full-screen text mode application that allows user to copy, move and delete files and whole directory trees, search for files and run commands in the subshell

--- a/components/sysutils/mc/mc.p5m
+++ b/components/sysutils/mc/mc.p5m
@@ -122,15 +122,15 @@ file path=usr/share/mc/examples/macros.d/macro.4.sh
 file path=usr/share/mc/examples/macros.d/macro.5.sh
 file path=usr/share/mc/examples/macros.d/macro.6.sh
 file path=usr/share/mc/examples/macros.d/macro.7.sh
-file path=usr/share/mc/ext.d/archive.sh
-file path=usr/share/mc/ext.d/doc.sh
-file path=usr/share/mc/ext.d/image.sh
-file path=usr/share/mc/ext.d/misc.sh
-file path=usr/share/mc/ext.d/package.sh
-file path=usr/share/mc/ext.d/sound.sh
-file path=usr/share/mc/ext.d/text.sh
-file path=usr/share/mc/ext.d/video.sh
-file path=usr/share/mc/ext.d/web.sh
+file path=usr/share/mc/ext.d/archive.sh mode=0555
+file path=usr/share/mc/ext.d/doc.sh mode=0555
+file path=usr/share/mc/ext.d/image.sh mode=0555
+file path=usr/share/mc/ext.d/misc.sh mode=0555
+file path=usr/share/mc/ext.d/package.sh mode=0555
+file path=usr/share/mc/ext.d/sound.sh mode=0555
+file path=usr/share/mc/ext.d/text.sh mode=0555
+file path=usr/share/mc/ext.d/video.sh mode=0555
+file path=usr/share/mc/ext.d/web.sh mode=0555
 file path=usr/share/mc/extfs.d/README
 file path=usr/share/mc/extfs.d/README.extfs
 file path=usr/share/mc/extfs.d/a+ mode=0555


### PR DESCRIPTION
Some .sh files weren't executable in `mc`.

Error message: `/usr/share/mc/ext.d/text.sh: cannot execute [Permission denied]`