### PR TITLE
new component itstool-2.0.6

### DIFF
--- a/components/developer/itstool/COPYING
+++ b/components/developer/itstool/COPYING
@@ -1,0 +1,19 @@
+ITS Tool - XML to PO and back again using ITS definitions
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+As a special exception, the copyright holders give you permission to
+copy, modify, and distribute the ITS definitions bundled with this
+program under the terms of your choosing, without restriction.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program in the file COPYING.GPL3.  If not, see
+<http://www.gnu.org/licenses/>.

--- a/components/developer/itstool/Makefile
+++ b/components/developer/itstool/Makefile
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019, Tim Mooney. All rights reserved
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		itstool
+COMPONENT_VERSION=	2.0.6
+COMPONENT_SUMMARY=	W3C International Tag Set (ITS) translation tool
+COMPONENT_FMRI=		developer/build/itstool
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:6233cc22726a9a5a83664bf67d1af79549a298c23185d926c3677afa917b92a9
+COMPONENT_ARCHIVE_URL=	http://files.itstool.org/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	http://itstool.org
+COMPONENT_CLASSIFICATION=Development/GNOME and GTK+
+COMPONENT_LICENSE_FILE=	COPYING
+COMPONENT_LICENSE=	GPLv3
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+CONFIGURE_ENV		+=	PYTHON="$(PYTHON)"
+
+build:		$(BUILD_32)
+
+install:	$(INSTALL_32)
+
+test:		$(NO_TESTS)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/python/libxml2-27
+REQUIRED_PACKAGES += runtime/python-27

--- a/components/developer/itstool/itstool.p5m
+++ b/components/developer/itstool/itstool.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/itstool
+file path=usr/share/itstool/its/docbook.its
+file path=usr/share/itstool/its/docbook5.its
+file path=usr/share/itstool/its/its.its
+file path=usr/share/itstool/its/mallard.its
+file path=usr/share/itstool/its/ttml.its
+file path=usr/share/itstool/its/xhtml.its
+file path=usr/share/man/man1/itstool.1

--- a/components/developer/itstool/manifests/sample-manifest.p5m
+++ b/components/developer/itstool/manifests/sample-manifest.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/itstool
+file path=usr/share/itstool/its/docbook.its
+file path=usr/share/itstool/its/docbook5.its
+file path=usr/share/itstool/its/its.its
+file path=usr/share/itstool/its/mallard.its
+file path=usr/share/itstool/its/ttml.its
+file path=usr/share/itstool/its/xhtml.its
+file path=usr/share/man/man1/itstool.1


### PR DESCRIPTION
This is a new component, [itstool](http://itstool.org) . It's used by some recent GNOME components at build time (not runtime) as part of the internationalization process.

Please review, @pyhalov and @Mno-hime .  In particular
  * COMPONENT_CLASSIFICATION . I used the same classification that glade is using, since this tool is mainly used when building GNOME applications, but perhaps Developer/GNU or something else would have been better?
  * It's a python script, but despite what the comments say in `shared-macros.mk`, there doesn't seem to be any way to do a `$(BUILD_NO_ARCH)/$(INSTALL_NO_ARCH)` for a general component, like Alp had me do when I packaged `python/virtualenv`.
  * since `PYTHON_VERSION` still defaults to 2.7, I built this component to use that version of python.  It does claim to support python 3, so I could rebuild with e.g. 3.4 or 3.5, if you prefer.
  * I added the man page transform in `itstool.p5m`, but I don't know if there are any other transforms that are appropriate?

Feedback welcome.