### PR TITLE
Create security policy file (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+The OpenIndiana project commits to providing fixes or mitigations to each
+and every security vulnerability in software we provide. List of source
+code repositories of software we develop is to be found in the
+[documentation](https://docs.openindiana.org/dev/building-openindiana/#source-repositories).
+
+Note that most of the software we deliver is developed independently and
+we merely distribute it. As such the original software author should be made
+aware about a potential security issue.
+
+Priority with which we handle security issues is based on the severity
+of the issue.
+
+OpenIndiana is a rolling release distribution and has only one maintained
+branch called *hipster*. Other (historical) branches are not supported.
+
+## Reporting a Vulnerability
+
+If you are aware of a security vulnerability in software delivered by
+the OpenIndiana project, please send us an email to security@openindiana.org.
+Thank you!
+
+Also see the [Security Issues](https://www.openindiana.org/community/security-issues/)
+page on our website.


### PR DESCRIPTION
Follow-up from https://github.com/OpenIndiana/oi-userland/pull/5040 as that one was created on OpenIndiana/oi-userland by the GitHub editor not in my for as I believed. Sorry about that.
***
GitHub now has fairly visible [Security] tab for repos (e.g. https://github.com/OpenIndiana/oi-userland/security/policy).

We should have this SECURITY.md file in oi-userland.