### PR TITLE
Update help2man to 1.47.10

### DIFF
--- a/components/developer/help2man/Makefile
+++ b/components/developer/help2man/Makefile
@@ -10,15 +10,16 @@
 
 #
 # Copyright 2013, Adam Stevko. All rights reserved.
+# Copyright 2019, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		help2man
-COMPONENT_VERSION=	1.47.4
+COMPONENT_VERSION=	1.47.10
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH=	sha256:d4ecf697d13f14dd1a78c5995f06459bff706fd1ce593d1c02d81667c0207753
+COMPONENT_ARCHIVE_HASH=	sha256:f371cbfd63f879065422b58fa6b81e21870cd791ef6e11d4528608204aa4dcfb
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/help2man/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://www.gnu.org/software/help2man/
 
@@ -26,10 +27,9 @@ include $(WS_TOP)/make-rules/prep.mk
 include $(WS_TOP)/make-rules/configure.mk
 include $(WS_TOP)/make-rules/ips.mk
 
-CONFIGURE_OPTIONS  +=		--infodir=$(CONFIGURE_INFODIR)
-CONFIGURE_ENV  +=	PERL="$(PERL)"
+CONFIGURE_OPTIONS	+=	--infodir=$(CONFIGURE_INFODIR)
+CONFIGURE_ENV		+=	PERL="$(PERL)"
 
-# common targets
 build:		$(BUILD_32)
 
 install:	$(INSTALL_32)
@@ -40,4 +40,5 @@ BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
 
 include $(WS_TOP)/make-rules/depend.mk
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/perl-522

--- a/components/developer/help2man/help2man.p5m
+++ b/components/developer/help2man/help2man.p5m
@@ -10,6 +10,7 @@
 
 #
 # Copyright 2013, Adam Stevko. All rights reserved.
+# Copyright 2019, Michal Nowak
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
@@ -23,14 +24,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license help2man.license license='GPLv3'
 
-dir path=usr
-dir path=usr/gnu
-dir path=usr/gnu/bin
-dir path=usr/gnu/share
-dir path=usr/gnu/share/info
-dir path=usr/gnu/share/man
-dir path=usr/gnu/share/man/man1
-
-file usr/bin/help2man path=usr/gnu/bin/help2man 
-file usr/share/info/help2man.info path=usr/gnu/share/info/help2man.info 
-file usr/share/man/man1/help2man.1 path=usr/gnu/share/man/man1/help2man.1
+file path=usr/bin/help2man
+file path=usr/share/info/help2man.info
+file path=usr/share/man/man1/help2man.1


### PR DESCRIPTION
Moved the script from `usr/gnu/bin/` to `usr/bin/` as we don't have any other `help2man` in `usr/bin/`.