### PR TITLE
Update LightDM to 1.30.0

### DIFF
--- a/components/desktop/lightdm/Makefile
+++ b/components/desktop/lightdm/Makefile
@@ -11,18 +11,18 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		lightdm
-COMPONENT_VERSION=	1.28.0
+COMPONENT_VERSION=	1.30.0
 COMPONENT_SUMMARY=	Light display manager
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:f20f599d8d7cf90b77a2df33c6e9e615abc443123b1b228de1c20a636aecfa07
+	sha256:a118779650a3a5b20f05d53c4f9e377b484fbc1810a6b0914a60840d9a581f95
 COMPONENT_ARCHIVE_URL= \
 	https://github.com/CanonicalLtd/lightdm/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://www.freedesktop.org/wiki/Software/LightDM/
@@ -37,7 +37,7 @@ include $(WS_MAKE_RULES)/ips.mk
 
 PATH=$(PATH.gnu)
 
-COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -f -i)
+COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -f -i )
 
 CPPFLAGS+= $(CPP_XPG7MODE)
 

--- a/components/desktop/lightdm/patches/04-config.patch
+++ b/components/desktop/lightdm/patches/04-config.patch
@@ -1,5 +1,5 @@
---- lightdm-1.19.3/data/users.conf.1	2016-08-07 23:00:37.539141710 +0300
-+++ lightdm-1.19.3/data/users.conf	2016-08-07 23:02:18.975865778 +0300
+--- lightdm-1.30.0/data/users.conf	2018-09-05 03:33:31.000000000 +0000
++++ lightdm-1.30.0/data/users.conf	2019-05-17 10:46:57.029559439 +0000
 @@ -9,6 +9,6 @@
  # hidden-shells = Shells that indicate a user cannot login
  #
@@ -7,5 +7,5 @@
 -minimum-uid=500
 +minimum-uid=101
  hidden-users=nobody nobody4 noaccess
--hidden-shells=/bin/false /usr/sbin/nologin
+-hidden-shells=/bin/false /usr/sbin/nologin /sbin/nologin
 +hidden-shells=/bin/false

--- a/components/desktop/lightdm/patches/17-customize-config.patch
+++ b/components/desktop/lightdm/patches/17-customize-config.patch
@@ -21,31 +21,30 @@ We need to customize default configuration:
      if (!config_has_key (config_get_instance (), "Seat:*", "xmir-command"))
          config_set_string (config_get_instance (), "Seat:*", "xmir-command", "Xmir");
      if (!config_has_key (config_get_instance (), "Seat:*", "xserver-share"))
---- lightdm-1.19.3/data/lightdm.conf.~1~	2016-06-20 03:31:51.000000000 +0300
-+++ lightdm-1.19.3/data/lightdm.conf	2016-08-12 19:58:31.887145185 +0300
-@@ -63,7 +63,7 @@
- # unity-compositor-command = Unity compositor command to run (can also contain arguments e.g. unity-system-compositor -special-option)
- # unity-compositor-timeout = Number of seconds to wait for compositor to start
+--- lightdm-1.30.0/data/lightdm.conf	2018-09-05 03:33:31.000000000 +0000
++++ lightdm-1.30.0/data/lightdm.conf	2019-05-17 10:49:49.548885198 +0000
+@@ -60,7 +60,7 @@
+ # xdmcp-port = XDMCP UDP/IP port to communicate on
+ # xdmcp-key = Authentication key to use for XDM-AUTHENTICATION-1 (stored in keys.conf)
  # greeter-session = Session to load for greeter
 -# greeter-hide-users = True to hide the user list
 +# greeter-hide-users = False to show the user list
  # greeter-allow-guest = True if the greeter should show a guest login option
  # greeter-show-manual-login = True if the greeter should offer a manual login option
  # greeter-show-remote-login = True if the greeter should offer a remote login option
-@@ -89,10 +89,10 @@
+@@ -86,9 +86,9 @@
  [Seat:*]
  #type=local
  #pam-service=lightdm
 -#pam-autologin-service=lightdm-autologin
 +#pam-autologin-service=gdm-autologin
  #pam-greeter-service=lightdm-greeter
- #xserver-backend=
 -#xserver-command=X
 +#xserver-command=Xorg
  #xmir-command=Xmir
  #xserver-config=
  #xserver-layout=
-@@ -110,7 +110,7 @@
+@@ -104,7 +104,7 @@
  #greeter-allow-guest=true
  #greeter-show-manual-login=false
  #greeter-show-remote-login=true
@@ -54,7 +53,7 @@ We need to customize default configuration:
  #allow-user-switching=true
  #allow-guest=true
  #guest-session=
-@@ -161,9 +161,9 @@
+@@ -155,9 +155,9 @@
  #
  [VNCServer]
  #enabled=false


### PR DESCRIPTION
Changelog: https://github.com/CanonicalLtd/lightdm/blob/master/NEWS

I added `reboot-needed=true` to the `lightdm` executable (is there a better place where to put it, how to do it?) because during LightDM update some processes tracked by the service are killed, including `Xorg` thus killing the desktop, service ends-up in maintenance.

No visual change this time.

**Testing**
- login
- autologin
- change of: environment, language, accessibility, power down.