### PR TITLE
top: use termios instead of termio

### DIFF
--- a/components/sysutils/top/Makefile
+++ b/components/sysutils/top/Makefile
@@ -26,7 +26,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		top
 COMPONENT_VERSION=	3.8beta1
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_PROJECT_URL=	https://sourceforge.net/projects/unixtop/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz

--- a/components/sysutils/top/patches/11.termios.patch
+++ b/components/sysutils/top/patches/11.termios.patch
@@ -1,0 +1,17 @@
+diff -Nurp top-3.8beta1/screen.c top-3.8beta1-termios/screen.c
+--- top-3.8beta1/screen.c	2008-05-07 06:41:39.000000000 +0000
++++ top-3.8beta1-termios/screen.c	2019-08-19 00:44:00.780585500 +0000
+@@ -84,13 +84,8 @@ char *tgetstr(const char *, char **);
+ # include <sgtty.h>
+ # define USE_SGTTY
+ #else
+-# ifdef TCGETA
+-#  define USE_TERMIO
+-#  include <termio.h>
+-# else
+ #  define USE_TERMIOS
+ #  include <termios.h>
+-# endif
+ #endif
+ #if defined(USE_TERMIO) || defined(USE_TERMIOS)
+ # ifndef TAB3


### PR DESCRIPTION
termio is using 8 control chars and we end up reading past array end.
Since termios is preferred interface, use it instead.