### PR TITLE
Fix gnome-fonts and obsolete baekmuk-ttf and freefonts-ttf

### DIFF
--- a/components/fonts/baekmuk/Makefile
+++ b/components/fonts/baekmuk/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         baekmuk
 COMPONENT_VERSION=      2.2
-COMPONENT_REVISION=     1
+COMPONENT_REVISION=     2
 COMPONENT_PROJECT_URL=  http://kldp.net/projects/baekmuk/
 COMPONENT_SUMMARY=      Baekmuk family Korean TrueType fonts
 COMPONENT_SRC_NAME=     baekmuk-ttf

--- a/components/fonts/baekmuk/history
+++ b/components/fonts/baekmuk/history
@@ -1,1 +1,1 @@
-system/font/baekmuk-ttf@2.2-2018.0.0.0 system/font/truetype/baekmuk
+system/font/baekmuk-ttf@2.2-2018.0.0.1 system/font/baekmuk

--- a/components/fonts/freefont/Makefile
+++ b/components/fonts/freefont/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=        freefont
 COMPONENT_VERSION=     20120503
 IPS_COMPONENT_VERSION= 0.$(COMPONENT_VERSION)
-COMPONENT_REVISION=    1
+COMPONENT_REVISION=    2
 COMPONENT_PROJECT_URL= https://savannah.gnu.org/projects/freefont/
 COMPONENT_SUMMARY=     Free UCS TrueType Fonts
 COMPONENT_SRC=         freefont-$(COMPONENT_VERSION)

--- a/components/fonts/freefont/history
+++ b/components/fonts/freefont/history
@@ -1,1 +1,1 @@
-system/font/freefont-ttf@0.20120503-2018.0.0.0 system/font/truetype/freefont
+system/font/freefont-ttf@0.20120503-2018.0.0.1 system/font/freefont

--- a/components/meta-packages/gnome-fonts/Makefile
+++ b/components/meta-packages/gnome-fonts/Makefile
@@ -16,6 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnome-fonts
 COMPONENT_VERSION=	2.30.1
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	GNOME Unicode and Korean TrueType fonts
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	system/font/gnome-fonts

--- a/components/meta-packages/gnome-fonts/gnome-fonts.p5m
+++ b/components/meta-packages/gnome-fonts/gnome-fonts.p5m
@@ -19,5 +19,5 @@ set name=description value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-depend fmri=system/font/freefont-ttf type=require
-depend fmri=system/font/baekmuk-ttf type=require
+depend fmri=system/font/freefont type=require
+depend fmri=system/font/baekmuk type=require


### PR DESCRIPTION
freefonts-ttf and baekmuk-ttf have been replaced by freefonts and baekmuk but gnome-fonts
requires the former. Furthermore the old fonts haven't been obsoleted yet.