### PR TITLE
[1/3] Update Nettle to 3.5.1

### DIFF
--- a/components/library/nettle/Makefile
+++ b/components/library/nettle/Makefile
@@ -11,48 +11,45 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME= nettle
-COMPONENT_VERSION= 3.3
-COMPONENT_SUMMARY= Library for desktop notifications
-COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
+COMPONENT_NAME=		nettle
+COMPONENT_VERSION=	3.5.1
+COMPONENT_SUMMARY=	A low-level cryptographic library
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:46942627d5d0ca11720fec18d81fc38f7ef837ea4197c1f630e71ce0d470b11e
+	sha256:75cca1998761b02e16f2db56da52992aef622bf55a3b45ec538bc2eedadc9419
 COMPONENT_ARCHIVE_URL= \
-  https://ftp.gnu.org/gnu/nettle/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = https://www.lysator.liu.se/~nisse/nettle/
-COMPONENT_FMRI=	library/nettle
+	https://ftp.gnu.org/gnu/nettle/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://www.lysator.liu.se/~nisse/nettle/
+COMPONENT_FMRI=		library/nettle
 COMPONENT_CLASSIFICATION= System/Libraries
-COMPONENT_LICENSE = LGPLv3, GPLv3, GPLv2
+COMPONENT_LICENSE=	LGPLv3, GPLv3, GPLv2
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -f -i )
 
 CPPFLAGS += -I/usr/include/gmp
 
-# Can't properly link library without this
-COMPONENT_PRE_CONFIGURE_ACTION = ($(CLONEY) $(SOURCE_DIR) $(@D))
-
-CONFIGURE_SCRIPT=       $(@D)/configure
-
 CONFIGURE_OPTIONS += --disable-assembler
 
 CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
 
-build: $(BUILD_32_and_64)
+build:		$(BUILD_32_and_64)
 
-install: $(INSTALL_32_and_64)
+install:	$(INSTALL_32_and_64)
 
-test: $(TEST_32_and_64)
+test:		$(TEST_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/gmp
 REQUIRED_PACKAGES += system/library

--- a/components/library/nettle/manifests/sample-manifest.p5m
+++ b/components/library/nettle/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -45,11 +45,12 @@ file path=usr/include/nettle/camellia.h
 file path=usr/include/nettle/cast128.h
 file path=usr/include/nettle/cbc.h
 file path=usr/include/nettle/ccm.h
+file path=usr/include/nettle/cfb.h
 file path=usr/include/nettle/chacha-poly1305.h
 file path=usr/include/nettle/chacha.h
+file path=usr/include/nettle/cmac.h
 file path=usr/include/nettle/ctr.h
 file path=usr/include/nettle/curve25519.h
-file path=usr/include/nettle/des-compat.h
 file path=usr/include/nettle/des.h
 file path=usr/include/nettle/dsa-compat.h
 file path=usr/include/nettle/dsa.h
@@ -60,6 +61,7 @@ file path=usr/include/nettle/ecdsa.h
 file path=usr/include/nettle/eddsa.h
 file path=usr/include/nettle/gcm.h
 file path=usr/include/nettle/gosthash94.h
+file path=usr/include/nettle/hkdf.h
 file path=usr/include/nettle/hmac.h
 file path=usr/include/nettle/knuth-lfib.h
 file path=usr/include/nettle/macros.h
@@ -70,12 +72,13 @@ file path=usr/include/nettle/md5.h
 file path=usr/include/nettle/memops.h
 file path=usr/include/nettle/memxor.h
 file path=usr/include/nettle/nettle-meta.h
-file path=usr/include/nettle/nettle-stdint.h
 file path=usr/include/nettle/nettle-types.h
 file path=usr/include/nettle/pbkdf2.h
 file path=usr/include/nettle/pgp.h
 file path=usr/include/nettle/pkcs1.h
 file path=usr/include/nettle/poly1305.h
+file path=usr/include/nettle/pss-mgf1.h
+file path=usr/include/nettle/pss.h
 file path=usr/include/nettle/realloc.h
 file path=usr/include/nettle/ripemd160.h
 file path=usr/include/nettle/rsa.h
@@ -89,25 +92,26 @@ file path=usr/include/nettle/sha3.h
 file path=usr/include/nettle/twofish.h
 file path=usr/include/nettle/umac.h
 file path=usr/include/nettle/version.h
+file path=usr/include/nettle/xts.h
 file path=usr/include/nettle/yarrow.h
 file path=usr/lib/$(MACH64)/libhogweed.a
-link path=usr/lib/$(MACH64)/libhogweed.so target=libhogweed.so.4.3
-link path=usr/lib/$(MACH64)/libhogweed.so.4 target=libhogweed.so.4.3
-file path=usr/lib/$(MACH64)/libhogweed.so.4.3
+link path=usr/lib/$(MACH64)/libhogweed.so target=libhogweed.so.5.0
+link path=usr/lib/$(MACH64)/libhogweed.so.5 target=libhogweed.so.5.0
+file path=usr/lib/$(MACH64)/libhogweed.so.5.0
 file path=usr/lib/$(MACH64)/libnettle.a
-link path=usr/lib/$(MACH64)/libnettle.so target=libnettle.so.6.3
-link path=usr/lib/$(MACH64)/libnettle.so.6 target=libnettle.so.6.3
-file path=usr/lib/$(MACH64)/libnettle.so.6.3
+link path=usr/lib/$(MACH64)/libnettle.so target=libnettle.so.7.0
+link path=usr/lib/$(MACH64)/libnettle.so.7 target=libnettle.so.7.0
+file path=usr/lib/$(MACH64)/libnettle.so.7.0
 file path=usr/lib/$(MACH64)/pkgconfig/hogweed.pc
 file path=usr/lib/$(MACH64)/pkgconfig/nettle.pc
 file path=usr/lib/libhogweed.a
-link path=usr/lib/libhogweed.so target=libhogweed.so.4.3
-link path=usr/lib/libhogweed.so.4 target=libhogweed.so.4.3
-file path=usr/lib/libhogweed.so.4.3
+link path=usr/lib/libhogweed.so target=libhogweed.so.5.0
+link path=usr/lib/libhogweed.so.5 target=libhogweed.so.5.0
+file path=usr/lib/libhogweed.so.5.0
 file path=usr/lib/libnettle.a
-link path=usr/lib/libnettle.so target=libnettle.so.6.3
-link path=usr/lib/libnettle.so.6 target=libnettle.so.6.3
-file path=usr/lib/libnettle.so.6.3
+link path=usr/lib/libnettle.so target=libnettle.so.7.0
+link path=usr/lib/libnettle.so.7 target=libnettle.so.7.0
+file path=usr/lib/libnettle.so.7.0
 file path=usr/lib/pkgconfig/hogweed.pc
 file path=usr/lib/pkgconfig/nettle.pc
 file path=usr/share/info/dir

--- a/components/library/nettle/nettle.p5m
+++ b/components/library/nettle/nettle.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2016 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -45,11 +46,12 @@ file path=usr/include/nettle/camellia.h
 file path=usr/include/nettle/cast128.h
 file path=usr/include/nettle/cbc.h
 file path=usr/include/nettle/ccm.h
+file path=usr/include/nettle/cfb.h
 file path=usr/include/nettle/chacha-poly1305.h
 file path=usr/include/nettle/chacha.h
+file path=usr/include/nettle/cmac.h
 file path=usr/include/nettle/ctr.h
 file path=usr/include/nettle/curve25519.h
-file path=usr/include/nettle/des-compat.h
 file path=usr/include/nettle/des.h
 file path=usr/include/nettle/dsa-compat.h
 file path=usr/include/nettle/dsa.h
@@ -60,6 +62,7 @@ file path=usr/include/nettle/ecdsa.h
 file path=usr/include/nettle/eddsa.h
 file path=usr/include/nettle/gcm.h
 file path=usr/include/nettle/gosthash94.h
+file path=usr/include/nettle/hkdf.h
 file path=usr/include/nettle/hmac.h
 file path=usr/include/nettle/knuth-lfib.h
 file path=usr/include/nettle/macros.h
@@ -70,12 +73,13 @@ file path=usr/include/nettle/md5.h
 file path=usr/include/nettle/memops.h
 file path=usr/include/nettle/memxor.h
 file path=usr/include/nettle/nettle-meta.h
-file path=usr/include/nettle/nettle-stdint.h
 file path=usr/include/nettle/nettle-types.h
 file path=usr/include/nettle/pbkdf2.h
 file path=usr/include/nettle/pgp.h
 file path=usr/include/nettle/pkcs1.h
 file path=usr/include/nettle/poly1305.h
+file path=usr/include/nettle/pss-mgf1.h
+file path=usr/include/nettle/pss.h
 file path=usr/include/nettle/realloc.h
 file path=usr/include/nettle/ripemd160.h
 file path=usr/include/nettle/rsa.h
@@ -89,21 +93,23 @@ file path=usr/include/nettle/sha3.h
 file path=usr/include/nettle/twofish.h
 file path=usr/include/nettle/umac.h
 file path=usr/include/nettle/version.h
+file path=usr/include/nettle/xts.h
 file path=usr/include/nettle/yarrow.h
-link path=usr/lib/$(MACH64)/libhogweed.so target=libhogweed.so.4.3
-link path=usr/lib/$(MACH64)/libhogweed.so.4 target=libhogweed.so.4.3
-file path=usr/lib/$(MACH64)/libhogweed.so.4.3
-link path=usr/lib/$(MACH64)/libnettle.so target=libnettle.so.6.3
-link path=usr/lib/$(MACH64)/libnettle.so.6 target=libnettle.so.6.3
-file path=usr/lib/$(MACH64)/libnettle.so.6.3
+link path=usr/lib/$(MACH64)/libhogweed.so target=libhogweed.so.5.0
+link path=usr/lib/$(MACH64)/libhogweed.so.5 target=libhogweed.so.5.0
+file path=usr/lib/$(MACH64)/libhogweed.so.5.0
+link path=usr/lib/$(MACH64)/libnettle.so target=libnettle.so.7.0
+link path=usr/lib/$(MACH64)/libnettle.so.7 target=libnettle.so.7.0
+file path=usr/lib/$(MACH64)/libnettle.so.7.0
 file path=usr/lib/$(MACH64)/pkgconfig/hogweed.pc
 file path=usr/lib/$(MACH64)/pkgconfig/nettle.pc
-link path=usr/lib/libhogweed.so target=libhogweed.so.4.3
-link path=usr/lib/libhogweed.so.4 target=libhogweed.so.4.3
-file path=usr/lib/libhogweed.so.4.3
-link path=usr/lib/libnettle.so target=libnettle.so.6.3
-link path=usr/lib/libnettle.so.6 target=libnettle.so.6.3
-file path=usr/lib/libnettle.so.6.3
+link path=usr/lib/libhogweed.so target=libhogweed.so.5.0
+link path=usr/lib/libhogweed.so.5 target=libhogweed.so.5.0
+file path=usr/lib/libhogweed.so.5.0
+link path=usr/lib/libnettle.so target=libnettle.so.7.0
+link path=usr/lib/libnettle.so.7 target=libnettle.so.7.0
+file path=usr/lib/libnettle.so.7.0
 file path=usr/lib/pkgconfig/hogweed.pc
 file path=usr/lib/pkgconfig/nettle.pc
+#file path=usr/share/info/dir
 file path=usr/share/info/nettle.info

--- a/components/library/nettle/patches/01-build.patch
+++ b/components/library/nettle/patches/01-build.patch
@@ -8,9 +8,9 @@
  
  OBJEXT = @OBJEXT@
  EXEEXT = @EXEEXT@
---- nettle-3.3/configure.ac.~1~	2016-10-01 10:28:38.000000000 +0300
-+++ nettle-3.3/configure.ac	2016-11-25 14:25:41.079412290 +0300
-@@ -627,16 +627,23 @@
+--- nettle-3.5.1/configure.ac	2019-06-27 07:35:06.000000000 +0000
++++ nettle-3.5.1/configure.ac	2019-07-19 07:39:23.958441212 +0000
+@@ -663,16 +663,23 @@ case "$host_os" in
      # Sun's ld uses -h to set the soname, and this option is passed
      # through by both Sun's compiler and gcc. Might not work with GNU
      # ld, but it's unusual to use GNU ld on Solaris.
@@ -36,8 +36,8 @@
      LIBHOGWEED_LIBS='libnettle.so $(LIBS)'
      ;;
    *)
-@@ -788,6 +795,8 @@
- AC_SUBST(W64_ABI)
+@@ -825,6 +832,8 @@ AC_SUBST(W64_ABI)
+ AC_SUBST(ASM_WORDS_BIGENDIAN)
  AC_SUBST(EMULATOR)
  
 +AC_SUBST(LINK_SHARED_FLAG)

--- a/components/library/nettle/test/results-all.master
+++ b/components/library/nettle/test/results-all.master
@@ -1,0 +1,136 @@
+make[1]: Entering directory '$(@D)'
+/usr/gnu/bin/make check-here
+make[2]: Entering directory '$(@D)'
+true
+make[2]: Leaving directory '$(@D)'
+set -e; for d in tools testsuite examples; do \
+  echo "Making check in $d" ; (cd $d && /usr/gnu/bin/make check); done
+Making check in tools
+make[2]: Entering directory '$(@D)/tools'
+true
+make[2]: Leaving directory '$(@D)/tools'
+Making check in testsuite
+make[2]: Entering directory '$(@D)/testsuite'
+LD_LIBRARY_PATH=../.lib PATH="../.lib:$PATH" DYLD_LIBRARY_PATH=../.lib \
+  srcdir="$(SOURCE_DIR)/testsuite" \
+  EMULATOR="" NM="nm" EXEEXT="" \
+          $(SOURCE_DIR)/run-tests aes-test arcfour-test arctwo-test blowfish-test cast128-test base16-test base64-test camellia-test chacha-test cnd-memcpy-test des-test des3-test md2-test md4-test md5-test md5-compat-test memeql-test memxor-test gosthash94-test ripemd160-test hkdf-test salsa20-test sha1-test sha224-test sha256-test sha384-test sha512-test sha512-224-test sha512-256-test sha3-permute-test sha3-224-test sha3-256-test sha3-384-test sha3-512-test serpent-test twofish-test version-test knuth-lfib-test cbc-test cfb-test ctr-test gcm-test eax-test ccm-test cmac-test poly1305-test chacha-poly1305-test hmac-test umac-test meta-hash-test meta-cipher-test meta-aead-test meta-armor-test buffer-test yarrow-test xts-test pbkdf2-test  sexp-test sexp-format-test rsa2sexp-test sexp2rsa-test bignum-test random-prime-test pkcs1-test pkcs1-sec-decrypt-test pss-test rsa-sign-tr-test pss-mgf1-test rsa-pss-sign-tr-test rsa-test rsa-encrypt-test rsa-keygen-test rsa-sec-decrypt-test rsa-compute-root-test dsa-test dsa-keygen-test curve25519-dh-test ecc-mod-test ecc-modinv-test ecc-redc-test ecc-sqrt-test ecc-dup-test ecc-add-test ecc-mul-g-test ecc-mul-a-test ecdsa-sign-test ecdsa-verify-test ecdsa-keygen-test ecdh-test eddsa-compress-test eddsa-sign-test eddsa-verify-test ed25519-test cxx-test sexp-conv-test pkcs1-conv-test nettle-pbkdf2-test symbols-test  dlopen-test
+PASS: aes
+PASS: arcfour
+PASS: arctwo
+PASS: blowfish
+PASS: cast128
+PASS: base16
+PASS: base64
+PASS: camellia
+PASS: chacha
+PASS: cnd-memcpy
+PASS: des
+PASS: des3
+PASS: md2
+PASS: md4
+PASS: md5
+PASS: md5-compat
+PASS: memeql
+PASS: memxor
+PASS: gosthash94
+PASS: ripemd160
+PASS: hkdf
+PASS: salsa20
+PASS: sha1
+PASS: sha224
+PASS: sha256
+PASS: sha384
+PASS: sha512
+PASS: sha512-224
+PASS: sha512-256
+PASS: sha3-permute
+PASS: sha3-224
+PASS: sha3-256
+PASS: sha3-384
+PASS: sha3-512
+PASS: serpent
+PASS: twofish
+PASS: version
+PASS: knuth-lfib
+PASS: cbc
+PASS: cfb
+PASS: ctr
+PASS: gcm
+PASS: eax
+PASS: ccm
+PASS: cmac
+PASS: poly1305
+PASS: chacha-poly1305
+PASS: hmac
+PASS: umac
+PASS: meta-hash
+PASS: meta-cipher
+PASS: meta-aead
+PASS: meta-armor
+PASS: buffer
+PASS: yarrow
+PASS: xts
+PASS: pbkdf2
+PASS: sexp
+PASS: sexp-format
+PASS: rsa2sexp
+PASS: sexp2rsa
+PASS: bignum
+PASS: random-prime
+PASS: pkcs1
+PASS: pkcs1-sec-decrypt
+PASS: pss
+PASS: rsa-sign-tr
+PASS: pss-mgf1
+PASS: rsa-pss-sign-tr
+PASS: rsa
+PASS: rsa-encrypt
+PASS: rsa-keygen
+PASS: rsa-sec-decrypt
+PASS: rsa-compute-root
+PASS: dsa
+PASS: dsa-keygen
+PASS: curve25519-dh
+PASS: ecc-mod
+PASS: ecc-modinv
+PASS: ecc-redc
+PASS: ecc-sqrt
+PASS: ecc-dup
+PASS: ecc-add
+PASS: ecc-mul-g
+PASS: ecc-mul-a
+PASS: ecdsa-sign
+PASS: ecdsa-verify
+PASS: ecdsa-keygen
+PASS: ecdh
+PASS: eddsa-compress
+PASS: eddsa-sign
+PASS: eddsa-verify
+PASS: ed25519
+PASS: cxx
+PASS: sexp-conv
+PASS: pkcs1-conv
+PASS: nettle-pbkdf2
+PASS: symbols
+PASS: dlopen
+===================
+All 99 tests passed
+===================
+make[2]: Leaving directory '$(@D)/testsuite'
+Making check in examples
+make[2]: Entering directory '$(@D)/examples'
+LD_LIBRARY_PATH=../.lib PATH="../.lib:$PATH" DYLD_LIBRARY_PATH=../.lib \
+  srcdir="$(SOURCE_DIR)/examples" EMULATOR="" EXEEXT="" \
+          "$(SOURCE_DIR)"/run-tests rsa-sign-test rsa-verify-test rsa-encrypt-test
+xxxxxx
+xxxxxx
+e
+PASS: rsa-sign
+PASS: rsa-verify
+PASS: rsa-encrypt
+==================
+All 3 tests passed
+==================
+make[2]: Leaving directory '$(@D)/examples'
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
Changes: https://git.lysator.liu.se/nettle/nettle/blob/master/NEWS

There's ABI breakage and GNU TLS 3 (https://github.com/OpenIndiana/oi-userland/pull/5128) needs to be rebuild, and aria2, gstreamer1-bad, and Squid need to be rebuild after Nettle 3.5 and GNU TLS 3 rebuild are in (https://github.com/OpenIndiana/oi-userland/pull/5129).

1/3: This PR
2/3: https://github.com/OpenIndiana/oi-userland/pull/5128
3/3: https://github.com/OpenIndiana/oi-userland/pull/5129

**Testing**
- test suite passed