### PR TITLE
Server: Install bash-completion by default

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	32
+COMPONENT_REVISION=	33
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/server_desktop
+++ b/components/meta-packages/install-types/includes/server_desktop
@@ -161,4 +161,5 @@ depend type=require fmri=text/gnu-sed
 depend type=require fmri=text/groff
 depend type=require fmri=text/texinfo
 depend type=require fmri=utilities/watch
+depend type=require fmri=utility/bash-completion
 depend type=require fmri=x11/compatibility/links-xorg


### PR DESCRIPTION
Brings no additional dependency to the Server image (does three for the Minimal image) and the user experience is way better (in my mind anyway).