### PR TITLE
zstd: Upstream fix for zstdless & zstdgrep installation

### DIFF
--- a/components/archiver/zstd/Makefile
+++ b/components/archiver/zstd/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zstd
 COMPONENT_VERSION=	1.4.0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Zstandard, or zstd as short version, is a fast lossless compression algorithm, targeting real-time compression scenarios
 COMPONENT_PROJECT_URL=	https://facebook.github.io/zstd/
 COMPONENT_FMRI=		compress/zstd
@@ -44,11 +45,6 @@ $(BUILD_DIR)/%/.configured:     $(SOURCE_DIR)/.prep
 		$(CMAKE) $(CMAKE_OPTIONS) $(COMPONENT_DIR)/$(COMPONENT_SRC)/build/cmake/)
 	$(COMPONENT_POST_CMAKE_ACTION)
 	$(TOUCH) $@
-
-# CMake does not install zstdgrep and zstdless shell scripts
-# (https://github.com/facebook/zstd/issues/1503)
-COMPONENT_POST_INSTALL_ACTION.64= ( cp $(@D)/programs/{zstdgrep,zstdless} $(PROTO_DIR)$(USRBINDIR) )
-COMPONENT_POST_INSTALL_ACTION=$(COMPONENT_POST_INSTALL_ACTION.$(BITS))
 
 build:		$(BUILD_32_and_64)
 

--- a/components/archiver/zstd/patches/02-install_zstdless_and_zstdgrep_as_PROGRAMS.patch
+++ b/components/archiver/zstd/patches/02-install_zstdless_and_zstdgrep_as_PROGRAMS.patch
@@ -1,0 +1,22 @@
+From a4c0c27410de75e92970b4eecfad59a8eaa57eb6 Mon Sep 17 00:00:00 2001
+From: LeeYoung624 <liyiang@hotmail.com>
+Date: Tue, 11 Jun 2019 11:29:18 +0800
+Subject: [PATCH] Install zstdless & zstdgrep as 'PROGRAMS' in CMake
+
+---
+ build/cmake/programs/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/build/cmake/programs/CMakeLists.txt b/build/cmake/programs/CMakeLists.txt
+index f6f7a3616..03194fa04 100644
+--- a/build/cmake/programs/CMakeLists.txt
++++ b/build/cmake/programs/CMakeLists.txt
+@@ -38,6 +38,8 @@ if (UNIX)
+     add_custom_target(unzstd ALL ${CMAKE_COMMAND} -E create_symlink zstd unzstd DEPENDS zstd COMMENT "Creating unzstd symlink")
+     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zstdcat DESTINATION "bin")
+     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/unzstd DESTINATION "bin")
++    install(PROGRAMS ${PROGRAMS_DIR}/zstdgrep DESTINATION "bin")
++    install(PROGRAMS ${PROGRAMS_DIR}/zstdless DESTINATION "bin")
+ 
+     add_custom_target(zstd.1 ALL
+         ${CMAKE_COMMAND} -E copy ${PROGRAMS_DIR}/zstd.1 .


### PR DESCRIPTION
Replace custom fix with upstream one (https://github.com/facebook/zstd/pull/1647).

**Testing**

Shell scripts still have sane permissions:
```
$ ll `find build/prototype/i386/ -name zstdgrep -o -name zstdless`
-rwxr-xr-x   1 newman   other      3.57K Jun 20 08:23 build/prototype/i386/usr/bin/zstdgrep*
-rwxr-xr-x   1 newman   other         30 Apr 17 00:37 build/prototype/i386/usr/bin/zstdless*
```