### PR TITLE
Update OpenSSL to 1.0.2s

### DIFF
--- a/components/library/openssl/openssl-1.0.2/Makefile
+++ b/components/library/openssl/openssl-1.0.2/Makefile
@@ -30,15 +30,15 @@ include ../../../../make-rules/shared-macros.mk
 COMPONENT_NAME =	openssl
 # When new version of OpenSSL comes in, you must update both COMPONENT_VERSION
 # and IPS_COMPONENT_VERSION.
-COMPONENT_VERSION =	1.0.2r
+COMPONENT_VERSION =	1.0.2s
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
-IPS_COMPONENT_VERSION = 1.0.2.18
+IPS_COMPONENT_VERSION = 1.0.2.19
 COMPONENT_PROJECT_URL=	https://www.openssl.org
 COMPONENT_SRC =		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE =	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
+	sha256:cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96
 COMPONENT_ARCHIVE_URL =	$(COMPONENT_PROJECT_URL)/source/$(COMPONENT_ARCHIVE)
 COMPONENT_BUGDB=	library/openssl
 


### PR DESCRIPTION
Changes: https://www.openssl.org/news/cl102.txt

**Testing**
- ABI Tracker clean: https://abi-laboratory.pro/index.php?view=timeline&l=openssl
- keep in my environment for some time: done, works fine