### PR TITLE
Update marco to 1.22.3

### DIFF
--- a/components/desktop/mate/marco/Makefile
+++ b/components/desktop/mate/marco/Makefile
@@ -14,39 +14,43 @@
 # Copyright 2019 Michal Nowak
 #
 
+BUILD_BITS=		64
+
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		marco
 COMPONENT_MJR_VERSION=	1.22
-COMPONENT_MNR_VERSION=	1
+COMPONENT_MNR_VERSION=	3
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE Window Manager
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:4e20f5ea006142f3e5c8931e2b354e1838cb9291ba245825ea82fa6611def7c8
+	sha256:0a3979f0ba9855a6dff5b889c619d07bcea52df29c354976f018d71093c45139
 COMPONENT_ARCHIVE_URL=	http://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_FMRI=		desktop/mate/$(COMPONENT_NAME)
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
 COMPONENT_PREP_ACTION = cd $(@D)  && NOCONFIGURE=1 ./autogen.sh;\
-	$(GSED) -i '/_XOPEN_SOURCE/d' $(@D)/src/tools/marco-mag.c; \
 	$(GSED) -i '/_POSIX_C_SOURCE/d' $(@D)/src/core/util.c; \
+	$(GSED) -i '/_XOPEN_SOURCE/d' $(@D)/src/compositor/compositor-xrender.c; \
+	$(GSED) -i '/_XOPEN_SOURCE/d' $(@D)/src/core/delete.c; \
+	$(GSED) -i '/_XOPEN_SOURCE/d' $(@D)/src/core/keybindings.c; \
+	$(GSED) -i '/_XOPEN_SOURCE/d' $(@D)/src/core/main.c; \
+	$(GSED) -i '/_XOPEN_SOURCE/d' $(@D)/src/core/window-props.c; \
 	$(GSED) -i '/_XOPEN_SOURCE/d' $(@D)/src/ui/preview-widget.c
 
 CFLAGS+=-D__EXTENSIONS__
 CFLAGS+=-std=gnu99
-
-CONFIGURE_BINDIR.64 = $(CONFIGURE_BINDIR.32)
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --disable-static
@@ -57,12 +61,6 @@ CONFIGURE_OPTIONS+= --enable-xinerama
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 COMPONENT_BUILD_ENV += CPPFLAGS="$(CPPFLAGS)"
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(NO_TESTS)
 
 # Build dependencies
 REQUIRED_PACKAGES += gnome/zenity

--- a/components/desktop/mate/marco/manifests/sample-manifest.p5m
+++ b/components/desktop/mate/marco/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -33,10 +33,10 @@ file path=usr/include/marco-1/marco-private/preview-widget.h
 file path=usr/include/marco-1/marco-private/theme-parser.h
 file path=usr/include/marco-1/marco-private/theme.h
 file path=usr/include/marco-1/marco-private/util.h
-link path=usr/lib/$(MACH64)/libmarco-private.so target=libmarco-private.so.1.0.0
-link path=usr/lib/$(MACH64)/libmarco-private.so.1 \
-    target=libmarco-private.so.1.0.0
-file path=usr/lib/$(MACH64)/libmarco-private.so.1.0.0
+link path=usr/lib/$(MACH64)/libmarco-private.so target=libmarco-private.so.2.0.0
+link path=usr/lib/$(MACH64)/libmarco-private.so.2 \
+    target=libmarco-private.so.2.0.0
+file path=usr/lib/$(MACH64)/libmarco-private.so.2.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libmarco-private.pc
 file path=usr/share/applications/marco.desktop
 file path=usr/share/glib-2.0/schemas/org.mate.marco.gschema.xml
@@ -89,6 +89,7 @@ file path=usr/share/locale/hr/LC_MESSAGES/marco.mo
 file path=usr/share/locale/hu/LC_MESSAGES/marco.mo
 file path=usr/share/locale/hy/LC_MESSAGES/marco.mo
 file path=usr/share/locale/id/LC_MESSAGES/marco.mo
+file path=usr/share/locale/ie/LC_MESSAGES/marco.mo
 file path=usr/share/locale/ig/LC_MESSAGES/marco.mo
 file path=usr/share/locale/is/LC_MESSAGES/marco.mo
 file path=usr/share/locale/it/LC_MESSAGES/marco.mo

--- a/components/desktop/mate/marco/marco.p5m
+++ b/components/desktop/mate/marco/marco.p5m
@@ -11,7 +11,7 @@
 
 #
 # Copyright 2016 Till Wegmueller
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -34,10 +34,10 @@ file path=usr/include/marco-1/marco-private/preview-widget.h
 file path=usr/include/marco-1/marco-private/theme-parser.h
 file path=usr/include/marco-1/marco-private/theme.h
 file path=usr/include/marco-1/marco-private/util.h
-link path=usr/lib/$(MACH64)/libmarco-private.so target=libmarco-private.so.1.0.0
-link path=usr/lib/$(MACH64)/libmarco-private.so.1 \
-    target=libmarco-private.so.1.0.0
-file path=usr/lib/$(MACH64)/libmarco-private.so.1.0.0
+link path=usr/lib/$(MACH64)/libmarco-private.so target=libmarco-private.so.2.0.0
+link path=usr/lib/$(MACH64)/libmarco-private.so.2 \
+    target=libmarco-private.so.2.0.0
+file path=usr/lib/$(MACH64)/libmarco-private.so.2.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libmarco-private.pc
 file path=usr/share/applications/marco.desktop
 file path=usr/share/glib-2.0/schemas/org.mate.marco.gschema.xml
@@ -90,6 +90,7 @@ file path=usr/share/locale/hr/LC_MESSAGES/marco.mo
 file path=usr/share/locale/hu/LC_MESSAGES/marco.mo
 file path=usr/share/locale/hy/LC_MESSAGES/marco.mo
 file path=usr/share/locale/id/LC_MESSAGES/marco.mo
+file path=usr/share/locale/ie/LC_MESSAGES/marco.mo
 file path=usr/share/locale/ig/LC_MESSAGES/marco.mo
 file path=usr/share/locale/is/LC_MESSAGES/marco.mo
 file path=usr/share/locale/it/LC_MESSAGES/marco.mo


### PR DESCRIPTION
Requires updated themes: https://github.com/OpenIndiana/oi-userland/pull/5098.

`mate-control-center` needs to be rebuild: https://github.com/OpenIndiana/oi-userland/pull/5100.