### PR TITLE
10918 Enable NTP service by default

### DIFF
--- a/components/network/ntp/Makefile
+++ b/components/network/ntp/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ntp
 COMPONENT_VERSION=	4.2.8p13
+COMPONENT_REVISION=	1
 IPS_COMPONENT_VERSION=	$(subst p,.,$(COMPONENT_VERSION))
 COMPONENT_SUMMARY=	Network Time Protocol Daemon v4
 COMPONENT_DESCRIPTION=	Network Time Protocol v4, NTP Daemon and Utilities
@@ -75,6 +76,11 @@ CONFIGURE_OPTIONS +=	--with-openssl-libdir=$(LIBDIR)/$(MACH64)
 CONFIGURE_OPTIONS +=	--disable-problem-tests
 
 BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
+
+$(BUILD_DIR)/ntp-ngz.xml: $(COMPONENT_DIR)/Solaris/ntp.xml $(BUILD_DIR)
+	$(GSED) -e '/instance name="default"/s/enabled="true"/enabled="false"/g' $< > $@
+
+$(INSTALL_64): $(BUILD_DIR)/ntp-ngz.xml
 
 COMPONENT_INSTALL_ENV += PATH=/usr/gnu/bin:/usr/bin
 

--- a/components/network/ntp/Solaris/ntp.xml
+++ b/components/network/ntp/Solaris/ntp.xml
@@ -101,7 +101,7 @@
 		value='solaris.smf.value.ntp' />
 	</property_group>
 
-	<instance name="default" enabled="false">
+	<instance name="default" enabled="true">
 		<property_group name='config' type='application' >
 			<!-- default property settings for ntpd(1M). -->
 		

--- a/components/network/ntp/ntp.p5m
+++ b/components/network/ntp/ntp.p5m
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,6 +29,7 @@ set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=variant.opensolaris.zone value=global value=nonglobal
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
@@ -41,7 +43,8 @@ file Solaris/ntp.client path=etc/inet/ntp.conf group=sys preserve=true
 file Solaris/ntp.server path=etc/inet/ntp.server group=sys
 file Solaris/auth_attr path=etc/security/auth_attr.d/ntp
 file Solaris/prof_attr path=etc/security/prof_attr.d/ntp
-file Solaris/ntp.xml path=lib/svc/manifest/network/ntp.xml
+file Solaris/ntp.xml path=lib/svc/manifest/network/ntp.xml variant.opensolaris.zone=global
+file build/ntp-ngz.xml path=lib/svc/manifest/network/ntp.xml variant.opensolaris.zone=nonglobal
 file Solaris/ntp.sh path=lib/svc/method/ntp
 file Solaris/RtNTPMngmnt.html \
     path=usr/lib/help/auths/locale/C/RtNTPMngmnt.html


### PR DESCRIPTION
GZ and non-GZ manifests differ only in:

`<instance name="default" enabled="true">` × `<instance name="default" enabled="false">`

Tested both installation and update in GZ and non-GZ.