### PR TITLE
convert gst-plugins-good to use libjpeg8

### DIFF
--- a/components/multimedia/gst-plugins-good/Makefile
+++ b/components/multimedia/gst-plugins-good/Makefile
@@ -11,13 +11,14 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright 2019 Tim Mooney.
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gst-plugins-good
 COMPONENT_VERSION= 0.10.31
-COMPONENT_REVISION= 4
+COMPONENT_REVISION= 5
 COMPONENT_SUMMARY= GNOME streaming media framework plugins
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
@@ -41,9 +42,14 @@ COMPONENT_PREP_ACTION =        ( cd $(SOURCE_DIR) && aclocal -I ./m4 -I./common/
                                         autoconf )
 gcc_OPT = -O2
 
-PATH = /usr/gnu/bin:/usr/bin
+PATH = $(PATH.gnu)
 
-CFLAGS += -I/usr/sfw/include -I/usr/X11/include
+# build with the distribution preferred libjpeg implementation
+CFLAGS   += $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
+CXXFLAGS += $(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
+LDFLAGS  += $(JPEG_LDFLAGS)
+
+CFLAGS   += -I/usr/X11/include
 
 CONFIGURE_OPTIONS += --sysconfdir=/etc
 CONFIGURE_OPTIONS.32 += --libexecdir=/usr/lib
@@ -65,12 +71,12 @@ install: $(INSTALL_32_and_64)
 
 test: $(TEST_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += codec/flac
 REQUIRED_PACKAGES += codec/speex
 REQUIRED_PACKAGES += compress/bzip2
 REQUIRED_PACKAGES += gnome/config/gconf
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg8-turbo
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/aalib
 REQUIRED_PACKAGES += library/audio/gstreamer


### PR DESCRIPTION
I've converted `library/audio/gstreamer/plugin/good` to use libjpeg8-turbo and done other component update tasks, but I'm wondering if perhaps the component should be marked obsolete instead.

Only `mate_install` meta-package requires `library/audio/gstreamer/plugin/good` (the depend is in includes/desktop_common).  Perhaps `mate_install` should be referencing the gstreamer1 versions of components instead?  I know that some components still depend on the older gstreamer 0.x components.

As far as my changes to library/audio/gstreamer/plugin/good, I
  * bumped `COMPONENT_REVISION`
  * added the `CFLAGS/CXXFLAGS/LDFLAGS` boilerplate to build with libjpeg8-turbo
  * updated the `PATH` to use `$(PATH.gnu)`
  * ran `gmake REQUIRED_PACKAGES` and updated the `Makefile`.  Only the JPEG dependency changed.
  * re-ran `gmake sample-manifest` to verify that there were no file changes