### PR TITLE
[2/3] Nettle 3.5: Rebuild GNU TLS 3

### DIFF
--- a/components/library/gnutls-3/Makefile
+++ b/components/library/gnutls-3/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnutls
 COMPONENT_VERSION=	3.5.14
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_PROJECT_URL=  ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5
 COMPONENT_SUMMARY=	GNU transport layer security library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)


### PR DESCRIPTION
Merge after Nettle 3.5 (https://github.com/OpenIndiana/oi-userland/pull/5127).

**Testing**
- Tests did not regress.