### PR TITLE
Convert photorec and qphotorec to libjpeg8

### DIFF
--- a/components/testdisk/Makefile
+++ b/components/testdisk/Makefile
@@ -19,11 +19,13 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2016 by Jim Klimov. All rights reserved.
+# Copyright (c) 2019 Tim Mooney <Timothy.V.Mooney@gmail.com>
 #
 include ../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		testdisk
 COMPONENT_VERSION=	7.0
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	https://www.cgsecurity.org/wiki/TestDisk
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
@@ -31,9 +33,14 @@ COMPONENT_ARCHIVE_HASH=	\
     sha256:00bb3b6b22e6aba88580eeb887037aef026968c21a87b5f906c6652cbee3442d
 COMPONENT_ARCHIVE_URL=	https://www.cgsecurity.org/$(COMPONENT_ARCHIVE)
 
-include ../../make-rules/prep.mk
-include ../../make-rules/configure.mk
-include ../../make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+# build with the distribution default libjpeg
+CFLAGS            +=    $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
+CXXFLAGS          +=    $(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
+LDFLAGS           +=    $(JPEG_LDFLAGS)
 
 CONFIGURE_OPTIONS  +=		--enable-qt
 
@@ -45,8 +52,7 @@ install:	$(INSTALL_32_and_64)
 test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/$(JPEG_IMPLEM)
 REQUIRED_PACKAGES += library/ncurses
 REQUIRED_PACKAGES += library/qt4
 REQUIRED_PACKAGES += library/zlib


### PR DESCRIPTION
Update photorec and qphotorec (built as part of testdisk) to use libjpeg8.

* No new version of the software, so bump COMPONENT_REVISION
* update prep.mk/configure.mk/ips.mk to use $(WS_MAKE_RULES)
* add the CFLAGS/CXXFLAGS/LDFLAGS to get libjpeg8
* update REQUIRED_PACKAGES

Please review, @pyhalov and @Mno-hime 