### PR TITLE
Update dbus to 1.12.16 (CVE-2019-12749)

### DIFF
--- a/components/library/dbus/Makefile
+++ b/components/library/dbus/Makefile
@@ -11,22 +11,20 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		dbus
-COMPONENT_VERSION=	1.12.12
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	1.12.16
 COMPONENT_SUMMARY=	Simple IPC library based on messages
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:9546f226011a1e5d9d77245fe5549ef25af4694053189d624d0d6ac127ecf5f8
+	sha256:54a22d2fa42f2eb2a871f32811c6005b531b9613b1b93a0d269b05e7549fec80
 COMPONENT_ARCHIVE_URL= \
 	http://dbus.freedesktop.org/releases/dbus/$(COMPONENT_ARCHIVE)
-COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).asc
 COMPONENT_PROJECT_URL=	https://www.freedesktop.org/wiki/Software/dbus/
 COMPONENT_LICENSE_FILE=	COPYING
 COMPONENT_LICENSE=	GPLv2,AFLv2.1
@@ -60,11 +58,11 @@ COMPONENT_TEST_TRANSFORMS = "'/TOTAL|PASS|FAIL|XFAIL|SKIP|XPASS|ERROR/'"
 # To prevent "libtool_install_magic: unbound variable"
 unexport SHELLOPTS
 
-build: $(BUILD_32_and_64)
+build:		$(BUILD_32_and_64)
 
-install: $(INSTALL_32_and_64)
+install:	$(INSTALL_32_and_64)
 
-test: $(TEST_32_and_64)
+test:		$(TEST_32_and_64)
 
 REQUIRED_PACKAGES += developer/documentation-tool/doxygen
 REQUIRED_PACKAGES += developer/build/autoconf-archive

--- a/components/library/dbus/dbus.p5m
+++ b/components/library/dbus/dbus.p5m
@@ -11,7 +11,7 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -206,8 +206,8 @@ file path=usr/share/doc/dbus/api/dbus-valgrind-internal_8h_source.html
 file path=usr/share/doc/dbus/api/dbus-watch_8c_source.html
 file path=usr/share/doc/dbus/api/dbus-watch_8h_source.html
 file path=usr/share/doc/dbus/api/dbus_8h_source.html
-file path=usr/share/doc/dbus/api/dir_819d03f0f7da5da793858d7809f8415d.html
-file path=usr/share/doc/dbus/api/dir_eceb646dd9940a44ae9960bd5a84ff59.html
+file path=usr/share/doc/dbus/api/dir_2d85ee8d34f094f1a20316e4026e9f95.html
+file path=usr/share/doc/dbus/api/dir_8bba7d27c87624a3602514be374c2ece.html
 file path=usr/share/doc/dbus/api/doc.png
 file path=usr/share/doc/dbus/api/doxygen.css
 file path=usr/share/doc/dbus/api/doxygen.png

--- a/components/library/dbus/libdbus.p5m
+++ b/components/library/dbus/libdbus.p5m
@@ -11,7 +11,7 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/system/library/libdbus@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -43,14 +43,14 @@ file path=usr/include/dbus-1.0/dbus/dbus.h
 file path=usr/lib/$(MACH64)/cmake/DBus1/DBus1Config.cmake
 file path=usr/lib/$(MACH64)/cmake/DBus1/DBus1ConfigVersion.cmake
 file path=usr/lib/$(MACH64)/dbus-1.0/include/dbus/dbus-arch-deps.h
-link path=usr/lib/$(MACH64)/libdbus-1.so target=libdbus-1.so.3.19.9
-link path=usr/lib/$(MACH64)/libdbus-1.so.3 target=libdbus-1.so.3.19.9
-file path=usr/lib/$(MACH64)/libdbus-1.so.3.19.9
+link path=usr/lib/$(MACH64)/libdbus-1.so target=libdbus-1.so.3.19.11
+link path=usr/lib/$(MACH64)/libdbus-1.so.3 target=libdbus-1.so.3.19.11
+file path=usr/lib/$(MACH64)/libdbus-1.so.3.19.11
 file path=usr/lib/$(MACH64)/pkgconfig/dbus-1.pc
 file path=usr/lib/cmake/DBus1/DBus1Config.cmake
 file path=usr/lib/cmake/DBus1/DBus1ConfigVersion.cmake
 file path=usr/lib/dbus-1.0/include/dbus/dbus-arch-deps.h
-link path=usr/lib/libdbus-1.so target=libdbus-1.so.3.19.9
-link path=usr/lib/libdbus-1.so.3 target=libdbus-1.so.3.19.9
-file path=usr/lib/libdbus-1.so.3.19.9
+link path=usr/lib/libdbus-1.so target=libdbus-1.so.3.19.11
+link path=usr/lib/libdbus-1.so.3 target=libdbus-1.so.3.19.11
+file path=usr/lib/libdbus-1.so.3.19.11
 file path=usr/lib/pkgconfig/dbus-1.pc

--- a/components/library/dbus/manifests/sample-manifest.p5m
+++ b/components/library/dbus/manifests/sample-manifest.p5m
@@ -62,18 +62,18 @@ file path=usr/lib/$(MACH64)/cmake/DBus1/DBus1ConfigVersion.cmake
 file path=usr/lib/$(MACH64)/dbus-1.0/include/dbus/dbus-arch-deps.h
 file path=usr/lib/$(MACH64)/dbus-daemon
 file path=usr/lib/$(MACH64)/dbus-daemon-launch-helper
-link path=usr/lib/$(MACH64)/libdbus-1.so target=libdbus-1.so.3.19.9
-link path=usr/lib/$(MACH64)/libdbus-1.so.3 target=libdbus-1.so.3.19.9
-file path=usr/lib/$(MACH64)/libdbus-1.so.3.19.9
+link path=usr/lib/$(MACH64)/libdbus-1.so target=libdbus-1.so.3.19.11
+link path=usr/lib/$(MACH64)/libdbus-1.so.3 target=libdbus-1.so.3.19.11
+file path=usr/lib/$(MACH64)/libdbus-1.so.3.19.11
 file path=usr/lib/$(MACH64)/pkgconfig/dbus-1.pc
 file path=usr/lib/cmake/DBus1/DBus1Config.cmake
 file path=usr/lib/cmake/DBus1/DBus1ConfigVersion.cmake
 file path=usr/lib/dbus-1.0/include/dbus/dbus-arch-deps.h
 file path=usr/lib/dbus-daemon
 file path=usr/lib/dbus-daemon-launch-helper
-link path=usr/lib/libdbus-1.so target=libdbus-1.so.3.19.9
-link path=usr/lib/libdbus-1.so.3 target=libdbus-1.so.3.19.9
-file path=usr/lib/libdbus-1.so.3.19.9
+link path=usr/lib/libdbus-1.so target=libdbus-1.so.3.19.11
+link path=usr/lib/libdbus-1.so.3 target=libdbus-1.so.3.19.11
+file path=usr/lib/libdbus-1.so.3.19.11
 file path=usr/lib/pkgconfig/dbus-1.pc
 file path=usr/share/dbus-1/session.conf
 file path=usr/share/dbus-1/system.conf
@@ -233,8 +233,8 @@ file path=usr/share/doc/dbus/api/dbus-valgrind-internal_8h_source.html
 file path=usr/share/doc/dbus/api/dbus-watch_8c_source.html
 file path=usr/share/doc/dbus/api/dbus-watch_8h_source.html
 file path=usr/share/doc/dbus/api/dbus_8h_source.html
-file path=usr/share/doc/dbus/api/dir_819d03f0f7da5da793858d7809f8415d.html
-file path=usr/share/doc/dbus/api/dir_eceb646dd9940a44ae9960bd5a84ff59.html
+file path=usr/share/doc/dbus/api/dir_2d85ee8d34f094f1a20316e4026e9f95.html
+file path=usr/share/doc/dbus/api/dir_8bba7d27c87624a3602514be374c2ece.html
 file path=usr/share/doc/dbus/api/doc.png
 file path=usr/share/doc/dbus/api/doxygen.css
 file path=usr/share/doc/dbus/api/doxygen.png


### PR DESCRIPTION
Release notes: https://github.com/freedesktop/dbus/blob/dbus-1.12/NEWS

**Testing**

- [x] test suite passed
- [x] illumos-gate build passed
- [x] illumos-gate debug build passed
- [x] works on my desktop for some time
- [x] removable device mounting / `gnome-mount`