### PR TITLE
[3/3] Nettle 3.5: Rebuild aria2, gstreamer1-bad, and update Squid

### DIFF
--- a/components/desktop/rdesktop/Makefile
+++ b/components/desktop/rdesktop/Makefile
@@ -23,6 +23,7 @@ include ../../../make-rules/shared-macros.mk
 # So, version 1.8.99 is to be read as development version before 1.9.0 is out.
 COMPONENT_NAME=		rdesktop
 COMPONENT_VERSION=	1.8.99
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	https://www.rdesktop.org/
 COMPONENT_SUMMARY=	RDP, Microsoft Terminal Services client
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_COMMIT)

--- a/components/encumbered/gst-plugins-bad1/Makefile
+++ b/components/encumbered/gst-plugins-bad1/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gst-plugins-bad1
 COMPONENT_VERSION= 1.16.0
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= GNOME streaming media framework plugins
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 COMPONENT_FMRI= library/audio/gstreamer1/plugin/bad

--- a/components/web/aria2/Makefile
+++ b/components/web/aria2/Makefile
@@ -19,16 +19,16 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2016 Predrag Zečević
-# Copyright (c) 2018 Michal Nowak
+# Copyright (c) 2019 Michal Nowak
 #
 
-PREFERRED_BITS=64
+PREFERRED_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           aria2
 COMPONENT_VERSION=        1.34.0
-COMPONENT_REVISION=       1
+COMPONENT_REVISION=       2
 COMPONENT_FMRI=           web/aria2
 COMPONENT_PROJECT_URL=    https://aria2.github.io/
 COMPONENT_CLASSIFICATION= Applications/Internet
@@ -46,7 +46,7 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+PATH=$(PATH.gnu)
 
 # Force use of gnutls-3 pkgconfig during 2.x->3.x transition
 GNUTLS_PKG_CONFIG_PATH_32 = /usr/lib/pkgconfig/gnutls-3

--- a/components/web/squid/Makefile
+++ b/components/web/squid/Makefile
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
@@ -28,15 +29,14 @@ include ../../../make-rules/shared-macros.mk
 PATH=/usr/bin:/usr/gnu/bin:/usr/sbin:/usr/perl5/bin
 
 COMPONENT_NAME=         squid
-COMPONENT_VERSION=      3.5.27
-COMPONENT_REVISION=     1
+COMPONENT_VERSION=      3.5.28
 COMPONENT_SUMMARY=	Squid Web Proxy Cache
 COMPONENT_DESCRIPTION=	Squid is a caching proxy for the Web supporting HTTP, HTTPS, FTP, and more.
 COMPONENT_PROJECT_URL=  http://www.squid-cache.org/
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-    sha256:5ddb4367f2dc635921f9ca7a59d8b87edb0412fa203d1543393ac3c7f9fef0ec
+	sha256:fd41b622e65c661ada9a98b0338c59e6f2d2ffdb367fe5c8c7212c535e298ed8
 COMPONENT_ARCHIVE_URL=  $(COMPONENT_PROJECT_URL)Versions/v3/3.5/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		web/proxy/squid
 COMPONENT_CLASSIFICATION=	Web Services/Application and Web Servers


### PR DESCRIPTION
Rebuild aria2 and gstreamer1-bad after Nettle 3.5 update (https://github.com/OpenIndiana/oi-userland/pull/5127) and GNU TLS 3 rebuild (https://github.com/OpenIndiana/oi-userland/pull/5128).

Squid has to be rebuild to but I'd rather update it to 3.5.28 as it has [two security fixes](http://www.squid-cache.org/Advisories/):
```
SQUID-2018:2 (CVE-2018-1000027), Jan 19, 2018
    Fixed from 4.0.23, 3.5.28
    Denial of Service issue in HTTP Response processing. 
SQUID-2018:1 (CVE-2018-1000024), Jan 19, 2018
    Fixed from 4.0.23, 3.5.28
    Denial of Service issue in ESI Response processing. 
```

**Testing**
- The test suite did not regress.