### PR TITLE
1/2: Update zstd to 1.4.0

### DIFF
--- a/components/archiver/zstd/Makefile
+++ b/components/archiver/zstd/Makefile
@@ -17,8 +17,7 @@ PREFERRED_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zstd
-COMPONENT_VERSION=	1.3.8
-COMPONENT_REVISION=	2
+COMPONENT_VERSION=	1.4.0
 COMPONENT_SUMMARY=	Zstandard, or zstd as short version, is a fast lossless compression algorithm, targeting real-time compression scenarios
 COMPONENT_PROJECT_URL=	https://facebook.github.io/zstd/
 COMPONENT_FMRI=		compress/zstd
@@ -26,7 +25,7 @@ COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/facebook/zstd/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	sha256:293fa004dfacfbe90b42660c474920ff27093e3fb6c99f7b76e6083b21d6d48e
+COMPONENT_ARCHIVE_HASH=	sha256:7f323f0e0c18488748f3d9b2d4353f00e904ea2ccd0372ea04d7f77aa1156557
 COMPONENT_LICENSE=	BSD,GPLv2.0
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 

--- a/components/archiver/zstd/manifests/sample-manifest.p5m
+++ b/components/archiver/zstd/manifests/sample-manifest.p5m
@@ -34,12 +34,14 @@ file path=usr/include/zdict.h
 file path=usr/include/zstd.h
 file path=usr/include/zstd_errors.h
 file path=usr/lib/$(MACH64)/libzstd.a
-link path=usr/lib/$(MACH64)/libzstd.so target=libzstd.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libzstd.so target=libzstd.so.1
 file path=usr/lib/$(MACH64)/libzstd.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libzstd.so.1 target=libzstd.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/libzstd.pc
 file path=usr/lib/libzstd.a
-link path=usr/lib/libzstd.so target=libzstd.so.$(COMPONENT_VERSION)
+link path=usr/lib/libzstd.so target=libzstd.so.1
 file path=usr/lib/libzstd.so.$(COMPONENT_VERSION)
+link path=usr/lib/libzstd.so.1 target=libzstd.so.$(COMPONENT_VERSION)
 file path=usr/lib/pkgconfig/libzstd.pc
 link path=usr/share/man/man1/unzstd.1 target=zstd.1
 file path=usr/share/man/man1/zstd.1

--- a/components/archiver/zstd/patches/01-zstdgrep-needs-gnu-grep.patch
+++ b/components/archiver/zstd/patches/01-zstdgrep-needs-gnu-grep.patch
@@ -1,13 +1,13 @@
 Some options are not present in illumos grep, use GNU grep instead.
 
---- zstd-1.3.8/programs/zstdgrep	2018-12-27 13:42:44.000000000 +0000
-+++ zstd-1.3.8/programs/zstdgrep.new	2019-01-19 18:00:23.843762244 +0000
+--- zstd-1.4.0/programs/zstdgrep	2019-04-17 00:37:24.000000000 +0000
++++ zstd-1.4.0/programs/zstdgrep.new	2019-05-11 14:09:27.963420412 +0000
 @@ -22,7 +22,7 @@
  # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  
--grep=grep
-+grep=ggrep
- zcat=zstdcat
+-grep=${GREP:-grep}
++grep=${GREP:-ggrep}
+ zcat=${ZCAT:-zstdcat}
  
  endofopts=0

--- a/components/archiver/zstd/zstd.p5m
+++ b/components/archiver/zstd/zstd.p5m
@@ -36,11 +36,15 @@ file path=usr/include/zbuff.h
 file path=usr/include/zdict.h
 file path=usr/include/zstd.h
 file path=usr/include/zstd_errors.h
-link path=usr/lib/$(MACH64)/libzstd.so target=libzstd.so.$(COMPONENT_VERSION)
+#file path=usr/lib/$(MACH64)/libzstd.a
+link path=usr/lib/$(MACH64)/libzstd.so target=libzstd.so.1
 file path=usr/lib/$(MACH64)/libzstd.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libzstd.so.1 target=libzstd.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/libzstd.pc
-link path=usr/lib/libzstd.so target=libzstd.so.$(COMPONENT_VERSION)
+#file path=usr/lib/libzstd.a
+link path=usr/lib/libzstd.so target=libzstd.so.1
 file path=usr/lib/libzstd.so.$(COMPONENT_VERSION)
+link path=usr/lib/libzstd.so.1 target=libzstd.so.$(COMPONENT_VERSION)
 file path=usr/lib/pkgconfig/libzstd.pc
 link path=usr/share/man/man1/unzstd.1 target=zstd.1
 file path=usr/share/man/man1/zstd.1


### PR DESCRIPTION
`zstd` 1.4.0 release notes: https://github.com/facebook/zstd/releases/tag/v1.4.0.

`zstd` ABI seems to be always bit ["on the run"](https://abi-laboratory.pro/index.php?view=timeline&l=zstd), so dependents need rebuild after this is integrated, see https://github.com/OpenIndiana/oi-userland/pull/5003.