### PR TITLE
Update brasero to 3.12.2 and include 64-bit

### DIFF
--- a/components/desktop/gnome3/brasero/Makefile
+++ b/components/desktop/gnome3/brasero/Makefile
@@ -15,13 +15,13 @@
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=	brasero
-COMPONENT_VERSION=	3.12.1
+COMPONENT_VERSION=	3.12.2
 COMPONENT_PROJECT_URL=	https://projects.gnome.org/brasero/
 COMPONENT_SUMMARY=	Gnome CD/DVD burner
 COMPONENT_SRC=	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:9a5eea53e57b66de3c7c8c2393ac21a58d5afa81c6cfb16b3c7f010a3d147127
+    sha256:6822166f9d08efcf8d900cab6f563e87f49f0e078ca10595dcd908498ef12041
 COMPONENT_ARCHIVE_URL=	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/3.12/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	desktop/cd-burning/brasero
 COMPONENT_CLASSIFICATION=	Applications/Internet
@@ -34,13 +34,14 @@ include $(WS_MAKE_RULES)/ips.mk
 
 PATH=$(PATH.gnu)
 
-CFLAGS += -D_FILE_OFFSET_BITS=64
+CFLAGS.32 += -D_FILE_OFFSET_BITS=64
 
 # Regenerate yelp rules
 COMPONENT_PREP_ACTION = ( cd $(@D) ; autoreconf -vif ) 
 
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
-CONFIGURE_OPTIONS+=	--libexecdir=/usr/lib
+CONFIGURE_OPTIONS.32+=	--libexecdir=/usr/lib
+CONFIGURE_OPTIONS.64+=	--libexecdir=/usr/lib/$(MACH64)
 CONFIGURE_OPTIONS+=	--localstatedir=/var
 CONFIGURE_OPTIONS+=	--enable-shared
 CONFIGURE_OPTIONS+=	--disable-static
@@ -57,12 +58,17 @@ COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
 # common targets
-build:		$(BUILD_32)
+build:		$(BUILD_32_and_64)
 
-install:	$(INSTALL_32)
+install:	$(INSTALL_32_and_64)
 
 test:		$(NO_TESTS)
 
+# build dependency
+REQUIRED_PACKAGES += developer/documentation-tool/gtk-doc
+REQUIRED_PACKAGES += library/gnome/yelp-tools
+
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/audio/gstreamer1
 REQUIRED_PACKAGES += library/audio/gstreamer1/plugin/base
 REQUIRED_PACKAGES += library/desktop/cairo
@@ -72,7 +78,6 @@ REQUIRED_PACKAGES += library/desktop/pango
 REQUIRED_PACKAGES += library/desktop/search/tracker
 REQUIRED_PACKAGES += library/desktop/xdg/libcanberra
 REQUIRED_PACKAGES += library/glib2
-REQUIRED_PACKAGES += library/gnome/yelp-tools
 REQUIRED_PACKAGES += library/libnotify
 REQUIRED_PACKAGES += library/libxml2
 REQUIRED_PACKAGES += library/media-player/totem-pl-parser

--- a/components/desktop/gnome3/brasero/brasero.p5m
+++ b/components/desktop/gnome3/brasero/brasero.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
+# Copyright 2019 Tim Mooney
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,6 +29,9 @@ file files/exec_attr path=etc/security/exec_attr.d/desktop-cd-burning-brasero
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+<transform dir path=usr/share/locale/([^/]+)(\..+){0,1}(/.+){0,1} -> default facet.locale.%<\1> true>
+
+file path=usr/bin/$(MACH64)/brasero
 file path=usr/bin/brasero
 file path=usr/include/brasero3/brasero-blank-dialog.h
 file path=usr/include/brasero3/brasero-burn-dialog.h
@@ -60,6 +64,45 @@ file path=usr/include/brasero3/brasero-track-type.h
 file path=usr/include/brasero3/brasero-track.h
 file path=usr/include/brasero3/brasero-units.h
 file path=usr/include/brasero3/brasero-volume.h
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-audio2cue.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-burn-uri.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-cdda2wav.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-cdrdao.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-cdrecord.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-checksum-file.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-checksum.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-dvdauthor.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-dvdcss.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-dvdrwformat.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-genisoimage.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-growisofs.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-local-track.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-mkisofs.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-normalize.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-readcd.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-readom.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-transcode.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-vcdimager.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-vob.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-wodim.so
+file path=usr/lib/$(MACH64)/girepository-1.0/BraseroBurn-3.1.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/BraseroMedia-3.1.typelib
+link path=usr/lib/$(MACH64)/libbrasero-burn3.so target=libbrasero-burn3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-burn3.so.1 \
+    target=libbrasero-burn3.so.1.2.6
+file path=usr/lib/$(MACH64)/libbrasero-burn3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-media3.so \
+    target=libbrasero-media3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-media3.so.1 \
+    target=libbrasero-media3.so.1.2.6
+file path=usr/lib/$(MACH64)/libbrasero-media3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-utils3.so \
+    target=libbrasero-utils3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-utils3.so.1 \
+    target=libbrasero-utils3.so.1.2.6
+file path=usr/lib/$(MACH64)/libbrasero-utils3.so.1.2.6
+file path=usr/lib/$(MACH64)/pkgconfig/libbrasero-burn3.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libbrasero-media3.pc
 file path=usr/lib/brasero3/plugins/libbrasero-audio2cue.so
 file path=usr/lib/brasero3/plugins/libbrasero-burn-uri.so
 file path=usr/lib/brasero3/plugins/libbrasero-cdda2wav.so
@@ -569,6 +612,42 @@ file path=usr/share/help/lv/brasero/project-video.page
 file path=usr/share/help/lv/brasero/split-track.page
 file path=usr/share/help/lv/brasero/tools-blank.page
 file path=usr/share/help/lv/brasero/tools-check-integrity.page
+file path=usr/share/help/pl/brasero/create-cover.page
+link path=usr/share/help/pl/brasero/figures/brasero-main-window.png \
+    target=../../../C/brasero/figures/brasero-main-window.png
+link path=usr/share/help/pl/brasero/figures/logo48.png \
+    target=../../../C/brasero/figures/logo48.png
+file path=usr/share/help/pl/brasero/index.page
+file path=usr/share/help/pl/brasero/introduction.page
+file path=usr/share/help/pl/brasero/prob-cd.page
+file path=usr/share/help/pl/brasero/prob-dvd.page
+file path=usr/share/help/pl/brasero/project-audio.page
+file path=usr/share/help/pl/brasero/project-data.page
+file path=usr/share/help/pl/brasero/project-disc-copy.page
+file path=usr/share/help/pl/brasero/project-image-burn.page
+file path=usr/share/help/pl/brasero/project-save.page
+file path=usr/share/help/pl/brasero/project-video.page
+file path=usr/share/help/pl/brasero/split-track.page
+file path=usr/share/help/pl/brasero/tools-blank.page
+file path=usr/share/help/pl/brasero/tools-check-integrity.page
+file path=usr/share/help/pt/brasero/create-cover.page
+link path=usr/share/help/pt/brasero/figures/brasero-main-window.png \
+    target=../../../C/brasero/figures/brasero-main-window.png
+link path=usr/share/help/pt/brasero/figures/logo48.png \
+    target=../../../C/brasero/figures/logo48.png
+file path=usr/share/help/pt/brasero/index.page
+file path=usr/share/help/pt/brasero/introduction.page
+file path=usr/share/help/pt/brasero/prob-cd.page
+file path=usr/share/help/pt/brasero/prob-dvd.page
+file path=usr/share/help/pt/brasero/project-audio.page
+file path=usr/share/help/pt/brasero/project-data.page
+file path=usr/share/help/pt/brasero/project-disc-copy.page
+file path=usr/share/help/pt/brasero/project-image-burn.page
+file path=usr/share/help/pt/brasero/project-save.page
+file path=usr/share/help/pt/brasero/project-video.page
+file path=usr/share/help/pt/brasero/split-track.page
+file path=usr/share/help/pt/brasero/tools-blank.page
+file path=usr/share/help/pt/brasero/tools-check-integrity.page
 file path=usr/share/help/pt_BR/brasero/create-cover.page
 file path=usr/share/help/pt_BR/brasero/figures/brasero-main-window.png
 link path=usr/share/help/pt_BR/brasero/figures/logo48.png \
@@ -763,14 +842,17 @@ file path=usr/share/locale/eu/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/fa/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/fi/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/fr/LC_MESSAGES/brasero.mo
+file path=usr/share/locale/fur/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/ga/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/gd/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/gl/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/gu/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/he/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/hi/LC_MESSAGES/brasero.mo
+file path=usr/share/locale/hr/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/hu/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/id/LC_MESSAGES/brasero.mo
+file path=usr/share/locale/is/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/it/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/ja/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/kk/LC_MESSAGES/brasero.mo

--- a/components/desktop/gnome3/brasero/manifests/sample-manifest.p5m
+++ b/components/desktop/gnome3/brasero/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,6 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=usr/bin/$(MACH64)/brasero
 file path=usr/bin/brasero
 file path=usr/include/brasero3/brasero-blank-dialog.h
 file path=usr/include/brasero3/brasero-burn-dialog.h
@@ -54,6 +55,45 @@ file path=usr/include/brasero3/brasero-track-type.h
 file path=usr/include/brasero3/brasero-track.h
 file path=usr/include/brasero3/brasero-units.h
 file path=usr/include/brasero3/brasero-volume.h
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-audio2cue.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-burn-uri.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-cdda2wav.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-cdrdao.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-cdrecord.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-checksum-file.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-checksum.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-dvdauthor.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-dvdcss.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-dvdrwformat.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-genisoimage.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-growisofs.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-local-track.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-mkisofs.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-normalize.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-readcd.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-readom.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-transcode.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-vcdimager.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-vob.so
+file path=usr/lib/$(MACH64)/brasero3/plugins/libbrasero-wodim.so
+file path=usr/lib/$(MACH64)/girepository-1.0/BraseroBurn-3.1.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/BraseroMedia-3.1.typelib
+link path=usr/lib/$(MACH64)/libbrasero-burn3.so target=libbrasero-burn3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-burn3.so.1 \
+    target=libbrasero-burn3.so.1.2.6
+file path=usr/lib/$(MACH64)/libbrasero-burn3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-media3.so \
+    target=libbrasero-media3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-media3.so.1 \
+    target=libbrasero-media3.so.1.2.6
+file path=usr/lib/$(MACH64)/libbrasero-media3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-utils3.so \
+    target=libbrasero-utils3.so.1.2.6
+link path=usr/lib/$(MACH64)/libbrasero-utils3.so.1 \
+    target=libbrasero-utils3.so.1.2.6
+file path=usr/lib/$(MACH64)/libbrasero-utils3.so.1.2.6
+file path=usr/lib/$(MACH64)/pkgconfig/libbrasero-burn3.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libbrasero-media3.pc
 file path=usr/lib/brasero3/plugins/libbrasero-audio2cue.so
 file path=usr/lib/brasero3/plugins/libbrasero-burn-uri.so
 file path=usr/lib/brasero3/plugins/libbrasero-cdda2wav.so
@@ -563,6 +603,42 @@ file path=usr/share/help/lv/brasero/project-video.page
 file path=usr/share/help/lv/brasero/split-track.page
 file path=usr/share/help/lv/brasero/tools-blank.page
 file path=usr/share/help/lv/brasero/tools-check-integrity.page
+file path=usr/share/help/pl/brasero/create-cover.page
+link path=usr/share/help/pl/brasero/figures/brasero-main-window.png \
+    target=../../../C/brasero/figures/brasero-main-window.png
+link path=usr/share/help/pl/brasero/figures/logo48.png \
+    target=../../../C/brasero/figures/logo48.png
+file path=usr/share/help/pl/brasero/index.page
+file path=usr/share/help/pl/brasero/introduction.page
+file path=usr/share/help/pl/brasero/prob-cd.page
+file path=usr/share/help/pl/brasero/prob-dvd.page
+file path=usr/share/help/pl/brasero/project-audio.page
+file path=usr/share/help/pl/brasero/project-data.page
+file path=usr/share/help/pl/brasero/project-disc-copy.page
+file path=usr/share/help/pl/brasero/project-image-burn.page
+file path=usr/share/help/pl/brasero/project-save.page
+file path=usr/share/help/pl/brasero/project-video.page
+file path=usr/share/help/pl/brasero/split-track.page
+file path=usr/share/help/pl/brasero/tools-blank.page
+file path=usr/share/help/pl/brasero/tools-check-integrity.page
+file path=usr/share/help/pt/brasero/create-cover.page
+link path=usr/share/help/pt/brasero/figures/brasero-main-window.png \
+    target=../../../C/brasero/figures/brasero-main-window.png
+link path=usr/share/help/pt/brasero/figures/logo48.png \
+    target=../../../C/brasero/figures/logo48.png
+file path=usr/share/help/pt/brasero/index.page
+file path=usr/share/help/pt/brasero/introduction.page
+file path=usr/share/help/pt/brasero/prob-cd.page
+file path=usr/share/help/pt/brasero/prob-dvd.page
+file path=usr/share/help/pt/brasero/project-audio.page
+file path=usr/share/help/pt/brasero/project-data.page
+file path=usr/share/help/pt/brasero/project-disc-copy.page
+file path=usr/share/help/pt/brasero/project-image-burn.page
+file path=usr/share/help/pt/brasero/project-save.page
+file path=usr/share/help/pt/brasero/project-video.page
+file path=usr/share/help/pt/brasero/split-track.page
+file path=usr/share/help/pt/brasero/tools-blank.page
+file path=usr/share/help/pt/brasero/tools-check-integrity.page
 file path=usr/share/help/pt_BR/brasero/create-cover.page
 file path=usr/share/help/pt_BR/brasero/figures/brasero-main-window.png
 link path=usr/share/help/pt_BR/brasero/figures/logo48.png \
@@ -757,14 +833,17 @@ file path=usr/share/locale/eu/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/fa/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/fi/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/fr/LC_MESSAGES/brasero.mo
+file path=usr/share/locale/fur/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/ga/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/gd/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/gl/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/gu/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/he/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/hi/LC_MESSAGES/brasero.mo
+file path=usr/share/locale/hr/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/hu/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/id/LC_MESSAGES/brasero.mo
+file path=usr/share/locale/is/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/it/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/ja/LC_MESSAGES/brasero.mo
 file path=usr/share/locale/kk/LC_MESSAGES/brasero.mo

--- a/components/desktop/gnome3/brasero/patches/03-pfexec.patch
+++ b/components/desktop/gnome3/brasero/patches/03-pfexec.patch
@@ -36,8 +36,9 @@
  	g_ptr_array_add (argv, g_strdup ("growisofs"));
  	brasero_job_get_flags (BRASERO_JOB (growisofs), &flags);
  	if (!(flags & BRASERO_BURN_FLAG_FAST_BLANK))
---- brasero-3.12.1/data/brasero.desktop.in.in.~1~	2014-09-10 17:41:19.000000000 +0400
-+++ brasero-3.12.1/data/brasero.desktop.in.in	2017-03-28 00:46:49.152818971 +0300
+diff -ur brasero-3.12.2.orig/data/brasero.desktop.in.in brasero-3.12.2/data/brasero.desktop.in.in
+--- brasero-3.12.2.orig/data/brasero.desktop.in.in	2017-07-21 08:55:58.000000000 +0000
++++ brasero-3.12.2/data/brasero.desktop.in.in	2019-06-15 01:55:51.790653250 +0000
 @@ -5,7 +5,7 @@
  _Keywords=disc;cdrom;dvd;burn;audio;video;
  Categories=GTK;GNOME;AudioVideo;Audio;Video;DiscBurning;
@@ -60,7 +61,7 @@
 +Exec=pfexec brasero --image
  
  [Desktop Action Disc]
- Name=Copy a Disc
+ _Name=Copy a Disc
 -Exec=brasero --copy
 +Exec=pfexec brasero --copy
  


### PR DESCRIPTION
This change requires that pull request #5086 and pull request #5087 be merged first.

This updates `brasero` from 3.12.1 to 3.12.2 and adds 64-bit to the build.

The only interesting change is that the patch for `pfexec` needed to change just slightly because of wording changes in the `brasero.desktop.in.in` file.

The other changes were pretty straightforward:
  * change the `-D_FILE_OFFSET_BITS=64` to only be for `CFLAGS.32`
  * differentiate between the `libexec` location for 32 and 64 bit builds
  * change `build` and `install` to use the 32_and_64 variant
  * **add** `gtk-doc` as a build dependency, since `configure` cannot be rebuilt if it's not installed
  * move the `library/gnome/yelp-tools` from the auto-generated section to the hand-curated build requirements.  It is not part of the output from `gmake REQUIRED_PACKAGES`
  * re-run `gmake sample-manifest`
  * import all the file changes from the `manifest/sample-manifest.p5m' into the main `brasero.p5m`.  Most are 64-bit related, some are new translation-related files with the minor version updated.
  * **add** the `transform` for locale-related files to `brasero.p5m`.
  * re-run `gmake REQUIRED_PACKAGES`

Since the version change is minor, I'm assuming I don't need to worry about triggering a dependency rebuild.

Feedback welcome!