### PR TITLE
sbcl 1.5.4

### DIFF
--- a/components/runtime/sbcl/Makefile
+++ b/components/runtime/sbcl/Makefile
@@ -15,13 +15,13 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		sbcl
-COMPONENT_VERSION=	1.4.10
+COMPONENT_VERSION=	1.5.4
 COMPONENT_PROJECT_URL=	http://www.sbcl.org/
 COMPONENT_FMRI=		runtime/sbcl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC)-source.tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:904ee7e90fd6d66dfb4da578ec9e3dab1a2a49b61b13fa1fbf30ce8b80593cc9
+    sha256:ec872be63697041fbb1c6324382b736c2aecb2fc1edb9961f9bfe7b017c1f45c
 COMPONENT_ARCHIVE_URL=	http://downloads.sourceforge.net/project/sbcl/sbcl/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	BSD-PublicDomain
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
@@ -43,20 +43,21 @@ COMPONENT_BUILD_ARGS += --with-sb-core-compression
 $(BUILD_DIR)/%/.built:	$(SOURCE_DIR)/.prep
 	$(RM) -r $(@D) ; $(MKDIR) $(BUILD_DIR)
 	$(CP) -a $(SOURCE_DIR) $(@D)
-	(cd $(@D) ; chmod +x find-gnumake.sh)
 	(cd $(@D) ; $(ENV) $(COMPONENT_ENV) /usr/gnu/bin/sh make.sh $(COMPONENT_BUILD_ARGS))
-ifeq   ($(strip $(PARFAIT_BUILD)),yes)
-	-$(PARFAIT) build
-endif
 	$(TOUCH) $@
 
 $(BUILD_DIR)/%/.installed:	$(BUILD_DIR)/%/.built
 	(cd $(@D) ; $(ENV) $(COMPONENT_ENV) BUILD_ROOT=$(PROTO_DIR) /usr/gnu/bin/sh install.sh)
 	$(TOUCH) $@
 
+$(BUILD_DIR)/%/.tested:		$(BUILD_DIR)/%/.installed
+	(cd $(@D)/tests; $(ENV) $(COMPONENT_ENV) BUILD_ROOT=$(PROTO_DIR) /usr/gnu/bin/sh run-tests.sh)
+
 build:		$(BUILD_32)
 
 install:	$(INSTALL_32)
+
+test:		$(TEST_32)
 
 clean::
 	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)

--- a/components/runtime/sbcl/files/sbclrc
+++ b/components/runtime/sbcl/files/sbclrc
@@ -2,6 +2,3 @@
 (in-package #:cl-user)
 (require :asdf)
 (push #p"/usr/share/common-lisp/systems/" asdf:*central-registry*)
-;(asdf:oos 'asdf:load-op :asdf-binary-locations)
-;(setf asdf:*centralize-lisp-binaries* t)
-;(setf asdf:*source-to-target-mappings* '((#p"/usr/lib/sbcl/" nil) (#p"/usr/lib64/sbcl/" nil)))

--- a/components/runtime/sbcl/patches/0001-Only-generate-versions-in-SBCL-git-checkouts.patch
+++ b/components/runtime/sbcl/patches/0001-Only-generate-versions-in-SBCL-git-checkouts.patch
@@ -1,0 +1,42 @@
+From 63da1c93b7e9fb868df22b850286a485e5d8be07 Mon Sep 17 00:00:00 2001
+From: Richard Lowe <richlowe@richlowe.net>
+Date: Mon, 15 Jul 2019 23:49:30 +0000
+Subject: [PATCH] Only generate versions in SBCL git checkouts
+
+Sometimes larger build systems contain copies of SBCL sources, if those
+systems are managed with git, we don't want to trample version.lisp-expr
+with _their_ version, but keep the version of SBCL.
+
+Attempt to detect this by checking whether
+`git rev-parse --show-top-level`/run-sbcl.sh exists, if not assume git
+is operating on a checkout of something other than SBCL
+---
+ generate-version.sh | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/generate-version.sh b/generate-version.sh
+index f51b46710..99ec6b1cb 100755
+--- a/generate-version.sh
++++ b/generate-version.sh
+@@ -2,7 +2,8 @@
+ 
+ git_available_p() {
+     # Check that (1) we have git (2) this is a git tree.
+-    if ( command -v git >/dev/null && git describe >/dev/null 2>/dev/null )
++    if ( command -v git >/dev/null && git describe >/dev/null 2>/dev/null && \
++       test -f `git rev-parse --show-toplevel`/run-sbcl.sh)
+     then
+         echo "ok"
+     else
+@@ -17,7 +18,7 @@ then
+     exit 0
+ elif [ -z "$AVAILABLE" ]
+ then
+-    echo "Can't run 'git describe' and version.lisp-expr is missing." >&2
++    echo "Can't 'git describe' SBCL source and version.lisp-expr is missing." >&2
+     echo "To fix this, either install git or create a fake version.lisp-expr file." >&2
+     echo "You can create a fake version.lisp-expr file like this:" >&2
+     echo "    \$ echo '\"1.0.99.999\"' > version.lisp-expr" >&2
+-- 
+2.21.0
+

--- a/components/runtime/sbcl/sbcl.p5m
+++ b/components/runtime/sbcl/sbcl.p5m
@@ -5,7 +5,7 @@
 # 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 


### PR DESCRIPTION
This has two real changes.

The most important one fixes the version number generation to only operate if in an _SBCL_ git checkout, such that we stop smashing the version string
(it current reads `SBCL 10919.-68f8bb0fe`).  I have submitted this upstream as https://bugs.launchpad.net/bugs/1836663

Also, and perhaps less importantly, this updates to SBCL 1.5.4 and adds a target for 'gmake test' to run the test suite.

/cc @jeffpc