### PR TITLE
[1/2] GnuPG 2.2: Add libassuan 2.5.3 and npth 1.6

### DIFF
--- a/components/library/gnu-npth/Makefile
+++ b/components/library/gnu-npth/Makefile
@@ -1,0 +1,77 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		npth
+COMPONENT_VERSION=	1.6
+COMPONENT_FMRI=		library/npth
+COMPONENT_SUMMARY=	The New GNU Portable Threads Library
+COMPONENT_CLASSIFICATION=	System/Libraries
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=	http://www.gnupg.org/related_software/npth/
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1
+COMPONENT_ARCHIVE_URL=	ftp://ftp.gnupg.org/gcrypt/npth/$(COMPONENT_ARCHIVE)
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+# Enable C99 mode + -Xc for its additional warnings.
+CFLAGS += -std=gnu99
+
+# -xbuiltin=%none -- builtins have been known to be buggy
+CFLAGS += -fno-builtin
+
+CFLAGS += -D_XPG6
+CFLAGS += $(CPP_POSIX)
+CFLAGS += -fPIC
+
+CPPFLAGS += $(CPP_LARGEFILES) $(CPP_POSIX)
+
+LDFLAGS =	-lpthread -lposix4 -lrt
+
+CONFIGURE_OPTIONS  +=	--localstatedir=$(VARDIR)
+CONFIGURE_OPTIONS  +=	--with-pic
+
+CONFIGURE_ENV += LD="$(CC) $(CFLAGS) $(LDFLAGS)"
+CONFIGURE_ENV += CPP="$(CC) $(CPPFLAGS) $(CFLAGS) -E"
+CONFIGURE_ENV += INSTALL="$(INSTALL)"
+
+COMPONENT_TEST_MASTER =	$(COMPONENT_TEST_RESULTS_DIR)/results-all.master
+COMPONENT_TEST_TRANSFORMS += '-e "s|\(^Pth:\).*|\1|" '
+
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library

--- a/components/library/gnu-npth/manifests/sample-manifest.p5m
+++ b/components/library/gnu-npth/manifests/sample-manifest.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/npth-config
+file path=usr/bin/npth-config
+file path=usr/include/npth.h
+link path=usr/lib/$(MACH64)/libnpth.so target=libnpth.so.0.1.2
+link path=usr/lib/$(MACH64)/libnpth.so.0 target=libnpth.so.0.1.2
+file path=usr/lib/$(MACH64)/libnpth.so.0.1.2
+link path=usr/lib/libnpth.so target=libnpth.so.0.1.2
+link path=usr/lib/libnpth.so.0 target=libnpth.so.0.1.2
+file path=usr/lib/libnpth.so.0.1.2
+file path=usr/share/aclocal/npth.m4

--- a/components/library/gnu-npth/npth.p5m
+++ b/components/library/gnu-npth/npth.p5m
@@ -1,0 +1,47 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability "pass-through volatile">
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=pkg.description \
+    value="A portable library that uses the system's standard threads library to provid non-preemptive priority-based scheduling for multiple threads using the npth API"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license COPYING.LIB license=LGPLv2.1
+
+file path=usr/bin/$(MACH64)/npth-config
+file path=usr/bin/npth-config
+file path=usr/include/npth.h
+link path=usr/lib/$(MACH64)/libnpth.so target=libnpth.so.0.1.2
+link path=usr/lib/$(MACH64)/libnpth.so.0 target=libnpth.so.0.1.2
+file path=usr/lib/$(MACH64)/libnpth.so.0.1.2
+link path=usr/lib/libnpth.so target=libnpth.so.0.1.2
+link path=usr/lib/libnpth.so.0 target=libnpth.so.0.1.2
+file path=usr/lib/libnpth.so.0.1.2
+file path=usr/share/aclocal/npth.m4

--- a/components/library/gnu-npth/test/results-all.master
+++ b/components/library/gnu-npth/test/results-all.master
@@ -1,0 +1,20 @@
+make[1]: Entering directory '$(@D)'
+Making check in src
+make[2]: Entering directory '$(@D)/src'
+make[2]: Nothing to be done for 'check'.
+make[2]: Leaving directory '$(@D)/src'
+Making check in tests
+make[2]: Entering directory '$(@D)/tests'
+/usr/gnu/bin/make  check-TESTS
+make[3]: Entering directory '$(@D)/tests'
+PASS: t-mutex
+PASS: t-thread
+PASS: t-fork
+==================
+All 3 tests passed
+==================
+make[3]: Leaving directory '$(@D)/tests'
+make[2]: Leaving directory '$(@D)/tests'
+make[2]: Entering directory '$(@D)'
+make[2]: Leaving directory '$(@D)'
+make[1]: Leaving directory '$(@D)'

--- a/components/library/libassuan/Makefile
+++ b/components/library/libassuan/Makefile
@@ -18,21 +18,24 @@
 #
 # CDDL HEADER END
 #
+
+#
 # Copyright (c) 2013, Colin Ellis. All rights reserved.
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libassuan
-COMPONENT_VERSION=	2.1.3
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	2.5.3
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	http://www.gnupg.org/related_software/libassuan/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:fa2170b353c928eb59610e0700c34947f1890634ddf7bcf2366c9c88b4f51d1a
+	sha256:91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702
 COMPONENT_ARCHIVE_URL=	ftp://ftp.gnupg.org/gcrypt/libassuan/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	utility/gnupg
+COMPONENT_FMRI=		library/security/libassuan
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk
@@ -42,18 +45,19 @@ CONFIGURE_ENV +=	INSTALL="$(INSTALL)"
 
 CFLAGS += -std=gnu89
 
-CONFIGURE_OPTIONS  +=		--localstatedir=/var
-CONFIGURE_OPTIONS  +=		--infodir=$(CONFIGURE_INFODIR)
-CONFIGURE_OPTIONS  +=		--enable-shared
-CONFIGURE_OPTIONS  +=		--disable-static
-CONFIGURE_OPTIONS  +=		--with-gpg-error-prefix=$(CONFIGURE_PREFIX)
-CONFIGURE_OPTIONS  +=		--with-pic
+CONFIGURE_OPTIONS  +=	--localstatedir=/var
+CONFIGURE_OPTIONS  +=	--infodir=$(CONFIGURE_INFODIR)
+CONFIGURE_OPTIONS  +=	--enable-shared
+CONFIGURE_OPTIONS  +=	--disable-static
+CONFIGURE_OPTIONS  +=	--disable-silent-rules
+CONFIGURE_OPTIONS  +=	--with-gpg-error-prefix=$(CONFIGURE_PREFIX)
+CONFIGURE_OPTIONS  +=	--with-pic
 
-build: $(BUILD_32_and_64)
+build:		$(BUILD_32_and_64)
 
-install: $(INSTALL_32_and_64)
+install:	$(INSTALL_32_and_64)
 
-test: $(TEST_32_and_64)
+test:		$(TEST_32_and_64)
 
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/security/libgpg-error

--- a/components/library/libassuan/libassuan.p5m
+++ b/components/library/libassuan/libassuan.p5m
@@ -20,32 +20,33 @@
 #
 # Copyright (c) 2013, Colin Ellis. All rights reserved.
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
+
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
 
-set name=pkg.fmri value=pkg:/library/security/libassuan@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="GnuPG IPC implementation library"
 set name=pkg.description value="A small library implementing the so-called Assuan protocol, used for interprocess communication between most GnuPG components."
 set name=com.oracle.info.description value="the GnuPG IPC implementation library"
 set name=info.classification value="org.opensolaris.category.2008:System/Libraries"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
-set name=org.opensolaris.arc-caseid \
-    value=PSARC/2009/397
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-#
-#
+
+license libassuan.license license="GPLv3, LGPLv2"
+
+file path=usr/bin/$(MACH64)/libassuan-config
 file path=usr/bin/libassuan-config
 file path=usr/include/assuan.h
-file path=usr/lib/libassuan.so.0.4.3
-file path=usr/lib/$(MACH64)/libassuan.so.0.4.3
+link path=usr/lib/$(MACH64)/libassuan.so target=libassuan.so.0.8.3
+link path=usr/lib/$(MACH64)/libassuan.so.0 target=libassuan.so.0.8.3
+file path=usr/lib/$(MACH64)/libassuan.so.0.8.3
+file path=usr/lib/$(MACH64)/pkgconfig/libassuan.pc
+link path=usr/lib/libassuan.so target=libassuan.so.0.8.3
+link path=usr/lib/libassuan.so.0 target=libassuan.so.0.8.3
+file path=usr/lib/libassuan.so.0.8.3
+file path=usr/lib/pkgconfig/libassuan.pc
 file path=usr/share/aclocal/libassuan.m4
 file path=usr/share/info/assuan.info
-#
-link path=usr/lib/libassuan.so.0 target=libassuan.so.0.4.3
-link path=usr/lib/libassuan.so target=libassuan.so.0.4.3
-link path=usr/lib/$(MACH64)/libassuan.so.0 target=libassuan.so.0.4.3
-link path=usr/lib/$(MACH64)/libassuan.so target=libassuan.so.0.4.3
-#
-license libassuan.license license="GPLv3, LGPLv2"
-#depend type=optional fmri=crypto/gnupg@2.0.21-0.151
+#file path=usr/share/info/dir

--- a/components/library/libassuan/manifests/sample-manifest.p5m
+++ b/components/library/libassuan/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -25,12 +25,14 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/bin/$(MACH64)/libassuan-config
 file path=usr/bin/libassuan-config
 file path=usr/include/assuan.h
-link path=usr/lib/$(MACH64)/libassuan.so target=libassuan.so.0.4.3
-link path=usr/lib/$(MACH64)/libassuan.so.0 target=libassuan.so.0.4.3
-file path=usr/lib/$(MACH64)/libassuan.so.0.4.3
-link path=usr/lib/libassuan.so target=libassuan.so.0.4.3
-link path=usr/lib/libassuan.so.0 target=libassuan.so.0.4.3
-file path=usr/lib/libassuan.so.0.4.3
+link path=usr/lib/$(MACH64)/libassuan.so target=libassuan.so.0.8.3
+link path=usr/lib/$(MACH64)/libassuan.so.0 target=libassuan.so.0.8.3
+file path=usr/lib/$(MACH64)/libassuan.so.0.8.3
+file path=usr/lib/$(MACH64)/pkgconfig/libassuan.pc
+link path=usr/lib/libassuan.so target=libassuan.so.0.8.3
+link path=usr/lib/libassuan.so.0 target=libassuan.so.0.8.3
+file path=usr/lib/libassuan.so.0.8.3
+file path=usr/lib/pkgconfig/libassuan.pc
 file path=usr/share/aclocal/libassuan.m4
 file path=usr/share/info/assuan.info
 file path=usr/share/info/dir


### PR DESCRIPTION
Needed for GnuPG 2.2 (https://github.com/OpenIndiana/oi-userland/pull/5133).