### PR TITLE
3/3: Rebuild libpeas due to gobject-introspection 1.60.0

### DIFF
--- a/components/library/libpeas/Makefile
+++ b/components/library/libpeas/Makefile
@@ -30,6 +30,7 @@ COMPONENT_SUMMARY=	A gobject-based plugins engine for GNOME
 COMPONENT_DESCRIPTION=	libpeas is a gobject-based plugins engine, and is targeted\
  at giving every application the chance to assume its own extensibility.
 COMPONENT_VERSION=	1.20.0
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=  https://wiki.gnome.org/Projects/Libpeas
 COMPONENT_MAJOR_MINOR=        $(basename $(COMPONENT_VERSION))
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)


### PR DESCRIPTION
Identified once `gobject-introspection` updated to 1.60.

Merge after GObject Introspection (https://github.com/OpenIndiana/oi-userland/pull/5017) is published.