### PR TITLE
1/2: Update libass to 0.14.0

### DIFF
--- a/components/library/libass/Makefile
+++ b/components/library/libass/Makefile
@@ -17,15 +17,14 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libass
-COMPONENT_VERSION=	0.13.4
-COMPONENT_REVISION=	2
+COMPONENT_VERSION=	0.14.0
 COMPONENT_FMRI=		library/video/libass
 COMPONENT_SUMMARY=	Portable renderer for the ASS/SSA (Substation Alpha) subtitle format
 COMPONENT_CLASSIFICATION=System/Multimedia Libraries
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:6711469df5fcc47d06e92f7383dcebcf1282591002d2356057997e8936840792
+	sha256:8d5a5c920b90b70a108007ffcd2289ac652c0e03fc88e6eecefa37df0f2e7fdf
 COMPONENT_ARCHIVE_URL= \
 	https://github.com/libass/libass/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://github.com/libass/libass

--- a/components/library/libass/libass.p5m
+++ b/components/library/libass/libass.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,11 +25,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.5.3.2
-link path=usr/lib/$(MACH64)/libass.so.5 target=libass.so.5.3.2
-file path=usr/lib/$(MACH64)/libass.so.5.3.2
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.0.2
+link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.0.2
+file path=usr/lib/$(MACH64)/libass.so.9.0.2
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-link path=usr/lib/libass.so target=libass.so.5.3.2
-link path=usr/lib/libass.so.5 target=libass.so.5.3.2
-file path=usr/lib/libass.so.5.3.2
+link path=usr/lib/libass.so target=libass.so.9.0.2
+link path=usr/lib/libass.so.9 target=libass.so.9.0.2
+file path=usr/lib/libass.so.9.0.2
 file path=usr/lib/pkgconfig/libass.pc

--- a/components/library/libass/manifests/sample-manifest.p5m
+++ b/components/library/libass/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,11 +24,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.5.3.2
-link path=usr/lib/$(MACH64)/libass.so.5 target=libass.so.5.3.2
-file path=usr/lib/$(MACH64)/libass.so.5.3.2
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.0.2
+link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.0.2
+file path=usr/lib/$(MACH64)/libass.so.9.0.2
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-link path=usr/lib/libass.so target=libass.so.5.3.2
-link path=usr/lib/libass.so.5 target=libass.so.5.3.2
-file path=usr/lib/libass.so.5.3.2
+link path=usr/lib/libass.so target=libass.so.9.0.2
+link path=usr/lib/libass.so.9 target=libass.so.9.0.2
+file path=usr/lib/libass.so.9.0.2
 file path=usr/lib/pkgconfig/libass.pc


### PR DESCRIPTION
These components need to be rebuild due to [change in soname](https://abi-laboratory.pro/index.php?view=timeline&l=libass) 5 -> 9: https://github.com/OpenIndiana/oi-userland/pull/5160.

Changelog: https://github.com/libass/libass/releases

**Testing**
- played a video with SSA subtitles in VLC