### PR TITLE
Update GNU FreeIPMI to 1.6.4

### DIFF
--- a/components/sysutils/freeipmi/Makefile
+++ b/components/sysutils/freeipmi/Makefile
@@ -15,10 +15,12 @@
 # Copyright 2019 Michal Nowak
 #
 
+BUILD_SYSTEM=		configure
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		freeipmi
-COMPONENT_VERSION=	1.6.3
+COMPONENT_VERSION=	1.6.4
 COMPONENT_SUMMARY=	GNU FreeIPMI - in-band and out-of-band IPMI
 COMPONENT_DESCRIPTION=	GNU FreeIPMI - in-band and out-of-band IPMI software based on the \
 IPMI v1.5/2.0 specification ($(COMPONENT_VERSION))
@@ -27,54 +29,31 @@ COMPONENT_CLASSIFICATION=	System/Hardware
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:aad4e735a7ac4a1f8ade20caadb35dfefc2a352fa2ef41d3f6e589179917e1e9
-COMPONENT_PROJECT_URL=	http://www.gnu.org/software/freeipmi/
+	sha256:65dfbb95a30438ba247f01a58498862a37d2e71c8c950bcfcee459d079241a3c
+COMPONENT_PROJECT_URL=	https://www.gnu.org/software/freeipmi/
 COMPONENT_ARCHIVE_URL=	\
 	http://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE_FILE=	COPYING
-COMPONENT_LICENSE=	GPLv2
+COMPONENT_LICENSE=	GPLv3
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CFLAGS += $(CPP_LARGEFILES) -DMAXHOSTNAMELEN=256
 CPPFLAGS += $(CPP_LARGEFILES) -DMAXHOSTNAMELEN=256
 
-USRLIBDIR.32=$(USRLIBDIR)
-USRLIBDIR.64=$(USRLIBDIR64)
-
-COMPONENT_PREP_ACTION = \
-    (cd $(@D) &&\
-        aclocal -I . &&\
-        autoheader &&\
-        automake -a -f -c --gnu &&\
-        autoconf &&\
-        $(RM) config.h )
-
-# Missing files in build dir for configure without this
-COMPONENT_PRE_CONFIGURE_ACTION = \
-	($(CLONEY) $(SOURCE_DIR) $(@D))
-
-#       configure(1) options to use
-# a default --prefix and --mandir are set in make-rules
-CONFIGURE_OPTIONS += --with-dont-check-for-root
-CONFIGURE_OPTIONS += --sysconfdir=/etc
-CONFIGURE_OPTIONS += --localstatedir=/var
 CONFIGURE_OPTIONS += --infodir=/usr/share/doc/freeipmi/info
-CONFIGURE_OPTIONS += --enable-static=no
 CONFIGURE_OPTIONS += --libdir=$(USRLIBDIR.$(BITS))
+CONFIGURE_OPTIONS += --localstatedir=/var
+CONFIGURE_OPTIONS += --sysconfdir=/etc
+CONFIGURE_OPTIONS += --disable-static
+CONFIGURE_OPTIONS += --with-dont-check-for-root
 
 # This is needed to avoid using CCACHE for CPP in this recipe:
 # they use CPP to build manpages! Go figure...
 CONFIGURE_ENV += CPP_FOR_BUILD=$(GCC_ROOT)/bin/cpp
 
-build:		$(BUILD_32_and_64)
-
 # Ensure 32-bit configs are installed last
 $(INSTALL_32): $(INSTALL_64)
-
-install:	$(INSTALL_32_and_64)
 
 test:		$(NO_TESTS)
 

--- a/components/sysutils/freeipmi/freeipmi.p5m
+++ b/components/sysutils/freeipmi/freeipmi.p5m
@@ -32,10 +32,10 @@ file path=etc/freeipmi/ipmidetectd.conf preserve=true
 file path=etc/freeipmi/ipmiseld.conf preserve=true
 file path=etc/freeipmi/libipmiconsole.conf preserve=true
 
-### NOTE: bmc-watchdog programs are delivered by this (freeipmi) package; but
-### the SMF service and binding to driver/ipmi are in bmc-watchdog package.
-### Not all deployments of freeipmi have a desire or (HW) ability to monitor a
-### local BMC, rather than networked remote IPMI cards.
+# NOTE: bmc-watchdog programs are delivered by this (freeipmi) package; but
+# the SMF service and binding to driver/ipmi are in bmc-watchdog package.
+# Not all deployments of freeipmi have a desire or (HW) ability to monitor a
+# local BMC, rather than networked remote IPMI cards.
 
 #file path=etc/init.d/ipmidetectd
 #file path=etc/init.d/ipmiseld
@@ -296,9 +296,9 @@ file path=usr/include/ipmi_monitoring_bitmasks.h
 file path=usr/include/ipmi_monitoring_offsets.h
 file path=usr/include/ipmiconsole.h
 file path=usr/include/ipmidetect.h
-link path=usr/lib/$(MACH64)/libfreeipmi.so target=libfreeipmi.so.17.2.2
-link path=usr/lib/$(MACH64)/libfreeipmi.so.17 target=libfreeipmi.so.17.2.2
-file path=usr/lib/$(MACH64)/libfreeipmi.so.17.2.2
+link path=usr/lib/$(MACH64)/libfreeipmi.so target=libfreeipmi.so.17.2.3
+link path=usr/lib/$(MACH64)/libfreeipmi.so.17 target=libfreeipmi.so.17.2.3
+file path=usr/lib/$(MACH64)/libfreeipmi.so.17.2.3
 link path=usr/lib/$(MACH64)/libipmiconsole.so target=libipmiconsole.so.2.3.5
 link path=usr/lib/$(MACH64)/libipmiconsole.so.2 target=libipmiconsole.so.2.3.5
 file path=usr/lib/$(MACH64)/libipmiconsole.so.2.3.5
@@ -314,9 +314,9 @@ file path=usr/lib/$(MACH64)/pkgconfig/libfreeipmi.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libipmiconsole.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libipmidetect.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libipmimonitoring.pc
-link path=usr/lib/libfreeipmi.so target=libfreeipmi.so.17.2.2
-link path=usr/lib/libfreeipmi.so.17 target=libfreeipmi.so.17.2.2
-file path=usr/lib/libfreeipmi.so.17.2.2
+link path=usr/lib/libfreeipmi.so target=libfreeipmi.so.17.2.3
+link path=usr/lib/libfreeipmi.so.17 target=libfreeipmi.so.17.2.3
+file path=usr/lib/libfreeipmi.so.17.2.3
 link path=usr/lib/libipmiconsole.so target=libipmiconsole.so.2.3.5
 link path=usr/lib/libipmiconsole.so.2 target=libipmiconsole.so.2.3.5
 file path=usr/lib/libipmiconsole.so.2.3.5
@@ -362,7 +362,6 @@ link path=usr/sbin/$(MACH64)/pef-config \
     target=ipmi-pef-config
 link path=usr/sbin/$(MACH64)/rmcp-ping target=rmcpping
 file path=usr/sbin/$(MACH64)/rmcpping
-
 file path=usr/sbin/bmc-config
 file path=usr/sbin/bmc-device
 file path=usr/sbin/bmc-info
@@ -394,7 +393,6 @@ file path=usr/sbin/ipmiseld
 link path=usr/sbin/pef-config target=ipmi-pef-config
 link path=usr/sbin/rmcp-ping target=rmcpping
 file path=usr/sbin/rmcpping
-
 file path=usr/share/doc/freeipmi/AUTHORS
 file path=usr/share/doc/freeipmi/COPYING
 file path=usr/share/doc/freeipmi/COPYING.ZRESEARCH
@@ -455,7 +453,6 @@ file path=usr/share/doc/freeipmi/freeipmi-oem-documentation-requirements.txt
 file path=usr/share/doc/freeipmi/freeipmi-testing.txt
 #file path=usr/share/doc/freeipmi/info/dir
 file path=usr/share/doc/freeipmi/info/freeipmi-faq.info
-
 file path=usr/share/man/man3/libfreeipmi.3
 file path=usr/share/man/man3/libipmiconsole.3
 file path=usr/share/man/man3/libipmidetect.3
@@ -507,5 +504,4 @@ file path=usr/share/man/man8/ipmiseld.8
 file path=usr/share/man/man8/pef-config.8
 file path=usr/share/man/man8/rmcp-ping.8
 file path=usr/share/man/man8/rmcpping.8
-
 file path=var/lib/freeipmi/ipckey

--- a/components/sysutils/freeipmi/manifests/sample-manifest.p5m
+++ b/components/sysutils/freeipmi/manifests/sample-manifest.p5m
@@ -279,9 +279,9 @@ file path=usr/include/ipmi_monitoring_bitmasks.h
 file path=usr/include/ipmi_monitoring_offsets.h
 file path=usr/include/ipmiconsole.h
 file path=usr/include/ipmidetect.h
-link path=usr/lib/$(MACH64)/libfreeipmi.so target=libfreeipmi.so.17.2.2
-link path=usr/lib/$(MACH64)/libfreeipmi.so.17 target=libfreeipmi.so.17.2.2
-file path=usr/lib/$(MACH64)/libfreeipmi.so.17.2.2
+link path=usr/lib/$(MACH64)/libfreeipmi.so target=libfreeipmi.so.17.2.3
+link path=usr/lib/$(MACH64)/libfreeipmi.so.17 target=libfreeipmi.so.17.2.3
+file path=usr/lib/$(MACH64)/libfreeipmi.so.17.2.3
 link path=usr/lib/$(MACH64)/libipmiconsole.so target=libipmiconsole.so.2.3.5
 link path=usr/lib/$(MACH64)/libipmiconsole.so.2 target=libipmiconsole.so.2.3.5
 file path=usr/lib/$(MACH64)/libipmiconsole.so.2.3.5
@@ -297,9 +297,9 @@ file path=usr/lib/$(MACH64)/pkgconfig/libfreeipmi.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libipmiconsole.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libipmidetect.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libipmimonitoring.pc
-link path=usr/lib/libfreeipmi.so target=libfreeipmi.so.17.2.2
-link path=usr/lib/libfreeipmi.so.17 target=libfreeipmi.so.17.2.2
-file path=usr/lib/libfreeipmi.so.17.2.2
+link path=usr/lib/libfreeipmi.so target=libfreeipmi.so.17.2.3
+link path=usr/lib/libfreeipmi.so.17 target=libfreeipmi.so.17.2.3
+file path=usr/lib/libfreeipmi.so.17.2.3
 link path=usr/lib/libipmiconsole.so target=libipmiconsole.so.2.3.5
 link path=usr/lib/libipmiconsole.so.2 target=libipmiconsole.so.2.3.5
 file path=usr/lib/libipmiconsole.so.2.3.5


### PR DESCRIPTION
Did a bit of a clean-up as some workarounds are not needed anymore.

**Release 1.6.4 Changes**
- In libfreeipmi, add additional workarounds for packets that are re-ordered during sensor bridging.
- In libfreeipmi, add additional sensor / event interpretations.
- In libfreeipmi, fix error return value on bridging requests.
- Add workaround in ipmi-sel for QuantaPlex T42D-2U motherboard, which lists a SDR record that makes no sense.
- Add workaround for Dell Poweredge FC830, which have an error when reading the last SDR record on a motherboard.
- Support Supermicro X10 OEM dimm events. 

**Testing**
- can't test it as I don't have access to an IPMI machine