### PR TITLE
totem-pl-parser: add 64-bit build

### DIFF
--- a/components/multimedia/totem-pl-parser/Makefile
+++ b/components/multimedia/totem-pl-parser/Makefile
@@ -11,12 +11,14 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
+# Copyright 2019 Tim Mooney
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= totem-pl-parser
 COMPONENT_VERSION= 3.10.7
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= a library to parse playlist
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
@@ -34,7 +36,7 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
 COMPONENT_PREP_ACTION =        ( cp $(COMPONENT_DIR)/files/ax_code_coverage.m4 $(@D) && \
 					 cd $(@D) && autoreconf -f -I .)
@@ -46,10 +48,11 @@ CONFIGURE_OPTIONS+= --disable-static
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
-build: $(BUILD_32)
+build: $(BUILD_32_and_64)
 
-install: $(INSTALL_32)
+install: $(INSTALL_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/gmime
 REQUIRED_PACKAGES += library/libarchive

--- a/components/multimedia/totem-pl-parser/manifests/sample-manifest.p5m
+++ b/components/multimedia/totem-pl-parser/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,6 +28,19 @@ file path=usr/include/totem-pl-parser/1/plparser/totem-pl-parser-features.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-parser-mini.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-parser.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-playlist.h
+file path=usr/lib/$(MACH64)/girepository-1.0/TotemPlParser-1.0.typelib
+link path=usr/lib/$(MACH64)/libtotem-plparser-mini.so \
+    target=libtotem-plparser-mini.so.18.1.0
+link path=usr/lib/$(MACH64)/libtotem-plparser-mini.so.18 \
+    target=libtotem-plparser-mini.so.18.1.0
+file path=usr/lib/$(MACH64)/libtotem-plparser-mini.so.18.1.0
+link path=usr/lib/$(MACH64)/libtotem-plparser.so \
+    target=libtotem-plparser.so.18.1.0
+link path=usr/lib/$(MACH64)/libtotem-plparser.so.18 \
+    target=libtotem-plparser.so.18.1.0
+file path=usr/lib/$(MACH64)/libtotem-plparser.so.18.1.0
+file path=usr/lib/$(MACH64)/pkgconfig/totem-plparser-mini.pc
+file path=usr/lib/$(MACH64)/pkgconfig/totem-plparser.pc
 file path=usr/lib/girepository-1.0/TotemPlParser-1.0.typelib
 link path=usr/lib/libtotem-plparser-mini.so \
     target=libtotem-plparser-mini.so.18.1.0

--- a/components/multimedia/totem-pl-parser/totem-pl-parser.p5m
+++ b/components/multimedia/totem-pl-parser/totem-pl-parser.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
+# Copyright 2019 Tim Mooney
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,12 +23,27 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+<transform file path=usr/share/locale/([^/]+)(\..+){0,1}(/.+){0,1} -> default facet.locale.%<\1> true>
+
 file path=usr/include/totem-pl-parser/1/plparser/totem-disc.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-parser-builtins.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-parser-features.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-parser-mini.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-parser.h
 file path=usr/include/totem-pl-parser/1/plparser/totem-pl-playlist.h
+file path=usr/lib/$(MACH64)/girepository-1.0/TotemPlParser-1.0.typelib
+link path=usr/lib/$(MACH64)/libtotem-plparser-mini.so \
+    target=libtotem-plparser-mini.so.18.1.0
+link path=usr/lib/$(MACH64)/libtotem-plparser-mini.so.18 \
+    target=libtotem-plparser-mini.so.18.1.0
+file path=usr/lib/$(MACH64)/libtotem-plparser-mini.so.18.1.0
+link path=usr/lib/$(MACH64)/libtotem-plparser.so \
+    target=libtotem-plparser.so.18.1.0
+link path=usr/lib/$(MACH64)/libtotem-plparser.so.18 \
+    target=libtotem-plparser.so.18.1.0
+file path=usr/lib/$(MACH64)/libtotem-plparser.so.18.1.0
+file path=usr/lib/$(MACH64)/pkgconfig/totem-plparser-mini.pc
+file path=usr/lib/$(MACH64)/pkgconfig/totem-plparser.pc
 file path=usr/lib/girepository-1.0/TotemPlParser-1.0.typelib
 link path=usr/lib/libtotem-plparser-mini.so \
     target=libtotem-plparser-mini.so.18.1.0


### PR DESCRIPTION
I modified the build for `totem-pl-parser` to also build 64 bit.

I investigated updating to latest, but upstream has abandoned autotools for this project and some others, and is now using [meson](http://mesonbuild.com).  At some point we'll probably need a port of `meson` to OI, and possibly something like `make-rules/meson.mk`.

I **added** the `transform` for locale files to the `totem-pl-parser.p5m`.  OI doesn't consistently use that transform, but I plan to add it to components where it's missing (and appropriate), unless anyone objects.

Other changes are mostly obvious:
  * add `COMPONENT_REVISION` since I didn't update the version
  * use `$(PATH.gnu)`
  * switch `build:` and `install:` targets to use the 32_and_64 variant
  * re-run `gmake sample-manifest`
  * re-run `gmake REQUIRED_PACKAGES`
  * port new file changes from `manifests/sample-manifest.p5m` into `totem-pl-parser.p5m`

Since I didn't actually change any of the 32 bit components, I'm assuming it's not necessary to do a dependency rebuild for all dependencies.

Please review, feedback welcome