### PR TITLE
Install gcc-7-runtime by default after 9996

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	34
+COMPONENT_REVISION=	35
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -174,6 +174,7 @@ depend type=require fmri=system/kernel/power
 depend type=require fmri=system/kernel/secure-rpc
 depend type=require fmri=system/kernel/suspend-resume
 depend type=require fmri=system/library
+depend type=require fmri=system/library/gcc-7-runtime
 depend type=require fmri=system/library/iconv/utf-8
 depend type=require fmri=system/library/install
 depend type=require fmri=system/library/libdiskmgt


### PR DESCRIPTION
After [9996](https://www.illumos.org/issues/9996) GCC 7 is the default compiler hence we need `gcc-7-runtime` installed by default. It's not installed with `0.5.11-2018.0.0.18599` but GCC 7 `RPATH` and `RUNPATH` are there:

```
newman@minimal:~$ elfdump /usr/sbin/beadm | grep -e RPATH -e RUNPATH
       [9]  RUNPATH           0x6b2               /usr/gcc/7/lib
      [10]  RPATH             0x6b2               /usr/gcc/7/lib
```

To prevent breakage we should install `gcc-7-runtime` never the less.