### PR TITLE
Create security policy file (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+The OpenIndiana project commits to providing fixes or mitigations to each
+and every security vulnerabilities in software we deliver. Such a repositories
+of software sources are [illumos-gate](https://github.com/illumos/illumos-gate),
+[pkg5](https://github.com/OpenIndiana/pkg5), [slim_source](https://github.com/OpenIndiana/slim_source),
+and [time-slider](https://github.com/OpenIndiana/time-slider).
+
+Priority with which we handle security issues is based on severity of the issue.
+
+OpenIndiana is a rolling release distribution and has only one maintained branch
+called `hipster`. Other (historical) branches are not supported.
+
+| Version        | Supported |
+| ---------------|---------- |
+| 147, 148, 151a | ✖         |
+| /dev           | ✖         |
+| /hipster       | ✔         |
+
+## Reporting a Vulnerability
+
+To report a security issue, please send an email to security@openindiana.org.
+
+Also see https://www.openindiana.org/community/security-issues/.


### PR DESCRIPTION
GitHub now has fairly visible [Security] tab for repos (e.g. https://github.com/OpenIndiana/oi-userland/security/policy).

We should have this `SECURITY.md` file in oi-userland.