### PR TITLE
Libmng deps rebuild

### DIFF
--- a/components/image/gimp/Makefile
+++ b/components/image/gimp/Makefile
@@ -10,13 +10,14 @@
 
 #
 # Copyright (c) 2017 Alexander Pyhalov
+# Copyright (c) 2019 Tim Mooney
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gimp
 COMPONENT_VERSION=	2.8.22
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_PROJECT_URL=	https://www.gimp.org/
 COMPONENT_SUMMARY=	Gimp - The Free & Open Source Image Editor
 COMPONENT_FMRI=		image/editor/gimp
@@ -66,6 +67,10 @@ build:		$(BUILD_32)
 install:	$(INSTALL_32)
 
 test:		$(TEST_32)
+
+# Build dependencies
+REQUIRED_PACKAGES += library/python/pygobject
+REQUIRED_PACKAGES += library/python/pygtk2
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += codec/jasper

--- a/components/library/qt4/Makefile
+++ b/components/library/qt4/Makefile
@@ -11,6 +11,7 @@
 #
 # Copyright 2014 EveryCity Ltd. All rights reserved.
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2019 Tim Mooney
 #
 
 include ../../../make-rules/shared-macros.mk
@@ -18,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		qt
 COMPONENT_FMRI=		library/qt4
 COMPONENT_VERSION=	4.8.7
-COMPONENT_REVISION=	5
+COMPONENT_REVISION=	6
 COMPONENT_VERSION_MJR=	4.8
 COMPONENT_LICENSE=	QT4
 COMPONENT_LICENSE_FILE=	qt4.license


### PR DESCRIPTION
This PR should only be merged after pull request #5056 

I bumped `COMPONENT_REVISION` and rebuilt the two dependencies of libmng that Michal identified.

gimp:
  * added missing build dependencies (thanks for the help Alp)
  * built updated version, installed and tested.  Note that gimp cannot read MNG files, but it can export to them.  Doing an export still worked after the libmng update.

qt4:
  * only two libraries (QImage imageformat plugins) link against libmng and I didn't see any other obvious way to test, so I ended up writing a very small C++ program to test loading an MNG file:

```C++

using namespace std;

#include <QImage>
#include <iostream>

int main(int argc, char** argv) {
        const QString &file = "/tmp/Delta-gray16.mng";
        bool loaded_successfully = false;

        QImage image;

        loaded_successfully = image.load(file);

        if (loaded_successfully) {
                cout << "Successfully loaded example MNG file\n";
        } else {
                cerr << "Failed to load example MNG file\n";
        }
}
```

I downloaded some of the MNG test images, saved them to `/tmp`, and then created a "qt project"
like this:

    mkdir /tmp/qimage-test
    cd /tmp/qimage-test
    vi qimage-test.cpp
    /usr/lib/qt/4.8/bin/qmake -project "QT += gui"
    /usr/lib/qt/4.8/bin/qmake
    gmake

I had to fix the generated `Makefile` (compile vs. link seem to have different 32 vs. 64 bit settings), but once I fixed it up to reference the correct architecture libraries, it generated a `tmp` binary that I could
run:

```bash
$ ./tmp
Successfully loaded example MNG file
```
