### PR TITLE
vim: Disable mouse visual selection, update to 8.1.1721

### DIFF
--- a/components/editor/vim/Makefile
+++ b/components/editor/vim/Makefile
@@ -30,14 +30,14 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		vim
-COMPONENT_VERSION=	8.1.1713
+COMPONENT_VERSION=	8.1.1721
 # Remove leading zeros in the patch-level part of $COMPONENT_VERSION (IPS does not like them)
 IPS_COMPONENT_VERSION=  $(shell echo $(COMPONENT_VERSION) | sed -e 's/\.00*\([1-9]\)/.\1/')
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://www.vim.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/vim/vim/archive/v$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:3d24a86444acd2f66d9e7b789296dafa45779cb9be4336ca437b93de9f989081
+COMPONENT_ARCHIVE_HASH=	sha256:05a52ea3e6455d305333c0ff46bea1a03fd7bec28172b53e11864bcb9fab61d6
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/configure.mk

--- a/components/editor/vim/files/vimrc
+++ b/components/editor/vim/files/vimrc
@@ -15,3 +15,6 @@ if &term == "sun-color"
 endif
 fixdel
 syntax on
+" Disable mouse in terminal
+set mouse=
+set ttymouse=

--- a/components/editor/vim/manifests/sample-manifest.p5m
+++ b/components/editor/vim/manifests/sample-manifest.p5m
@@ -916,6 +916,7 @@ file path=usr/share/vim/vim81/lang/ja.euc-jp/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/ja.sjis/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/ja/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/ko.UTF-8/LC_MESSAGES/vim.mo
+file path=usr/share/vim/vim81/lang/ko/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/lv/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/menu_af.latin1.vim
 file path=usr/share/vim/vim81/lang/menu_af.utf-8.vim

--- a/components/editor/vim/vim.p5m
+++ b/components/editor/vim/vim.p5m
@@ -875,6 +875,7 @@ file path=usr/share/vim/vim81/lang/ja.euc-jp/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/ja.sjis/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/ja/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/ko.UTF-8/LC_MESSAGES/vim.mo
+file path=usr/share/vim/vim81/lang/ko/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/lv/LC_MESSAGES/vim.mo
 file path=usr/share/vim/vim81/lang/menu_af.latin1.vim
 file path=usr/share/vim/vim81/lang/menu_af.utf-8.vim


### PR DESCRIPTION
I think use of mouse entering to visual editing mode (when one does not have `~/.vimrc`) from https://github.com/OpenIndiana/oi-userland/pull/5062 is confusing and arguably not desired (by myself at least). This disables it. Also update to 8.1.1721.