### PR TITLE
WIP: Port WebRTC to Solaris

### DIFF
--- a/components/web/firefox/Makefile
+++ b/components/web/firefox/Makefile
@@ -67,11 +67,11 @@ CONFIGURE_OPTIONS +=	--disable-debug-symbols
 CONFIGURE_OPTIONS +=	--enable-update-channel=esr
 CONFIGURE_OPTIONS +=	--disable-tests
 CONFIGURE_OPTIONS +=	--disable-jemalloc
-CONFIGURE_OPTIONS +=	--enable-optimize="-O2 -fno-schedule-insns2 -fno-lifetime-dse -fno-delete-null-pointer-checks"
+CONFIGURE_OPTIONS +=	--enable-optimize="-O3 -fno-lifetime-dse -fno-delete-null-pointer-checks"
 CONFIGURE_OPTIONS +=	--disable-dtrace
 CONFIGURE_OPTIONS +=	--disable-crashreporter
 CONFIGURE_OPTIONS +=	--enable-pulseaudio
-CONFIGURE_OPTIONS +=	--disable-webrtc
+CONFIGURE_OPTIONS +=	--enable-webrtc
 CONFIGURE_OPTIONS +=	--with-intl-api
 CONFIGURE_OPTIONS +=	--disable-debug
 CONFIGURE_OPTIONS +=	--enable-default-toolkit=cairo-gtk3
@@ -84,6 +84,7 @@ CONFIGURE_OPTIONS +=	--prefix=$(CONFIGURE_PREFIX)
 CONFIGURE_OPTIONS +=	--libdir=$(FIREFOX_LIBDIR)
 CONFIGURE_OPTIONS +=	--host=$(GNU_ARCH)
 CONFIGURE_OPTIONS +=	--target=$(GNU_ARCH)
+CONFIGURE_OPTIONS +=	--enable-rust-simd
 
 ENV +=  PATH=$(PATH)
 ENV +=	CC=$(CC)
@@ -168,3 +169,8 @@ REQUIRED_PACKAGES += x11/library/libxcb
 REQUIRED_PACKAGES += x11/library/libxext
 REQUIRED_PACKAGES += x11/library/libxrender
 REQUIRED_PACKAGES += x11/library/toolkit/libxt
+REQUIRED_PACKAGES += x11/library/libxdamage
+REQUIRED_PACKAGES += x11/library/libxcomposite
+REQUIRED_PACKAGES += x11/library/libxcursor
+REQUIRED_PACKAGES += x11/library/libxfixes
+REQUIRED_PACKAGES += x11/library/libxi

--- a/components/web/firefox/patches/webrtc-solaris.patch
+++ b/components/web/firefox/patches/webrtc-solaris.patch
@@ -1,0 +1,19393 @@
+diff --git firefox-60.8.0/media/webrtc/trunk/moz.build firefox-patched/media/webrtc/trunk/moz.build
+index 880b277c1..5900fe56d 100644
+--- firefox-60.8.0/media/webrtc/trunk/moz.build
++++ firefox-patched/media/webrtc/trunk/moz.build
+@@ -108,6 +108,18 @@ if CONFIG["OS_TARGET"] == "DragonFly":
+         "/media/webrtc/trunk/webrtc/video_engine/video_engine_gn"
+     ]
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DIRS += [
++        "/media/webrtc/trunk/webrtc/common_audio/common_audio_sse2_gn",
++        "/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_sse2_gn",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_gn",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/primitives_gn",
++        "/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_sse2_gn",
++        "/media/webrtc/trunk/webrtc/video_engine/video_engine_gn"
++    ]
++
+ if CONFIG["OS_TARGET"] == "Darwin":
+ 
+     DIRS += [
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/api/audio_mixer_api_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/api/audio_mixer_api_gn/moz.build
+index a1c2a111b..82acad4df 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/api/audio_mixer_api_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/api/audio_mixer_api_gn/moz.build
+@@ -100,6 +100,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -149,6 +156,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/api/call_api_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/api/call_api_gn/moz.build
+index ac476c4d2..d8111ecef 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/api/call_api_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/api/call_api_gn/moz.build
+@@ -100,6 +100,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -149,6 +156,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/api/transport_api_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/api/transport_api_gn/moz.build
+index 331eb541b..a6307047c 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/api/transport_api_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/api/transport_api_gn/moz.build
+@@ -96,6 +96,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -145,6 +152,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/api/video_frame_api_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/api/video_frame_api_gn/moz.build
+index 27107dc52..87c670812 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/api/video_frame_api_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/api/video_frame_api_gn/moz.build
+@@ -110,6 +110,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -163,6 +170,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/audio/audio_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/audio/audio_gn/moz.build
+index 90a56a085..786fb5c72 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/audio/audio_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/audio/audio_gn/moz.build
+@@ -130,6 +130,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -183,6 +191,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/audio/audio_send_stream.h firefox-patched/media/webrtc/trunk/webrtc/audio/audio_send_stream.h
+index 05ed3aaeb..80203efbb 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/audio/audio_send_stream.h
++++ firefox-patched/media/webrtc/trunk/webrtc/audio/audio_send_stream.h
+@@ -13,6 +13,7 @@
+ 
+ #include <memory>
+ 
++#include "webrtc/base/stringutils.h"
+ #include "webrtc/base/constructormagic.h"
+ #include "webrtc/base/thread_checker.h"
+ #include "webrtc/call/audio_send_stream.h"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/audio/utility/audio_frame_operations_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/audio/utility/audio_frame_operations_gn/moz.build
+index 1c228d3ef..97c92a312 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/audio/utility/audio_frame_operations_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/audio/utility/audio_frame_operations_gn/moz.build
+@@ -104,6 +104,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -153,6 +160,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/base/gtest_prod_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/base/gtest_prod_gn/moz.build
+index 3cfd5128a..2c9aa225e 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/base/gtest_prod_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/base/gtest_prod_gn/moz.build
+@@ -96,6 +96,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -145,6 +152,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/base/platform_thread.cc firefox-patched/media/webrtc/trunk/webrtc/base/platform_thread.cc
+index e72640613..a5980da13 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/base/platform_thread.cc
++++ firefox-patched/media/webrtc/trunk/webrtc/base/platform_thread.cc
+@@ -21,6 +21,8 @@
+ #include <lwp.h>
+ #elif defined(__FreeBSD__)
+ #include <pthread_np.h>
++#elif defined(__sun)
++#include <thread.h>
+ #endif
+ 
+ namespace rtc {
+@@ -53,6 +55,8 @@ PlatformThreadId CurrentThreadId() {
+   ret = reinterpret_cast<uintptr_t> (pthread_self());
+ #elif defined(__FreeBSD__)
+   ret = pthread_getthreadid_np();
++#elif defined(__sun)
++  ret = thr_self();
+ #else
+   // Default implementation for nacl and solaris.
+   ret = reinterpret_cast<pid_t>(pthread_self());
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/base/rtc_base_approved_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/base/rtc_base_approved_gn/moz.build
+index e511d3567..8c4977ada 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/base/rtc_base_approved_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/base/rtc_base_approved_gn/moz.build
+@@ -162,6 +162,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+         "/media/webrtc/trunk/webrtc/base/file_posix.cc"
+     ]
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/base/file_posix.cc"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -216,6 +227,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/base/rtc_numerics_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/base/rtc_numerics_gn/moz.build
+index 914470933..aa8d5826f 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/base/rtc_numerics_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/base/rtc_numerics_gn/moz.build
+@@ -104,6 +104,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -153,6 +160,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/base/rtc_task_queue_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/base/rtc_task_queue_gn/moz.build
+index c3b4cad00..8089421e8 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/base/rtc_task_queue_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/base/rtc_task_queue_gn/moz.build
+@@ -176,6 +176,24 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+         "/media/webrtc/trunk/webrtc/base/task_queue_posix.cc"
+     ]
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    LOCAL_INCLUDES += [
++        "/ipc/chromium/src/third_party/libevent/include/",
++        "/ipc/chromium/src/third_party/libevent/linux/"
++    ]
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/base/task_queue_libevent.cc",
++        "/media/webrtc/trunk/webrtc/base/task_queue_posix.cc"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -229,6 +247,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/call/call_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/call/call_gn/moz.build
+index a73e7927c..2bdf9cf04 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/call/call_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/call/call_gn/moz.build
+@@ -121,6 +121,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -174,6 +182,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/call/call_interfaces_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/call/call_interfaces_gn/moz.build
+index 3200ae2fe..b9a415346 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/call/call_interfaces_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/call/call_interfaces_gn/moz.build
+@@ -100,6 +100,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -149,6 +156,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/common_audio/common_audio_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/common_audio/common_audio_c_gn/moz.build
+index 97bf5813f..d21965443 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/common_audio/common_audio_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/common_audio/common_audio_c_gn/moz.build
+@@ -161,6 +161,19 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/common_audio/signal_processing/complex_bit_reverse.c",
++        "/media/webrtc/trunk/webrtc/common_audio/signal_processing/filter_ar_fast_q12.c",
++        "/media/webrtc/trunk/webrtc/common_audio/signal_processing/spl_sqrt_floor.c"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -216,6 +229,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/common_audio/common_audio_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/common_audio/common_audio_gn/moz.build
+index b93db3279..c4e2a0f84 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/common_audio/common_audio_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/common_audio/common_audio_gn/moz.build
+@@ -129,6 +129,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -182,6 +189,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/common_audio/common_audio_sse2_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/common_audio/common_audio_sse2_gn/moz.build
+index 763c439e0..ec2331733 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/common_audio/common_audio_sse2_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/common_audio/common_audio_sse2_gn/moz.build
+@@ -111,6 +111,7 @@ if CONFIG["OS_TARGET"] == "Linux":
+ if CONFIG["OS_TARGET"] == "NetBSD":
+ 
+     CXXFLAGS += [
++        "-msse2",
+         "-msse2"
+     ]
+ 
+@@ -131,6 +132,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    CXXFLAGS += [
++        "-msse2"
++    ]
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -180,6 +192,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/common_video/common_video_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/common_video/common_video_gn/moz.build
+index 73328d60a..7fb227e3f 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/common_video/common_video_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/common_video/common_video_gn/moz.build
+@@ -137,6 +137,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -190,6 +198,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/logging/rtc_event_log_api_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/logging/rtc_event_log_api_gn/moz.build
+index caef5a023..93e80965e 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/logging/rtc_event_log_api_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/logging/rtc_event_log_api_gn/moz.build
+@@ -96,6 +96,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -145,6 +152,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/logging/rtc_event_log_impl_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/logging/rtc_event_log_impl_gn/moz.build
+index 4ea7312f1..ac5cf76f7 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/logging/rtc_event_log_impl_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/logging/rtc_event_log_impl_gn/moz.build
+@@ -119,6 +119,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -172,6 +180,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/media/mozilla_rtc_media_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/media/mozilla_rtc_media_gn/moz.build
+index b1021cc1d..557df0f84 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/media/mozilla_rtc_media_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/media/mozilla_rtc_media_gn/moz.build
+@@ -102,6 +102,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -151,6 +158,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_coding_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_coding_gn/moz.build
+index e96cea46a..0b3190c8d 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_coding_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_coding_gn/moz.build
+@@ -140,6 +140,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    LOCAL_INCLUDES += [
++        "/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/main/include/"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -197,6 +208,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_factory_interface_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_factory_interface_gn/moz.build
+index 7b7a7af25..bccf011cc 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_factory_interface_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_factory_interface_gn/moz.build
+@@ -100,6 +100,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -149,6 +156,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_interface_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_interface_gn/moz.build
+index e635989f1..f4695da48 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_interface_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_decoder_interface_gn/moz.build
+@@ -105,6 +105,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -154,6 +161,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_encoder_interface_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_encoder_interface_gn/moz.build
+index 5d0970c60..52743548a 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_encoder_interface_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_encoder_interface_gn/moz.build
+@@ -104,6 +104,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -153,6 +160,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_conversion_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_conversion_gn/moz.build
+index 023e9e78a..9ad9489c2 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_conversion_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_conversion_gn/moz.build
+@@ -104,6 +104,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -153,6 +160,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_gn/moz.build
+index f3ca52df0..19f150666 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_format_gn/moz.build
+@@ -100,6 +100,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -149,6 +156,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
+index 3afb473ca..0462e4828 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
+@@ -120,6 +120,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -173,6 +180,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/builtin_audio_decoder_factory_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/builtin_audio_decoder_factory_gn/moz.build
+index 4f2b2fe7a..3cf806cdf 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/builtin_audio_decoder_factory_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/builtin_audio_decoder_factory_gn/moz.build
+@@ -128,6 +128,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    LOCAL_INCLUDES += [
++        "/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/main/include/"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -185,6 +196,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/cng_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/cng_gn/moz.build
+index 8aea4c10b..f41a8dc32 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/cng_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/cng_gn/moz.build
+@@ -113,6 +113,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -166,6 +173,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g711_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g711_c_gn/moz.build
+index c2e18cd2a..eb257c3b5 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g711_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g711_c_gn/moz.build
+@@ -101,6 +101,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -150,6 +157,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g711_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g711_gn/moz.build
+index 2cbbed7df..90c239d19 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g711_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g711_gn/moz.build
+@@ -106,6 +106,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -155,6 +162,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g722_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g722_c_gn/moz.build
+index 74fb52d91..f7c79ec91 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g722_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g722_c_gn/moz.build
+@@ -105,6 +105,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -154,6 +161,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g722_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g722_gn/moz.build
+index 5411a863d..c99b6d8e8 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/g722_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/g722_gn/moz.build
+@@ -106,6 +106,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -155,6 +162,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_c_gn/moz.build
+index e92473f4b..a2ad7b040 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_c_gn/moz.build
+@@ -141,6 +141,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -194,6 +201,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_common_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_common_gn/moz.build
+index 601876cf0..a2f8cda14 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_common_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_common_gn/moz.build
+@@ -104,6 +104,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -153,6 +160,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_c_gn/moz.build
+index ae07364c3..f7b689256 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_c_gn/moz.build
+@@ -165,6 +165,21 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    SOURCES += [
++        "/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_filter_c.c"
++    ]
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/fix/source/lattice_c.c"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -226,6 +241,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_gn/moz.build
+index 464111ebd..f60ac2582 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_fix_gn/moz.build
+@@ -114,6 +114,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -167,6 +174,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_gn/moz.build
+index 7a5e54d79..dadff8eb5 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/isac_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/isac_gn/moz.build
+@@ -112,6 +112,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -165,6 +172,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/neteq_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/neteq_gn/moz.build
+index 996a7b9ad..cf3d1bb9d 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/neteq_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/neteq_gn/moz.build
+@@ -173,6 +173,18 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_CODEC_ISAC"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    LOCAL_INCLUDES += [
++        "/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/main/include/"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -231,6 +243,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_c_gn/moz.build
+index 457d6a04b..3633d0863 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_c_gn/moz.build
+@@ -101,6 +101,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -150,6 +157,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_gn/moz.build
+index da8b8f4a9..33ee47390 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/pcm16b_gn/moz.build
+@@ -107,6 +107,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -156,6 +163,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/rent_a_codec_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/rent_a_codec_gn/moz.build
+index a1b1d7763..43e6b587c 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/rent_a_codec_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/rent_a_codec_gn/moz.build
+@@ -129,6 +129,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    LOCAL_INCLUDES += [
++        "/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/main/include/"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -186,6 +197,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_c_gn/moz.build
+index 9e7ffbed2..bae971076 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_c_gn/moz.build
+@@ -105,6 +105,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -154,6 +161,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_gn/moz.build
+index 43f7c5745..25ce749c1 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_coding/webrtc_opus_gn/moz.build
+@@ -113,6 +113,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -166,6 +173,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_conference_mixer/audio_conference_mixer_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_conference_mixer/audio_conference_mixer_gn/moz.build
+index 7138cd2df..3445b04ad 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_conference_mixer/audio_conference_mixer_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_conference_mixer/audio_conference_mixer_gn/moz.build
+@@ -113,6 +113,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -166,6 +173,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_device/audio_device_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_device/audio_device_gn/moz.build
+index 78fcfca6d..63d8806f6 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_device/audio_device_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_device/audio_device_gn/moz.build
+@@ -140,6 +140,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -197,6 +205,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
+index f08c08dc5..614d7b2b1 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
+@@ -104,6 +104,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -153,6 +160,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
+index b04fb43d3..4fd965463 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
+@@ -110,6 +110,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -163,6 +170,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_c_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_c_gn/moz.build
+index 5e2241c1d..de1b1870e 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_c_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_c_gn/moz.build
+@@ -130,6 +130,18 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/modules/audio_processing/ns/noise_suppression.c",
++        "/media/webrtc/trunk/webrtc/modules/audio_processing/ns/ns_core.c"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -188,6 +200,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_gn/moz.build
+index c1dbe7032..1c03bf671 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_gn/moz.build
+@@ -188,6 +188,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_NS_FLOAT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -242,6 +250,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_sse2_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_sse2_gn/moz.build
+index 50aa160d6..c3dc3b25a 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_sse2_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/audio_processing/audio_processing_sse2_gn/moz.build
+@@ -112,6 +112,7 @@ if CONFIG["OS_TARGET"] == "Linux":
+ if CONFIG["OS_TARGET"] == "NetBSD":
+ 
+     CXXFLAGS += [
++        "-msse2",
+         "-msse2"
+     ]
+ 
+@@ -132,6 +133,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    CXXFLAGS += [
++        "-msse2"
++    ]
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -181,6 +193,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_gn/moz.build
+index f43046275..4c41d79ce 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/bitrate_controller/bitrate_controller_gn/moz.build
+@@ -120,6 +120,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -173,6 +181,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/congestion_controller/congestion_controller_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/congestion_controller/congestion_controller_gn/moz.build
+index 7e7c6f2a0..fcc24b43e 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/congestion_controller/congestion_controller_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/congestion_controller/congestion_controller_gn/moz.build
+@@ -130,6 +130,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -183,6 +191,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn/moz.build
+index 8acbae366..a39391f3f 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn/moz.build
+@@ -90,6 +90,7 @@ if CONFIG["OS_TARGET"] == "Linux":
+ if CONFIG["OS_TARGET"] == "NetBSD":
+ 
+     CXXFLAGS += [
++        "-msse2",
+         "-msse2"
+     ]
+ 
+@@ -110,6 +111,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    CXXFLAGS += [
++        "-msse2"
++    ]
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -155,6 +167,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_gn/moz.build
+index fff0efd4a..8d4def44a 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/desktop_capture/desktop_capture_gn/moz.build
+@@ -242,6 +242,38 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+         "/media/webrtc/trunk/webrtc/modules/desktop_capture/x11/x_server_pixel_buffer.cc"
+     ]
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    OS_LIBS += [
++        "X11",
++        "X11-xcb",
++        "xcb",
++        "Xcomposite",
++        "Xcursor",
++        "Xdamage",
++        "Xext",
++        "Xfixes",
++        "Xi",
++        "Xrender"
++    ]
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/app_capturer_x11.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/mouse_cursor_monitor_x11.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/screen_capturer_x11.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/window_capturer_x11.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/x11/desktop_device_info_x11.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/x11/shared_x_display.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/x11/shared_x_util.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/x11/x_error_trap.cc",
++        "/media/webrtc/trunk/webrtc/modules/desktop_capture/x11/x_server_pixel_buffer.cc"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -322,6 +354,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/desktop_capture/primitives_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/desktop_capture/primitives_gn/moz.build
+index 26b7ce57c..28613fa17 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/desktop_capture/primitives_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/desktop_capture/primitives_gn/moz.build
+@@ -89,6 +89,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -134,6 +141,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/media_file/media_file_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/media_file/media_file_gn/moz.build
+index 8c69e8350..8e2fe2db5 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/media_file/media_file_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/media_file/media_file_gn/moz.build
+@@ -112,6 +112,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -165,6 +172,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/pacing/pacing_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/pacing/pacing_gn/moz.build
+index 734a3292e..a9780d013 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/pacing/pacing_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/pacing/pacing_gn/moz.build
+@@ -121,6 +121,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -174,6 +182,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
+index 0374bc61c..bfa975111 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
+@@ -120,6 +120,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -173,6 +180,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
+index 9a8730b90..f6fb71f66 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
+@@ -191,6 +191,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -244,6 +252,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/rtp_rtcp/source/rtp_utility.cc firefox-patched/media/webrtc/trunk/webrtc/modules/rtp_rtcp/source/rtp_utility.cc
+index 526675be2..b121845fe 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/rtp_rtcp/source/rtp_utility.cc
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/rtp_rtcp/source/rtp_utility.cc
+@@ -53,7 +53,7 @@ bool StringCompare(const char* str1, const char* str2,
+                    const uint32_t length) {
+   return _strnicmp(str1, str2, length) == 0;
+ }
+-#elif defined(WEBRTC_LINUX) || defined(WEBRTC_BSD) || defined(WEBRTC_MAC)
++#elif defined(WEBRTC_LINUX) || defined(WEBRTC_BSD) || defined(WEBRTC_MAC) || defined(WEBRTC_SOLARIS)
+ bool StringCompare(const char* str1, const char* str2,
+                    const uint32_t length) {
+   return strncasecmp(str1, str2, length) == 0;
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/utility/utility_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/utility/utility_gn/moz.build
+index e07b74b7d..bce853517 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/utility/utility_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/utility/utility_gn/moz.build
+@@ -125,6 +125,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -178,6 +186,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/device_info_impl.h firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/device_info_impl.h
+index 0a9e94dfc..3b5947aaa 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/device_info_impl.h
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/device_info_impl.h
+@@ -13,6 +13,7 @@
+ 
+ #include <vector>
+ 
++#include "webrtc/base/stringutils.h"
+ #include "webrtc/modules/video_capture/video_capture.h"
+ #include "webrtc/modules/video_capture/video_capture_delay.h"
+ #include "webrtc/system_wrappers/include/rw_lock_wrapper.h"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc
+index f9cf38ac3..f6b0aebf6 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc
+@@ -466,6 +466,8 @@ bool DeviceInfoLinux::IsDeviceNameMatches(const char* name,
+ int32_t DeviceInfoLinux::FillCapabilities(int fd)
+ {
+     struct v4l2_fmtdesc fmt;
++    VideoCaptureCapability cap;
++#ifndef __sun
+     struct v4l2_frmsizeenum frmsize;
+     struct v4l2_frmivalenum frmival;
+ 
+@@ -485,7 +487,6 @@ int32_t DeviceInfoLinux::FillCapabilities(int fd)
+                         fmt.pixelformat == V4L2_PIX_FMT_YUV420 ||
+                         fmt.pixelformat == V4L2_PIX_FMT_MJPEG) {
+ 
+-                        VideoCaptureCapability cap;
+                         cap.width = frmsize.discrete.width;
+                         cap.height = frmsize.discrete.height;
+                         cap.expectedCaptureDelay = 120;
+@@ -512,7 +513,40 @@ int32_t DeviceInfoLinux::FillCapabilities(int fd)
+         }
+         fmt.index++;
+     }
++#else
++    // On Solaris, we can use VIDIOC_G_PARM and VIDIOC_G_FMT to get this information.
++    struct v4l2_format vfmt;
++    struct v4l2_streamparm sparm;
+ 
++    fmt.index = 0;
++    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
++    while (ioctl(fd, VIDIOC_ENUM_FMT, &fmt) >= 0) {
++        vfmt.type = fmt.type;
++        sparm.type = fmt.type;
++        ioctl(fd, VIDIOC_G_FMT, &vfmt);
++        ioctl(fd, VIDIOC_G_PARM, &sparm);
++        cap.width = vfmt.fmt.pix.width;
++        cap.height = vfmt.fmt.pix.height;
++        cap.expectedCaptureDelay = 120;
++        switch (fmt.pixelformat)
++        {
++        case V4L2_PIX_FMT_YUYV:
++            cap.rawType = kVideoYUY2;
++            break;
++        case V4L2_PIX_FMT_YUV420:
++            cap.rawType = kVideoI420;
++            break;
++        case V4L2_PIX_FMT_MJPEG:
++            cap.rawType = kVideoMJPEG;
++            break;
++        default:
++            break;
++        }
++        cap.maxFPS = sparm.parm.capture.timeperframe.denominator / sparm.parm.capture.timeperframe.numerator;
++        _captureCapabilities.push_back(cap);
++        fmt.index++;
++    }
++#endif
+     WEBRTC_TRACE(webrtc::kTraceInfo,
+                  webrtc::kTraceVideoCapture,
+                  0,
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
+index 471ee5474..4555237bb 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
+@@ -161,6 +161,19 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+         "/media/webrtc/trunk/webrtc/modules/video_capture/linux/video_capture_linux.cc"
+     ]
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc",
++        "/media/webrtc/trunk/webrtc/modules/video_capture/linux/video_capture_linux.cc"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -232,6 +245,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_module_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_module_gn/moz.build
+index 9ef02b158..b6a5c5d64 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_module_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/video_capture_module_gn/moz.build
+@@ -123,6 +123,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -176,6 +184,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_gn/moz.build
+index b7291db61..26871f50a 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_gn/moz.build
+@@ -151,6 +151,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -204,6 +212,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_utility_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_utility_gn/moz.build
+index 8e74a91ab..2c5dae6c0 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_utility_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/video_coding_utility_gn/moz.build
+@@ -127,6 +127,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -180,6 +188,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_h264_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_h264_gn/moz.build
+index f5b82fd74..b020a9a2d 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_h264_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_h264_gn/moz.build
+@@ -118,6 +118,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -171,6 +179,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_i420_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_i420_gn/moz.build
+index 5141761d6..d369d4945 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_i420_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_i420_gn/moz.build
+@@ -120,6 +120,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -173,6 +181,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp8_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp8_gn/moz.build
+index 0626de8c0..5f253b55b 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp8_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp8_gn/moz.build
+@@ -126,6 +126,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -179,6 +187,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp9_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp9_gn/moz.build
+index c95abc863..958f967b5 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp9_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_coding/webrtc_vp9_gn/moz.build
+@@ -122,6 +122,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -175,6 +183,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_gn/moz.build
+index 86c355aba..a8ea6deb7 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_gn/moz.build
+@@ -129,6 +129,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -182,6 +190,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_sse2_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_sse2_gn/moz.build
+index e078dd02c..d1a7efe55 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_sse2_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_processing/video_processing_sse2_gn/moz.build
+@@ -118,6 +118,7 @@ if CONFIG["OS_TARGET"] == "Linux":
+ if CONFIG["OS_TARGET"] == "NetBSD":
+ 
+     CXXFLAGS += [
++        "-msse2",
+         "-msse2"
+     ]
+ 
+@@ -138,6 +139,17 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    CXXFLAGS += [
++        "-msse2"
++    ]
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -191,6 +203,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/system_wrappers/field_trial_default_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/system_wrappers/field_trial_default_gn/moz.build
+index bff2e26f1..e7127ed97 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/system_wrappers/field_trial_default_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/system_wrappers/field_trial_default_gn/moz.build
+@@ -100,6 +100,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -149,6 +156,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/system_wrappers/metrics_default_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/system_wrappers/metrics_default_gn/moz.build
+index b94dee217..5191a1357 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/system_wrappers/metrics_default_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/system_wrappers/metrics_default_gn/moz.build
+@@ -100,6 +100,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -149,6 +156,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/system_wrappers/system_wrappers_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/system_wrappers/system_wrappers_gn/moz.build
+index 59878cd08..8abc9d216 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/system_wrappers/system_wrappers_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/system_wrappers/system_wrappers_gn/moz.build
+@@ -182,6 +182,21 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+         "/media/webrtc/trunk/webrtc/system_wrappers/source/trace_posix.cc"
+     ]
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["WEBRTC_THREAD_RR"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    UNIFIED_SOURCES += [
++        "/media/webrtc/trunk/webrtc/system_wrappers/source/atomic32_non_darwin_unix.cc",
++        "/media/webrtc/trunk/webrtc/system_wrappers/source/event_timer_posix.cc",
++        "/media/webrtc/trunk/webrtc/system_wrappers/source/rw_lock_posix.cc",
++        "/media/webrtc/trunk/webrtc/system_wrappers/source/trace_posix.cc"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -244,6 +259,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/video/video_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/video/video_gn/moz.build
+index 9c6209f30..bbdc46bfb 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/video/video_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/video/video_gn/moz.build
+@@ -144,6 +144,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -197,6 +205,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/video_engine/video_engine_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/video_engine/video_engine_gn/moz.build
+index 8f77e8dc2..96faf8ed2 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/video_engine/video_engine_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/video_engine/video_engine_gn/moz.build
+@@ -85,6 +85,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -130,6 +137,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/audio_coder_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/voice_engine/audio_coder_gn/moz.build
+index 312eb9217..02e17e852 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/audio_coder_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/voice_engine/audio_coder_gn/moz.build
+@@ -111,6 +111,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -164,6 +171,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/file_player_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/voice_engine/file_player_gn/moz.build
+index 09dbf9236..6887c038e 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/file_player_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/voice_engine/file_player_gn/moz.build
+@@ -112,6 +112,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -165,6 +172,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/file_recorder_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/voice_engine/file_recorder_gn/moz.build
+index b2e5cc794..933b937a5 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/file_recorder_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/voice_engine/file_recorder_gn/moz.build
+@@ -112,6 +112,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -165,6 +172,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/level_indicator_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/voice_engine/level_indicator_gn/moz.build
+index fc8ade6a3..1fb0837a7 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/level_indicator_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/voice_engine/level_indicator_gn/moz.build
+@@ -111,6 +111,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -164,6 +171,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/voice_engine_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/voice_engine/voice_engine_gn/moz.build
+index 02f2620ae..ce1097d2e 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/voice_engine_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/voice_engine/voice_engine_gn/moz.build
+@@ -149,6 +149,14 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -203,6 +211,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/webrtc_common_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/webrtc_common_gn/moz.build
+index d4bb93a58..8f323ca6f 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/webrtc_common_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/webrtc_common_gn/moz.build
+@@ -101,6 +101,13 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+     DEFINES["WEBRTC_POSIX"] = True
+     DEFINES["_FILE_OFFSET_BITS"] = "64"
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -150,6 +157,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/webrtc_gn/moz.build firefox-patched/media/webrtc/trunk/webrtc/webrtc_gn/moz.build
+index 41788f0c4..afea0b125 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/webrtc_gn/moz.build
++++ firefox-patched/media/webrtc/trunk/webrtc/webrtc_gn/moz.build
+@@ -198,6 +198,27 @@ if CONFIG["OS_TARGET"] == "OpenBSD":
+         "Xrender"
+     ]
+ 
++if CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_BUILD_LIBEVENT"] = True
++    DEFINES["WEBRTC_POSIX"] = True
++    DEFINES["WEBRTC_SOLARIS"] = True
++    DEFINES["_FILE_OFFSET_BITS"] = "64"
++
++    OS_LIBS += [
++        "X11",
++        "X11-xcb",
++        "xcb",
++        "Xcomposite",
++        "Xcursor",
++        "Xdamage",
++        "Xext",
++        "Xfixes",
++        "Xi",
++        "Xrender"
++    ]
++
+ if CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["CERT_CHAIN_PARA_HAS_EXTRA_FIELDS"] = True
+@@ -254,6 +275,10 @@ if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "OpenBSD":
+ 
+     DEFINES["_FORTIFY_SOURCE"] = "2"
+ 
++if not CONFIG["MOZ_DEBUG"] and CONFIG["OS_TARGET"] == "SunOS":
++
++    DEFINES["_FORTIFY_SOURCE"] = "2"
++
+ if CONFIG["MOZ_DEBUG"] == "1" and CONFIG["OS_TARGET"] == "WINNT":
+ 
+     DEFINES["_HAS_ITERATOR_DEBUGGING"] = "0"
+diff --git firefox-60.8.0/media/webrtc/webrtc.mozbuild firefox-patched/media/webrtc/webrtc.mozbuild
+index ace183728..0f5584f15 100644
+--- firefox-60.8.0/media/webrtc/webrtc.mozbuild
++++ firefox-patched/media/webrtc/webrtc.mozbuild
+@@ -19,6 +19,8 @@ if CONFIG['MOZ_WEBRTC']:
+         DEFINES['HAVE_WINSOCK2_H'] = True
+     elif CONFIG['OS_TARGET'] in ('DragonFly', 'FreeBSD', 'NetBSD', 'OpenBSD'):
+         DEFINES['WEBRTC_BSD'] = True
++    elif CONFIG['OS_TARGET'] == 'SunOS':
++        DEFINES['WEBRTC_SOLARIS'] = True
+     elif CONFIG['OS_TARGET'] == 'Android':
+         DEFINES['WEBRTC_ANDROID'] = True
+ 
+diff --git firefox-60.8.0/netwerk/sctp/src/moz.build firefox-patched/netwerk/sctp/src/moz.build
+index dd2af17ba..50c58b354 100644
+--- firefox-60.8.0/netwerk/sctp/src/moz.build
++++ firefox-patched/netwerk/sctp/src/moz.build
+@@ -86,6 +86,10 @@ if CONFIG['OS_TARGET'] == 'OpenBSD':
+ if CONFIG['OS_TARGET'] == 'DragonFly':
+     DEFINES['__DragonFly__'] = False
+ 
++if CONFIG['OS_TARGET'] == 'SunOS':
++    DEFINES['__sun'] = False
++    DEFINES['sun'] = False
++
+ NO_PGO = True # Don't PGO
+ 
+ if CONFIG['CC_TYPE'] in ('clang', 'gcc'):
+
+diff --git firefox-60.8.0/media/mtransport/common.build firefox-patched/media/mtransport/common.build
+index e8de9a91c..8d06a00a4 100644
+--- firefox-60.8.0/media/mtransport/common.build
++++ firefox-patched/media/mtransport/common.build
+@@ -62,6 +62,11 @@ elif CONFIG['OS_TARGET'] == 'Linux':
+     LOCAL_INCLUDES += [
+         '/media/mtransport/third_party/nrappkit/src/port/linux/include',
+     ]
++elif CONFIG['OS_TARGET'] == 'SunOS':
++    DEFINES['SOLARIS'] = True
++    LOCAL_INCLUDES += [
++        '/media/mtransport/third_party/nrappkit/src/port/linux/include',
++    ]
+ elif CONFIG['OS_TARGET'] == 'Android':
+     DEFINES['LINUX'] = True
+     DEFINES['ANDROID'] = True
+diff --git firefox-60.8.0/media/mtransport/third_party/nICEr/nicer.gyp firefox-patched/media/mtransport/third_party/nICEr/nicer.gyp
+index c4da4fbb9..8a2a89627 100644
+--- firefox-60.8.0/media/mtransport/third_party/nICEr/nicer.gyp
++++ firefox-patched/media/mtransport/third_party/nICEr/nicer.gyp
+@@ -154,6 +154,36 @@
+                     'BSD',
+                 ],
+               }],
++              ## Solaris
++              [ 'OS == "solaris"', {
++                'cflags_mozilla': [
++                    '-Wall',
++                    '-Wno-parentheses',
++                    '-Wno-strict-prototypes',
++                    '-Wmissing-prototypes',
++                    '-Wno-format',
++                    '-Wno-format-security',
++                 ],
++                 'defines' : [
++                     'HAVE_LIBM=1',
++                     'HAVE_STRDUP=1',
++                     'HAVE_STRLCPY=1',
++                     'HAVE_SYS_TIME_H=1',
++                     'HAVE_VFPRINTF=1',
++                     'SOLARIS',
++                     'NEW_STDIO'
++                     'RETSIGTYPE=void',
++                     'TIME_WITH_SYS_TIME_H=1',
++                     '__UNUSED__=__attribute__((unused))',
++                 ],
++
++		 'include_dirs': [
++		     '../nrappkit/src/port/darwin/include'
++		 ],
++
++		 'sources': [
++		 ],
++              }],
+               [ 'OS == "mac" or OS == "ios" or os_bsd == 1', {
+                 'cflags_mozilla': [
+                     '-Wall',
+diff --git firefox-60.8.0/media/mtransport/third_party/nICEr/src/ice/ice_socket.c firefox-patched/media/mtransport/third_party/nICEr/src/ice/ice_socket.c
+index f9251a280..1f39a3e43 100644
+--- firefox-60.8.0/media/mtransport/third_party/nICEr/src/ice/ice_socket.c
++++ firefox-patched/media/mtransport/third_party/nICEr/src/ice/ice_socket.c
+@@ -36,6 +36,8 @@ static char *RCSSTRING __UNUSED__="$Id: ice_socket.c,v 1.2 2008/04/28 17:59:01 e
+ 
+ #include <assert.h>
+ #include <string.h>
++#include <stddef.h>
++#include <limits.h>
+ #include "nr_api.h"
+ #include "ice_ctx.h"
+ #include "stun.h"
+diff --git firefox-60.8.0/media/mtransport/third_party/nICEr/src/stun/stun.h firefox-patched/media/mtransport/third_party/nICEr/src/stun/stun.h
+index 0d55b63a9..8eaf412a1 100644
+--- firefox-60.8.0/media/mtransport/third_party/nICEr/src/stun/stun.h
++++ firefox-patched/media/mtransport/third_party/nICEr/src/stun/stun.h
+@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <sys/socket.h>
+ #ifndef LINUX
+ #include <net/if.h>
+-#if !defined(__OpenBSD__) && !defined(__NetBSD__)
++#if !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__sun)
+ #include <net/if_var.h>
+ #endif
+ #include <net/if_dl.h>
+diff --git firefox-60.8.0/media/mtransport/third_party/nrappkit/nrappkit.gyp firefox-patched/media/mtransport/third_party/nrappkit/nrappkit.gyp
+index 614a6c7ac..c25ccbc0d 100644
+--- firefox-60.8.0/media/mtransport/third_party/nrappkit/nrappkit.gyp
++++ firefox-patched/media/mtransport/third_party/nrappkit/nrappkit.gyp
+@@ -153,6 +153,37 @@
+                     'BSD',
+                 ],
+               }],
++              ## Solaris
++              [ 'OS == "solaris"', {
++                'cflags_mozilla': [
++                    '-Wall',
++                    '-Wno-parentheses',
++                    '-Wno-strict-prototypes',
++                    '-Wmissing-prototypes',
++                    '-Wno-format',
++                    '-Wno-format-security',
++                 ],
++                 'defines' : [
++                     'HAVE_LIBM=1',
++                     'HAVE_STRDUP=1',
++                     'HAVE_STRLCPY=1',
++                     'HAVE_SYS_TIME_H=1',
++                     'HAVE_VFPRINTF=1',
++                     'SOLARIS',
++                     'NEW_STDIO'
++                     'RETSIGTYPE=void',
++                     'TIME_WITH_SYS_TIME_H=1',
++                     '__UNUSED__=__attribute__((unused))',
++                 ],
++
++		 'include_dirs': [
++		     'src/port/linux/include'
++		 ],
++
++		 'sources': [
++              	      './src/port/linux/include/csi_platform.h',
++		 ],
++              }],
+               [ 'OS == "mac" or OS == "ios" or os_bsd == 1', {
+                 'cflags_mozilla': [
+                     '-Wall',
+diff --git firefox-60.8.0/media/mtransport/third_party/nrappkit/src/util/libekr/r_crc32.c firefox-patched/media/mtransport/third_party/nrappkit/src/util/libekr/r_crc32.c
+index f1aca53ec..7575c6f48 100644
+--- firefox-60.8.0/media/mtransport/third_party/nrappkit/src/util/libekr/r_crc32.c
++++ firefox-patched/media/mtransport/third_party/nrappkit/src/util/libekr/r_crc32.c
+@@ -69,7 +69,7 @@
+ 
+ static char *RCSSTRING __UNUSED__ ="$Id: r_crc32.c,v 1.4 2008/11/26 03:22:02 adamcain Exp $";
+ 
+-#ifdef WIN32
++#if defined(WIN32) || defined(__sun)
+ #define u_int32_t  UINT4
+ #endif
+ 
+diff --git firefox_patched/media/webrtc/gn-configs/x64_False_x64_solaris.json firefox_patched/media/webrtc/gn-configs/x64_False_x64_solaris.json
+new file mode 100644
+index 000000000..b275bd99e
+--- /dev/null
++++ firefox_patched/media/webrtc/gn-configs/x64_False_x64_solaris.json
+@@ -0,0 +1,8244 @@
++{
++    "gn_gen_args": {
++        "host_cpu": "x64",
++        "is_debug": false,
++        "target_cpu": "x64",
++        "target_os": "solaris"
++    },
++    "mozbuild_args": {
++        "CPU_ARCH": "x86_64",
++        "HOST_CPU_ARCH": "x86_64",
++        "MOZ_DEBUG": null,
++        "OS_TARGET": "SunOS"
++    },
++    "sandbox_vars": {
++        "COMPILE_FLAGS": {
++            "WARNINGS_AS_ERRORS": []
++        },
++        "FINAL_LIBRARY": "webrtc"
++    },
++    "targets": {
++        "//webrtc/api:audio_mixer_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O3",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/audio/audio_mixer.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/api:call_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/api:transport_api",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/call/audio_sink.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/api:transport_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/call/transport.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/api:video_frame_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/video/i420_buffer.cc",
++                "//webrtc/api/video/i420_buffer.h",
++                "//webrtc/api/video/video_frame.cc",
++                "//webrtc/api/video/video_frame.h",
++                "//webrtc/api/video/video_frame_buffer.h",
++                "//webrtc/api/video/video_rotation.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/audio/utility:audio_frame_operations": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_format_conversion"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/audio/utility/audio_frame_operations.cc",
++                "//webrtc/audio/utility/audio_frame_operations.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/audio:audio": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/api:call_api",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_device:audio_device",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/modules/congestion_controller:congestion_controller",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:voice_engine"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/audio/audio_receive_stream.cc",
++                "//webrtc/audio/audio_receive_stream.h",
++                "//webrtc/audio/audio_send_stream.cc",
++                "//webrtc/audio/audio_send_stream.h",
++                "//webrtc/audio/audio_state.cc",
++                "//webrtc/audio/audio_state.h",
++                "//webrtc/audio/audio_transport_proxy.cc",
++                "//webrtc/audio/audio_transport_proxy.h",
++                "//webrtc/audio/conversion.h",
++                "//webrtc/audio/scoped_voe_interface.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/base:gtest_prod": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/gtest_prod_util.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/base:rtc_base_approved": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/array_view.h",
++                "//webrtc/base/arraysize.h",
++                "//webrtc/base/atomicops.h",
++                "//webrtc/base/base64.cc",
++                "//webrtc/base/base64.h",
++                "//webrtc/base/basictypes.h",
++                "//webrtc/base/bind.h",
++                "//webrtc/base/bitbuffer.cc",
++                "//webrtc/base/bitbuffer.h",
++                "//webrtc/base/buffer.h",
++                "//webrtc/base/bufferqueue.cc",
++                "//webrtc/base/bufferqueue.h",
++                "//webrtc/base/bytebuffer.cc",
++                "//webrtc/base/bytebuffer.h",
++                "//webrtc/base/byteorder.h",
++                "//webrtc/base/checks.cc",
++                "//webrtc/base/checks.h",
++                "//webrtc/base/constructormagic.h",
++                "//webrtc/base/copyonwritebuffer.cc",
++                "//webrtc/base/copyonwritebuffer.h",
++                "//webrtc/base/criticalsection.cc",
++                "//webrtc/base/criticalsection.h",
++                "//webrtc/base/deprecation.h",
++                "//webrtc/base/event.cc",
++                "//webrtc/base/event.h",
++                "//webrtc/base/event_tracer.cc",
++                "//webrtc/base/event_tracer.h",
++                "//webrtc/base/file.cc",
++                "//webrtc/base/file.h",
++                "//webrtc/base/flags.cc",
++                "//webrtc/base/flags.h",
++                "//webrtc/base/format_macros.h",
++                "//webrtc/base/function_view.h",
++                "//webrtc/base/ignore_wundef.h",
++                "//webrtc/base/location.cc",
++                "//webrtc/base/location.h",
++                "//webrtc/base/md5.cc",
++                "//webrtc/base/md5.h",
++                "//webrtc/base/md5digest.cc",
++                "//webrtc/base/md5digest.h",
++                "//webrtc/base/mod_ops.h",
++                "//webrtc/base/onetimeevent.h",
++                "//webrtc/base/optional.cc",
++                "//webrtc/base/optional.h",
++                "//webrtc/base/pathutils.cc",
++                "//webrtc/base/pathutils.h",
++                "//webrtc/base/platform_file.cc",
++                "//webrtc/base/platform_file.h",
++                "//webrtc/base/platform_thread.cc",
++                "//webrtc/base/platform_thread.h",
++                "//webrtc/base/platform_thread_types.h",
++                "//webrtc/base/race_checker.cc",
++                "//webrtc/base/race_checker.h",
++                "//webrtc/base/random.cc",
++                "//webrtc/base/random.h",
++                "//webrtc/base/rate_limiter.cc",
++                "//webrtc/base/rate_limiter.h",
++                "//webrtc/base/rate_statistics.cc",
++                "//webrtc/base/rate_statistics.h",
++                "//webrtc/base/ratetracker.cc",
++                "//webrtc/base/ratetracker.h",
++                "//webrtc/base/refcount.h",
++                "//webrtc/base/refcountedobject.h",
++                "//webrtc/base/safe_compare.h",
++                "//webrtc/base/safe_conversions.h",
++                "//webrtc/base/safe_conversions_impl.h",
++                "//webrtc/base/sanitizer.h",
++                "//webrtc/base/scoped_ref_ptr.h",
++                "//webrtc/base/stringencode.cc",
++                "//webrtc/base/stringencode.h",
++                "//webrtc/base/stringutils.cc",
++                "//webrtc/base/stringutils.h",
++                "//webrtc/base/swap_queue.h",
++                "//webrtc/base/template_util.h",
++                "//webrtc/base/thread_annotations.h",
++                "//webrtc/base/thread_checker.h",
++                "//webrtc/base/thread_checker_impl.cc",
++                "//webrtc/base/thread_checker_impl.h",
++                "//webrtc/base/timestampaligner.cc",
++                "//webrtc/base/timestampaligner.h",
++                "//webrtc/base/timeutils.cc",
++                "//webrtc/base/timeutils.h",
++                "//webrtc/base/trace_event.h",
++                "//webrtc/base/type_traits.h",
++                "//webrtc/base/file_posix.cc",
++                "//webrtc/base/logging.cc",
++                "//webrtc/base/logging.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/base:rtc_numerics": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/numerics/exp_filter.cc",
++                "//webrtc/base/numerics/exp_filter.h",
++                "//webrtc/base/numerics/percentile_filter.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/base:rtc_task_queue": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_BUILD_LIBEVENT",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "/ipc/chromium/src/third_party/libevent/include/",
++                "/ipc/chromium/src/third_party/libevent/linux/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/sequenced_task_checker.h",
++                "//webrtc/base/sequenced_task_checker_impl.cc",
++                "//webrtc/base/sequenced_task_checker_impl.h",
++                "//webrtc/base/weak_ptr.cc",
++                "//webrtc/base/weak_ptr.h",
++                "//webrtc/base/task_queue.h",
++                "//webrtc/base/task_queue_posix.h",
++                "//webrtc/base/task_queue_libevent.cc",
++                "//webrtc/base/task_queue_posix.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/call:call": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:call_api",
++                "//webrtc/api:transport_api",
++                "//webrtc/audio:audio",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/logging:rtc_event_log_impl",
++                "//webrtc/modules/congestion_controller:congestion_controller",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/video:video"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/call/bitrate_allocator.cc",
++                "//webrtc/call/call.cc",
++                "//webrtc/call/flexfec_receive_stream_impl.cc",
++                "//webrtc/call/flexfec_receive_stream_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/call:call_interfaces": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/call/audio_receive_stream.h",
++                "//webrtc/call/audio_send_stream.h",
++                "//webrtc/call/audio_state.h",
++                "//webrtc/call/call.h",
++                "//webrtc/call/flexfec_receive_stream.h",
++                "//webrtc/call/audio_send_stream_call.cc"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/common_audio:common_audio": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/common_audio:common_audio_c",
++                "//webrtc/common_audio:common_audio_sse2",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_audio/audio_converter.cc",
++                "//webrtc/common_audio/audio_converter.h",
++                "//webrtc/common_audio/audio_ring_buffer.cc",
++                "//webrtc/common_audio/audio_ring_buffer.h",
++                "//webrtc/common_audio/audio_util.cc",
++                "//webrtc/common_audio/blocker.cc",
++                "//webrtc/common_audio/blocker.h",
++                "//webrtc/common_audio/channel_buffer.cc",
++                "//webrtc/common_audio/channel_buffer.h",
++                "//webrtc/common_audio/fir_filter.cc",
++                "//webrtc/common_audio/fir_filter.h",
++                "//webrtc/common_audio/fir_filter_neon.h",
++                "//webrtc/common_audio/fir_filter_sse.h",
++                "//webrtc/common_audio/include/audio_util.h",
++                "//webrtc/common_audio/lapped_transform.cc",
++                "//webrtc/common_audio/lapped_transform.h",
++                "//webrtc/common_audio/real_fourier.cc",
++                "//webrtc/common_audio/real_fourier.h",
++                "//webrtc/common_audio/real_fourier_ooura.cc",
++                "//webrtc/common_audio/real_fourier_ooura.h",
++                "//webrtc/common_audio/resampler/include/push_resampler.h",
++                "//webrtc/common_audio/resampler/include/resampler.h",
++                "//webrtc/common_audio/resampler/push_resampler.cc",
++                "//webrtc/common_audio/resampler/push_sinc_resampler.cc",
++                "//webrtc/common_audio/resampler/push_sinc_resampler.h",
++                "//webrtc/common_audio/resampler/resampler.cc",
++                "//webrtc/common_audio/resampler/sinc_resampler.cc",
++                "//webrtc/common_audio/resampler/sinc_resampler.h",
++                "//webrtc/common_audio/smoothing_filter.cc",
++                "//webrtc/common_audio/smoothing_filter.h",
++                "//webrtc/common_audio/sparse_fir_filter.cc",
++                "//webrtc/common_audio/sparse_fir_filter.h",
++                "//webrtc/common_audio/vad/include/vad.h",
++                "//webrtc/common_audio/vad/vad.cc",
++                "//webrtc/common_audio/wav_file.cc",
++                "//webrtc/common_audio/wav_file.h",
++                "//webrtc/common_audio/wav_header.cc",
++                "//webrtc/common_audio/wav_header.h",
++                "//webrtc/common_audio/window_generator.cc",
++                "//webrtc/common_audio/window_generator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/common_audio:common_audio_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_audio/fft4g.c",
++                "//webrtc/common_audio/fft4g.h",
++                "//webrtc/common_audio/ring_buffer.c",
++                "//webrtc/common_audio/ring_buffer.h",
++                "//webrtc/common_audio/signal_processing/auto_corr_to_refl_coef.c",
++                "//webrtc/common_audio/signal_processing/auto_correlation.c",
++                "//webrtc/common_audio/signal_processing/complex_fft_tables.h",
++                "//webrtc/common_audio/signal_processing/copy_set_operations.c",
++                "//webrtc/common_audio/signal_processing/cross_correlation.c",
++                "//webrtc/common_audio/signal_processing/division_operations.c",
++                "//webrtc/common_audio/signal_processing/dot_product_with_scale.c",
++                "//webrtc/common_audio/signal_processing/downsample_fast.c",
++                "//webrtc/common_audio/signal_processing/energy.c",
++                "//webrtc/common_audio/signal_processing/filter_ar.c",
++                "//webrtc/common_audio/signal_processing/filter_ma_fast_q12.c",
++                "//webrtc/common_audio/signal_processing/get_hanning_window.c",
++                "//webrtc/common_audio/signal_processing/get_scaling_square.c",
++                "//webrtc/common_audio/signal_processing/ilbc_specific_functions.c",
++                "//webrtc/common_audio/signal_processing/include/real_fft.h",
++                "//webrtc/common_audio/signal_processing/include/signal_processing_library.h",
++                "//webrtc/common_audio/signal_processing/include/spl_inl.h",
++                "//webrtc/common_audio/signal_processing/levinson_durbin.c",
++                "//webrtc/common_audio/signal_processing/lpc_to_refl_coef.c",
++                "//webrtc/common_audio/signal_processing/min_max_operations.c",
++                "//webrtc/common_audio/signal_processing/randomization_functions.c",
++                "//webrtc/common_audio/signal_processing/real_fft.c",
++                "//webrtc/common_audio/signal_processing/refl_coef_to_lpc.c",
++                "//webrtc/common_audio/signal_processing/resample.c",
++                "//webrtc/common_audio/signal_processing/resample_48khz.c",
++                "//webrtc/common_audio/signal_processing/resample_by_2.c",
++                "//webrtc/common_audio/signal_processing/resample_by_2_internal.c",
++                "//webrtc/common_audio/signal_processing/resample_by_2_internal.h",
++                "//webrtc/common_audio/signal_processing/resample_fractional.c",
++                "//webrtc/common_audio/signal_processing/spl_init.c",
++                "//webrtc/common_audio/signal_processing/spl_inl.c",
++                "//webrtc/common_audio/signal_processing/spl_sqrt.c",
++                "//webrtc/common_audio/signal_processing/splitting_filter.c",
++                "//webrtc/common_audio/signal_processing/sqrt_of_one_minus_x_squared.c",
++                "//webrtc/common_audio/signal_processing/vector_scaling_operations.c",
++                "//webrtc/common_audio/vad/include/webrtc_vad.h",
++                "//webrtc/common_audio/vad/vad_core.c",
++                "//webrtc/common_audio/vad/vad_core.h",
++                "//webrtc/common_audio/vad/vad_filterbank.c",
++                "//webrtc/common_audio/vad/vad_filterbank.h",
++                "//webrtc/common_audio/vad/vad_gmm.c",
++                "//webrtc/common_audio/vad/vad_gmm.h",
++                "//webrtc/common_audio/vad/vad_sp.c",
++                "//webrtc/common_audio/vad/vad_sp.h",
++                "//webrtc/common_audio/vad/webrtc_vad.c",
++                "//webrtc/common_audio/signal_processing/complex_fft.c",
++                "//webrtc/common_audio/signal_processing/complex_bit_reverse.c",
++                "//webrtc/common_audio/signal_processing/filter_ar_fast_q12.c",
++                "//webrtc/common_audio/signal_processing/spl_sqrt_floor.c"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/common_audio:common_audio_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_audio/fir_filter_sse.cc",
++                "//webrtc/common_audio/resampler/sinc_resampler_sse.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/common_video:common_video": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:video_frame_api",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//webrtc/modules/interface/",
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_video/bitrate_adjuster.cc",
++                "//webrtc/common_video/h264/h264_bitstream_parser.cc",
++                "//webrtc/common_video/h264/h264_bitstream_parser.h",
++                "//webrtc/common_video/h264/h264_common.cc",
++                "//webrtc/common_video/h264/h264_common.h",
++                "//webrtc/common_video/h264/pps_parser.cc",
++                "//webrtc/common_video/h264/pps_parser.h",
++                "//webrtc/common_video/h264/profile_level_id.cc",
++                "//webrtc/common_video/h264/profile_level_id.h",
++                "//webrtc/common_video/h264/sps_parser.cc",
++                "//webrtc/common_video/h264/sps_parser.h",
++                "//webrtc/common_video/h264/sps_vui_rewriter.cc",
++                "//webrtc/common_video/h264/sps_vui_rewriter.h",
++                "//webrtc/common_video/i420_buffer_pool.cc",
++                "//webrtc/common_video/include/bitrate_adjuster.h",
++                "//webrtc/common_video/include/frame_callback.h",
++                "//webrtc/common_video/include/i420_buffer_pool.h",
++                "//webrtc/common_video/include/incoming_video_stream.h",
++                "//webrtc/common_video/include/video_bitrate_allocator.h",
++                "//webrtc/common_video/include/video_frame_buffer.h",
++                "//webrtc/common_video/incoming_video_stream.cc",
++                "//webrtc/common_video/libyuv/include/webrtc_libyuv.h",
++                "//webrtc/common_video/libyuv/webrtc_libyuv.cc",
++                "//webrtc/common_video/video_frame.cc",
++                "//webrtc/common_video/video_frame_buffer.cc",
++                "//webrtc/common_video/video_render_frames.cc",
++                "//webrtc/common_video/video_render_frames.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/logging:rtc_event_log_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/logging/rtc_event_log/rtc_event_log.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/logging:rtc_event_log_impl": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/logging/rtc_event_log/ringbuffer.h",
++                "//webrtc/logging/rtc_event_log/rtc_event_log.cc",
++                "//webrtc/logging/rtc_event_log/rtc_event_log_helper_thread.cc",
++                "//webrtc/logging/rtc_event_log/rtc_event_log_helper_thread.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/media:mozilla_rtc_media": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/media/base/videoadapter.cc",
++                "//webrtc/media/base/videoadapter.h",
++                "//webrtc/media/base/videobroadcaster.cc",
++                "//webrtc/media/base/videobroadcaster.h",
++                "//webrtc/media/base/videosourcebase.cc",
++                "//webrtc/media/base/videosourcebase.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_coding": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:neteq",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/audio_coding:webrtc_opus",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/acm2/acm_common_defs.h",
++                "//webrtc/modules/audio_coding/acm2/acm_receiver.cc",
++                "//webrtc/modules/audio_coding/acm2/acm_receiver.h",
++                "//webrtc/modules/audio_coding/acm2/acm_resampler.cc",
++                "//webrtc/modules/audio_coding/acm2/acm_resampler.h",
++                "//webrtc/modules/audio_coding/acm2/audio_coding_module.cc",
++                "//webrtc/modules/audio_coding/acm2/call_statistics.cc",
++                "//webrtc/modules/audio_coding/acm2/call_statistics.h",
++                "//webrtc/modules/audio_coding/acm2/codec_manager.cc",
++                "//webrtc/modules/audio_coding/acm2/codec_manager.h",
++                "//webrtc/modules/audio_coding/include/audio_coding_module.h",
++                "//webrtc/modules/audio_coding/include/audio_coding_module_typedefs.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_decoder_factory_interface": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_format",
++                "//webrtc/modules/audio_coding:audio_format_conversion"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_decoder_factory.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:audio_decoder_interface": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_decoder.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_decoder.h",
++                "//webrtc/modules/audio_coding/codecs/legacy_encoded_audio_frame.cc",
++                "//webrtc/modules/audio_coding/codecs/legacy_encoded_audio_frame.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_encoder_interface": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_encoder.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_encoder.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_format": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_format.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_format.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_format_conversion": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_format"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_format_conversion.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_format_conversion.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_network_adaptor": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/audio_network_adaptor/audio_network_adaptor.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/audio_network_adaptor_impl.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/audio_network_adaptor_impl.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/bitrate_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/bitrate_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/channel_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/channel_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller_manager.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller_manager.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/debug_dump_writer.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/debug_dump_writer.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/dtx_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/dtx_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/fec_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/fec_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/frame_length_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/frame_length_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/include/audio_network_adaptor.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:builtin_audio_decoder_factory": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:webrtc_opus"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/builtin_audio_decoder_factory.cc",
++                "//webrtc/modules/audio_coding/codecs/builtin_audio_decoder_factory.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:cng": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_encoder_interface"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/cng/audio_encoder_cng.cc",
++                "//webrtc/modules/audio_coding/codecs/cng/audio_encoder_cng.h",
++                "//webrtc/modules/audio_coding/codecs/cng/webrtc_cng.cc",
++                "//webrtc/modules/audio_coding/codecs/cng/webrtc_cng.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:g711": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:g711_c"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g711/audio_decoder_pcm.cc",
++                "//webrtc/modules/audio_coding/codecs/g711/audio_decoder_pcm.h",
++                "//webrtc/modules/audio_coding/codecs/g711/audio_encoder_pcm.cc",
++                "//webrtc/modules/audio_coding/codecs/g711/audio_encoder_pcm.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:g711_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g711/g711.c",
++                "//webrtc/modules/audio_coding/codecs/g711/g711.h",
++                "//webrtc/modules/audio_coding/codecs/g711/g711_interface.c",
++                "//webrtc/modules/audio_coding/codecs/g711/g711_interface.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:g722": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:g722_c"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g722/audio_decoder_g722.cc",
++                "//webrtc/modules/audio_coding/codecs/g722/audio_decoder_g722.h",
++                "//webrtc/modules/audio_coding/codecs/g722/audio_encoder_g722.cc",
++                "//webrtc/modules/audio_coding/codecs/g722/audio_encoder_g722.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:g722_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g722/g722_decode.c",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_enc_dec.h",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_encode.c",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_interface.c",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_interface.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:isac": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:isac_c",
++                "//webrtc/modules/audio_coding:isac_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/audio_decoder_isac.cc",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/audio_encoder_isac.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:isac_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/audio_decoder_isac.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/audio_encoder_isac.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/isac.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines_hist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines_logist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/bandwidth_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/bandwidth_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/codec.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/crc.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/crc.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/decode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/decode_bwe.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/encode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/encode_lpc_swb.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/encode_lpc_swb.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/entropy_coding.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/entropy_coding.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/fft.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/fft.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filter_functions.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filterbank_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filterbank_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filterbanks.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/intialize.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/isac.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/isac_float_type.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lattice.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_analysis.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_analysis.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_gain_swb_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_gain_swb_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb12_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb12_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb16_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb16_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/os_specific_inline.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_filter.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_gain_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_gain_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_lag_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_lag_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/settings.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/spectrum_ar_model_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/spectrum_ar_model_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/structs.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/transform.c"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_common": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_encoder_interface"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/audio_encoder_isac_t.h",
++                "//webrtc/modules/audio_coding/codecs/isac/audio_encoder_isac_t_impl.h",
++                "//webrtc/modules/audio_coding/codecs/isac/locked_bandwidth_info.cc",
++                "//webrtc/modules/audio_coding/codecs/isac/locked_bandwidth_info.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_fix": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:isac_common",
++                "//webrtc/modules/audio_coding:isac_fix_c",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/audio_decoder_isacfix.cc",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/audio_encoder_isacfix.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_fix_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:isac_common",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/audio_decoder_isacfix.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/audio_encoder_isacfix.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/isacfix.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routines.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routines_hist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routines_logist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routins.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/bandwidth_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/bandwidth_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/codec.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/decode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/decode_bwe.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/decode_plc.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/encode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/entropy_coding.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/entropy_coding.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/fft.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/fft.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filterbank_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filterbank_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filterbanks.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filters.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/initialize.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/isac_fix_type.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/isacfix.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lattice.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lattice_c.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_masking_model.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_masking_model.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_estimator_c.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_filter.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_filter_c.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_gain_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_gain_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_lag_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_lag_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/settings.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/spectrum_ar_model_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/spectrum_ar_model_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/structs.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/transform.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/transform_tables.c"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:neteq": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_ISAC",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:gtest_prod",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_format",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:isac_fix",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/audio_coding:webrtc_opus",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/neteq/accelerate.cc",
++                "//webrtc/modules/audio_coding/neteq/accelerate.h",
++                "//webrtc/modules/audio_coding/neteq/audio_decoder_impl.cc",
++                "//webrtc/modules/audio_coding/neteq/audio_decoder_impl.h",
++                "//webrtc/modules/audio_coding/neteq/audio_multi_vector.cc",
++                "//webrtc/modules/audio_coding/neteq/audio_multi_vector.h",
++                "//webrtc/modules/audio_coding/neteq/audio_vector.cc",
++                "//webrtc/modules/audio_coding/neteq/audio_vector.h",
++                "//webrtc/modules/audio_coding/neteq/background_noise.cc",
++                "//webrtc/modules/audio_coding/neteq/background_noise.h",
++                "//webrtc/modules/audio_coding/neteq/buffer_level_filter.cc",
++                "//webrtc/modules/audio_coding/neteq/buffer_level_filter.h",
++                "//webrtc/modules/audio_coding/neteq/comfort_noise.cc",
++                "//webrtc/modules/audio_coding/neteq/comfort_noise.h",
++                "//webrtc/modules/audio_coding/neteq/cross_correlation.cc",
++                "//webrtc/modules/audio_coding/neteq/cross_correlation.h",
++                "//webrtc/modules/audio_coding/neteq/decision_logic.cc",
++                "//webrtc/modules/audio_coding/neteq/decision_logic.h",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_fax.cc",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_fax.h",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_normal.cc",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_normal.h",
++                "//webrtc/modules/audio_coding/neteq/decoder_database.cc",
++                "//webrtc/modules/audio_coding/neteq/decoder_database.h",
++                "//webrtc/modules/audio_coding/neteq/defines.h",
++                "//webrtc/modules/audio_coding/neteq/delay_manager.cc",
++                "//webrtc/modules/audio_coding/neteq/delay_manager.h",
++                "//webrtc/modules/audio_coding/neteq/delay_peak_detector.cc",
++                "//webrtc/modules/audio_coding/neteq/delay_peak_detector.h",
++                "//webrtc/modules/audio_coding/neteq/dsp_helper.cc",
++                "//webrtc/modules/audio_coding/neteq/dsp_helper.h",
++                "//webrtc/modules/audio_coding/neteq/dtmf_buffer.cc",
++                "//webrtc/modules/audio_coding/neteq/dtmf_buffer.h",
++                "//webrtc/modules/audio_coding/neteq/dtmf_tone_generator.cc",
++                "//webrtc/modules/audio_coding/neteq/dtmf_tone_generator.h",
++                "//webrtc/modules/audio_coding/neteq/expand.cc",
++                "//webrtc/modules/audio_coding/neteq/expand.h",
++                "//webrtc/modules/audio_coding/neteq/include/neteq.h",
++                "//webrtc/modules/audio_coding/neteq/merge.cc",
++                "//webrtc/modules/audio_coding/neteq/merge.h",
++                "//webrtc/modules/audio_coding/neteq/nack_tracker.cc",
++                "//webrtc/modules/audio_coding/neteq/nack_tracker.h",
++                "//webrtc/modules/audio_coding/neteq/neteq.cc",
++                "//webrtc/modules/audio_coding/neteq/neteq_impl.cc",
++                "//webrtc/modules/audio_coding/neteq/neteq_impl.h",
++                "//webrtc/modules/audio_coding/neteq/normal.cc",
++                "//webrtc/modules/audio_coding/neteq/normal.h",
++                "//webrtc/modules/audio_coding/neteq/packet.cc",
++                "//webrtc/modules/audio_coding/neteq/packet.h",
++                "//webrtc/modules/audio_coding/neteq/packet_buffer.cc",
++                "//webrtc/modules/audio_coding/neteq/packet_buffer.h",
++                "//webrtc/modules/audio_coding/neteq/post_decode_vad.cc",
++                "//webrtc/modules/audio_coding/neteq/post_decode_vad.h",
++                "//webrtc/modules/audio_coding/neteq/preemptive_expand.cc",
++                "//webrtc/modules/audio_coding/neteq/preemptive_expand.h",
++                "//webrtc/modules/audio_coding/neteq/random_vector.cc",
++                "//webrtc/modules/audio_coding/neteq/random_vector.h",
++                "//webrtc/modules/audio_coding/neteq/red_payload_splitter.cc",
++                "//webrtc/modules/audio_coding/neteq/red_payload_splitter.h",
++                "//webrtc/modules/audio_coding/neteq/rtcp.cc",
++                "//webrtc/modules/audio_coding/neteq/rtcp.h",
++                "//webrtc/modules/audio_coding/neteq/statistics_calculator.cc",
++                "//webrtc/modules/audio_coding/neteq/statistics_calculator.h",
++                "//webrtc/modules/audio_coding/neteq/sync_buffer.cc",
++                "//webrtc/modules/audio_coding/neteq/sync_buffer.h",
++                "//webrtc/modules/audio_coding/neteq/tick_timer.cc",
++                "//webrtc/modules/audio_coding/neteq/tick_timer.h",
++                "//webrtc/modules/audio_coding/neteq/time_stretch.cc",
++                "//webrtc/modules/audio_coding/neteq/time_stretch.h",
++                "//webrtc/modules/audio_coding/neteq/timestamp_scaler.cc",
++                "//webrtc/modules/audio_coding/neteq/timestamp_scaler.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:pcm16b": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:pcm16b_c"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_decoder_pcm16b.cc",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_decoder_pcm16b.h",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_encoder_pcm16b.cc",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_encoder_pcm16b.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:pcm16b_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/pcm16b/pcm16b.c",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/pcm16b.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:rent_a_codec": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:webrtc_opus"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/acm2/acm_codec_database.cc",
++                "//webrtc/modules/audio_coding/acm2/acm_codec_database.h",
++                "//webrtc/modules/audio_coding/acm2/rent_a_codec.cc",
++                "//webrtc/modules/audio_coding/acm2/rent_a_codec.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:webrtc_opus": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_OPUS_VARIABLE_COMPLEXITY=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:audio_network_adaptor",
++                "//webrtc/modules/audio_coding:webrtc_opus_c",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/include/opus/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/opus/audio_decoder_opus.cc",
++                "//webrtc/modules/audio_coding/codecs/opus/audio_decoder_opus.h",
++                "//webrtc/modules/audio_coding/codecs/opus/audio_encoder_opus.cc",
++                "//webrtc/modules/audio_coding/codecs/opus/audio_encoder_opus.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:webrtc_opus_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "/media/libopus/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/opus/opus_inst.h",
++                "//webrtc/modules/audio_coding/codecs/opus/opus_interface.c",
++                "//webrtc/modules/audio_coding/codecs/opus/opus_interface.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_conference_mixer:audio_conference_mixer": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_conference_mixer/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_conference_mixer/include/audio_conference_mixer.h",
++                "//webrtc/modules/audio_conference_mixer/include/audio_conference_mixer_defines.h",
++                "//webrtc/modules/audio_conference_mixer/source/audio_conference_mixer_impl.cc",
++                "//webrtc/modules/audio_conference_mixer/source/audio_conference_mixer_impl.h",
++                "//webrtc/modules/audio_conference_mixer/source/audio_frame_manipulator.cc",
++                "//webrtc/modules/audio_conference_mixer/source/audio_frame_manipulator.h",
++                "//webrtc/modules/audio_conference_mixer/source/memory_pool.h",
++                "//webrtc/modules/audio_conference_mixer/source/memory_pool_posix.h",
++                "//webrtc/modules/audio_conference_mixer/source/time_scheduler.cc",
++                "//webrtc/modules/audio_conference_mixer/source/time_scheduler.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_device:audio_device": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_DUMMY_AUDIO_BUILD",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_device/audio_device_buffer.cc",
++                "//webrtc/modules/audio_device/audio_device_buffer.h",
++                "//webrtc/modules/audio_device/audio_device_config.h",
++                "//webrtc/modules/audio_device/audio_device_generic.cc",
++                "//webrtc/modules/audio_device/audio_device_generic.h",
++                "//webrtc/modules/audio_device/dummy/audio_device_dummy.cc",
++                "//webrtc/modules/audio_device/dummy/audio_device_dummy.h",
++                "//webrtc/modules/audio_device/dummy/file_audio_device.cc",
++                "//webrtc/modules/audio_device/dummy/file_audio_device.h",
++                "//webrtc/modules/audio_device/fine_audio_buffer.cc",
++                "//webrtc/modules/audio_device/fine_audio_buffer.h",
++                "//webrtc/modules/audio_device/include/audio_device.h",
++                "//webrtc/modules/audio_device/include/audio_device_defines.h",
++                "//webrtc/modules/audio_device/opensl/single_rw_fifo.cc",
++                "//webrtc/modules/audio_device/opensl/single_rw_fifo.h",
++                "//webrtc/modules/audio_device/dummy/file_audio_device_factory.cc",
++                "//webrtc/modules/audio_device/dummy/file_audio_device_factory.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_mixer:audio_frame_manipulator": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/audio/utility:utility",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_mixer/audio_frame_manipulator.cc",
++                "//webrtc/modules/audio_mixer/audio_frame_manipulator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_mixer:audio_mixer_impl": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_mixer:audio_frame_manipulator",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_mixer/audio_mixer_impl.cc",
++                "//webrtc/modules/audio_mixer/audio_mixer_impl.h",
++                "//webrtc/modules/audio_mixer/default_output_rate_calculator.cc",
++                "//webrtc/modules/audio_mixer/default_output_rate_calculator.h",
++                "//webrtc/modules/audio_mixer/output_rate_calculator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_processing:audio_processing": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_APM_DEBUG_DUMP=1",
++                "WEBRTC_INTELLIGIBILITY_ENHANCER=0",
++                "WEBRTC_NS_FLOAT",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:gtest_prod",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_processing:audio_processing_c",
++                "//webrtc/modules/audio_processing:audio_processing_sse2",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_processing/aec/aec_core.cc",
++                "//webrtc/modules/audio_processing/aec/aec_core.h",
++                "//webrtc/modules/audio_processing/aec/aec_core_optimized_methods.h",
++                "//webrtc/modules/audio_processing/aec/aec_resampler.cc",
++                "//webrtc/modules/audio_processing/aec/aec_resampler.h",
++                "//webrtc/modules/audio_processing/aec/echo_cancellation.cc",
++                "//webrtc/modules/audio_processing/aec/echo_cancellation.h",
++                "//webrtc/modules/audio_processing/aec3/aec3_constants.h",
++                "//webrtc/modules/audio_processing/aec3/block_framer.cc",
++                "//webrtc/modules/audio_processing/aec3/block_framer.h",
++                "//webrtc/modules/audio_processing/aec3/block_processor.cc",
++                "//webrtc/modules/audio_processing/aec3/block_processor.h",
++                "//webrtc/modules/audio_processing/aec3/cascaded_biquad_filter.cc",
++                "//webrtc/modules/audio_processing/aec3/cascaded_biquad_filter.h",
++                "//webrtc/modules/audio_processing/aec3/echo_canceller3.cc",
++                "//webrtc/modules/audio_processing/aec3/echo_canceller3.h",
++                "//webrtc/modules/audio_processing/aec3/frame_blocker.cc",
++                "//webrtc/modules/audio_processing/aec3/frame_blocker.h",
++                "//webrtc/modules/audio_processing/aecm/aecm_core.cc",
++                "//webrtc/modules/audio_processing/aecm/aecm_core.h",
++                "//webrtc/modules/audio_processing/aecm/echo_control_mobile.cc",
++                "//webrtc/modules/audio_processing/aecm/echo_control_mobile.h",
++                "//webrtc/modules/audio_processing/agc/agc.cc",
++                "//webrtc/modules/audio_processing/agc/agc.h",
++                "//webrtc/modules/audio_processing/agc/agc_manager_direct.cc",
++                "//webrtc/modules/audio_processing/agc/agc_manager_direct.h",
++                "//webrtc/modules/audio_processing/agc/gain_map_internal.h",
++                "//webrtc/modules/audio_processing/agc/loudness_histogram.cc",
++                "//webrtc/modules/audio_processing/agc/loudness_histogram.h",
++                "//webrtc/modules/audio_processing/agc/utility.cc",
++                "//webrtc/modules/audio_processing/agc/utility.h",
++                "//webrtc/modules/audio_processing/audio_buffer.cc",
++                "//webrtc/modules/audio_processing/audio_buffer.h",
++                "//webrtc/modules/audio_processing/audio_processing_impl.cc",
++                "//webrtc/modules/audio_processing/audio_processing_impl.h",
++                "//webrtc/modules/audio_processing/beamformer/array_util.cc",
++                "//webrtc/modules/audio_processing/beamformer/array_util.h",
++                "//webrtc/modules/audio_processing/beamformer/complex_matrix.h",
++                "//webrtc/modules/audio_processing/beamformer/covariance_matrix_generator.cc",
++                "//webrtc/modules/audio_processing/beamformer/covariance_matrix_generator.h",
++                "//webrtc/modules/audio_processing/beamformer/matrix.h",
++                "//webrtc/modules/audio_processing/beamformer/nonlinear_beamformer.cc",
++                "//webrtc/modules/audio_processing/beamformer/nonlinear_beamformer.h",
++                "//webrtc/modules/audio_processing/common.h",
++                "//webrtc/modules/audio_processing/echo_cancellation_impl.cc",
++                "//webrtc/modules/audio_processing/echo_cancellation_impl.h",
++                "//webrtc/modules/audio_processing/echo_control_mobile_impl.cc",
++                "//webrtc/modules/audio_processing/echo_control_mobile_impl.h",
++                "//webrtc/modules/audio_processing/echo_detector/circular_buffer.cc",
++                "//webrtc/modules/audio_processing/echo_detector/circular_buffer.h",
++                "//webrtc/modules/audio_processing/echo_detector/mean_variance_estimator.cc",
++                "//webrtc/modules/audio_processing/echo_detector/mean_variance_estimator.h",
++                "//webrtc/modules/audio_processing/echo_detector/moving_max.cc",
++                "//webrtc/modules/audio_processing/echo_detector/moving_max.h",
++                "//webrtc/modules/audio_processing/echo_detector/normalized_covariance_estimator.cc",
++                "//webrtc/modules/audio_processing/echo_detector/normalized_covariance_estimator.h",
++                "//webrtc/modules/audio_processing/gain_control_for_experimental_agc.cc",
++                "//webrtc/modules/audio_processing/gain_control_for_experimental_agc.h",
++                "//webrtc/modules/audio_processing/gain_control_impl.cc",
++                "//webrtc/modules/audio_processing/gain_control_impl.h",
++                "//webrtc/modules/audio_processing/include/audio_processing.cc",
++                "//webrtc/modules/audio_processing/include/audio_processing.h",
++                "//webrtc/modules/audio_processing/include/config.cc",
++                "//webrtc/modules/audio_processing/include/config.h",
++                "//webrtc/modules/audio_processing/level_controller/biquad_filter.cc",
++                "//webrtc/modules/audio_processing/level_controller/biquad_filter.h",
++                "//webrtc/modules/audio_processing/level_controller/down_sampler.cc",
++                "//webrtc/modules/audio_processing/level_controller/down_sampler.h",
++                "//webrtc/modules/audio_processing/level_controller/gain_applier.cc",
++                "//webrtc/modules/audio_processing/level_controller/gain_applier.h",
++                "//webrtc/modules/audio_processing/level_controller/gain_selector.cc",
++                "//webrtc/modules/audio_processing/level_controller/gain_selector.h",
++                "//webrtc/modules/audio_processing/level_controller/level_controller.cc",
++                "//webrtc/modules/audio_processing/level_controller/level_controller.h",
++                "//webrtc/modules/audio_processing/level_controller/level_controller_constants.h",
++                "//webrtc/modules/audio_processing/level_controller/noise_level_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/noise_level_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/noise_spectrum_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/noise_spectrum_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/peak_level_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/peak_level_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/saturating_gain_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/saturating_gain_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/signal_classifier.cc",
++                "//webrtc/modules/audio_processing/level_controller/signal_classifier.h",
++                "//webrtc/modules/audio_processing/level_estimator_impl.cc",
++                "//webrtc/modules/audio_processing/level_estimator_impl.h",
++                "//webrtc/modules/audio_processing/logging/apm_data_dumper.cc",
++                "//webrtc/modules/audio_processing/logging/apm_data_dumper.h",
++                "//webrtc/modules/audio_processing/low_cut_filter.cc",
++                "//webrtc/modules/audio_processing/low_cut_filter.h",
++                "//webrtc/modules/audio_processing/noise_suppression_impl.cc",
++                "//webrtc/modules/audio_processing/noise_suppression_impl.h",
++                "//webrtc/modules/audio_processing/render_queue_item_verifier.h",
++                "//webrtc/modules/audio_processing/residual_echo_detector.cc",
++                "//webrtc/modules/audio_processing/residual_echo_detector.h",
++                "//webrtc/modules/audio_processing/rms_level.cc",
++                "//webrtc/modules/audio_processing/rms_level.h",
++                "//webrtc/modules/audio_processing/splitting_filter.cc",
++                "//webrtc/modules/audio_processing/splitting_filter.h",
++                "//webrtc/modules/audio_processing/three_band_filter_bank.cc",
++                "//webrtc/modules/audio_processing/three_band_filter_bank.h",
++                "//webrtc/modules/audio_processing/transient/common.h",
++                "//webrtc/modules/audio_processing/transient/daubechies_8_wavelet_coeffs.h",
++                "//webrtc/modules/audio_processing/transient/dyadic_decimator.h",
++                "//webrtc/modules/audio_processing/transient/moving_moments.cc",
++                "//webrtc/modules/audio_processing/transient/moving_moments.h",
++                "//webrtc/modules/audio_processing/transient/transient_detector.cc",
++                "//webrtc/modules/audio_processing/transient/transient_detector.h",
++                "//webrtc/modules/audio_processing/transient/transient_suppressor.cc",
++                "//webrtc/modules/audio_processing/transient/transient_suppressor.h",
++                "//webrtc/modules/audio_processing/transient/wpd_node.cc",
++                "//webrtc/modules/audio_processing/transient/wpd_node.h",
++                "//webrtc/modules/audio_processing/transient/wpd_tree.cc",
++                "//webrtc/modules/audio_processing/transient/wpd_tree.h",
++                "//webrtc/modules/audio_processing/typing_detection.cc",
++                "//webrtc/modules/audio_processing/typing_detection.h",
++                "//webrtc/modules/audio_processing/utility/block_mean_calculator.cc",
++                "//webrtc/modules/audio_processing/utility/block_mean_calculator.h",
++                "//webrtc/modules/audio_processing/utility/delay_estimator.cc",
++                "//webrtc/modules/audio_processing/utility/delay_estimator.h",
++                "//webrtc/modules/audio_processing/utility/delay_estimator_internal.h",
++                "//webrtc/modules/audio_processing/utility/delay_estimator_wrapper.cc",
++                "//webrtc/modules/audio_processing/utility/delay_estimator_wrapper.h",
++                "//webrtc/modules/audio_processing/utility/ooura_fft.cc",
++                "//webrtc/modules/audio_processing/utility/ooura_fft.h",
++                "//webrtc/modules/audio_processing/utility/ooura_fft_tables_common.h",
++                "//webrtc/modules/audio_processing/vad/common.h",
++                "//webrtc/modules/audio_processing/vad/gmm.cc",
++                "//webrtc/modules/audio_processing/vad/gmm.h",
++                "//webrtc/modules/audio_processing/vad/noise_gmm_tables.h",
++                "//webrtc/modules/audio_processing/vad/pitch_based_vad.cc",
++                "//webrtc/modules/audio_processing/vad/pitch_based_vad.h",
++                "//webrtc/modules/audio_processing/vad/pitch_internal.cc",
++                "//webrtc/modules/audio_processing/vad/pitch_internal.h",
++                "//webrtc/modules/audio_processing/vad/pole_zero_filter.cc",
++                "//webrtc/modules/audio_processing/vad/pole_zero_filter.h",
++                "//webrtc/modules/audio_processing/vad/standalone_vad.cc",
++                "//webrtc/modules/audio_processing/vad/standalone_vad.h",
++                "//webrtc/modules/audio_processing/vad/vad_audio_proc.cc",
++                "//webrtc/modules/audio_processing/vad/vad_audio_proc.h",
++                "//webrtc/modules/audio_processing/vad/vad_audio_proc_internal.h",
++                "//webrtc/modules/audio_processing/vad/vad_circular_buffer.cc",
++                "//webrtc/modules/audio_processing/vad/vad_circular_buffer.h",
++                "//webrtc/modules/audio_processing/vad/voice_activity_detector.cc",
++                "//webrtc/modules/audio_processing/vad/voice_activity_detector.h",
++                "//webrtc/modules/audio_processing/vad/voice_gmm_tables.h",
++                "//webrtc/modules/audio_processing/voice_detection_impl.cc",
++                "//webrtc/modules/audio_processing/voice_detection_impl.h",
++                "//webrtc/modules/audio_processing/aecm/aecm_core_c.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_processing:audio_processing_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_processing/agc/legacy/analog_agc.c",
++                "//webrtc/modules/audio_processing/agc/legacy/analog_agc.h",
++                "//webrtc/modules/audio_processing/agc/legacy/digital_agc.c",
++                "//webrtc/modules/audio_processing/agc/legacy/digital_agc.h",
++                "//webrtc/modules/audio_processing/agc/legacy/gain_control.h",
++                "//webrtc/modules/audio_processing/ns/defines.h",
++                "//webrtc/modules/audio_processing/ns/noise_suppression.c",
++                "//webrtc/modules/audio_processing/ns/noise_suppression.h",
++                "//webrtc/modules/audio_processing/ns/ns_core.c",
++                "//webrtc/modules/audio_processing/ns/ns_core.h",
++                "//webrtc/modules/audio_processing/ns/windows_private.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_processing:audio_processing_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_APM_DEBUG_DUMP=1",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_processing/aec/aec_core_sse2.cc",
++                "//webrtc/modules/audio_processing/utility/ooura_fft_sse2.cc",
++                "//webrtc/modules/audio_processing/utility/ooura_fft_tables_neon_sse2.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/bitrate_controller:bitrate_controller": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/bitrate_controller/bitrate_controller_impl.cc",
++                "//webrtc/modules/bitrate_controller/bitrate_controller_impl.h",
++                "//webrtc/modules/bitrate_controller/include/bitrate_controller.h",
++                "//webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc",
++                "//webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/congestion_controller:congestion_controller": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/modules/bitrate_controller:bitrate_controller",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/congestion_controller/congestion_controller.cc",
++                "//webrtc/modules/congestion_controller/delay_based_bwe.cc",
++                "//webrtc/modules/congestion_controller/delay_based_bwe.h",
++                "//webrtc/modules/congestion_controller/include/congestion_controller.h",
++                "//webrtc/modules/congestion_controller/median_slope_estimator.cc",
++                "//webrtc/modules/congestion_controller/median_slope_estimator.h",
++                "//webrtc/modules/congestion_controller/probe_bitrate_estimator.cc",
++                "//webrtc/modules/congestion_controller/probe_bitrate_estimator.h",
++                "//webrtc/modules/congestion_controller/probe_controller.cc",
++                "//webrtc/modules/congestion_controller/probe_controller.h",
++                "//webrtc/modules/congestion_controller/probing_interval_estimator.cc",
++                "//webrtc/modules/congestion_controller/probing_interval_estimator.h",
++                "//webrtc/modules/congestion_controller/transport_feedback_adapter.cc",
++                "//webrtc/modules/congestion_controller/transport_feedback_adapter.h",
++                "//webrtc/modules/congestion_controller/trendline_estimator.cc",
++                "//webrtc/modules/congestion_controller/trendline_estimator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/desktop_capture:desktop_capture": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "MULTI_MONITOR_SCREENSHARE",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/desktop_capture:desktop_capture_differ_sse2",
++                "//webrtc/modules/desktop_capture:primitives",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [
++                "X11",
++                "X11-xcb",
++                "xcb",
++                "Xcomposite",
++                "Xcursor",
++                "Xdamage",
++                "Xext",
++                "Xfixes",
++                "Xi",
++                "Xrender"
++            ],
++            "sources": [
++                "//webrtc/modules/desktop_capture/cropped_desktop_frame.cc",
++                "//webrtc/modules/desktop_capture/cropped_desktop_frame.h",
++                "//webrtc/modules/desktop_capture/cropping_window_capturer.cc",
++                "//webrtc/modules/desktop_capture/cropping_window_capturer.h",
++                "//webrtc/modules/desktop_capture/desktop_and_cursor_composer.cc",
++                "//webrtc/modules/desktop_capture/desktop_and_cursor_composer.h",
++                "//webrtc/modules/desktop_capture/desktop_capture_options.cc",
++                "//webrtc/modules/desktop_capture/desktop_capture_options.h",
++                "//webrtc/modules/desktop_capture/desktop_capturer.cc",
++                "//webrtc/modules/desktop_capture/desktop_capturer.h",
++                "//webrtc/modules/desktop_capture/desktop_capturer_differ_wrapper.cc",
++                "//webrtc/modules/desktop_capture/desktop_capturer_differ_wrapper.h",
++                "//webrtc/modules/desktop_capture/desktop_frame_rotation.cc",
++                "//webrtc/modules/desktop_capture/desktop_frame_rotation.h",
++                "//webrtc/modules/desktop_capture/differ_block.cc",
++                "//webrtc/modules/desktop_capture/differ_block.h",
++                "//webrtc/modules/desktop_capture/mouse_cursor.cc",
++                "//webrtc/modules/desktop_capture/mouse_cursor.h",
++                "//webrtc/modules/desktop_capture/mouse_cursor_monitor.h",
++                "//webrtc/modules/desktop_capture/screen_capture_frame_queue.h",
++                "//webrtc/modules/desktop_capture/screen_capturer_helper.cc",
++                "//webrtc/modules/desktop_capture/screen_capturer_helper.h",
++                "//webrtc/modules/desktop_capture/desktop_device_info.cc",
++                "//webrtc/modules/desktop_capture/desktop_device_info.h",
++                "//webrtc/modules/desktop_capture/mouse_cursor_monitor_x11.cc",
++                "//webrtc/modules/desktop_capture/screen_capturer_x11.cc",
++                "//webrtc/modules/desktop_capture/window_capturer_x11.cc",
++                "//webrtc/modules/desktop_capture/x11/shared_x_display.cc",
++                "//webrtc/modules/desktop_capture/x11/shared_x_display.h",
++                "//webrtc/modules/desktop_capture/x11/x_error_trap.cc",
++                "//webrtc/modules/desktop_capture/x11/x_error_trap.h",
++                "//webrtc/modules/desktop_capture/x11/x_server_pixel_buffer.cc",
++                "//webrtc/modules/desktop_capture/x11/x_server_pixel_buffer.h",
++                "//webrtc/modules/desktop_capture/app_capturer_x11.cc",
++                "//webrtc/modules/desktop_capture/app_capturer_x11.h",
++                "//webrtc/modules/desktop_capture/x11/desktop_device_info_x11.cc",
++                "//webrtc/modules/desktop_capture/x11/desktop_device_info_x11.h",
++                "//webrtc/modules/desktop_capture/x11/shared_x_util.cc",
++                "//webrtc/modules/desktop_capture/x11/shared_x_util.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/desktop_capture:desktop_capture_differ_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/desktop_capture/differ_vector_sse2.cc",
++                "//webrtc/modules/desktop_capture/differ_vector_sse2.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/desktop_capture:primitives": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/desktop_capture/desktop_capture_types.h",
++                "//webrtc/modules/desktop_capture/desktop_frame.cc",
++                "//webrtc/modules/desktop_capture/desktop_frame.h",
++                "//webrtc/modules/desktop_capture/desktop_geometry.cc",
++                "//webrtc/modules/desktop_capture/desktop_geometry.h",
++                "//webrtc/modules/desktop_capture/desktop_region.cc",
++                "//webrtc/modules/desktop_capture/desktop_region.h",
++                "//webrtc/modules/desktop_capture/shared_desktop_frame.cc",
++                "//webrtc/modules/desktop_capture/shared_desktop_frame.h",
++                "//webrtc/modules/desktop_capture/shared_memory.cc",
++                "//webrtc/modules/desktop_capture/shared_memory.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/media_file:media_file": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/media_file/media_file.h",
++                "//webrtc/modules/media_file/media_file_defines.h",
++                "//webrtc/modules/media_file/media_file_impl.cc",
++                "//webrtc/modules/media_file/media_file_impl.h",
++                "//webrtc/modules/media_file/media_file_utility.cc",
++                "//webrtc/modules/media_file/media_file_utility.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/pacing:pacing": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/pacing/alr_detector.cc",
++                "//webrtc/modules/pacing/alr_detector.h",
++                "//webrtc/modules/pacing/bitrate_prober.cc",
++                "//webrtc/modules/pacing/bitrate_prober.h",
++                "//webrtc/modules/pacing/paced_sender.cc",
++                "//webrtc/modules/pacing/paced_sender.h",
++                "//webrtc/modules/pacing/packet_router.cc",
++                "//webrtc/modules/pacing/packet_router.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/remote_bitrate_estimator/aimd_rate_control.cc",
++                "//webrtc/modules/remote_bitrate_estimator/aimd_rate_control.h",
++                "//webrtc/modules/remote_bitrate_estimator/bwe_defines.cc",
++                "//webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h",
++                "//webrtc/modules/remote_bitrate_estimator/include/remote_bitrate_estimator.h",
++                "//webrtc/modules/remote_bitrate_estimator/include/send_time_history.h",
++                "//webrtc/modules/remote_bitrate_estimator/inter_arrival.cc",
++                "//webrtc/modules/remote_bitrate_estimator/inter_arrival.h",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_detector.cc",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_detector.h",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_estimator.cc",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_estimator.h",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.h",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_single_stream.cc",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_single_stream.h",
++                "//webrtc/modules/remote_bitrate_estimator/remote_estimator_proxy.cc",
++                "//webrtc/modules/remote_bitrate_estimator/remote_estimator_proxy.h",
++                "//webrtc/modules/remote_bitrate_estimator/send_time_history.cc",
++                "//webrtc/modules/remote_bitrate_estimator/test/bwe_test_logging.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/rtp_rtcp:rtp_rtcp": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:transport_api",
++                "//webrtc/base:gtest_prod",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/common_video:common_video",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/rtp_rtcp/include/flexfec_receiver.h",
++                "//webrtc/modules/rtp_rtcp/include/flexfec_sender.h",
++                "//webrtc/modules/rtp_rtcp/include/receive_statistics.h",
++                "//webrtc/modules/rtp_rtcp/include/remote_ntp_time_estimator.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_audio_level_observer.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_header_parser.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_payload_registry.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_receiver.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_rtcp.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.h",
++                "//webrtc/modules/rtp_rtcp/include/ulpfec_receiver.h",
++                "//webrtc/modules/rtp_rtcp/source/byte_io.h",
++                "//webrtc/modules/rtp_rtcp/source/dtmf_queue.cc",
++                "//webrtc/modules/rtp_rtcp/source/dtmf_queue.h",
++                "//webrtc/modules/rtp_rtcp/source/fec_private_tables_bursty.h",
++                "//webrtc/modules/rtp_rtcp/source/fec_private_tables_random.h",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_header_reader_writer.cc",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_header_reader_writer.h",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_receiver.cc",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_sender.cc",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction.cc",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction.h",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction_internal.cc",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction_internal.h",
++                "//webrtc/modules/rtp_rtcp/source/packet_loss_stats.cc",
++                "//webrtc/modules/rtp_rtcp/source/packet_loss_stats.h",
++                "//webrtc/modules/rtp_rtcp/source/playout_delay_oracle.cc",
++                "//webrtc/modules/rtp_rtcp/source/playout_delay_oracle.h",
++                "//webrtc/modules/rtp_rtcp/source/receive_statistics_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/receive_statistics_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/remote_ntp_time_estimator.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/app.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/app.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/bye.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/bye.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/common_header.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/common_header.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/compound_packet.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/compound_packet.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/dlrr.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/dlrr.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_jitter_report.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_jitter_report.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_reports.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_reports.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/fir.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/fir.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/nack.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/nack.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/pli.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/pli.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/psfb.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/psfb.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rapid_resync_request.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rapid_resync_request.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/receiver_report.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/receiver_report.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/remb.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/remb.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/report_block.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/report_block.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rpsi.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rpsi.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rrtr.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rrtr.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rtpfb.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rtpfb.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sdes.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sdes.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sender_report.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sender_report.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sli.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sli.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/target_bitrate.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/target_bitrate.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmb_item.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmb_item.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbn.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbn.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbr.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbr.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/transport_feedback.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/transport_feedback.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/voip_metric.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/voip_metric.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_receiver.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_receiver.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_sender.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_sender.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_utility.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_utility.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_h264.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_video_generic.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_video_generic.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp8.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp8.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp9.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extension.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extension.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extensions.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extensions.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_parser.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_history.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_history.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_received.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_to_send.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_payload_registry.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_audio.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_audio.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_strategy.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_strategy.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_video.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_video.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_rtcp_config.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_rtcp_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_rtcp_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_audio.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_audio.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_video.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_video.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_utility.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_utility.h",
++                "//webrtc/modules/rtp_rtcp/source/ssrc_database.cc",
++                "//webrtc/modules/rtp_rtcp/source/ssrc_database.h",
++                "//webrtc/modules/rtp_rtcp/source/time_util.cc",
++                "//webrtc/modules/rtp_rtcp/source/time_util.h",
++                "//webrtc/modules/rtp_rtcp/source/tmmbr_help.cc",
++                "//webrtc/modules/rtp_rtcp/source/tmmbr_help.h",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_generator.cc",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_generator.h",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_header_reader_writer.cc",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_header_reader_writer.h",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_receiver_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_receiver_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/video_codec_information.h",
++                "//webrtc/modules/rtp_rtcp/source/vp8_partition_aggregator.cc",
++                "//webrtc/modules/rtp_rtcp/source/vp8_partition_aggregator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/utility:utility": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_coding",
++                "//webrtc/modules/audio_coding:audio_format_conversion",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/utility/include/audio_frame_operations.h",
++                "//webrtc/modules/utility/include/process_thread.h",
++                "//webrtc/modules/utility/source/process_thread_impl.cc",
++                "//webrtc/modules/utility/source/process_thread_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_capture:video_capture_internal_impl": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/video_capture:video_capture_module",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_capture/linux/device_info_linux.cc",
++                "//webrtc/modules/video_capture/linux/device_info_linux.h",
++                "//webrtc/modules/video_capture/linux/video_capture_linux.cc",
++                "//webrtc/modules/video_capture/linux/video_capture_linux.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_capture:video_capture_module": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_capture/device_info_impl.cc",
++                "//webrtc/modules/video_capture/device_info_impl.h",
++                "//webrtc/modules/video_capture/video_capture.h",
++                "//webrtc/modules/video_capture/video_capture_config.h",
++                "//webrtc/modules/video_capture/video_capture_defines.h",
++                "//webrtc/modules/video_capture/video_capture_delay.h",
++                "//webrtc/modules/video_capture/video_capture_factory.cc",
++                "//webrtc/modules/video_capture/video_capture_factory.h",
++                "//webrtc/modules/video_capture/video_capture_impl.cc",
++                "//webrtc/modules/video_capture/video_capture_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:video_coding": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/modules/video_coding:webrtc_h264",
++                "//webrtc/modules/video_coding:webrtc_i420",
++                "//webrtc/modules/video_coding:webrtc_vp8",
++                "//webrtc/modules/video_coding:webrtc_vp9",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codec_database.cc",
++                "//webrtc/modules/video_coding/codec_database.h",
++                "//webrtc/modules/video_coding/codec_timer.cc",
++                "//webrtc/modules/video_coding/codec_timer.h",
++                "//webrtc/modules/video_coding/decoding_state.cc",
++                "//webrtc/modules/video_coding/decoding_state.h",
++                "//webrtc/modules/video_coding/encoded_frame.cc",
++                "//webrtc/modules/video_coding/encoded_frame.h",
++                "//webrtc/modules/video_coding/fec_rate_table.h",
++                "//webrtc/modules/video_coding/frame_buffer.cc",
++                "//webrtc/modules/video_coding/frame_buffer.h",
++                "//webrtc/modules/video_coding/frame_buffer2.cc",
++                "//webrtc/modules/video_coding/frame_buffer2.h",
++                "//webrtc/modules/video_coding/frame_object.cc",
++                "//webrtc/modules/video_coding/frame_object.h",
++                "//webrtc/modules/video_coding/generic_decoder.cc",
++                "//webrtc/modules/video_coding/generic_decoder.h",
++                "//webrtc/modules/video_coding/generic_encoder.cc",
++                "//webrtc/modules/video_coding/generic_encoder.h",
++                "//webrtc/modules/video_coding/h264_sprop_parameter_sets.cc",
++                "//webrtc/modules/video_coding/h264_sprop_parameter_sets.h",
++                "//webrtc/modules/video_coding/h264_sps_pps_tracker.cc",
++                "//webrtc/modules/video_coding/h264_sps_pps_tracker.h",
++                "//webrtc/modules/video_coding/histogram.cc",
++                "//webrtc/modules/video_coding/histogram.h",
++                "//webrtc/modules/video_coding/include/video_codec_initializer.h",
++                "//webrtc/modules/video_coding/include/video_coding.h",
++                "//webrtc/modules/video_coding/include/video_coding_defines.h",
++                "//webrtc/modules/video_coding/inter_frame_delay.cc",
++                "//webrtc/modules/video_coding/inter_frame_delay.h",
++                "//webrtc/modules/video_coding/internal_defines.h",
++                "//webrtc/modules/video_coding/jitter_buffer.cc",
++                "//webrtc/modules/video_coding/jitter_buffer.h",
++                "//webrtc/modules/video_coding/jitter_buffer_common.h",
++                "//webrtc/modules/video_coding/jitter_estimator.cc",
++                "//webrtc/modules/video_coding/jitter_estimator.h",
++                "//webrtc/modules/video_coding/media_opt_util.cc",
++                "//webrtc/modules/video_coding/media_opt_util.h",
++                "//webrtc/modules/video_coding/media_optimization.cc",
++                "//webrtc/modules/video_coding/media_optimization.h",
++                "//webrtc/modules/video_coding/nack_fec_tables.h",
++                "//webrtc/modules/video_coding/nack_module.cc",
++                "//webrtc/modules/video_coding/nack_module.h",
++                "//webrtc/modules/video_coding/packet.cc",
++                "//webrtc/modules/video_coding/packet.h",
++                "//webrtc/modules/video_coding/packet_buffer.cc",
++                "//webrtc/modules/video_coding/packet_buffer.h",
++                "//webrtc/modules/video_coding/protection_bitrate_calculator.cc",
++                "//webrtc/modules/video_coding/protection_bitrate_calculator.h",
++                "//webrtc/modules/video_coding/receiver.cc",
++                "//webrtc/modules/video_coding/receiver.h",
++                "//webrtc/modules/video_coding/rtp_frame_reference_finder.cc",
++                "//webrtc/modules/video_coding/rtp_frame_reference_finder.h",
++                "//webrtc/modules/video_coding/rtt_filter.cc",
++                "//webrtc/modules/video_coding/rtt_filter.h",
++                "//webrtc/modules/video_coding/session_info.cc",
++                "//webrtc/modules/video_coding/session_info.h",
++                "//webrtc/modules/video_coding/timestamp_map.cc",
++                "//webrtc/modules/video_coding/timestamp_map.h",
++                "//webrtc/modules/video_coding/timing.cc",
++                "//webrtc/modules/video_coding/timing.h",
++                "//webrtc/modules/video_coding/video_codec_initializer.cc",
++                "//webrtc/modules/video_coding/video_coding_impl.cc",
++                "//webrtc/modules/video_coding/video_coding_impl.h",
++                "//webrtc/modules/video_coding/video_receiver.cc",
++                "//webrtc/modules/video_coding/video_sender.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:video_coding_utility": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/common_video:common_video",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/utility/default_video_bitrate_allocator.cc",
++                "//webrtc/modules/video_coding/utility/default_video_bitrate_allocator.h",
++                "//webrtc/modules/video_coding/utility/frame_dropper.cc",
++                "//webrtc/modules/video_coding/utility/frame_dropper.h",
++                "//webrtc/modules/video_coding/utility/ivf_file_writer.cc",
++                "//webrtc/modules/video_coding/utility/ivf_file_writer.h",
++                "//webrtc/modules/video_coding/utility/moving_average.cc",
++                "//webrtc/modules/video_coding/utility/moving_average.h",
++                "//webrtc/modules/video_coding/utility/qp_parser.cc",
++                "//webrtc/modules/video_coding/utility/qp_parser.h",
++                "//webrtc/modules/video_coding/utility/quality_scaler.cc",
++                "//webrtc/modules/video_coding/utility/quality_scaler.h",
++                "//webrtc/modules/video_coding/utility/simulcast_rate_allocator.cc",
++                "//webrtc/modules/video_coding/utility/simulcast_rate_allocator.h",
++                "//webrtc/modules/video_coding/utility/vp8_header_parser.cc",
++                "//webrtc/modules/video_coding/utility/vp8_header_parser.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_h264": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/h264/h264.cc",
++                "//webrtc/modules/video_coding/codecs/h264/include/h264.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_i420": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/i420/i420.cc",
++                "//webrtc/modules/video_coding/codecs/i420/include/i420.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_vp8": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/vp8/default_temporal_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/default_temporal_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp8/include/vp8.h",
++                "//webrtc/modules/video_coding/codecs/vp8/include/vp8_common_types.h",
++                "//webrtc/modules/video_coding/codecs/vp8/realtime_temporal_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/reference_picture_selection.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/reference_picture_selection.h",
++                "//webrtc/modules/video_coding/codecs/vp8/screenshare_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/screenshare_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp8/simulcast_encoder_adapter.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/simulcast_encoder_adapter.h",
++                "//webrtc/modules/video_coding/codecs/vp8/temporal_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp8/vp8_impl.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/vp8_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_vp9": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/vp9/include/vp9.h",
++                "//webrtc/modules/video_coding/codecs/vp9/screenshare_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp9/screenshare_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_frame_buffer_pool.cc",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_frame_buffer_pool.h",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_impl.cc",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_processing:video_processing": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/modules/video_processing:video_processing_sse2",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_processing/util/denoiser_filter.cc",
++                "//webrtc/modules/video_processing/util/denoiser_filter.h",
++                "//webrtc/modules/video_processing/util/denoiser_filter_c.cc",
++                "//webrtc/modules/video_processing/util/denoiser_filter_c.h",
++                "//webrtc/modules/video_processing/util/noise_estimation.cc",
++                "//webrtc/modules/video_processing/util/noise_estimation.h",
++                "//webrtc/modules/video_processing/util/skin_detection.cc",
++                "//webrtc/modules/video_processing/util/skin_detection.h",
++                "//webrtc/modules/video_processing/video_denoiser.cc",
++                "//webrtc/modules/video_processing/video_denoiser.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_processing:video_processing_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_processing/util/denoiser_filter_sse2.cc",
++                "//webrtc/modules/video_processing/util/denoiser_filter_sse2.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/system_wrappers:field_trial_default": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/system_wrappers/include/field_trial_default.h",
++                "//webrtc/system_wrappers/source/field_trial_default.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/system_wrappers:metrics_default": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/system_wrappers/include/metrics_default.h",
++                "//webrtc/system_wrappers/source/metrics_default.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/system_wrappers:system_wrappers": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_THREAD_RR",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/system_wrappers/include/aligned_array.h",
++                "//webrtc/system_wrappers/include/aligned_malloc.h",
++                "//webrtc/system_wrappers/include/atomic32.h",
++                "//webrtc/system_wrappers/include/clock.h",
++                "//webrtc/system_wrappers/include/cpu_features_wrapper.h",
++                "//webrtc/system_wrappers/include/cpu_info.h",
++                "//webrtc/system_wrappers/include/critical_section_wrapper.h",
++                "//webrtc/system_wrappers/include/event_wrapper.h",
++                "//webrtc/system_wrappers/include/field_trial.h",
++                "//webrtc/system_wrappers/include/file_wrapper.h",
++                "//webrtc/system_wrappers/include/logging.h",
++                "//webrtc/system_wrappers/include/metrics.h",
++                "//webrtc/system_wrappers/include/ntp_time.h",
++                "//webrtc/system_wrappers/include/rtp_to_ntp_estimator.h",
++                "//webrtc/system_wrappers/include/rw_lock_wrapper.h",
++                "//webrtc/system_wrappers/include/sleep.h",
++                "//webrtc/system_wrappers/include/static_instance.h",
++                "//webrtc/system_wrappers/include/stringize_macros.h",
++                "//webrtc/system_wrappers/include/timestamp_extrapolator.h",
++                "//webrtc/system_wrappers/include/trace.h",
++                "//webrtc/system_wrappers/source/aligned_malloc.cc",
++                "//webrtc/system_wrappers/source/clock.cc",
++                "//webrtc/system_wrappers/source/cpu_features.cc",
++                "//webrtc/system_wrappers/source/cpu_info.cc",
++                "//webrtc/system_wrappers/source/event.cc",
++                "//webrtc/system_wrappers/source/event_timer_posix.cc",
++                "//webrtc/system_wrappers/source/event_timer_posix.h",
++                "//webrtc/system_wrappers/source/file_impl.cc",
++                "//webrtc/system_wrappers/source/logging.cc",
++                "//webrtc/system_wrappers/source/rtp_to_ntp_estimator.cc",
++                "//webrtc/system_wrappers/source/rw_lock.cc",
++                "//webrtc/system_wrappers/source/rw_lock_posix.cc",
++                "//webrtc/system_wrappers/source/rw_lock_posix.h",
++                "//webrtc/system_wrappers/source/sleep.cc",
++                "//webrtc/system_wrappers/source/timestamp_extrapolator.cc",
++                "//webrtc/system_wrappers/source/trace_impl.cc",
++                "//webrtc/system_wrappers/source/trace_impl.h",
++                "//webrtc/system_wrappers/source/trace_posix.cc",
++                "//webrtc/system_wrappers/source/trace_posix.h",
++                "//webrtc/system_wrappers/source/atomic32_non_darwin_unix.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/video:video": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:transport_api",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_video:common_video",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/bitrate_controller:bitrate_controller",
++                "//webrtc/modules/congestion_controller:congestion_controller",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/modules/video_coding:video_coding",
++                "//webrtc/modules/video_processing:video_processing",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:voice_engine"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/video/call_stats.cc",
++                "//webrtc/video/call_stats.h",
++                "//webrtc/video/encoder_rtcp_feedback.cc",
++                "//webrtc/video/encoder_rtcp_feedback.h",
++                "//webrtc/video/overuse_frame_detector.cc",
++                "//webrtc/video/overuse_frame_detector.h",
++                "//webrtc/video/payload_router.cc",
++                "//webrtc/video/payload_router.h",
++                "//webrtc/video/quality_threshold.cc",
++                "//webrtc/video/quality_threshold.h",
++                "//webrtc/video/receive_statistics_proxy.cc",
++                "//webrtc/video/receive_statistics_proxy.h",
++                "//webrtc/video/report_block_stats.cc",
++                "//webrtc/video/report_block_stats.h",
++                "//webrtc/video/rtp_stream_receiver.cc",
++                "//webrtc/video/rtp_stream_receiver.h",
++                "//webrtc/video/rtp_streams_synchronizer.cc",
++                "//webrtc/video/rtp_streams_synchronizer.h",
++                "//webrtc/video/send_delay_stats.cc",
++                "//webrtc/video/send_delay_stats.h",
++                "//webrtc/video/send_statistics_proxy.cc",
++                "//webrtc/video/send_statistics_proxy.h",
++                "//webrtc/video/stats_counter.cc",
++                "//webrtc/video/stats_counter.h",
++                "//webrtc/video/stream_synchronization.cc",
++                "//webrtc/video/stream_synchronization.h",
++                "//webrtc/video/transport_adapter.cc",
++                "//webrtc/video/transport_adapter.h",
++                "//webrtc/video/video_receive_stream.cc",
++                "//webrtc/video/video_receive_stream.h",
++                "//webrtc/video/video_send_stream.cc",
++                "//webrtc/video/video_send_stream.h",
++                "//webrtc/video/video_stream_decoder.cc",
++                "//webrtc/video/video_stream_decoder.h",
++                "//webrtc/video/vie_encoder.cc",
++                "//webrtc/video/vie_encoder.h",
++                "//webrtc/video/vie_remb.cc",
++                "//webrtc/video/vie_remb.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/video_engine:video_engine": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/video_engine/browser_capture_impl.h",
++                "//webrtc/video_engine/desktop_capture_impl.cc",
++                "//webrtc/video_engine/desktop_capture_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:audio_coder": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/modules/audio_coding:audio_coding",
++                "//webrtc/modules/audio_coding:audio_format_conversion",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:rent_a_codec"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/coder.cc",
++                "//webrtc/voice_engine/coder.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:file_player": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:audio_coder"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/file_player.cc",
++                "//webrtc/voice_engine/file_player.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:file_recorder": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:audio_coder"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/file_recorder.cc",
++                "//webrtc/voice_engine/file_recorder.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:level_indicator": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/level_indicator.cc",
++                "//webrtc/voice_engine/level_indicator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:voice_engine": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/api:call_api",
++                "//webrtc/api:transport_api",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/audio_coding:audio_coding",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_format_conversion",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/audio_conference_mixer:audio_conference_mixer",
++                "//webrtc/modules/audio_device:audio_device",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/modules/bitrate_controller:bitrate_controller",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:file_player",
++                "//webrtc/voice_engine:file_recorder",
++                "//webrtc/voice_engine:level_indicator"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/modules/audio_conference_mixer/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/channel.cc",
++                "//webrtc/voice_engine/channel.h",
++                "//webrtc/voice_engine/channel_manager.cc",
++                "//webrtc/voice_engine/channel_manager.h",
++                "//webrtc/voice_engine/channel_proxy.cc",
++                "//webrtc/voice_engine/channel_proxy.h",
++                "//webrtc/voice_engine/include/voe_audio_processing.h",
++                "//webrtc/voice_engine/include/voe_base.h",
++                "//webrtc/voice_engine/include/voe_codec.h",
++                "//webrtc/voice_engine/include/voe_errors.h",
++                "//webrtc/voice_engine/include/voe_external_media.h",
++                "//webrtc/voice_engine/include/voe_file.h",
++                "//webrtc/voice_engine/include/voe_hardware.h",
++                "//webrtc/voice_engine/include/voe_neteq_stats.h",
++                "//webrtc/voice_engine/include/voe_network.h",
++                "//webrtc/voice_engine/include/voe_rtp_rtcp.h",
++                "//webrtc/voice_engine/include/voe_video_sync.h",
++                "//webrtc/voice_engine/include/voe_volume_control.h",
++                "//webrtc/voice_engine/monitor_module.cc",
++                "//webrtc/voice_engine/monitor_module.h",
++                "//webrtc/voice_engine/output_mixer.cc",
++                "//webrtc/voice_engine/output_mixer.h",
++                "//webrtc/voice_engine/shared_data.cc",
++                "//webrtc/voice_engine/shared_data.h",
++                "//webrtc/voice_engine/statistics.cc",
++                "//webrtc/voice_engine/statistics.h",
++                "//webrtc/voice_engine/transmit_mixer.cc",
++                "//webrtc/voice_engine/transmit_mixer.h",
++                "//webrtc/voice_engine/utility.cc",
++                "//webrtc/voice_engine/utility.h",
++                "//webrtc/voice_engine/voe_audio_processing_impl.cc",
++                "//webrtc/voice_engine/voe_audio_processing_impl.h",
++                "//webrtc/voice_engine/voe_base_impl.cc",
++                "//webrtc/voice_engine/voe_base_impl.h",
++                "//webrtc/voice_engine/voe_codec_impl.cc",
++                "//webrtc/voice_engine/voe_codec_impl.h",
++                "//webrtc/voice_engine/voe_external_media_impl.cc",
++                "//webrtc/voice_engine/voe_external_media_impl.h",
++                "//webrtc/voice_engine/voe_file_impl.cc",
++                "//webrtc/voice_engine/voe_file_impl.h",
++                "//webrtc/voice_engine/voe_hardware_impl.cc",
++                "//webrtc/voice_engine/voe_hardware_impl.h",
++                "//webrtc/voice_engine/voe_neteq_stats_impl.cc",
++                "//webrtc/voice_engine/voe_neteq_stats_impl.h",
++                "//webrtc/voice_engine/voe_network_impl.cc",
++                "//webrtc/voice_engine/voe_network_impl.h",
++                "//webrtc/voice_engine/voe_rtp_rtcp_impl.cc",
++                "//webrtc/voice_engine/voe_rtp_rtcp_impl.h",
++                "//webrtc/voice_engine/voe_video_sync_impl.cc",
++                "//webrtc/voice_engine/voe_video_sync_impl.h",
++                "//webrtc/voice_engine/voe_volume_control_impl.cc",
++                "//webrtc/voice_engine/voe_volume_control_impl.h",
++                "//webrtc/voice_engine/voice_engine_defines.h",
++                "//webrtc/voice_engine/voice_engine_impl.cc",
++                "//webrtc/voice_engine/voice_engine_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc:webrtc": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:transport_api",
++                "//webrtc/api:video_frame_api",
++                "//webrtc/audio:audio",
++                "//webrtc/base:base",
++                "//webrtc/call:call",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/common_video:common_video",
++                "//webrtc/media:media",
++                "//webrtc/modules:modules",
++                "//webrtc/modules/video_capture:video_capture_internal_impl",
++                "//webrtc/sdk:sdk",
++                "//webrtc/system_wrappers:field_trial_default",
++                "//webrtc/system_wrappers:metrics_default",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/video:video",
++                "//webrtc/video_engine:video_engine",
++                "//webrtc/voice_engine:voice_engine"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_conference_mixer/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/"
++            ],
++            "libs": [
++                "X11",
++                "X11-xcb",
++                "xcb",
++                "Xcomposite",
++                "Xcursor",
++                "Xdamage",
++                "Xext",
++                "Xfixes",
++                "Xi",
++                "Xrender"
++            ],
++            "sources": [
++                "//webrtc/build/no_op_function.cc",
++                "//webrtc/call.h",
++                "//webrtc/config.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc:webrtc_common": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O2",
++                "-fno-ident",
++                "-fdata-sections",
++                "-ffunction-sections",
++                "-fomit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "_FORTIFY_SOURCE=2",
++                "NDEBUG",
++                "NVALGRIND",
++                "DYNAMIC_ANNOTATIONS_ENABLED=0",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_types.cc",
++                "//webrtc/common_types.h",
++                "//webrtc/config.cc",
++                "//webrtc/config.h",
++                "//webrtc/typedefs.h"
++            ],
++            "type": "static_library"
++        }
++    }
++}
+\ No newline at end of file
+diff --git firefox_patched/media/webrtc/gn-configs/x64_True_x64_solaris.json firefox_patched/media/webrtc/gn-configs/x64_True_x64_solaris.json
+new file mode 100644
+index 000000000..b2356c343
+--- /dev/null
++++ firefox_patched/media/webrtc/gn-configs/x64_True_x64_solaris.json
+@@ -0,0 +1,7836 @@
++{
++    "gn_gen_args": {
++        "host_cpu": "x64",
++        "is_debug": true,
++        "target_cpu": "x64",
++        "target_os": "solaris"
++    },
++    "mozbuild_args": {
++        "CPU_ARCH": "x86_64",
++        "HOST_CPU_ARCH": "x86_64",
++        "MOZ_DEBUG": "1",
++        "OS_TARGET": "SunOS"
++    },
++    "sandbox_vars": {
++        "COMPILE_FLAGS": {
++            "WARNINGS_AS_ERRORS": []
++        },
++        "FINAL_LIBRARY": "webrtc"
++    },
++    "targets": {
++        "//webrtc/api:audio_mixer_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/audio/audio_mixer.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/api:call_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/api:transport_api",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/call/audio_sink.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/api:transport_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/call/transport.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/api:video_frame_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/api/video/i420_buffer.cc",
++                "//webrtc/api/video/i420_buffer.h",
++                "//webrtc/api/video/video_frame.cc",
++                "//webrtc/api/video/video_frame.h",
++                "//webrtc/api/video/video_frame_buffer.h",
++                "//webrtc/api/video/video_rotation.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/audio/utility:audio_frame_operations": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_format_conversion"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/audio/utility/audio_frame_operations.cc",
++                "//webrtc/audio/utility/audio_frame_operations.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/audio:audio": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/api:call_api",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_device:audio_device",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/modules/congestion_controller:congestion_controller",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:voice_engine"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/audio/audio_receive_stream.cc",
++                "//webrtc/audio/audio_receive_stream.h",
++                "//webrtc/audio/audio_send_stream.cc",
++                "//webrtc/audio/audio_send_stream.h",
++                "//webrtc/audio/audio_state.cc",
++                "//webrtc/audio/audio_state.h",
++                "//webrtc/audio/audio_transport_proxy.cc",
++                "//webrtc/audio/audio_transport_proxy.h",
++                "//webrtc/audio/conversion.h",
++                "//webrtc/audio/scoped_voe_interface.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/base:gtest_prod": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/gtest_prod_util.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/base:rtc_base_approved": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/array_view.h",
++                "//webrtc/base/arraysize.h",
++                "//webrtc/base/atomicops.h",
++                "//webrtc/base/base64.cc",
++                "//webrtc/base/base64.h",
++                "//webrtc/base/basictypes.h",
++                "//webrtc/base/bind.h",
++                "//webrtc/base/bitbuffer.cc",
++                "//webrtc/base/bitbuffer.h",
++                "//webrtc/base/buffer.h",
++                "//webrtc/base/bufferqueue.cc",
++                "//webrtc/base/bufferqueue.h",
++                "//webrtc/base/bytebuffer.cc",
++                "//webrtc/base/bytebuffer.h",
++                "//webrtc/base/byteorder.h",
++                "//webrtc/base/checks.cc",
++                "//webrtc/base/checks.h",
++                "//webrtc/base/constructormagic.h",
++                "//webrtc/base/copyonwritebuffer.cc",
++                "//webrtc/base/copyonwritebuffer.h",
++                "//webrtc/base/criticalsection.cc",
++                "//webrtc/base/criticalsection.h",
++                "//webrtc/base/deprecation.h",
++                "//webrtc/base/event.cc",
++                "//webrtc/base/event.h",
++                "//webrtc/base/event_tracer.cc",
++                "//webrtc/base/event_tracer.h",
++                "//webrtc/base/file.cc",
++                "//webrtc/base/file.h",
++                "//webrtc/base/flags.cc",
++                "//webrtc/base/flags.h",
++                "//webrtc/base/format_macros.h",
++                "//webrtc/base/function_view.h",
++                "//webrtc/base/ignore_wundef.h",
++                "//webrtc/base/location.cc",
++                "//webrtc/base/location.h",
++                "//webrtc/base/md5.cc",
++                "//webrtc/base/md5.h",
++                "//webrtc/base/md5digest.cc",
++                "//webrtc/base/md5digest.h",
++                "//webrtc/base/mod_ops.h",
++                "//webrtc/base/onetimeevent.h",
++                "//webrtc/base/optional.cc",
++                "//webrtc/base/optional.h",
++                "//webrtc/base/pathutils.cc",
++                "//webrtc/base/pathutils.h",
++                "//webrtc/base/platform_file.cc",
++                "//webrtc/base/platform_file.h",
++                "//webrtc/base/platform_thread.cc",
++                "//webrtc/base/platform_thread.h",
++                "//webrtc/base/platform_thread_types.h",
++                "//webrtc/base/race_checker.cc",
++                "//webrtc/base/race_checker.h",
++                "//webrtc/base/random.cc",
++                "//webrtc/base/random.h",
++                "//webrtc/base/rate_limiter.cc",
++                "//webrtc/base/rate_limiter.h",
++                "//webrtc/base/rate_statistics.cc",
++                "//webrtc/base/rate_statistics.h",
++                "//webrtc/base/ratetracker.cc",
++                "//webrtc/base/ratetracker.h",
++                "//webrtc/base/refcount.h",
++                "//webrtc/base/refcountedobject.h",
++                "//webrtc/base/safe_compare.h",
++                "//webrtc/base/safe_conversions.h",
++                "//webrtc/base/safe_conversions_impl.h",
++                "//webrtc/base/sanitizer.h",
++                "//webrtc/base/scoped_ref_ptr.h",
++                "//webrtc/base/stringencode.cc",
++                "//webrtc/base/stringencode.h",
++                "//webrtc/base/stringutils.cc",
++                "//webrtc/base/stringutils.h",
++                "//webrtc/base/swap_queue.h",
++                "//webrtc/base/template_util.h",
++                "//webrtc/base/thread_annotations.h",
++                "//webrtc/base/thread_checker.h",
++                "//webrtc/base/thread_checker_impl.cc",
++                "//webrtc/base/thread_checker_impl.h",
++                "//webrtc/base/timestampaligner.cc",
++                "//webrtc/base/timestampaligner.h",
++                "//webrtc/base/timeutils.cc",
++                "//webrtc/base/timeutils.h",
++                "//webrtc/base/trace_event.h",
++                "//webrtc/base/type_traits.h",
++                "//webrtc/base/file_posix.cc",
++                "//webrtc/base/logging.cc",
++                "//webrtc/base/logging.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/base:rtc_numerics": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/numerics/exp_filter.cc",
++                "//webrtc/base/numerics/exp_filter.h",
++                "//webrtc/base/numerics/percentile_filter.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/base:rtc_task_queue": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_BUILD_LIBEVENT",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "/ipc/chromium/src/third_party/libevent/include/",
++                "/ipc/chromium/src/third_party/libevent/linux/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/base/sequenced_task_checker.h",
++                "//webrtc/base/sequenced_task_checker_impl.cc",
++                "//webrtc/base/sequenced_task_checker_impl.h",
++                "//webrtc/base/weak_ptr.cc",
++                "//webrtc/base/weak_ptr.h",
++                "//webrtc/base/task_queue.h",
++                "//webrtc/base/task_queue_posix.h",
++                "//webrtc/base/task_queue_libevent.cc",
++                "//webrtc/base/task_queue_posix.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/call:call": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:call_api",
++                "//webrtc/api:transport_api",
++                "//webrtc/audio:audio",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/logging:rtc_event_log_impl",
++                "//webrtc/modules/congestion_controller:congestion_controller",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/video:video"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/call/bitrate_allocator.cc",
++                "//webrtc/call/call.cc",
++                "//webrtc/call/flexfec_receive_stream_impl.cc",
++                "//webrtc/call/flexfec_receive_stream_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/call:call_interfaces": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/call/audio_receive_stream.h",
++                "//webrtc/call/audio_send_stream.h",
++                "//webrtc/call/audio_state.h",
++                "//webrtc/call/call.h",
++                "//webrtc/call/flexfec_receive_stream.h",
++                "//webrtc/call/audio_send_stream_call.cc"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/common_audio:common_audio": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/common_audio:common_audio_c",
++                "//webrtc/common_audio:common_audio_sse2",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_audio/audio_converter.cc",
++                "//webrtc/common_audio/audio_converter.h",
++                "//webrtc/common_audio/audio_ring_buffer.cc",
++                "//webrtc/common_audio/audio_ring_buffer.h",
++                "//webrtc/common_audio/audio_util.cc",
++                "//webrtc/common_audio/blocker.cc",
++                "//webrtc/common_audio/blocker.h",
++                "//webrtc/common_audio/channel_buffer.cc",
++                "//webrtc/common_audio/channel_buffer.h",
++                "//webrtc/common_audio/fir_filter.cc",
++                "//webrtc/common_audio/fir_filter.h",
++                "//webrtc/common_audio/fir_filter_neon.h",
++                "//webrtc/common_audio/fir_filter_sse.h",
++                "//webrtc/common_audio/include/audio_util.h",
++                "//webrtc/common_audio/lapped_transform.cc",
++                "//webrtc/common_audio/lapped_transform.h",
++                "//webrtc/common_audio/real_fourier.cc",
++                "//webrtc/common_audio/real_fourier.h",
++                "//webrtc/common_audio/real_fourier_ooura.cc",
++                "//webrtc/common_audio/real_fourier_ooura.h",
++                "//webrtc/common_audio/resampler/include/push_resampler.h",
++                "//webrtc/common_audio/resampler/include/resampler.h",
++                "//webrtc/common_audio/resampler/push_resampler.cc",
++                "//webrtc/common_audio/resampler/push_sinc_resampler.cc",
++                "//webrtc/common_audio/resampler/push_sinc_resampler.h",
++                "//webrtc/common_audio/resampler/resampler.cc",
++                "//webrtc/common_audio/resampler/sinc_resampler.cc",
++                "//webrtc/common_audio/resampler/sinc_resampler.h",
++                "//webrtc/common_audio/smoothing_filter.cc",
++                "//webrtc/common_audio/smoothing_filter.h",
++                "//webrtc/common_audio/sparse_fir_filter.cc",
++                "//webrtc/common_audio/sparse_fir_filter.h",
++                "//webrtc/common_audio/vad/include/vad.h",
++                "//webrtc/common_audio/vad/vad.cc",
++                "//webrtc/common_audio/wav_file.cc",
++                "//webrtc/common_audio/wav_file.h",
++                "//webrtc/common_audio/wav_header.cc",
++                "//webrtc/common_audio/wav_header.h",
++                "//webrtc/common_audio/window_generator.cc",
++                "//webrtc/common_audio/window_generator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/common_audio:common_audio_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_audio/fft4g.c",
++                "//webrtc/common_audio/fft4g.h",
++                "//webrtc/common_audio/ring_buffer.c",
++                "//webrtc/common_audio/ring_buffer.h",
++                "//webrtc/common_audio/signal_processing/auto_corr_to_refl_coef.c",
++                "//webrtc/common_audio/signal_processing/auto_correlation.c",
++                "//webrtc/common_audio/signal_processing/complex_fft_tables.h",
++                "//webrtc/common_audio/signal_processing/copy_set_operations.c",
++                "//webrtc/common_audio/signal_processing/cross_correlation.c",
++                "//webrtc/common_audio/signal_processing/division_operations.c",
++                "//webrtc/common_audio/signal_processing/dot_product_with_scale.c",
++                "//webrtc/common_audio/signal_processing/downsample_fast.c",
++                "//webrtc/common_audio/signal_processing/energy.c",
++                "//webrtc/common_audio/signal_processing/filter_ar.c",
++                "//webrtc/common_audio/signal_processing/filter_ma_fast_q12.c",
++                "//webrtc/common_audio/signal_processing/get_hanning_window.c",
++                "//webrtc/common_audio/signal_processing/get_scaling_square.c",
++                "//webrtc/common_audio/signal_processing/ilbc_specific_functions.c",
++                "//webrtc/common_audio/signal_processing/include/real_fft.h",
++                "//webrtc/common_audio/signal_processing/include/signal_processing_library.h",
++                "//webrtc/common_audio/signal_processing/include/spl_inl.h",
++                "//webrtc/common_audio/signal_processing/levinson_durbin.c",
++                "//webrtc/common_audio/signal_processing/lpc_to_refl_coef.c",
++                "//webrtc/common_audio/signal_processing/min_max_operations.c",
++                "//webrtc/common_audio/signal_processing/randomization_functions.c",
++                "//webrtc/common_audio/signal_processing/real_fft.c",
++                "//webrtc/common_audio/signal_processing/refl_coef_to_lpc.c",
++                "//webrtc/common_audio/signal_processing/resample.c",
++                "//webrtc/common_audio/signal_processing/resample_48khz.c",
++                "//webrtc/common_audio/signal_processing/resample_by_2.c",
++                "//webrtc/common_audio/signal_processing/resample_by_2_internal.c",
++                "//webrtc/common_audio/signal_processing/resample_by_2_internal.h",
++                "//webrtc/common_audio/signal_processing/resample_fractional.c",
++                "//webrtc/common_audio/signal_processing/spl_init.c",
++                "//webrtc/common_audio/signal_processing/spl_inl.c",
++                "//webrtc/common_audio/signal_processing/spl_sqrt.c",
++                "//webrtc/common_audio/signal_processing/splitting_filter.c",
++                "//webrtc/common_audio/signal_processing/sqrt_of_one_minus_x_squared.c",
++                "//webrtc/common_audio/signal_processing/vector_scaling_operations.c",
++                "//webrtc/common_audio/vad/include/webrtc_vad.h",
++                "//webrtc/common_audio/vad/vad_core.c",
++                "//webrtc/common_audio/vad/vad_core.h",
++                "//webrtc/common_audio/vad/vad_filterbank.c",
++                "//webrtc/common_audio/vad/vad_filterbank.h",
++                "//webrtc/common_audio/vad/vad_gmm.c",
++                "//webrtc/common_audio/vad/vad_gmm.h",
++                "//webrtc/common_audio/vad/vad_sp.c",
++                "//webrtc/common_audio/vad/vad_sp.h",
++                "//webrtc/common_audio/vad/webrtc_vad.c",
++                "//webrtc/common_audio/signal_processing/complex_fft.c",
++                "//webrtc/common_audio/signal_processing/complex_bit_reverse.c",
++                "//webrtc/common_audio/signal_processing/filter_ar_fast_q12.c",
++                "//webrtc/common_audio/signal_processing/spl_sqrt_floor.c"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/common_audio:common_audio_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_audio/fir_filter_sse.cc",
++                "//webrtc/common_audio/resampler/sinc_resampler_sse.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/common_video:common_video": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:video_frame_api",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//webrtc/modules/interface/",
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_video/bitrate_adjuster.cc",
++                "//webrtc/common_video/h264/h264_bitstream_parser.cc",
++                "//webrtc/common_video/h264/h264_bitstream_parser.h",
++                "//webrtc/common_video/h264/h264_common.cc",
++                "//webrtc/common_video/h264/h264_common.h",
++                "//webrtc/common_video/h264/pps_parser.cc",
++                "//webrtc/common_video/h264/pps_parser.h",
++                "//webrtc/common_video/h264/profile_level_id.cc",
++                "//webrtc/common_video/h264/profile_level_id.h",
++                "//webrtc/common_video/h264/sps_parser.cc",
++                "//webrtc/common_video/h264/sps_parser.h",
++                "//webrtc/common_video/h264/sps_vui_rewriter.cc",
++                "//webrtc/common_video/h264/sps_vui_rewriter.h",
++                "//webrtc/common_video/i420_buffer_pool.cc",
++                "//webrtc/common_video/include/bitrate_adjuster.h",
++                "//webrtc/common_video/include/frame_callback.h",
++                "//webrtc/common_video/include/i420_buffer_pool.h",
++                "//webrtc/common_video/include/incoming_video_stream.h",
++                "//webrtc/common_video/include/video_bitrate_allocator.h",
++                "//webrtc/common_video/include/video_frame_buffer.h",
++                "//webrtc/common_video/incoming_video_stream.cc",
++                "//webrtc/common_video/libyuv/include/webrtc_libyuv.h",
++                "//webrtc/common_video/libyuv/webrtc_libyuv.cc",
++                "//webrtc/common_video/video_frame.cc",
++                "//webrtc/common_video/video_frame_buffer.cc",
++                "//webrtc/common_video/video_render_frames.cc",
++                "//webrtc/common_video/video_render_frames.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/logging:rtc_event_log_api": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/logging/rtc_event_log/rtc_event_log.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/logging:rtc_event_log_impl": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/logging/rtc_event_log/ringbuffer.h",
++                "//webrtc/logging/rtc_event_log/rtc_event_log.cc",
++                "//webrtc/logging/rtc_event_log/rtc_event_log_helper_thread.cc",
++                "//webrtc/logging/rtc_event_log/rtc_event_log_helper_thread.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/media:mozilla_rtc_media": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/media/base/videoadapter.cc",
++                "//webrtc/media/base/videoadapter.h",
++                "//webrtc/media/base/videobroadcaster.cc",
++                "//webrtc/media/base/videobroadcaster.h",
++                "//webrtc/media/base/videosourcebase.cc",
++                "//webrtc/media/base/videosourcebase.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_coding": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:neteq",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/audio_coding:webrtc_opus",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/acm2/acm_common_defs.h",
++                "//webrtc/modules/audio_coding/acm2/acm_receiver.cc",
++                "//webrtc/modules/audio_coding/acm2/acm_receiver.h",
++                "//webrtc/modules/audio_coding/acm2/acm_resampler.cc",
++                "//webrtc/modules/audio_coding/acm2/acm_resampler.h",
++                "//webrtc/modules/audio_coding/acm2/audio_coding_module.cc",
++                "//webrtc/modules/audio_coding/acm2/call_statistics.cc",
++                "//webrtc/modules/audio_coding/acm2/call_statistics.h",
++                "//webrtc/modules/audio_coding/acm2/codec_manager.cc",
++                "//webrtc/modules/audio_coding/acm2/codec_manager.h",
++                "//webrtc/modules/audio_coding/include/audio_coding_module.h",
++                "//webrtc/modules/audio_coding/include/audio_coding_module_typedefs.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_decoder_factory_interface": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_format",
++                "//webrtc/modules/audio_coding:audio_format_conversion"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_decoder_factory.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:audio_decoder_interface": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_decoder.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_decoder.h",
++                "//webrtc/modules/audio_coding/codecs/legacy_encoded_audio_frame.cc",
++                "//webrtc/modules/audio_coding/codecs/legacy_encoded_audio_frame.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_encoder_interface": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_encoder.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_encoder.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_format": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_format.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_format.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_format_conversion": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_format"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/audio_format_conversion.cc",
++                "//webrtc/modules/audio_coding/codecs/audio_format_conversion.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:audio_network_adaptor": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/audio_network_adaptor/audio_network_adaptor.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/audio_network_adaptor_impl.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/audio_network_adaptor_impl.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/bitrate_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/bitrate_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/channel_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/channel_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller_manager.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/controller_manager.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/debug_dump_writer.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/debug_dump_writer.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/dtx_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/dtx_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/fec_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/fec_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/frame_length_controller.cc",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/frame_length_controller.h",
++                "//webrtc/modules/audio_coding/audio_network_adaptor/include/audio_network_adaptor.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:builtin_audio_decoder_factory": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:webrtc_opus"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/builtin_audio_decoder_factory.cc",
++                "//webrtc/modules/audio_coding/codecs/builtin_audio_decoder_factory.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:cng": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_encoder_interface"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/cng/audio_encoder_cng.cc",
++                "//webrtc/modules/audio_coding/codecs/cng/audio_encoder_cng.h",
++                "//webrtc/modules/audio_coding/codecs/cng/webrtc_cng.cc",
++                "//webrtc/modules/audio_coding/codecs/cng/webrtc_cng.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:g711": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:g711_c"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g711/audio_decoder_pcm.cc",
++                "//webrtc/modules/audio_coding/codecs/g711/audio_decoder_pcm.h",
++                "//webrtc/modules/audio_coding/codecs/g711/audio_encoder_pcm.cc",
++                "//webrtc/modules/audio_coding/codecs/g711/audio_encoder_pcm.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:g711_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g711/g711.c",
++                "//webrtc/modules/audio_coding/codecs/g711/g711.h",
++                "//webrtc/modules/audio_coding/codecs/g711/g711_interface.c",
++                "//webrtc/modules/audio_coding/codecs/g711/g711_interface.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:g722": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:g722_c"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g722/audio_decoder_g722.cc",
++                "//webrtc/modules/audio_coding/codecs/g722/audio_decoder_g722.h",
++                "//webrtc/modules/audio_coding/codecs/g722/audio_encoder_g722.cc",
++                "//webrtc/modules/audio_coding/codecs/g722/audio_encoder_g722.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:g722_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/g722/g722_decode.c",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_enc_dec.h",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_encode.c",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_interface.c",
++                "//webrtc/modules/audio_coding/codecs/g722/g722_interface.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:isac": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:isac_c",
++                "//webrtc/modules/audio_coding:isac_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/audio_decoder_isac.cc",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/audio_encoder_isac.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:isac_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/audio_decoder_isac.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/audio_encoder_isac.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/isac.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines_hist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/arith_routines_logist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/bandwidth_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/bandwidth_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/codec.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/crc.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/crc.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/decode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/decode_bwe.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/encode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/encode_lpc_swb.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/encode_lpc_swb.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/entropy_coding.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/entropy_coding.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/fft.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/fft.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filter_functions.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filterbank_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filterbank_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/filterbanks.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/intialize.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/isac.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/isac_float_type.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lattice.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_analysis.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_analysis.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_gain_swb_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_gain_swb_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb12_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb12_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb16_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_shape_swb16_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/lpc_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/os_specific_inline.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_filter.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_gain_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_gain_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_lag_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/pitch_lag_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/settings.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/spectrum_ar_model_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/spectrum_ar_model_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/structs.h",
++                "//webrtc/modules/audio_coding/codecs/isac/main/source/transform.c"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_common": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_encoder_interface"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/audio_encoder_isac_t.h",
++                "//webrtc/modules/audio_coding/codecs/isac/audio_encoder_isac_t_impl.h",
++                "//webrtc/modules/audio_coding/codecs/isac/locked_bandwidth_info.cc",
++                "//webrtc/modules/audio_coding/codecs/isac/locked_bandwidth_info.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_fix": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:isac_common",
++                "//webrtc/modules/audio_coding:isac_fix_c",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/audio_decoder_isacfix.cc",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/audio_encoder_isacfix.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:isac_fix_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:isac_common",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/audio_decoder_isacfix.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/audio_encoder_isacfix.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/isacfix.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routines.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routines_hist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routines_logist.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/arith_routins.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/bandwidth_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/bandwidth_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/codec.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/decode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/decode_bwe.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/decode_plc.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/encode.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/entropy_coding.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/entropy_coding.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/fft.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/fft.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filterbank_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filterbank_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filterbanks.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/filters.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/initialize.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/isac_fix_type.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/isacfix.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lattice.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lattice_c.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_masking_model.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_masking_model.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/lpc_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_estimator.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_estimator.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_estimator_c.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_filter.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_filter_c.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_gain_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_gain_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_lag_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/pitch_lag_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/settings.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/spectrum_ar_model_tables.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/spectrum_ar_model_tables.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/structs.h",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/transform.c",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/source/transform_tables.c"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:neteq": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_ISAC",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:gtest_prod",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_format",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:isac_fix",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/audio_coding:webrtc_opus",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/fix/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/neteq/accelerate.cc",
++                "//webrtc/modules/audio_coding/neteq/accelerate.h",
++                "//webrtc/modules/audio_coding/neteq/audio_decoder_impl.cc",
++                "//webrtc/modules/audio_coding/neteq/audio_decoder_impl.h",
++                "//webrtc/modules/audio_coding/neteq/audio_multi_vector.cc",
++                "//webrtc/modules/audio_coding/neteq/audio_multi_vector.h",
++                "//webrtc/modules/audio_coding/neteq/audio_vector.cc",
++                "//webrtc/modules/audio_coding/neteq/audio_vector.h",
++                "//webrtc/modules/audio_coding/neteq/background_noise.cc",
++                "//webrtc/modules/audio_coding/neteq/background_noise.h",
++                "//webrtc/modules/audio_coding/neteq/buffer_level_filter.cc",
++                "//webrtc/modules/audio_coding/neteq/buffer_level_filter.h",
++                "//webrtc/modules/audio_coding/neteq/comfort_noise.cc",
++                "//webrtc/modules/audio_coding/neteq/comfort_noise.h",
++                "//webrtc/modules/audio_coding/neteq/cross_correlation.cc",
++                "//webrtc/modules/audio_coding/neteq/cross_correlation.h",
++                "//webrtc/modules/audio_coding/neteq/decision_logic.cc",
++                "//webrtc/modules/audio_coding/neteq/decision_logic.h",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_fax.cc",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_fax.h",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_normal.cc",
++                "//webrtc/modules/audio_coding/neteq/decision_logic_normal.h",
++                "//webrtc/modules/audio_coding/neteq/decoder_database.cc",
++                "//webrtc/modules/audio_coding/neteq/decoder_database.h",
++                "//webrtc/modules/audio_coding/neteq/defines.h",
++                "//webrtc/modules/audio_coding/neteq/delay_manager.cc",
++                "//webrtc/modules/audio_coding/neteq/delay_manager.h",
++                "//webrtc/modules/audio_coding/neteq/delay_peak_detector.cc",
++                "//webrtc/modules/audio_coding/neteq/delay_peak_detector.h",
++                "//webrtc/modules/audio_coding/neteq/dsp_helper.cc",
++                "//webrtc/modules/audio_coding/neteq/dsp_helper.h",
++                "//webrtc/modules/audio_coding/neteq/dtmf_buffer.cc",
++                "//webrtc/modules/audio_coding/neteq/dtmf_buffer.h",
++                "//webrtc/modules/audio_coding/neteq/dtmf_tone_generator.cc",
++                "//webrtc/modules/audio_coding/neteq/dtmf_tone_generator.h",
++                "//webrtc/modules/audio_coding/neteq/expand.cc",
++                "//webrtc/modules/audio_coding/neteq/expand.h",
++                "//webrtc/modules/audio_coding/neteq/include/neteq.h",
++                "//webrtc/modules/audio_coding/neteq/merge.cc",
++                "//webrtc/modules/audio_coding/neteq/merge.h",
++                "//webrtc/modules/audio_coding/neteq/nack_tracker.cc",
++                "//webrtc/modules/audio_coding/neteq/nack_tracker.h",
++                "//webrtc/modules/audio_coding/neteq/neteq.cc",
++                "//webrtc/modules/audio_coding/neteq/neteq_impl.cc",
++                "//webrtc/modules/audio_coding/neteq/neteq_impl.h",
++                "//webrtc/modules/audio_coding/neteq/normal.cc",
++                "//webrtc/modules/audio_coding/neteq/normal.h",
++                "//webrtc/modules/audio_coding/neteq/packet.cc",
++                "//webrtc/modules/audio_coding/neteq/packet.h",
++                "//webrtc/modules/audio_coding/neteq/packet_buffer.cc",
++                "//webrtc/modules/audio_coding/neteq/packet_buffer.h",
++                "//webrtc/modules/audio_coding/neteq/post_decode_vad.cc",
++                "//webrtc/modules/audio_coding/neteq/post_decode_vad.h",
++                "//webrtc/modules/audio_coding/neteq/preemptive_expand.cc",
++                "//webrtc/modules/audio_coding/neteq/preemptive_expand.h",
++                "//webrtc/modules/audio_coding/neteq/random_vector.cc",
++                "//webrtc/modules/audio_coding/neteq/random_vector.h",
++                "//webrtc/modules/audio_coding/neteq/red_payload_splitter.cc",
++                "//webrtc/modules/audio_coding/neteq/red_payload_splitter.h",
++                "//webrtc/modules/audio_coding/neteq/rtcp.cc",
++                "//webrtc/modules/audio_coding/neteq/rtcp.h",
++                "//webrtc/modules/audio_coding/neteq/statistics_calculator.cc",
++                "//webrtc/modules/audio_coding/neteq/statistics_calculator.h",
++                "//webrtc/modules/audio_coding/neteq/sync_buffer.cc",
++                "//webrtc/modules/audio_coding/neteq/sync_buffer.h",
++                "//webrtc/modules/audio_coding/neteq/tick_timer.cc",
++                "//webrtc/modules/audio_coding/neteq/tick_timer.h",
++                "//webrtc/modules/audio_coding/neteq/time_stretch.cc",
++                "//webrtc/modules/audio_coding/neteq/time_stretch.h",
++                "//webrtc/modules/audio_coding/neteq/timestamp_scaler.cc",
++                "//webrtc/modules/audio_coding/neteq/timestamp_scaler.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:pcm16b": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:pcm16b_c"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_decoder_pcm16b.cc",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_decoder_pcm16b.h",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_encoder_pcm16b.cc",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/audio_encoder_pcm16b.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:pcm16b_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/pcm16b/pcm16b.c",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/pcm16b.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_coding:rent_a_codec": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_CODEC_OPUS",
++                "WEBRTC_CODEC_G722",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:cng",
++                "//webrtc/modules/audio_coding:g711",
++                "//webrtc/modules/audio_coding:g722",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_coding:pcm16b",
++                "//webrtc/modules/audio_coding:webrtc_opus"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/cng/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g711/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/pcm16b/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/g722/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/acm2/acm_codec_database.cc",
++                "//webrtc/modules/audio_coding/acm2/acm_codec_database.h",
++                "//webrtc/modules/audio_coding/acm2/rent_a_codec.cc",
++                "//webrtc/modules/audio_coding/acm2/rent_a_codec.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:webrtc_opus": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_OPUS_VARIABLE_COMPLEXITY=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_decoder_interface",
++                "//webrtc/modules/audio_coding:audio_encoder_interface",
++                "//webrtc/modules/audio_coding:audio_network_adaptor",
++                "//webrtc/modules/audio_coding:webrtc_opus_c",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/include/opus/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/opus/audio_decoder_opus.cc",
++                "//webrtc/modules/audio_coding/codecs/opus/audio_decoder_opus.h",
++                "//webrtc/modules/audio_coding/codecs/opus/audio_encoder_opus.cc",
++                "//webrtc/modules/audio_coding/codecs/opus/audio_encoder_opus.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_coding:webrtc_opus_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "/media/libopus/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_coding/codecs/opus/opus_inst.h",
++                "//webrtc/modules/audio_coding/codecs/opus/opus_interface.c",
++                "//webrtc/modules/audio_coding/codecs/opus/opus_interface.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_conference_mixer:audio_conference_mixer": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_conference_mixer/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_conference_mixer/include/audio_conference_mixer.h",
++                "//webrtc/modules/audio_conference_mixer/include/audio_conference_mixer_defines.h",
++                "//webrtc/modules/audio_conference_mixer/source/audio_conference_mixer_impl.cc",
++                "//webrtc/modules/audio_conference_mixer/source/audio_conference_mixer_impl.h",
++                "//webrtc/modules/audio_conference_mixer/source/audio_frame_manipulator.cc",
++                "//webrtc/modules/audio_conference_mixer/source/audio_frame_manipulator.h",
++                "//webrtc/modules/audio_conference_mixer/source/memory_pool.h",
++                "//webrtc/modules/audio_conference_mixer/source/memory_pool_posix.h",
++                "//webrtc/modules/audio_conference_mixer/source/time_scheduler.cc",
++                "//webrtc/modules/audio_conference_mixer/source/time_scheduler.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_device:audio_device": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_DUMMY_AUDIO_BUILD",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_device/audio_device_buffer.cc",
++                "//webrtc/modules/audio_device/audio_device_buffer.h",
++                "//webrtc/modules/audio_device/audio_device_config.h",
++                "//webrtc/modules/audio_device/audio_device_generic.cc",
++                "//webrtc/modules/audio_device/audio_device_generic.h",
++                "//webrtc/modules/audio_device/dummy/audio_device_dummy.cc",
++                "//webrtc/modules/audio_device/dummy/audio_device_dummy.h",
++                "//webrtc/modules/audio_device/dummy/file_audio_device.cc",
++                "//webrtc/modules/audio_device/dummy/file_audio_device.h",
++                "//webrtc/modules/audio_device/fine_audio_buffer.cc",
++                "//webrtc/modules/audio_device/fine_audio_buffer.h",
++                "//webrtc/modules/audio_device/include/audio_device.h",
++                "//webrtc/modules/audio_device/include/audio_device_defines.h",
++                "//webrtc/modules/audio_device/opensl/single_rw_fifo.cc",
++                "//webrtc/modules/audio_device/opensl/single_rw_fifo.h",
++                "//webrtc/modules/audio_device/dummy/file_audio_device_factory.cc",
++                "//webrtc/modules/audio_device/dummy/file_audio_device_factory.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_mixer:audio_frame_manipulator": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/audio/utility:utility",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_mixer/audio_frame_manipulator.cc",
++                "//webrtc/modules/audio_mixer/audio_frame_manipulator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_mixer:audio_mixer_impl": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/audio_mixer:audio_frame_manipulator",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_mixer/audio_mixer_impl.cc",
++                "//webrtc/modules/audio_mixer/audio_mixer_impl.h",
++                "//webrtc/modules/audio_mixer/default_output_rate_calculator.cc",
++                "//webrtc/modules/audio_mixer/default_output_rate_calculator.h",
++                "//webrtc/modules/audio_mixer/output_rate_calculator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_processing:audio_processing": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_APM_DEBUG_DUMP=1",
++                "WEBRTC_INTELLIGIBILITY_ENHANCER=0",
++                "WEBRTC_NS_FLOAT",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:gtest_prod",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:isac",
++                "//webrtc/modules/audio_processing:audio_processing_c",
++                "//webrtc/modules/audio_processing:audio_processing_sse2",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//",
++                "//webrtc/modules/audio_coding/codecs/isac/main/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_processing/aec/aec_core.cc",
++                "//webrtc/modules/audio_processing/aec/aec_core.h",
++                "//webrtc/modules/audio_processing/aec/aec_core_optimized_methods.h",
++                "//webrtc/modules/audio_processing/aec/aec_resampler.cc",
++                "//webrtc/modules/audio_processing/aec/aec_resampler.h",
++                "//webrtc/modules/audio_processing/aec/echo_cancellation.cc",
++                "//webrtc/modules/audio_processing/aec/echo_cancellation.h",
++                "//webrtc/modules/audio_processing/aec3/aec3_constants.h",
++                "//webrtc/modules/audio_processing/aec3/block_framer.cc",
++                "//webrtc/modules/audio_processing/aec3/block_framer.h",
++                "//webrtc/modules/audio_processing/aec3/block_processor.cc",
++                "//webrtc/modules/audio_processing/aec3/block_processor.h",
++                "//webrtc/modules/audio_processing/aec3/cascaded_biquad_filter.cc",
++                "//webrtc/modules/audio_processing/aec3/cascaded_biquad_filter.h",
++                "//webrtc/modules/audio_processing/aec3/echo_canceller3.cc",
++                "//webrtc/modules/audio_processing/aec3/echo_canceller3.h",
++                "//webrtc/modules/audio_processing/aec3/frame_blocker.cc",
++                "//webrtc/modules/audio_processing/aec3/frame_blocker.h",
++                "//webrtc/modules/audio_processing/aecm/aecm_core.cc",
++                "//webrtc/modules/audio_processing/aecm/aecm_core.h",
++                "//webrtc/modules/audio_processing/aecm/echo_control_mobile.cc",
++                "//webrtc/modules/audio_processing/aecm/echo_control_mobile.h",
++                "//webrtc/modules/audio_processing/agc/agc.cc",
++                "//webrtc/modules/audio_processing/agc/agc.h",
++                "//webrtc/modules/audio_processing/agc/agc_manager_direct.cc",
++                "//webrtc/modules/audio_processing/agc/agc_manager_direct.h",
++                "//webrtc/modules/audio_processing/agc/gain_map_internal.h",
++                "//webrtc/modules/audio_processing/agc/loudness_histogram.cc",
++                "//webrtc/modules/audio_processing/agc/loudness_histogram.h",
++                "//webrtc/modules/audio_processing/agc/utility.cc",
++                "//webrtc/modules/audio_processing/agc/utility.h",
++                "//webrtc/modules/audio_processing/audio_buffer.cc",
++                "//webrtc/modules/audio_processing/audio_buffer.h",
++                "//webrtc/modules/audio_processing/audio_processing_impl.cc",
++                "//webrtc/modules/audio_processing/audio_processing_impl.h",
++                "//webrtc/modules/audio_processing/beamformer/array_util.cc",
++                "//webrtc/modules/audio_processing/beamformer/array_util.h",
++                "//webrtc/modules/audio_processing/beamformer/complex_matrix.h",
++                "//webrtc/modules/audio_processing/beamformer/covariance_matrix_generator.cc",
++                "//webrtc/modules/audio_processing/beamformer/covariance_matrix_generator.h",
++                "//webrtc/modules/audio_processing/beamformer/matrix.h",
++                "//webrtc/modules/audio_processing/beamformer/nonlinear_beamformer.cc",
++                "//webrtc/modules/audio_processing/beamformer/nonlinear_beamformer.h",
++                "//webrtc/modules/audio_processing/common.h",
++                "//webrtc/modules/audio_processing/echo_cancellation_impl.cc",
++                "//webrtc/modules/audio_processing/echo_cancellation_impl.h",
++                "//webrtc/modules/audio_processing/echo_control_mobile_impl.cc",
++                "//webrtc/modules/audio_processing/echo_control_mobile_impl.h",
++                "//webrtc/modules/audio_processing/echo_detector/circular_buffer.cc",
++                "//webrtc/modules/audio_processing/echo_detector/circular_buffer.h",
++                "//webrtc/modules/audio_processing/echo_detector/mean_variance_estimator.cc",
++                "//webrtc/modules/audio_processing/echo_detector/mean_variance_estimator.h",
++                "//webrtc/modules/audio_processing/echo_detector/moving_max.cc",
++                "//webrtc/modules/audio_processing/echo_detector/moving_max.h",
++                "//webrtc/modules/audio_processing/echo_detector/normalized_covariance_estimator.cc",
++                "//webrtc/modules/audio_processing/echo_detector/normalized_covariance_estimator.h",
++                "//webrtc/modules/audio_processing/gain_control_for_experimental_agc.cc",
++                "//webrtc/modules/audio_processing/gain_control_for_experimental_agc.h",
++                "//webrtc/modules/audio_processing/gain_control_impl.cc",
++                "//webrtc/modules/audio_processing/gain_control_impl.h",
++                "//webrtc/modules/audio_processing/include/audio_processing.cc",
++                "//webrtc/modules/audio_processing/include/audio_processing.h",
++                "//webrtc/modules/audio_processing/include/config.cc",
++                "//webrtc/modules/audio_processing/include/config.h",
++                "//webrtc/modules/audio_processing/level_controller/biquad_filter.cc",
++                "//webrtc/modules/audio_processing/level_controller/biquad_filter.h",
++                "//webrtc/modules/audio_processing/level_controller/down_sampler.cc",
++                "//webrtc/modules/audio_processing/level_controller/down_sampler.h",
++                "//webrtc/modules/audio_processing/level_controller/gain_applier.cc",
++                "//webrtc/modules/audio_processing/level_controller/gain_applier.h",
++                "//webrtc/modules/audio_processing/level_controller/gain_selector.cc",
++                "//webrtc/modules/audio_processing/level_controller/gain_selector.h",
++                "//webrtc/modules/audio_processing/level_controller/level_controller.cc",
++                "//webrtc/modules/audio_processing/level_controller/level_controller.h",
++                "//webrtc/modules/audio_processing/level_controller/level_controller_constants.h",
++                "//webrtc/modules/audio_processing/level_controller/noise_level_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/noise_level_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/noise_spectrum_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/noise_spectrum_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/peak_level_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/peak_level_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/saturating_gain_estimator.cc",
++                "//webrtc/modules/audio_processing/level_controller/saturating_gain_estimator.h",
++                "//webrtc/modules/audio_processing/level_controller/signal_classifier.cc",
++                "//webrtc/modules/audio_processing/level_controller/signal_classifier.h",
++                "//webrtc/modules/audio_processing/level_estimator_impl.cc",
++                "//webrtc/modules/audio_processing/level_estimator_impl.h",
++                "//webrtc/modules/audio_processing/logging/apm_data_dumper.cc",
++                "//webrtc/modules/audio_processing/logging/apm_data_dumper.h",
++                "//webrtc/modules/audio_processing/low_cut_filter.cc",
++                "//webrtc/modules/audio_processing/low_cut_filter.h",
++                "//webrtc/modules/audio_processing/noise_suppression_impl.cc",
++                "//webrtc/modules/audio_processing/noise_suppression_impl.h",
++                "//webrtc/modules/audio_processing/render_queue_item_verifier.h",
++                "//webrtc/modules/audio_processing/residual_echo_detector.cc",
++                "//webrtc/modules/audio_processing/residual_echo_detector.h",
++                "//webrtc/modules/audio_processing/rms_level.cc",
++                "//webrtc/modules/audio_processing/rms_level.h",
++                "//webrtc/modules/audio_processing/splitting_filter.cc",
++                "//webrtc/modules/audio_processing/splitting_filter.h",
++                "//webrtc/modules/audio_processing/three_band_filter_bank.cc",
++                "//webrtc/modules/audio_processing/three_band_filter_bank.h",
++                "//webrtc/modules/audio_processing/transient/common.h",
++                "//webrtc/modules/audio_processing/transient/daubechies_8_wavelet_coeffs.h",
++                "//webrtc/modules/audio_processing/transient/dyadic_decimator.h",
++                "//webrtc/modules/audio_processing/transient/moving_moments.cc",
++                "//webrtc/modules/audio_processing/transient/moving_moments.h",
++                "//webrtc/modules/audio_processing/transient/transient_detector.cc",
++                "//webrtc/modules/audio_processing/transient/transient_detector.h",
++                "//webrtc/modules/audio_processing/transient/transient_suppressor.cc",
++                "//webrtc/modules/audio_processing/transient/transient_suppressor.h",
++                "//webrtc/modules/audio_processing/transient/wpd_node.cc",
++                "//webrtc/modules/audio_processing/transient/wpd_node.h",
++                "//webrtc/modules/audio_processing/transient/wpd_tree.cc",
++                "//webrtc/modules/audio_processing/transient/wpd_tree.h",
++                "//webrtc/modules/audio_processing/typing_detection.cc",
++                "//webrtc/modules/audio_processing/typing_detection.h",
++                "//webrtc/modules/audio_processing/utility/block_mean_calculator.cc",
++                "//webrtc/modules/audio_processing/utility/block_mean_calculator.h",
++                "//webrtc/modules/audio_processing/utility/delay_estimator.cc",
++                "//webrtc/modules/audio_processing/utility/delay_estimator.h",
++                "//webrtc/modules/audio_processing/utility/delay_estimator_internal.h",
++                "//webrtc/modules/audio_processing/utility/delay_estimator_wrapper.cc",
++                "//webrtc/modules/audio_processing/utility/delay_estimator_wrapper.h",
++                "//webrtc/modules/audio_processing/utility/ooura_fft.cc",
++                "//webrtc/modules/audio_processing/utility/ooura_fft.h",
++                "//webrtc/modules/audio_processing/utility/ooura_fft_tables_common.h",
++                "//webrtc/modules/audio_processing/vad/common.h",
++                "//webrtc/modules/audio_processing/vad/gmm.cc",
++                "//webrtc/modules/audio_processing/vad/gmm.h",
++                "//webrtc/modules/audio_processing/vad/noise_gmm_tables.h",
++                "//webrtc/modules/audio_processing/vad/pitch_based_vad.cc",
++                "//webrtc/modules/audio_processing/vad/pitch_based_vad.h",
++                "//webrtc/modules/audio_processing/vad/pitch_internal.cc",
++                "//webrtc/modules/audio_processing/vad/pitch_internal.h",
++                "//webrtc/modules/audio_processing/vad/pole_zero_filter.cc",
++                "//webrtc/modules/audio_processing/vad/pole_zero_filter.h",
++                "//webrtc/modules/audio_processing/vad/standalone_vad.cc",
++                "//webrtc/modules/audio_processing/vad/standalone_vad.h",
++                "//webrtc/modules/audio_processing/vad/vad_audio_proc.cc",
++                "//webrtc/modules/audio_processing/vad/vad_audio_proc.h",
++                "//webrtc/modules/audio_processing/vad/vad_audio_proc_internal.h",
++                "//webrtc/modules/audio_processing/vad/vad_circular_buffer.cc",
++                "//webrtc/modules/audio_processing/vad/vad_circular_buffer.h",
++                "//webrtc/modules/audio_processing/vad/voice_activity_detector.cc",
++                "//webrtc/modules/audio_processing/vad/voice_activity_detector.h",
++                "//webrtc/modules/audio_processing/vad/voice_gmm_tables.h",
++                "//webrtc/modules/audio_processing/voice_detection_impl.cc",
++                "//webrtc/modules/audio_processing/voice_detection_impl.h",
++                "//webrtc/modules/audio_processing/aecm/aecm_core_c.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/audio_processing:audio_processing_c": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_processing/agc/legacy/analog_agc.c",
++                "//webrtc/modules/audio_processing/agc/legacy/analog_agc.h",
++                "//webrtc/modules/audio_processing/agc/legacy/digital_agc.c",
++                "//webrtc/modules/audio_processing/agc/legacy/digital_agc.h",
++                "//webrtc/modules/audio_processing/agc/legacy/gain_control.h",
++                "//webrtc/modules/audio_processing/ns/defines.h",
++                "//webrtc/modules/audio_processing/ns/noise_suppression.c",
++                "//webrtc/modules/audio_processing/ns/noise_suppression.h",
++                "//webrtc/modules/audio_processing/ns/ns_core.c",
++                "//webrtc/modules/audio_processing/ns/ns_core.h",
++                "//webrtc/modules/audio_processing/ns/windows_private.h"
++            ],
++            "type": "source_set"
++        },
++        "//webrtc/modules/audio_processing:audio_processing_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_APM_DEBUG_DUMP=1",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/audio_processing/aec/aec_core_sse2.cc",
++                "//webrtc/modules/audio_processing/utility/ooura_fft_sse2.cc",
++                "//webrtc/modules/audio_processing/utility/ooura_fft_tables_neon_sse2.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/bitrate_controller:bitrate_controller": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/bitrate_controller/bitrate_controller_impl.cc",
++                "//webrtc/modules/bitrate_controller/bitrate_controller_impl.h",
++                "//webrtc/modules/bitrate_controller/include/bitrate_controller.h",
++                "//webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc",
++                "//webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/congestion_controller:congestion_controller": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/modules/bitrate_controller:bitrate_controller",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/congestion_controller/congestion_controller.cc",
++                "//webrtc/modules/congestion_controller/delay_based_bwe.cc",
++                "//webrtc/modules/congestion_controller/delay_based_bwe.h",
++                "//webrtc/modules/congestion_controller/include/congestion_controller.h",
++                "//webrtc/modules/congestion_controller/median_slope_estimator.cc",
++                "//webrtc/modules/congestion_controller/median_slope_estimator.h",
++                "//webrtc/modules/congestion_controller/probe_bitrate_estimator.cc",
++                "//webrtc/modules/congestion_controller/probe_bitrate_estimator.h",
++                "//webrtc/modules/congestion_controller/probe_controller.cc",
++                "//webrtc/modules/congestion_controller/probe_controller.h",
++                "//webrtc/modules/congestion_controller/probing_interval_estimator.cc",
++                "//webrtc/modules/congestion_controller/probing_interval_estimator.h",
++                "//webrtc/modules/congestion_controller/transport_feedback_adapter.cc",
++                "//webrtc/modules/congestion_controller/transport_feedback_adapter.h",
++                "//webrtc/modules/congestion_controller/trendline_estimator.cc",
++                "//webrtc/modules/congestion_controller/trendline_estimator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/desktop_capture:desktop_capture": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "MULTI_MONITOR_SCREENSHARE",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/desktop_capture:desktop_capture_differ_sse2",
++                "//webrtc/modules/desktop_capture:primitives",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [
++                "X11",
++                "X11-xcb",
++                "xcb",
++                "Xcomposite",
++                "Xcursor",
++                "Xdamage",
++                "Xext",
++                "Xfixes",
++                "Xi",
++                "Xrender"
++            ],
++            "sources": [
++                "//webrtc/modules/desktop_capture/cropped_desktop_frame.cc",
++                "//webrtc/modules/desktop_capture/cropped_desktop_frame.h",
++                "//webrtc/modules/desktop_capture/cropping_window_capturer.cc",
++                "//webrtc/modules/desktop_capture/cropping_window_capturer.h",
++                "//webrtc/modules/desktop_capture/desktop_and_cursor_composer.cc",
++                "//webrtc/modules/desktop_capture/desktop_and_cursor_composer.h",
++                "//webrtc/modules/desktop_capture/desktop_capture_options.cc",
++                "//webrtc/modules/desktop_capture/desktop_capture_options.h",
++                "//webrtc/modules/desktop_capture/desktop_capturer.cc",
++                "//webrtc/modules/desktop_capture/desktop_capturer.h",
++                "//webrtc/modules/desktop_capture/desktop_capturer_differ_wrapper.cc",
++                "//webrtc/modules/desktop_capture/desktop_capturer_differ_wrapper.h",
++                "//webrtc/modules/desktop_capture/desktop_frame_rotation.cc",
++                "//webrtc/modules/desktop_capture/desktop_frame_rotation.h",
++                "//webrtc/modules/desktop_capture/differ_block.cc",
++                "//webrtc/modules/desktop_capture/differ_block.h",
++                "//webrtc/modules/desktop_capture/mouse_cursor.cc",
++                "//webrtc/modules/desktop_capture/mouse_cursor.h",
++                "//webrtc/modules/desktop_capture/mouse_cursor_monitor.h",
++                "//webrtc/modules/desktop_capture/screen_capture_frame_queue.h",
++                "//webrtc/modules/desktop_capture/screen_capturer_helper.cc",
++                "//webrtc/modules/desktop_capture/screen_capturer_helper.h",
++                "//webrtc/modules/desktop_capture/desktop_device_info.cc",
++                "//webrtc/modules/desktop_capture/desktop_device_info.h",
++                "//webrtc/modules/desktop_capture/mouse_cursor_monitor_x11.cc",
++                "//webrtc/modules/desktop_capture/screen_capturer_x11.cc",
++                "//webrtc/modules/desktop_capture/window_capturer_x11.cc",
++                "//webrtc/modules/desktop_capture/x11/shared_x_display.cc",
++                "//webrtc/modules/desktop_capture/x11/shared_x_display.h",
++                "//webrtc/modules/desktop_capture/x11/x_error_trap.cc",
++                "//webrtc/modules/desktop_capture/x11/x_error_trap.h",
++                "//webrtc/modules/desktop_capture/x11/x_server_pixel_buffer.cc",
++                "//webrtc/modules/desktop_capture/x11/x_server_pixel_buffer.h",
++                "//webrtc/modules/desktop_capture/app_capturer_x11.cc",
++                "//webrtc/modules/desktop_capture/app_capturer_x11.h",
++                "//webrtc/modules/desktop_capture/x11/desktop_device_info_x11.cc",
++                "//webrtc/modules/desktop_capture/x11/desktop_device_info_x11.h",
++                "//webrtc/modules/desktop_capture/x11/shared_x_util.cc",
++                "//webrtc/modules/desktop_capture/x11/shared_x_util.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/desktop_capture:desktop_capture_differ_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/desktop_capture/differ_vector_sse2.cc",
++                "//webrtc/modules/desktop_capture/differ_vector_sse2.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/desktop_capture:primitives": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/desktop_capture/desktop_capture_types.h",
++                "//webrtc/modules/desktop_capture/desktop_frame.cc",
++                "//webrtc/modules/desktop_capture/desktop_frame.h",
++                "//webrtc/modules/desktop_capture/desktop_geometry.cc",
++                "//webrtc/modules/desktop_capture/desktop_geometry.h",
++                "//webrtc/modules/desktop_capture/desktop_region.cc",
++                "//webrtc/modules/desktop_capture/desktop_region.h",
++                "//webrtc/modules/desktop_capture/shared_desktop_frame.cc",
++                "//webrtc/modules/desktop_capture/shared_desktop_frame.h",
++                "//webrtc/modules/desktop_capture/shared_memory.cc",
++                "//webrtc/modules/desktop_capture/shared_memory.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/media_file:media_file": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/media_file/media_file.h",
++                "//webrtc/modules/media_file/media_file_defines.h",
++                "//webrtc/modules/media_file/media_file_impl.cc",
++                "//webrtc/modules/media_file/media_file_impl.h",
++                "//webrtc/modules/media_file/media_file_utility.cc",
++                "//webrtc/modules/media_file/media_file_utility.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/pacing:pacing": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/pacing/alr_detector.cc",
++                "//webrtc/modules/pacing/alr_detector.h",
++                "//webrtc/modules/pacing/bitrate_prober.cc",
++                "//webrtc/modules/pacing/bitrate_prober.h",
++                "//webrtc/modules/pacing/paced_sender.cc",
++                "//webrtc/modules/pacing/paced_sender.h",
++                "//webrtc/modules/pacing/packet_router.cc",
++                "//webrtc/modules/pacing/packet_router.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/remote_bitrate_estimator/aimd_rate_control.cc",
++                "//webrtc/modules/remote_bitrate_estimator/aimd_rate_control.h",
++                "//webrtc/modules/remote_bitrate_estimator/bwe_defines.cc",
++                "//webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h",
++                "//webrtc/modules/remote_bitrate_estimator/include/remote_bitrate_estimator.h",
++                "//webrtc/modules/remote_bitrate_estimator/include/send_time_history.h",
++                "//webrtc/modules/remote_bitrate_estimator/inter_arrival.cc",
++                "//webrtc/modules/remote_bitrate_estimator/inter_arrival.h",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_detector.cc",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_detector.h",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_estimator.cc",
++                "//webrtc/modules/remote_bitrate_estimator/overuse_estimator.h",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.h",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_single_stream.cc",
++                "//webrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_single_stream.h",
++                "//webrtc/modules/remote_bitrate_estimator/remote_estimator_proxy.cc",
++                "//webrtc/modules/remote_bitrate_estimator/remote_estimator_proxy.h",
++                "//webrtc/modules/remote_bitrate_estimator/send_time_history.cc",
++                "//webrtc/modules/remote_bitrate_estimator/test/bwe_test_logging.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/rtp_rtcp:rtp_rtcp": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "BWE_TEST_LOGGING_COMPILE_TIME_ENABLE=0",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:transport_api",
++                "//webrtc/base:gtest_prod",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/call:call_interfaces",
++                "//webrtc/common_video:common_video",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/rtp_rtcp/include/flexfec_receiver.h",
++                "//webrtc/modules/rtp_rtcp/include/flexfec_sender.h",
++                "//webrtc/modules/rtp_rtcp/include/receive_statistics.h",
++                "//webrtc/modules/rtp_rtcp/include/remote_ntp_time_estimator.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_audio_level_observer.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_header_parser.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_payload_registry.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_receiver.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_rtcp.h",
++                "//webrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.h",
++                "//webrtc/modules/rtp_rtcp/include/ulpfec_receiver.h",
++                "//webrtc/modules/rtp_rtcp/source/byte_io.h",
++                "//webrtc/modules/rtp_rtcp/source/dtmf_queue.cc",
++                "//webrtc/modules/rtp_rtcp/source/dtmf_queue.h",
++                "//webrtc/modules/rtp_rtcp/source/fec_private_tables_bursty.h",
++                "//webrtc/modules/rtp_rtcp/source/fec_private_tables_random.h",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_header_reader_writer.cc",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_header_reader_writer.h",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_receiver.cc",
++                "//webrtc/modules/rtp_rtcp/source/flexfec_sender.cc",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction.cc",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction.h",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction_internal.cc",
++                "//webrtc/modules/rtp_rtcp/source/forward_error_correction_internal.h",
++                "//webrtc/modules/rtp_rtcp/source/packet_loss_stats.cc",
++                "//webrtc/modules/rtp_rtcp/source/packet_loss_stats.h",
++                "//webrtc/modules/rtp_rtcp/source/playout_delay_oracle.cc",
++                "//webrtc/modules/rtp_rtcp/source/playout_delay_oracle.h",
++                "//webrtc/modules/rtp_rtcp/source/receive_statistics_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/receive_statistics_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/remote_ntp_time_estimator.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/app.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/app.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/bye.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/bye.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/common_header.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/common_header.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/compound_packet.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/compound_packet.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/dlrr.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/dlrr.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_jitter_report.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_jitter_report.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_reports.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/extended_reports.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/fir.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/fir.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/nack.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/nack.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/pli.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/pli.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/psfb.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/psfb.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rapid_resync_request.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rapid_resync_request.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/receiver_report.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/receiver_report.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/remb.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/remb.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/report_block.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/report_block.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rpsi.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rpsi.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rrtr.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rrtr.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rtpfb.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/rtpfb.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sdes.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sdes.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sender_report.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sender_report.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sli.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/sli.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/target_bitrate.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/target_bitrate.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmb_item.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmb_item.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbn.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbn.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbr.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/tmmbr.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/transport_feedback.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/transport_feedback.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/voip_metric.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_packet/voip_metric.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_receiver.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_receiver.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_sender.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_sender.h",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_utility.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtcp_utility.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_h264.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_h264.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_video_generic.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_video_generic.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp8.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp8.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_format_vp9.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extension.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extension.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extensions.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_extensions.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_header_parser.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_history.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_history.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_received.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_packet_to_send.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_payload_registry.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_audio.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_audio.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_strategy.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_strategy.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_video.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_receiver_video.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_rtcp_config.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_rtcp_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_rtcp_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_audio.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_audio.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_video.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_sender_video.h",
++                "//webrtc/modules/rtp_rtcp/source/rtp_utility.cc",
++                "//webrtc/modules/rtp_rtcp/source/rtp_utility.h",
++                "//webrtc/modules/rtp_rtcp/source/ssrc_database.cc",
++                "//webrtc/modules/rtp_rtcp/source/ssrc_database.h",
++                "//webrtc/modules/rtp_rtcp/source/time_util.cc",
++                "//webrtc/modules/rtp_rtcp/source/time_util.h",
++                "//webrtc/modules/rtp_rtcp/source/tmmbr_help.cc",
++                "//webrtc/modules/rtp_rtcp/source/tmmbr_help.h",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_generator.cc",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_generator.h",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_header_reader_writer.cc",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_header_reader_writer.h",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_receiver_impl.cc",
++                "//webrtc/modules/rtp_rtcp/source/ulpfec_receiver_impl.h",
++                "//webrtc/modules/rtp_rtcp/source/video_codec_information.h",
++                "//webrtc/modules/rtp_rtcp/source/vp8_partition_aggregator.cc",
++                "//webrtc/modules/rtp_rtcp/source/vp8_partition_aggregator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/utility:utility": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/audio_coding:audio_coding",
++                "//webrtc/modules/audio_coding:audio_format_conversion",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/utility/include/audio_frame_operations.h",
++                "//webrtc/modules/utility/include/process_thread.h",
++                "//webrtc/modules/utility/source/process_thread_impl.cc",
++                "//webrtc/modules/utility/source/process_thread_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_capture:video_capture_internal_impl": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/video_capture:video_capture_module",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_capture/linux/device_info_linux.cc",
++                "//webrtc/modules/video_capture/linux/device_info_linux.h",
++                "//webrtc/modules/video_capture/linux/video_capture_linux.cc",
++                "//webrtc/modules/video_capture/linux/video_capture_linux.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_capture:video_capture_module": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_capture/device_info_impl.cc",
++                "//webrtc/modules/video_capture/device_info_impl.h",
++                "//webrtc/modules/video_capture/video_capture.h",
++                "//webrtc/modules/video_capture/video_capture_config.h",
++                "//webrtc/modules/video_capture/video_capture_defines.h",
++                "//webrtc/modules/video_capture/video_capture_delay.h",
++                "//webrtc/modules/video_capture/video_capture_factory.cc",
++                "//webrtc/modules/video_capture/video_capture_factory.h",
++                "//webrtc/modules/video_capture/video_capture_impl.cc",
++                "//webrtc/modules/video_capture/video_capture_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:video_coding": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/modules/video_coding:webrtc_h264",
++                "//webrtc/modules/video_coding:webrtc_i420",
++                "//webrtc/modules/video_coding:webrtc_vp8",
++                "//webrtc/modules/video_coding:webrtc_vp9",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codec_database.cc",
++                "//webrtc/modules/video_coding/codec_database.h",
++                "//webrtc/modules/video_coding/codec_timer.cc",
++                "//webrtc/modules/video_coding/codec_timer.h",
++                "//webrtc/modules/video_coding/decoding_state.cc",
++                "//webrtc/modules/video_coding/decoding_state.h",
++                "//webrtc/modules/video_coding/encoded_frame.cc",
++                "//webrtc/modules/video_coding/encoded_frame.h",
++                "//webrtc/modules/video_coding/fec_rate_table.h",
++                "//webrtc/modules/video_coding/frame_buffer.cc",
++                "//webrtc/modules/video_coding/frame_buffer.h",
++                "//webrtc/modules/video_coding/frame_buffer2.cc",
++                "//webrtc/modules/video_coding/frame_buffer2.h",
++                "//webrtc/modules/video_coding/frame_object.cc",
++                "//webrtc/modules/video_coding/frame_object.h",
++                "//webrtc/modules/video_coding/generic_decoder.cc",
++                "//webrtc/modules/video_coding/generic_decoder.h",
++                "//webrtc/modules/video_coding/generic_encoder.cc",
++                "//webrtc/modules/video_coding/generic_encoder.h",
++                "//webrtc/modules/video_coding/h264_sprop_parameter_sets.cc",
++                "//webrtc/modules/video_coding/h264_sprop_parameter_sets.h",
++                "//webrtc/modules/video_coding/h264_sps_pps_tracker.cc",
++                "//webrtc/modules/video_coding/h264_sps_pps_tracker.h",
++                "//webrtc/modules/video_coding/histogram.cc",
++                "//webrtc/modules/video_coding/histogram.h",
++                "//webrtc/modules/video_coding/include/video_codec_initializer.h",
++                "//webrtc/modules/video_coding/include/video_coding.h",
++                "//webrtc/modules/video_coding/include/video_coding_defines.h",
++                "//webrtc/modules/video_coding/inter_frame_delay.cc",
++                "//webrtc/modules/video_coding/inter_frame_delay.h",
++                "//webrtc/modules/video_coding/internal_defines.h",
++                "//webrtc/modules/video_coding/jitter_buffer.cc",
++                "//webrtc/modules/video_coding/jitter_buffer.h",
++                "//webrtc/modules/video_coding/jitter_buffer_common.h",
++                "//webrtc/modules/video_coding/jitter_estimator.cc",
++                "//webrtc/modules/video_coding/jitter_estimator.h",
++                "//webrtc/modules/video_coding/media_opt_util.cc",
++                "//webrtc/modules/video_coding/media_opt_util.h",
++                "//webrtc/modules/video_coding/media_optimization.cc",
++                "//webrtc/modules/video_coding/media_optimization.h",
++                "//webrtc/modules/video_coding/nack_fec_tables.h",
++                "//webrtc/modules/video_coding/nack_module.cc",
++                "//webrtc/modules/video_coding/nack_module.h",
++                "//webrtc/modules/video_coding/packet.cc",
++                "//webrtc/modules/video_coding/packet.h",
++                "//webrtc/modules/video_coding/packet_buffer.cc",
++                "//webrtc/modules/video_coding/packet_buffer.h",
++                "//webrtc/modules/video_coding/protection_bitrate_calculator.cc",
++                "//webrtc/modules/video_coding/protection_bitrate_calculator.h",
++                "//webrtc/modules/video_coding/receiver.cc",
++                "//webrtc/modules/video_coding/receiver.h",
++                "//webrtc/modules/video_coding/rtp_frame_reference_finder.cc",
++                "//webrtc/modules/video_coding/rtp_frame_reference_finder.h",
++                "//webrtc/modules/video_coding/rtt_filter.cc",
++                "//webrtc/modules/video_coding/rtt_filter.h",
++                "//webrtc/modules/video_coding/session_info.cc",
++                "//webrtc/modules/video_coding/session_info.h",
++                "//webrtc/modules/video_coding/timestamp_map.cc",
++                "//webrtc/modules/video_coding/timestamp_map.h",
++                "//webrtc/modules/video_coding/timing.cc",
++                "//webrtc/modules/video_coding/timing.h",
++                "//webrtc/modules/video_coding/video_codec_initializer.cc",
++                "//webrtc/modules/video_coding/video_coding_impl.cc",
++                "//webrtc/modules/video_coding/video_coding_impl.h",
++                "//webrtc/modules/video_coding/video_receiver.cc",
++                "//webrtc/modules/video_coding/video_sender.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:video_coding_utility": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/common_video:common_video",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/utility/default_video_bitrate_allocator.cc",
++                "//webrtc/modules/video_coding/utility/default_video_bitrate_allocator.h",
++                "//webrtc/modules/video_coding/utility/frame_dropper.cc",
++                "//webrtc/modules/video_coding/utility/frame_dropper.h",
++                "//webrtc/modules/video_coding/utility/ivf_file_writer.cc",
++                "//webrtc/modules/video_coding/utility/ivf_file_writer.h",
++                "//webrtc/modules/video_coding/utility/moving_average.cc",
++                "//webrtc/modules/video_coding/utility/moving_average.h",
++                "//webrtc/modules/video_coding/utility/qp_parser.cc",
++                "//webrtc/modules/video_coding/utility/qp_parser.h",
++                "//webrtc/modules/video_coding/utility/quality_scaler.cc",
++                "//webrtc/modules/video_coding/utility/quality_scaler.h",
++                "//webrtc/modules/video_coding/utility/simulcast_rate_allocator.cc",
++                "//webrtc/modules/video_coding/utility/simulcast_rate_allocator.h",
++                "//webrtc/modules/video_coding/utility/vp8_header_parser.cc",
++                "//webrtc/modules/video_coding/utility/vp8_header_parser.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_h264": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/h264/h264.cc",
++                "//webrtc/modules/video_coding/codecs/h264/include/h264.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_i420": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/i420/i420.cc",
++                "//webrtc/modules/video_coding/codecs/i420/include/i420.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_vp8": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/vp8/default_temporal_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/default_temporal_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp8/include/vp8.h",
++                "//webrtc/modules/video_coding/codecs/vp8/include/vp8_common_types.h",
++                "//webrtc/modules/video_coding/codecs/vp8/realtime_temporal_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/reference_picture_selection.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/reference_picture_selection.h",
++                "//webrtc/modules/video_coding/codecs/vp8/screenshare_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/screenshare_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp8/simulcast_encoder_adapter.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/simulcast_encoder_adapter.h",
++                "//webrtc/modules/video_coding/codecs/vp8/temporal_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp8/vp8_impl.cc",
++                "//webrtc/modules/video_coding/codecs/vp8/vp8_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_coding:webrtc_vp9": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/video_coding:video_coding_utility",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_coding/codecs/vp9/include/vp9.h",
++                "//webrtc/modules/video_coding/codecs/vp9/screenshare_layers.cc",
++                "//webrtc/modules/video_coding/codecs/vp9/screenshare_layers.h",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_frame_buffer_pool.cc",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_frame_buffer_pool.h",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_impl.cc",
++                "//webrtc/modules/video_coding/codecs/vp9/vp9_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_processing:video_processing": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/common_video:common_video",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/modules/video_processing:video_processing_sse2",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "/media/libyuv/libyuv/include/",
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_processing/util/denoiser_filter.cc",
++                "//webrtc/modules/video_processing/util/denoiser_filter.h",
++                "//webrtc/modules/video_processing/util/denoiser_filter_c.cc",
++                "//webrtc/modules/video_processing/util/denoiser_filter_c.h",
++                "//webrtc/modules/video_processing/util/noise_estimation.cc",
++                "//webrtc/modules/video_processing/util/noise_estimation.h",
++                "//webrtc/modules/video_processing/util/skin_detection.cc",
++                "//webrtc/modules/video_processing/util/skin_detection.h",
++                "//webrtc/modules/video_processing/video_denoiser.cc",
++                "//webrtc/modules/video_processing/video_denoiser.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/modules/video_processing:video_processing_sse2": {
++            "cflags": [
++                "-msse2",
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/system_wrappers:system_wrappers"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/modules/video_processing/util/denoiser_filter_sse2.cc",
++                "//webrtc/modules/video_processing/util/denoiser_filter_sse2.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/system_wrappers:field_trial_default": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/system_wrappers/include/field_trial_default.h",
++                "//webrtc/system_wrappers/source/field_trial_default.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/system_wrappers:metrics_default": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/system_wrappers/include/metrics_default.h",
++                "//webrtc/system_wrappers/source/metrics_default.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/system_wrappers:system_wrappers": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "WEBRTC_THREAD_RR",
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/system_wrappers/include/aligned_array.h",
++                "//webrtc/system_wrappers/include/aligned_malloc.h",
++                "//webrtc/system_wrappers/include/atomic32.h",
++                "//webrtc/system_wrappers/include/clock.h",
++                "//webrtc/system_wrappers/include/cpu_features_wrapper.h",
++                "//webrtc/system_wrappers/include/cpu_info.h",
++                "//webrtc/system_wrappers/include/critical_section_wrapper.h",
++                "//webrtc/system_wrappers/include/event_wrapper.h",
++                "//webrtc/system_wrappers/include/field_trial.h",
++                "//webrtc/system_wrappers/include/file_wrapper.h",
++                "//webrtc/system_wrappers/include/logging.h",
++                "//webrtc/system_wrappers/include/metrics.h",
++                "//webrtc/system_wrappers/include/ntp_time.h",
++                "//webrtc/system_wrappers/include/rtp_to_ntp_estimator.h",
++                "//webrtc/system_wrappers/include/rw_lock_wrapper.h",
++                "//webrtc/system_wrappers/include/sleep.h",
++                "//webrtc/system_wrappers/include/static_instance.h",
++                "//webrtc/system_wrappers/include/stringize_macros.h",
++                "//webrtc/system_wrappers/include/timestamp_extrapolator.h",
++                "//webrtc/system_wrappers/include/trace.h",
++                "//webrtc/system_wrappers/source/aligned_malloc.cc",
++                "//webrtc/system_wrappers/source/clock.cc",
++                "//webrtc/system_wrappers/source/cpu_features.cc",
++                "//webrtc/system_wrappers/source/cpu_info.cc",
++                "//webrtc/system_wrappers/source/event.cc",
++                "//webrtc/system_wrappers/source/event_timer_posix.cc",
++                "//webrtc/system_wrappers/source/event_timer_posix.h",
++                "//webrtc/system_wrappers/source/file_impl.cc",
++                "//webrtc/system_wrappers/source/logging.cc",
++                "//webrtc/system_wrappers/source/rtp_to_ntp_estimator.cc",
++                "//webrtc/system_wrappers/source/rw_lock.cc",
++                "//webrtc/system_wrappers/source/rw_lock_posix.cc",
++                "//webrtc/system_wrappers/source/rw_lock_posix.h",
++                "//webrtc/system_wrappers/source/sleep.cc",
++                "//webrtc/system_wrappers/source/timestamp_extrapolator.cc",
++                "//webrtc/system_wrappers/source/trace_impl.cc",
++                "//webrtc/system_wrappers/source/trace_impl.h",
++                "//webrtc/system_wrappers/source/trace_posix.cc",
++                "//webrtc/system_wrappers/source/trace_posix.h",
++                "//webrtc/system_wrappers/source/atomic32_non_darwin_unix.cc"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/video:video": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:transport_api",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/base:rtc_numerics",
++                "//webrtc/base:rtc_task_queue",
++                "//webrtc/common_video:common_video",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/bitrate_controller:bitrate_controller",
++                "//webrtc/modules/congestion_controller:congestion_controller",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/remote_bitrate_estimator:remote_bitrate_estimator",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/modules/video_coding:video_coding",
++                "//webrtc/modules/video_processing:video_processing",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:voice_engine"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/video/call_stats.cc",
++                "//webrtc/video/call_stats.h",
++                "//webrtc/video/encoder_rtcp_feedback.cc",
++                "//webrtc/video/encoder_rtcp_feedback.h",
++                "//webrtc/video/overuse_frame_detector.cc",
++                "//webrtc/video/overuse_frame_detector.h",
++                "//webrtc/video/payload_router.cc",
++                "//webrtc/video/payload_router.h",
++                "//webrtc/video/quality_threshold.cc",
++                "//webrtc/video/quality_threshold.h",
++                "//webrtc/video/receive_statistics_proxy.cc",
++                "//webrtc/video/receive_statistics_proxy.h",
++                "//webrtc/video/report_block_stats.cc",
++                "//webrtc/video/report_block_stats.h",
++                "//webrtc/video/rtp_stream_receiver.cc",
++                "//webrtc/video/rtp_stream_receiver.h",
++                "//webrtc/video/rtp_streams_synchronizer.cc",
++                "//webrtc/video/rtp_streams_synchronizer.h",
++                "//webrtc/video/send_delay_stats.cc",
++                "//webrtc/video/send_delay_stats.h",
++                "//webrtc/video/send_statistics_proxy.cc",
++                "//webrtc/video/send_statistics_proxy.h",
++                "//webrtc/video/stats_counter.cc",
++                "//webrtc/video/stats_counter.h",
++                "//webrtc/video/stream_synchronization.cc",
++                "//webrtc/video/stream_synchronization.h",
++                "//webrtc/video/transport_adapter.cc",
++                "//webrtc/video/transport_adapter.h",
++                "//webrtc/video/video_receive_stream.cc",
++                "//webrtc/video/video_receive_stream.h",
++                "//webrtc/video/video_send_stream.cc",
++                "//webrtc/video/video_send_stream.h",
++                "//webrtc/video/video_stream_decoder.cc",
++                "//webrtc/video/video_stream_decoder.h",
++                "//webrtc/video/vie_encoder.cc",
++                "//webrtc/video/vie_encoder.h",
++                "//webrtc/video/vie_remb.cc",
++                "//webrtc/video/vie_remb.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/video_engine:video_engine": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/video_engine/browser_capture_impl.h",
++                "//webrtc/video_engine/desktop_capture_impl.cc",
++                "//webrtc/video_engine/desktop_capture_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:audio_coder": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/modules/audio_coding:audio_coding",
++                "//webrtc/modules/audio_coding:audio_format_conversion",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:rent_a_codec"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/coder.cc",
++                "//webrtc/voice_engine/coder.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:file_player": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:audio_coder"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/file_player.cc",
++                "//webrtc/voice_engine/file_player.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:file_recorder": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:audio_coder"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/file_recorder.cc",
++                "//webrtc/voice_engine/file_recorder.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:level_indicator": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/level_indicator.cc",
++                "//webrtc/voice_engine/level_indicator.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc/voice_engine:voice_engine": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:audio_mixer_api",
++                "//webrtc/api:call_api",
++                "//webrtc/api:transport_api",
++                "//webrtc/audio/utility:audio_frame_operations",
++                "//webrtc/base:rtc_base_approved",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/logging:rtc_event_log_api",
++                "//webrtc/modules/audio_coding:audio_coding",
++                "//webrtc/modules/audio_coding:audio_decoder_factory_interface",
++                "//webrtc/modules/audio_coding:audio_format_conversion",
++                "//webrtc/modules/audio_coding:builtin_audio_decoder_factory",
++                "//webrtc/modules/audio_coding:rent_a_codec",
++                "//webrtc/modules/audio_conference_mixer:audio_conference_mixer",
++                "//webrtc/modules/audio_device:audio_device",
++                "//webrtc/modules/audio_processing:audio_processing",
++                "//webrtc/modules/bitrate_controller:bitrate_controller",
++                "//webrtc/modules/media_file:media_file",
++                "//webrtc/modules/pacing:pacing",
++                "//webrtc/modules/rtp_rtcp:rtp_rtcp",
++                "//webrtc/modules/utility:utility",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/voice_engine:file_player",
++                "//webrtc/voice_engine:file_recorder",
++                "//webrtc/voice_engine:level_indicator"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/modules/audio_conference_mixer/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/voice_engine/channel.cc",
++                "//webrtc/voice_engine/channel.h",
++                "//webrtc/voice_engine/channel_manager.cc",
++                "//webrtc/voice_engine/channel_manager.h",
++                "//webrtc/voice_engine/channel_proxy.cc",
++                "//webrtc/voice_engine/channel_proxy.h",
++                "//webrtc/voice_engine/include/voe_audio_processing.h",
++                "//webrtc/voice_engine/include/voe_base.h",
++                "//webrtc/voice_engine/include/voe_codec.h",
++                "//webrtc/voice_engine/include/voe_errors.h",
++                "//webrtc/voice_engine/include/voe_external_media.h",
++                "//webrtc/voice_engine/include/voe_file.h",
++                "//webrtc/voice_engine/include/voe_hardware.h",
++                "//webrtc/voice_engine/include/voe_neteq_stats.h",
++                "//webrtc/voice_engine/include/voe_network.h",
++                "//webrtc/voice_engine/include/voe_rtp_rtcp.h",
++                "//webrtc/voice_engine/include/voe_video_sync.h",
++                "//webrtc/voice_engine/include/voe_volume_control.h",
++                "//webrtc/voice_engine/monitor_module.cc",
++                "//webrtc/voice_engine/monitor_module.h",
++                "//webrtc/voice_engine/output_mixer.cc",
++                "//webrtc/voice_engine/output_mixer.h",
++                "//webrtc/voice_engine/shared_data.cc",
++                "//webrtc/voice_engine/shared_data.h",
++                "//webrtc/voice_engine/statistics.cc",
++                "//webrtc/voice_engine/statistics.h",
++                "//webrtc/voice_engine/transmit_mixer.cc",
++                "//webrtc/voice_engine/transmit_mixer.h",
++                "//webrtc/voice_engine/utility.cc",
++                "//webrtc/voice_engine/utility.h",
++                "//webrtc/voice_engine/voe_audio_processing_impl.cc",
++                "//webrtc/voice_engine/voe_audio_processing_impl.h",
++                "//webrtc/voice_engine/voe_base_impl.cc",
++                "//webrtc/voice_engine/voe_base_impl.h",
++                "//webrtc/voice_engine/voe_codec_impl.cc",
++                "//webrtc/voice_engine/voe_codec_impl.h",
++                "//webrtc/voice_engine/voe_external_media_impl.cc",
++                "//webrtc/voice_engine/voe_external_media_impl.h",
++                "//webrtc/voice_engine/voe_file_impl.cc",
++                "//webrtc/voice_engine/voe_file_impl.h",
++                "//webrtc/voice_engine/voe_hardware_impl.cc",
++                "//webrtc/voice_engine/voe_hardware_impl.h",
++                "//webrtc/voice_engine/voe_neteq_stats_impl.cc",
++                "//webrtc/voice_engine/voe_neteq_stats_impl.h",
++                "//webrtc/voice_engine/voe_network_impl.cc",
++                "//webrtc/voice_engine/voe_network_impl.h",
++                "//webrtc/voice_engine/voe_rtp_rtcp_impl.cc",
++                "//webrtc/voice_engine/voe_rtp_rtcp_impl.h",
++                "//webrtc/voice_engine/voe_video_sync_impl.cc",
++                "//webrtc/voice_engine/voe_video_sync_impl.h",
++                "//webrtc/voice_engine/voe_volume_control_impl.cc",
++                "//webrtc/voice_engine/voe_volume_control_impl.h",
++                "//webrtc/voice_engine/voice_engine_defines.h",
++                "//webrtc/voice_engine/voice_engine_impl.cc",
++                "//webrtc/voice_engine/voice_engine_impl.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc:webrtc": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Xclang",
++                "-add-plugin",
++                "-Xclang",
++                "find-bad-constructs",
++                "-Xclang",
++                "-plugin-arg-find-bad-constructs",
++                "-Xclang",
++                "check-auto-raw-pointer",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS",
++                "WEBRTC_BUILD_LIBEVENT"
++            ],
++            "deps": [
++                "//webrtc:webrtc_common",
++                "//webrtc/api:transport_api",
++                "//webrtc/api:video_frame_api",
++                "//webrtc/audio:audio",
++                "//webrtc/base:base",
++                "//webrtc/call:call",
++                "//webrtc/common_audio:common_audio",
++                "//webrtc/common_video:common_video",
++                "//webrtc/media:media",
++                "//webrtc/modules:modules",
++                "//webrtc/modules/video_capture:video_capture_internal_impl",
++                "//webrtc/sdk:sdk",
++                "//webrtc/system_wrappers:field_trial_default",
++                "//webrtc/system_wrappers:metrics_default",
++                "//webrtc/system_wrappers:system_wrappers",
++                "//webrtc/video:video",
++                "//webrtc/video_engine:video_engine",
++                "//webrtc/voice_engine:voice_engine"
++            ],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/",
++                "//webrtc/common_audio/resampler/include/",
++                "//webrtc/common_audio/signal_processing/include/",
++                "//webrtc/common_audio/vad/include/",
++                "//webrtc/common_video/include/",
++                "//webrtc/common_video/libyuv/include/",
++                "//webrtc/modules/audio_coding/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_conference_mixer/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/include/",
++                "//webrtc/modules/audio_device/include/",
++                "//webrtc/modules/audio_device/dummy/"
++            ],
++            "libs": [
++                "X11",
++                "X11-xcb",
++                "xcb",
++                "Xcomposite",
++                "Xcursor",
++                "Xdamage",
++                "Xext",
++                "Xfixes",
++                "Xi",
++                "Xrender"
++            ],
++            "sources": [
++                "//webrtc/build/no_op_function.cc",
++                "//webrtc/call.h",
++                "//webrtc/config.h"
++            ],
++            "type": "static_library"
++        },
++        "//webrtc:webrtc_common": {
++            "cflags": [
++                "-fno-strict-aliasing",
++                "--param=ssp-buffer-size=4",
++                "-fstack-protector",
++                "-Wno-builtin-macro-redefined",
++                "-D__DATE__=",
++                "-D__TIME__=",
++                "-D__TIMESTAMP__=",
++                "-funwind-tables",
++                "-fcolor-diagnostics",
++                "-m64",
++                "-march=x86-64",
++                "-Wall",
++                "-Werror",
++                "-Wextra",
++                "-Wno-missing-field-initializers",
++                "-Wno-unused-parameter",
++                "-Wno-c++11-narrowing",
++                "-Wno-covered-switch-default",
++                "-Wno-unneeded-internal-declaration",
++                "-Wno-inconsistent-missing-override",
++                "-Wno-undefined-var-template",
++                "-Wno-nonportable-include-path",
++                "-Wno-address-of-packed-member",
++                "-Wno-unused-lambda-capture",
++                "-Wno-user-defined-warnings",
++                "-O0",
++                "-fno-omit-frame-pointer",
++                "-g2",
++                "-fvisibility=hidden",
++                "-Wheader-hygiene",
++                "-Wstring-conversion",
++                "-Wtautological-overlap-compare",
++                "-Wextra",
++                "-Wno-unused-parameter",
++                "-Wno-missing-field-initializers",
++                "-Wno-strict-overflow",
++                "-Wimplicit-fallthrough",
++                "-Wthread-safety",
++                "-Winconsistent-missing-override",
++                "-Wundef"
++            ],
++            "defines": [
++                "V8_DEPRECATION_WARNINGS",
++                "USE_X11=1",
++                "CHROMIUM_BUILD",
++                "_FILE_OFFSET_BITS=64",
++                "DYNAMIC_ANNOTATIONS_ENABLED=1",
++                "WTF_USE_DYNAMIC_ANNOTATIONS=1",
++                "WEBRTC_RESTRICT_LOGGING",
++                "EXPAT_RELATIVE_PATH",
++                "WEBRTC_MOZILLA_BUILD",
++                "WEBRTC_POSIX",
++                "WEBRTC_SOLARIS"
++            ],
++            "deps": [],
++            "include_dirs": [
++                "//",
++                "/tmp/objdir/media/webrtc/trunk/gn-output/gen/"
++            ],
++            "libs": [],
++            "sources": [
++                "//webrtc/common_types.cc",
++                "//webrtc/common_types.h",
++                "//webrtc/config.cc",
++                "//webrtc/config.h",
++                "//webrtc/typedefs.h"
++            ],
++            "type": "static_library"
++        }
++    }
++}
+\ No newline at end of file
+diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/voice_engine_defines.h firefox-patched/media/webrtc/trunk/webrtc/voice_engine/voice_engine_defines.h
+index 6ccd75886..e074dd336 100644
+--- firefox-60.8.0/media/webrtc/trunk/webrtc/voice_engine/voice_engine_defines.h
++++ firefox-patched/media/webrtc/trunk/webrtc/voice_engine/voice_engine_defines.h
+@@ -203,19 +203,19 @@ inline int VoEChannelId(int moduleId) {
+ 
+ // *** LINUX ***
+ 
+-#ifdef WEBRTC_LINUX
++#if defined(WEBRTC_LINUX) || defined(WEBRTC_SOLARIS)
+ 
+ #include <arpa/inet.h>
+ #include <netinet/in.h>
+ #include <pthread.h>
+ #include <sys/socket.h>
+ #include <sys/types.h>
+-#ifndef QNX
++#if !defined(QNX) && !defined(__sun)
+ #include <linux/net.h>
++#endif  // QNX && __sun
+ #ifndef ANDROID
+ #include <sys/soundcard.h>
+ #endif  // ANDROID
+-#endif  // QNX
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <sched.h>
+@@ -253,7 +253,7 @@ inline int VoEChannelId(int moduleId) {
+ #define __cdecl
+ #define LPSOCKADDR struct sockaddr *
+ 
+-// Default device for Linux and Android
++// Default device for Linux, Android, and Solaris
+ #define WEBRTC_VOICE_ENGINE_DEFAULT_DEVICE 0
+ 
+ #endif  // #ifdef WEBRTC_LINUX
+diff --git firefox-60.8.0/netwerk/sctp/src/netinet/sctp_os_userspace.h firefox-patched/netwerk/sctp/src/netinet/sctp_os_userspace.h
+index 431e04cd7..770a20e75 100755
+--- firefox-60.8.0/netwerk/sctp/src/netinet/sctp_os_userspace.h
++++ firefox-patched/netwerk/sctp/src/netinet/sctp_os_userspace.h
+@@ -276,7 +276,7 @@ typedef char* caddr_t;
+ 
+ #else /* !defined(Userspace_os_Windows) */
+ #include <sys/socket.h>
+-#if defined(__Userspace_os_DragonFly) || defined(__Userspace_os_FreeBSD) || defined(__Userspace_os_Linux) || defined(__Userspace_os_NetBSD) || defined(__Userspace_os_OpenBSD) || defined(__Userspace_os_NaCl) || defined(__Userspace_os_Fuchsia)
++#if defined(__Userspace_os_DragonFly) || defined(__Userspace_os_FreeBSD) || defined(__Userspace_os_Linux) || defined(__Userspace_os_NetBSD) || defined(__Userspace_os_OpenBSD) || defined(__Userspace_os_NaCl) || defined(__Userspace_os_Fuchsia) || defined(__Userspace_os_SunOS)
+ #include <pthread.h>
+ #endif
+ typedef pthread_mutex_t userland_mutex_t;
+@@ -284,6 +284,44 @@ typedef pthread_cond_t userland_cond_t;
+ typedef pthread_t userland_thread_t;
+ #endif
+ 
++/* These don't seem to be defined in the usual network header locations */
++#if defined(__Userspace_os_SunOS)
++#define u_int32_t  unsigned int
++#define u_int16_t  unsigned short
++#define u_int8_t   unsigned char
++/* Ripped straight from the system header */
++#define _CMSG_HDR_ALIGNMENT     4
++#define _CMSG_DATA_ALIGNMENT    (sizeof (int))
++#define _CMSG_HDR_ALIGN(x)      (((uintptr_t)(x) + _CMSG_HDR_ALIGNMENT - 1) & \
++                                    ~(_CMSG_HDR_ALIGNMENT - 1))
++#define _CMSG_DATA_ALIGN(x)     (((uintptr_t)(x) + _CMSG_DATA_ALIGNMENT - 1) & \
++                                    ~(_CMSG_DATA_ALIGNMENT - 1))
++#define CMSG_DATA(c)                                                    \
++        ((unsigned char *)_CMSG_DATA_ALIGN((struct cmsghdr *)(c) + 1))
++
++#define CMSG_FIRSTHDR(m)                                                \
++        (((m)->msg_controllen < sizeof (struct cmsghdr)) ?              \
++            (struct cmsghdr *)0 : (struct cmsghdr *)((m)->msg_control))
++
++#define CMSG_NXTHDR(m, c)                                               \
++        (((c) == 0) ? CMSG_FIRSTHDR(m) :                        \
++        ((((uintptr_t)_CMSG_HDR_ALIGN((char *)(c) +                     \
++        ((struct cmsghdr *)(c))->cmsg_len) + sizeof (struct cmsghdr)) > \
++        (((uintptr_t)((struct msghdr *)(m))->msg_control) +             \
++        ((uintptr_t)((struct msghdr *)(m))->msg_controllen))) ?         \
++        ((struct cmsghdr *)0) :                                         \
++        ((struct cmsghdr *)_CMSG_HDR_ALIGN((char *)(c) +                \
++            ((struct cmsghdr *)(c))->cmsg_len))))
++
++/* Amount of space + padding needed for a message of length l */
++#define CMSG_SPACE(l)                                                   \
++        ((unsigned int)_CMSG_HDR_ALIGN(sizeof (struct cmsghdr) + (l)))
++
++/* Value to be used in cmsg_len, does not include trailing padding */
++#define CMSG_LEN(l)                                                     \
++        ((unsigned int)_CMSG_DATA_ALIGN(sizeof (struct cmsghdr)) + (l))
++#endif
++
+ #if defined(__Userspace_os_Windows) || defined(__Userspace_os_NaCl)
+ 
+ #define IFNAMSIZ 64
+@@ -503,6 +541,9 @@ struct sx {int dummy;};
+ 
+ /* for ioctl */
+ #include <sys/ioctl.h>
++#ifdef __Userspace_os_SunOS
++#include <sys/sockio.h>
++#endif // __Userspace_os_SunOS
+ 
+ /* for close, etc. */
+ #include <unistd.h>
+@@ -1094,6 +1135,8 @@ sctp_get_mbuf_for_msg(unsigned int space_needed, int want_header, int how, int a
+ #if defined(__Userspace_os_DragonFly) || defined(__Userspace_os_FreeBSD) || defined(__Userspace_os_OpenBSD) || defined(__Userspace_os_NaCl)
+ /* stolen from /usr/include/sys/socket.h */
+ #define CMSG_ALIGN(n)   _ALIGN(n)
++#elif defined(__Userspace_os_SunOS)
++#define CMSG_ALIGN(len) ( ((len)+sizeof(long)-1) & ~(sizeof(long)-1) )
+ #elif defined(__Userspace_os_NetBSD)
+ #define CMSG_ALIGN(n)   (((n) + __ALIGNBYTES) & ~__ALIGNBYTES)
+ #elif defined(__Userspace_os_Darwin)
+diff --git firefox-60.8.0/netwerk/sctp/src/netinet/sctp_output.c firefox-patched/netwerk/sctp/src/netinet/sctp_output.c
+index 6ac2059b3..c29504bf5 100755
+--- firefox-60.8.0/netwerk/sctp/src/netinet/sctp_output.c
++++ firefox-patched/netwerk/sctp/src/netinet/sctp_output.c
+@@ -7304,7 +7304,7 @@ sctp_sendall_completes(void *ptr, uint32_t val SCTP_UNUSED)
+ }
+ 
+ static struct mbuf *
+-sctp_copy_out_all(struct uio *uio, int len)
++sctp_copy_out_all(struct uio_user *uio, int len)
+ {
+ 	struct mbuf *ret, *at;
+ 	int left, willcpy, cancpy, error;
+@@ -7346,7 +7346,7 @@ sctp_copy_out_all(struct uio *uio, int len)
+ }
+ 
+ static int
+-sctp_sendall(struct sctp_inpcb *inp, struct uio *uio, struct mbuf *m,
++sctp_sendall(struct sctp_inpcb *inp, struct uio_user *uio, struct mbuf *m,
+     struct sctp_sndrcvinfo *srcv)
+ {
+ 	int ret;
+@@ -10811,7 +10811,7 @@ sctp_output(
+ 	}
+ 	return (sctp_sosend(inp->sctp_socket,
+ 			    addr,
+-			    (struct uio *)NULL,
++			    (struct uio_user *)NULL,
+ 			    m,
+ 			    control,
+ #if defined(__APPLE__) || defined(__Panda__)
+@@ -13078,7 +13078,7 @@ sctp_send_operr_to(struct sockaddr *src, struct sockaddr *dst,
+ }
+ 
+ static struct mbuf *
+-sctp_copy_resume(struct uio *uio,
++sctp_copy_resume(struct uio_user *uio,
+ 		 int max_send_len,
+ #if defined(__FreeBSD__) && __FreeBSD_version > 602000
+ 		 int user_marks_eor,
+@@ -13180,7 +13180,7 @@ sctp_copy_resume(struct uio *uio,
+ 
+ static int
+ sctp_copy_one(struct sctp_stream_queue_pending *sp,
+-              struct uio *uio,
++              struct uio_user *uio,
+               int resv_upfront)
+ {
+ #if defined(__Panda__)
+@@ -13264,7 +13264,7 @@ static struct sctp_stream_queue_pending *
+ sctp_copy_it_in(struct sctp_tcb *stcb,
+     struct sctp_association *asoc,
+     struct sctp_sndrcvinfo *srcv,
+-    struct uio *uio,
++    struct uio_user *uio,
+     struct sctp_nets *net,
+     int max_send_len,
+     int user_marks_eor,
+@@ -13384,7 +13384,7 @@ out_now:
+ int
+ sctp_sosend(struct socket *so,
+             struct sockaddr *addr,
+-            struct uio *uio,
++            struct uio_user *uio,
+ #ifdef __Panda__
+             pakhandle_type top,
+             pakhandle_type icontrol,
+@@ -13473,7 +13473,7 @@ sctp_sosend(struct socket *so,
+ int
+ sctp_lower_sosend(struct socket *so,
+                   struct sockaddr *addr,
+-                  struct uio *uio,
++                  struct uio_user *uio,
+ #ifdef __Panda__
+                   pakhandle_type i_pak,
+                   pakhandle_type i_control,
+diff --git firefox-60.8.0/netwerk/sctp/src/netinet/sctp_output.h firefox-patched/netwerk/sctp/src/netinet/sctp_output.h
+index 597ddc3bf..05bccaa2b 100755
+--- firefox-60.8.0/netwerk/sctp/src/netinet/sctp_output.h
++++ firefox-patched/netwerk/sctp/src/netinet/sctp_output.h
+@@ -243,7 +243,7 @@ void sctp_send_operr_to(struct sockaddr *, struct sockaddr *,
+ int
+ sctp_sosend(struct socket *so,
+     struct sockaddr *addr,
+-    struct uio *uio,
++    struct uio_user *uio,
+ #ifdef __Panda__
+     pakhandle_type top,
+     pakhandle_type control,
+diff --git firefox-60.8.0/netwerk/sctp/src/netinet/sctp_uio.h firefox-patched/netwerk/sctp/src/netinet/sctp_uio.h
+index 956d754ea..f014f1a57 100755
+--- firefox-60.8.0/netwerk/sctp/src/netinet/sctp_uio.h
++++ firefox-patched/netwerk/sctp/src/netinet/sctp_uio.h
+@@ -1345,7 +1345,7 @@ struct sctp_log {
+ int
+ sctp_lower_sosend(struct socket *so,
+     struct sockaddr *addr,
+-    struct uio *uio,
++    struct uio_user *uio,
+ #if defined(__Panda__)
+     pakhandle_type i_pak,
+     pakhandle_type i_control,
+@@ -1368,7 +1368,7 @@ sctp_lower_sosend(struct socket *so,
+ 
+ int
+ sctp_sorecvmsg(struct socket *so,
+-    struct uio *uio,
++    struct uio_user *uio,
+ #if defined(__Panda__)
+     particletype **mp,
+ #else
+diff --git firefox-60.8.0/netwerk/sctp/src/netinet/sctputil.c firefox-patched/netwerk/sctp/src/netinet/sctputil.c
+index 2e404eb73..df40d21e9 100755
+--- firefox-60.8.0/netwerk/sctp/src/netinet/sctputil.c
++++ firefox-patched/netwerk/sctp/src/netinet/sctputil.c
+@@ -5585,7 +5585,7 @@ sctp_user_rcvd(struct sctp_tcb *stcb, uint32_t *freed_so_far, int hold_rlock,
+ 
+ int
+ sctp_sorecvmsg(struct socket *so,
+-    struct uio *uio,
++    struct uio_user *uio,
+     struct mbuf **mp,
+     struct sockaddr *from,
+     int fromlen,
+@@ -6754,7 +6754,7 @@ sctp_dynamic_set_primary(struct sockaddr *sa, uint32_t vrf_id)
+ int
+ sctp_soreceive(	struct socket *so,
+ 		struct sockaddr **psa,
+-		struct uio *uio,
++		struct uio_user *uio,
+ 		struct mbuf **mp0,
+ 		struct mbuf **controlp,
+ 		int *flagsp)
+diff --git firefox-60.8.0/netwerk/sctp/src/netinet/sctputil.h firefox-patched/netwerk/sctp/src/netinet/sctputil.h
+index 69fe48498..a40f33601 100755
+--- firefox-60.8.0/netwerk/sctp/src/netinet/sctputil.h
++++ firefox-patched/netwerk/sctp/src/netinet/sctputil.h
+@@ -363,7 +363,7 @@ void sctp_over_udp_restart(void);
+ 
+ int
+ sctp_soreceive(struct socket *so, struct sockaddr **psa,
+-    struct uio *uio,
++    struct uio_user *uio,
+     struct mbuf **mp0,
+     struct mbuf **controlp,
+     int *flagsp);
+diff --git firefox-60.8.0/netwerk/sctp/src/user_socket.c firefox-patched/netwerk/sctp/src/user_socket.c
+index 8122e5856..a944c656f 100755
+--- firefox-60.8.0/netwerk/sctp/src/user_socket.c
++++ firefox-patched/netwerk/sctp/src/user_socket.c
+@@ -69,7 +69,7 @@ MALLOC_DEFINE(M_SONAME, "sctp_soname", "sctp soname");
+ #define MAXLEN_MBUF_CHAIN  32
+ 
+ /* Prototypes */
+-extern int sctp_sosend(struct socket *so, struct sockaddr *addr, struct uio *uio,
++extern int sctp_sosend(struct socket *so, struct sockaddr *addr, struct uio_user *uio,
+                        struct mbuf *top, struct mbuf *control, int flags,
+                        /* proc is a dummy in __Userspace__ and will not be passed to sctp_lower_sosend */
+                        struct proc *p);
+@@ -629,7 +629,7 @@ copyiniov(struct iovec *iovp, u_int iovcnt, struct iovec **iov, int error)
+ 
+ /* (__Userspace__) version of uiomove */
+ int
+-uiomove(void *cp, int n, struct uio *uio)
++uiomove(void *cp, int n, struct uio_user *uio)
+ {
+ 	struct iovec *iov;
+ 	size_t cnt;
+@@ -772,7 +772,7 @@ userspace_sctp_sendmsg(struct socket *so,
+                        u_int32_t context)
+ {
+ 	struct sctp_sndrcvinfo sndrcvinfo, *sinfo = &sndrcvinfo;
+-	struct uio auio;
++	struct uio_user auio;
+ 	struct iovec iov[1];
+ 
+ 	memset(sinfo, 0, sizeof(struct sctp_sndrcvinfo));
+@@ -836,7 +836,7 @@ usrsctp_sendv(struct socket *so,
+               int flags)
+ {
+ 	struct sctp_sndrcvinfo sinfo;
+-	struct uio auio;
++	struct uio_user auio;
+ 	struct iovec iov[1];
+ 	int use_sinfo;
+ 	sctp_assoc_t *assoc_id;
+@@ -957,7 +957,7 @@ userspace_sctp_sendmbuf(struct socket *so,
+ {
+ 
+     struct sctp_sndrcvinfo sndrcvinfo, *sinfo = &sndrcvinfo;
+-    /*    struct uio auio;
++    /*    struct uio_user auio;
+           struct iovec iov[1]; */
+     int error = 0;
+     int uflags = 0;
+@@ -1021,7 +1021,7 @@ userspace_sctp_recvmsg(struct socket *so,
+     struct sctp_sndrcvinfo *sinfo,
+     int *msg_flags)
+ {
+-	struct uio auio;
++	struct uio_user auio;
+ 	struct iovec iov[SCTP_SMALL_IOVEC_SIZE];
+ 	struct iovec *tiov;
+ 	int iovlen = 1;
+@@ -1110,7 +1110,7 @@ usrsctp_recvv(struct socket *so,
+     unsigned int *infotype,
+     int *msg_flags)
+ {
+-	struct uio auio;
++	struct uio_user auio;
+ 	struct iovec iov[SCTP_SMALL_IOVEC_SIZE];
+ 	struct iovec *tiov;
+ 	int iovlen = 1;
+diff --git firefox-60.8.0/netwerk/sctp/src/user_socketvar.h firefox-patched/netwerk/sctp/src/user_socketvar.h
+index ffc8270ef..19e7fe888 100755
+--- firefox-60.8.0/netwerk/sctp/src/user_socketvar.h
++++ firefox-patched/netwerk/sctp/src/user_socketvar.h
+@@ -42,7 +42,7 @@
+ /* #include <sys/_lock.h>  was 0 byte file */
+ /* #include <sys/_mutex.h> was 0 byte file */
+ /* #include <sys/_sx.h> */ /*__Userspace__ alternative?*/
+-#if !defined(__Userspace_os_DragonFly) && !defined(__Userspace_os_FreeBSD) && !defined(__Userspace_os_NetBSD) && !defined(__Userspace_os_Windows) && !defined(__Userspace_os_NaCl)
++#if !defined(__Userspace_os_DragonFly) && !defined(__Userspace_os_FreeBSD) && !defined(__Userspace_os_NetBSD) && !defined(__Userspace_os_Windows) && !defined(__Userspace_os_NaCl) && !defined(__Userspace_os_SunOS)
+ #include <sys/uio.h>
+ #endif
+ #define SOCK_MAXADDRLEN 255
+@@ -54,16 +54,16 @@
+ #define SS_CANTRCVMORE 0x020
+ #define SS_CANTSENDMORE 0x010
+ 
+-#if defined(__Userspace_os_Darwin) || defined(__Userspace_os_DragonFly) || defined(__Userspace_os_FreeBSD) || defined(__Userspace_os_OpenBSD) || defined (__Userspace_os_Windows) || defined(__Userspace_os_NaCl)
++#if defined(__Userspace_os_Darwin) || defined(__Userspace_os_DragonFly) || defined(__Userspace_os_FreeBSD) || defined(__Userspace_os_OpenBSD) || defined (__Userspace_os_Windows) || defined(__Userspace_os_NaCl) || defined(__Userspace_os_SunOS)
+ #define UIO_MAXIOV 1024
+-#define ERESTART (-1)
++//#define ERESTART (-1)
+ #endif
+ 
+-#if !defined(__Userspace_os_Darwin) && !defined(__Userspace_os_NetBSD) && !defined(__Userspace_os_OpenBSD)
++#if !defined(__Userspace_os_Darwin) && !defined(__Userspace_os_NetBSD) && !defined(__Userspace_os_OpenBSD) && !defined(__Userspace_os_SunOS)
+ enum	uio_rw { UIO_READ, UIO_WRITE };
+ #endif
+ 
+-#if !defined(__Userspace_os_NetBSD) && !defined(__Userspace_os_OpenBSD)
++#if !defined(__Userspace_os_NetBSD) && !defined(__Userspace_os_OpenBSD) && !defined(__Userspace_os_SunOS)
+ /* Segment flag values. */
+ enum uio_seg {
+ 	UIO_USERSPACE,		/* from user data space */
+@@ -78,11 +78,12 @@ struct proc {
+ MALLOC_DECLARE(M_ACCF);
+ MALLOC_DECLARE(M_PCB);
+ MALLOC_DECLARE(M_SONAME);
++#undef uio_offset
+ 
+ /* __Userspace__ Are these all the fields we need?
+  * Removing struct thread *uio_td;    owner field
+ */
+-struct uio {
++struct uio_user {
+     struct	iovec *uio_iov;		/* scatter/gather list */
+     int		uio_iovcnt;		/* length of scatter/gather list */
+     off_t	uio_offset;		/* offset in target object */
+@@ -91,7 +92,6 @@ struct uio {
+     enum	uio_rw uio_rw;		/* operation */
+ };
+ 
+-
+ /* __Userspace__ */
+ 
+ /*
+@@ -563,7 +563,7 @@ extern so_gen_t so_gencnt;
+ struct mbuf;
+ struct sockaddr;
+ struct ucred;
+-struct uio;
++struct uio_user;
+ 
+ /*
+  * From uipc_socket and friends
+@@ -622,7 +622,7 @@ void	socantsendmore_locked(struct socket *so);
+ int	soclose(struct socket *so);
+ int	soconnect(struct socket *so, struct sockaddr *nam, struct thread *td);
+ int	soconnect2(struct socket *so1, struct socket *so2);
+-int	socow_setup(struct mbuf *m0, struct uio *uio);
++int	socow_setup(struct mbuf *m0, struct uio_user *uio);
+ int	socreate(int dom, struct socket **aso, int type, int proto,
+ 	    struct ucred *cred, struct thread *td);
+ int	sodisconnect(struct socket *so);
+@@ -651,21 +651,21 @@ int	sopoll(struct socket *so, int events, struct ucred *active_cred,
+ 	    struct thread *td);
+ int	sopoll_generic(struct socket *so, int events,
+ 	    struct ucred *active_cred, struct thread *td);
+-int	soreceive(struct socket *so, struct sockaddr **paddr, struct uio *uio,
++int	soreceive(struct socket *so, struct sockaddr **paddr, struct uio_user *uio,
+ 	    struct mbuf **mp0, struct mbuf **controlp, int *flagsp);
+ int	soreceive_generic(struct socket *so, struct sockaddr **paddr,
+-	    struct uio *uio, struct mbuf **mp0, struct mbuf **controlp,
++	    struct uio_user *uio, struct mbuf **mp0, struct mbuf **controlp,
+ 	    int *flagsp);
+ int	soreserve(struct socket *so, u_long sndcc, u_long rcvcc);
+ void	sorflush(struct socket *so);
+-int	sosend(struct socket *so, struct sockaddr *addr, struct uio *uio,
++int	sosend(struct socket *so, struct sockaddr *addr, struct uio_user *uio,
+ 	    struct mbuf *top, struct mbuf *control, int flags,
+ 	    struct thread *td);
+ int	sosend_dgram(struct socket *so, struct sockaddr *addr,
+-	    struct uio *uio, struct mbuf *top, struct mbuf *control,
++	    struct uio_user *uio, struct mbuf *top, struct mbuf *control,
+ 	    int flags, struct thread *td);
+ int	sosend_generic(struct socket *so, struct sockaddr *addr,
+-	    struct uio *uio, struct mbuf *top, struct mbuf *control,
++	    struct uio_user *uio, struct mbuf *top, struct mbuf *control,
+ 	    int flags, struct thread *td);
+ int	sosetopt(struct socket *so, struct sockopt *sopt);
+ int	soshutdown(struct socket *so, int how);
+@@ -796,7 +796,7 @@ extern int solisten(struct socket *so, int backlog);
+ extern int  soreserve(struct socket *so, u_long sndcc, u_long rcvcc);
+ extern void sowakeup(struct socket *so, struct sockbuf *sb);
+ extern void wakeup(void *ident, struct socket *so); /*__Userspace__ */
+-extern int uiomove(void *cp, int n, struct uio *uio);
++extern int uiomove(void *cp, int n, struct uio_user *uio);
+ extern int sbwait(struct sockbuf *sb);
+ extern int sodisconnect(struct socket *so);
+ extern int soconnect(struct socket *so, struct sockaddr *nam);


### PR DESCRIPTION
decided to take a couple of days to see if a native webrtc would work here, as the lack of same was impacting part of my own workflow. Also tested some potential performance switches. This is also where i found out that we don't implement all of V4L2:
```diff
diff --git firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc
index f9cf38ac3..f6b0aebf6 100644
--- firefox-60.8.0/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc
+++ firefox-patched/media/webrtc/trunk/webrtc/modules/video_capture/linux/device_info_linux.cc
@@ -466,6 +466,8 @@ bool DeviceInfoLinux::IsDeviceNameMatches(const char* name,
 int32_t DeviceInfoLinux::FillCapabilities(int fd)
 {
     struct v4l2_fmtdesc fmt;
+    VideoCaptureCapability cap;
+#ifndef __sun
     struct v4l2_frmsizeenum frmsize;
     struct v4l2_frmivalenum frmival;
 
@@ -485,7 +487,6 @@ int32_t DeviceInfoLinux::FillCapabilities(int fd)
                         fmt.pixelformat == V4L2_PIX_FMT_YUV420 ||
                         fmt.pixelformat == V4L2_PIX_FMT_MJPEG) {
 
-                        VideoCaptureCapability cap;
                         cap.width = frmsize.discrete.width;
                         cap.height = frmsize.discrete.height;
                         cap.expectedCaptureDelay = 120;
@@ -512,7 +513,40 @@ int32_t DeviceInfoLinux::FillCapabilities(int fd)
         }
         fmt.index++;
     }
+#else
+    // On Solaris, we can use VIDIOC_G_PARM and VIDIOC_G_FMT to get this information.
+    // Ideally, usbvc(4D) should implement the now-stable IOCTLs above.
+    struct v4l2_format vfmt;
+    struct v4l2_streamparm sparm;
 
+    fmt.index = 0;
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    while (ioctl(fd, VIDIOC_ENUM_FMT, &fmt) >= 0) {
+        vfmt.type = fmt.type;
+        sparm.type = fmt.type;
+        ioctl(fd, VIDIOC_G_FMT, &vfmt);
+        ioctl(fd, VIDIOC_G_PARM, &sparm);
+        cap.width = vfmt.fmt.pix.width;
+        cap.height = vfmt.fmt.pix.height;
+        cap.expectedCaptureDelay = 120;
+        switch (fmt.pixelformat)
+        {
+        case V4L2_PIX_FMT_YUYV:
+            cap.rawType = kVideoYUY2;
+            break;
+        case V4L2_PIX_FMT_YUV420:
+            cap.rawType = kVideoI420;
+            break;
+        case V4L2_PIX_FMT_MJPEG:
+            cap.rawType = kVideoMJPEG;
+            break;
+        default:
+            break;
+        }
+        cap.maxFPS = sparm.parm.capture.timeperframe.denominator / sparm.parm.capture.timeperframe.numerator;
+        _captureCapabilities.push_back(cap);
+        fmt.index++;
+    }
+#endif
     WEBRTC_TRACE(webrtc::kTraceInfo,
                  webrtc::kTraceVideoCapture,
                  0,
```
Not quite ready to merge yet, as initialising the video engine still bombs (and there is no self-attribution yet, among other details).