### PR TITLE
1/2: Update libebml to 1.3.9 (CVE-2019-13615)

### DIFF
--- a/components/library/libebml/Makefile
+++ b/components/library/libebml/Makefile
@@ -10,30 +10,33 @@
 
 #
 # Copyright (c) 2015 Alexander Pyhalov
+# Copyright (c) 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           libebml
-COMPONENT_VERSION=        1.3.5
+COMPONENT_VERSION=        1.3.9
 COMPONENT_PROJECT_URL=    http://matroska-org.github.io/libebml/
 COMPONENT_SUMMARY=        Extensible Binary Markup Language
 COMPONENT_SRC=            $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:d818413f60742c2f036ba6f582c5e0320d12bffec1b0fc0fc17a398b6f04aa00
+	sha256:c6b6c6cd8b20a46203cb5dce636883aef68beb2846f1e4103b660a7da2c9c548
 COMPONENT_ARCHIVE_URL= \
-  http://dl.matroska.org/downloads/libebml/$(COMPONENT_ARCHIVE)
+	http://dl.matroska.org/downloads/libebml/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	LICENSE.LGPL
 COMPONENT_FMRI=		library/libebml
 COMPONENT_CLASSIFICATION=	System/Libraries
 
 include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/cmake.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-# common targets
+CMAKE_OPTIONS += -DBUILD_SHARED_LIBS:BOOL=ON
+CMAKE_OPTIONS += -DSTATIC_BUILD:BOOL=OFF
+
 build:		$(BUILD_32_and_64)
 
 install:	$(INSTALL_32_and_64)

--- a/components/library/libebml/libebml.p5m
+++ b/components/library/libebml/libebml.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -50,11 +51,20 @@ file path=usr/include/ebml/MemReadIOCallback.h
 file path=usr/include/ebml/SafeReadIOCallback.h
 file path=usr/include/ebml/StdIOCallback.h
 file path=usr/include/ebml/c/libebml_t.h
-link path=usr/lib/$(MACH64)/libebml.so target=libebml.so.4.0.0
+file path=usr/include/ebml/ebml_export.h
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLConfigVersion.cmake
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLTargets-noconfig.cmake
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLTargets.cmake
+link path=usr/lib/$(MACH64)/libebml.so target=libebml.so.4
 link path=usr/lib/$(MACH64)/libebml.so.4 target=libebml.so.4.0.0
 file path=usr/lib/$(MACH64)/libebml.so.4.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libebml.pc
-link path=usr/lib/libebml.so target=libebml.so.4.0.0
+file path=usr/lib/cmake/EBML/EBMLConfig.cmake
+file path=usr/lib/cmake/EBML/EBMLConfigVersion.cmake
+file path=usr/lib/cmake/EBML/EBMLTargets-noconfig.cmake
+file path=usr/lib/cmake/EBML/EBMLTargets.cmake
+link path=usr/lib/libebml.so target=libebml.so.4
 link path=usr/lib/libebml.so.4 target=libebml.so.4.0.0
 file path=usr/lib/libebml.so.4.0.0
 file path=usr/lib/pkgconfig/libebml.pc

--- a/components/library/libebml/manifests/sample-manifest.p5m
+++ b/components/library/libebml/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -50,13 +50,20 @@ file path=usr/include/ebml/MemReadIOCallback.h
 file path=usr/include/ebml/SafeReadIOCallback.h
 file path=usr/include/ebml/StdIOCallback.h
 file path=usr/include/ebml/c/libebml_t.h
-file path=usr/lib/$(MACH64)/libebml.a
-link path=usr/lib/$(MACH64)/libebml.so target=libebml.so.4.0.0
+file path=usr/include/ebml/ebml_export.h
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLConfigVersion.cmake
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLTargets-noconfig.cmake
+file path=usr/lib/$(MACH64)/cmake/EBML/EBMLTargets.cmake
+link path=usr/lib/$(MACH64)/libebml.so target=libebml.so.4
 link path=usr/lib/$(MACH64)/libebml.so.4 target=libebml.so.4.0.0
 file path=usr/lib/$(MACH64)/libebml.so.4.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libebml.pc
-file path=usr/lib/libebml.a
-link path=usr/lib/libebml.so target=libebml.so.4.0.0
+file path=usr/lib/cmake/EBML/EBMLConfig.cmake
+file path=usr/lib/cmake/EBML/EBMLConfigVersion.cmake
+file path=usr/lib/cmake/EBML/EBMLTargets-noconfig.cmake
+file path=usr/lib/cmake/EBML/EBMLTargets.cmake
+link path=usr/lib/libebml.so target=libebml.so.4
 link path=usr/lib/libebml.so.4 target=libebml.so.4.0.0
 file path=usr/lib/libebml.so.4.0.0
 file path=usr/lib/pkgconfig/libebml.pc


### PR DESCRIPTION
Changelog: https://github.com/Matroska-Org/libebml/blob/release-1.3.9/ChangeLog
ABI checker: https://abi-laboratory.pro/index.php?view=timeline&l=libebml

https://security-tracker.debian.org/tracker/CVE-2019-13615
https://trac.videolan.org/vlc/ticket/22474#comment:21

libmatroska & VLC rebuild: https://github.com/OpenIndiana/oi-userland/pull/5173.

**Testing**
- MKV videos in VLC work