### PR TITLE
chezscheme: Add 9.5.2

### DIFF
--- a/components/runtime/chezscheme/Makefile
+++ b/components/runtime/chezscheme/Makefile
@@ -1,0 +1,85 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Richard Lowe
+#
+
+BUILD_BITS= 64
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		chezscheme
+COMPONENT_VERSION=	9.5.2
+COMPONENT_SUMMARY=	Chez Scheme
+COMPONENT_PROJECT_URL=	https://github.com/cisco/ChezScheme
+COMPONENT_FMRI=		runtime/chezscheme
+COMPONENT_CLASSIFICATION=Development/Other Languages
+COMPONENT_SRC=		ChezScheme-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+  sha256:3a370fdf2ffd67d6a0ccbb993dfab1cbaf4a0a97983c869cfaab40528c33c48b
+COMPONENT_ARCHIVE_URL= \
+  https://github.com/cisco/ChezScheme/archive/v$(COMPONENT_VERSION).tar.gz
+
+COMPONENT_LICENSE_FILE=	LICENSE
+COMPONENT_LICENSE=	Apache-2.0
+
+# SunOS-ish bootstrap files not included in the release tarballs These must be
+# generated according to the instructions provided by ChezScheme on a system
+# which _is_ supported for bootstrap, and then provided by us
+COMPONENT_NAME_1= chezscheme-bootstrap
+COMPONENT_VERSION_1= $(COMPONENT_VERSION)
+COMPONENT_SRC_1= $(COMPONENT_NAME_1)-$(COMPONENT_VERSION_1)
+COMPONENT_ARCHIVE_1= $(COMPONENT_SRC_1).tar.gz
+COMPONENT_ARCHIVE_URL_1= https://github.com/OpenIndiana/$(COMPONENT_NAME_1)/archive/$(COMPONENT_VERSION_1).tar.gz
+COMPONENT_ARCHIVE_HASH_1= \
+  sha256:1f00d017e5ebf8eb0ee2c6ae6b101917c0e10bf5bcbcebe2827882eb1025015e
+COMPONENT_SRC_BOOTSTRAP= $(COMPONENT_SRC_1)
+
+# Nanopass
+COMPONENT_NAME_2= nanopass-framework-scheme
+COMPONENT_VERSION_2= 1.9
+COMPONENT_SRC_2= $(COMPONENT_NAME_2)-$(COMPONENT_VERSION_2)
+COMPONENT_ARCHIVE_2= $(COMPONENT_SRC_2).tar.gz
+COMPONENT_ARCHIVE_URL_2= https://github.com/nanopass/$(COMPONENT_NAME_2)/archive/v$(COMPONENT_VERSION_2).tar.gz
+COMPONENT_ARCHIVE_HASH_2=	\
+  sha256:625b239f9030d0b1e86b1fffd8b69f7249a63e8b8ca85195a00cf22889f7fc86
+COMPONENT_SRC_NANOPASS= $(COMPONENT_SRC_2)
+
+# stex
+COMPONENT_NAME_3= stex
+COMPONENT_VERSION_3= 1.2.1
+COMPONENT_SRC_3= $(COMPONENT_NAME_3)-$(COMPONENT_VERSION_3)
+COMPONENT_ARCHIVE_3= $(COMPONENT_SRC_3).tar.gz
+COMPONENT_ARCHIVE_URL_3= https://github.com/dybvig/stex/archive/v$(COMPONENT_VERSION_3).tar.gz
+COMPONENT_ARCHIVE_HASH_3=	\
+  sha256:bf784ca46aaca9b665b7eb0c39f04f6a695aa40e99b11d8a6d4440648c1bf40e
+COMPONENT_SRC_STEX= $(COMPONENT_SRC_3)
+
+include $(WS_MAKE_RULES)/common.mk
+
+PATH=$(PATH.gnu)
+
+COMPONENT_PRE_CONFIGURE_ACTION= ($(CLONEY) $(SOURCE_DIR) $(@D)) && \
+	($(CP) -R $(COMPONENT_SRC_NANOPASS)/* $(@D)/nanopass) && \
+	($(CP) -R $(COMPONENT_SRC_STEX)/* $(@D)/stex) && \
+	($(CP) -R $(COMPONENT_SRC_BOOTSTRAP)/* $(@D)/boot/)
+
+CONFIGURE_OPTIONS= --64 --threads --installlib=/usr/lib/amd64
+
+COMPONENT_INSTALL_ARGS +=	TempRoot=$(PROTO_DIR)
+COMPONENT_TEST_TARGETS= test
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += library/zlib

--- a/components/runtime/chezscheme/chezscheme.p5m
+++ b/components/runtime/chezscheme/chezscheme.p5m
@@ -1,0 +1,64 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019, Richard Lowe.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+hardlink path=usr/bin/petite target=scheme
+hardlink path=usr/bin/scheme-script target=scheme
+file path=usr/bin/scheme
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/Makefile
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/compat.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/crepl.c
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/csocket.c
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/def.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/edit.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/ez-grammar-test.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/ez-grammar.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/fact.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/fatfib.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/fft.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/fib.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/foreign.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/freq.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/interpret.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/m4.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/macro.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/matrix.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/object.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/power.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/queue.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/rabbit.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/rsa.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/scons.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/setof.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/socket.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/template.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/examples/unify.ss
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/ta6s2/kernel.o
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/ta6s2/main.o
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/ta6s2/petite.boot
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/ta6s2/scheme.boot
+hardlink path=usr/lib/amd64/csv$(COMPONENT_VERSION)/ta6s2/scheme-script.boot \
+    target=scheme.boot
+file path=usr/lib/amd64/csv$(COMPONENT_VERSION)/ta6s2/scheme.h
+file path=usr/share/man/man1/petite.1
+file path=usr/share/man/man1/scheme.1

--- a/components/runtime/chezscheme/manifests/sample-manifest.p5m
+++ b/components/runtime/chezscheme/manifests/sample-manifest.p5m
@@ -1,0 +1,64 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+hardlink path=usr/bin/petite target=scheme-script
+hardlink path=usr/bin/scheme target=scheme-script
+file path=usr/bin/scheme-script
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/Makefile
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/compat.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/crepl.c
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/csocket.c
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/def.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/edit.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/ez-grammar-test.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/ez-grammar.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/fact.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/fatfib.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/fft.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/fib.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/foreign.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/freq.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/interpret.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/m4.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/macro.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/matrix.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/object.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/power.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/queue.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/rabbit.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/rsa.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/scons.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/setof.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/socket.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/template.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/examples/unify.ss
+file path=usr/lib/csv$(COMPONENT_VERSION)/ta6s2/kernel.o
+file path=usr/lib/csv$(COMPONENT_VERSION)/ta6s2/main.o
+file path=usr/lib/csv$(COMPONENT_VERSION)/ta6s2/petite.boot
+file path=usr/lib/csv$(COMPONENT_VERSION)/ta6s2/scheme-script.boot
+hardlink path=usr/lib/csv$(COMPONENT_VERSION)/ta6s2/scheme.boot \
+    target=scheme-script.boot
+file path=usr/lib/csv$(COMPONENT_VERSION)/ta6s2/scheme.h
+file path=usr/share/man/man1/petite.1
+file path=usr/share/man/man1/scheme.1

--- a/components/runtime/chezscheme/patches/01-luuid.patch
+++ b/components/runtime/chezscheme/patches/01-luuid.patch
@@ -1,0 +1,47 @@
+diff -ru ChezScheme-9.5.2/c/Mf-a6s2 /builds/richlowe/ChezScheme-9.5.2/c/Mf-a6s2
+--- ChezScheme-9.5.2/c/Mf-a6s2	2019-03-21 22:05:24.000000000 +0000
++++ /builds/richlowe/ChezScheme-9.5.2/c/Mf-a6s2	2019-08-06 00:16:29.279014957 +0000
+@@ -16,7 +16,7 @@
+ m = a6s2
+ Cpu = X86_64
+ 
+-mdclib = -lnsl -ldl -lm -lcurses -lrt
++mdclib = -lnsl -ldl -lm -lcurses -lrt -luuid
+ C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wextra -Werror -O ${CFLAGS}
+ o = o
+ mdsrc = i3le.c
+--- ChezScheme-9.5.2/c/Mf-ta6s2	2019-03-21 22:05:24.000000000 +0000
++++ /builds/richlowe/ChezScheme-9.5.2/c/Mf-ta6s2	2019-08-06 00:16:36.818329868 +0000
+@@ -16,7 +16,7 @@
+ m = ta6s2
+ Cpu = X86_64
+ 
+-mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt
++mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt -luuid
+ C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT ${CFLAGS}
+ o = o
+ mdsrc = i3le.c
+diff -ru ChezScheme-9.5.2.orig/c/Mf-i3s2 ChezScheme-9.5.2/c/Mf-i3s2
+--- ChezScheme-9.5.2.orig/c/Mf-i3s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-i3s2	2019-08-25 16:24:13.152327983 +0000
+@@ -16,7 +16,7 @@
+ m = i3s2
+ Cpu = I386
+ 
+-mdclib = -lnsl -ldl -lm -lcurses -lrt
++mdclib = -lnsl -ldl -lm -lcurses -lrt -luuid
+ C = ${CC} ${CFLAGS} -m32 -Wpointer-arith -Wextra -Werror -O ${CPPFLAGS}
+ o = o
+ mdsrc = i3le.c
+diff -ru ChezScheme-9.5.2.orig/c/Mf-ti3s2 ChezScheme-9.5.2/c/Mf-ti3s2
+--- ChezScheme-9.5.2.orig/c/Mf-ti3s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-ti3s2	2019-08-25 16:24:36.560269634 +0000
+@@ -16,7 +16,7 @@
+ m = ti3s2
+ Cpu = I386
+ 
+-mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt
++mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt -luuid
+ C = ${CC} ${CPPFLAGS} -m32 -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT ${CFLAGS}
+ o = o
+ mdsrc = i3le.c

--- a/components/runtime/chezscheme/patches/02-il-ld.patch
+++ b/components/runtime/chezscheme/patches/02-il-ld.patch
@@ -1,0 +1,48 @@
+diff -ru ChezScheme-9.5.2.orig/c/Mf-a6s2 ChezScheme-9.5.2/c/Mf-a6s2
+--- ChezScheme-9.5.2.orig/c/Mf-a6s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-a6s2	2019-08-25 16:30:45.196593078 +0000
+@@ -31,7 +31,7 @@
+ include Mf-base
+ 
+ ${Kernel}: ${kernelobj} ../zlib/libz.a
+-	ld -melf_x86_64 -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
++	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+diff -ru ChezScheme-9.5.2.orig/c/Mf-i3s2 ChezScheme-9.5.2/c/Mf-i3s2
+--- ChezScheme-9.5.2.orig/c/Mf-i3s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-i3s2	2019-08-25 16:31:04.882010980 +0000
+@@ -31,7 +31,7 @@
+ include Mf-base
+ 
+ ${Kernel}: ${kernelobj} ../zlib/libz.a
+-	ld -melf_i386 -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
++	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+diff -ru ChezScheme-9.5.2.orig/c/Mf-ta6s2 ChezScheme-9.5.2/c/Mf-ta6s2
+--- ChezScheme-9.5.2.orig/c/Mf-ta6s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-ta6s2	2019-08-25 16:30:45.196775283 +0000
+@@ -31,7 +31,7 @@
+ include Mf-base
+ 
+ ${Kernel}: ${kernelobj} ../zlib/libz.a
+-	ld -melf_x86_64 -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
++	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+diff -ru ChezScheme-9.5.2.orig/c/Mf-ti3s2 ChezScheme-9.5.2/c/Mf-ti3s2
+--- ChezScheme-9.5.2.orig/c/Mf-ti3s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-ti3s2	2019-08-25 16:31:18.894981878 +0000
+@@ -31,7 +31,7 @@
+ include Mf-base
+ 
+ ${Kernel}: ${kernelobj} ../zlib/libz.a
+-	ld -melf_i386 -r -X -o ${Kernel} ${kernelobj} ../zlib/libz.a
++	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}

--- a/components/runtime/chezscheme/patches/03-gmtoff.patch
+++ b/components/runtime/chezscheme/patches/03-gmtoff.patch
@@ -1,0 +1,15 @@
+diff -ru ChezScheme-9.5.2/c/stats.c /builds/richlowe/ChezScheme-9.5.2/c/stats.c
+--- ChezScheme-9.5.2/c/stats.c	2019-03-21 22:05:24.000000000 +0000
++++ /builds/richlowe/ChezScheme-9.5.2/c/stats.c	2019-08-06 00:12:59.343648209 +0000
+@@ -417,7 +417,11 @@
+     }
+   }
+ #else
++# if defined(SOLARIS)
++  tzoff = tmxp->tm_isdst ? -altzone : -timezone;
++# else
+   tzoff = tmxp->tm_gmtoff;
++# endif
+   if (given_tzoff == Sfalse) {
+ # if defined(__linux__) || defined(SOLARIS)
+     /* Linux and Solaris set `tzname`: */

--- a/components/runtime/chezscheme/patches/04-system-zlib.patch
+++ b/components/runtime/chezscheme/patches/04-system-zlib.patch
@@ -1,0 +1,153 @@
+Only in ChezScheme-9.5.2: .patched
+Only in ChezScheme-9.5.2: .patched-01-luuid.patch
+Only in ChezScheme-9.5.2: .patched-02-il-ld.patch
+Only in ChezScheme-9.5.2: .patched-03-gmtoff.patch
+Only in ChezScheme-9.5.2: .prep
+diff -ru ChezScheme-9.5.2.orig/c/Mf-a6s2 ChezScheme-9.5.2/c/Mf-a6s2
+--- ChezScheme-9.5.2.orig/c/Mf-a6s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-a6s2	2019-08-25 16:23:34.243758990 +0000
+@@ -16,7 +16,7 @@
+ m = a6s2
+ Cpu = X86_64
+ 
+-mdclib = -lnsl -ldl -lm -lcurses -lrt -luuid
++mdclib = -lnsl -ldl -lm -lcurses -lrt -luuid -lz
+ C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wextra -Werror -O ${CFLAGS}
+ o = o
+ mdsrc = i3le.c
+@@ -30,11 +30,8 @@
+ 
+ include Mf-base
+ 
+-${Kernel}: ${kernelobj} ../zlib/libz.a
+-	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
++${Kernel}: ${kernelobj}
++	/bin/ld -r -o ${Kernel} ${kernelobj}
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+-
+-../zlib/configure.log:
+-	(cd ../zlib; CFLAGS=-m64 ./configure --64)
+Only in ChezScheme-9.5.2/c: Mf-a6s2.~1~
+Only in ChezScheme-9.5.2/c: Mf-a6s2.~2~
+diff -ru ChezScheme-9.5.2.orig/c/Mf-base ChezScheme-9.5.2/c/Mf-base
+--- ChezScheme-9.5.2.orig/c/Mf-base	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-base	2019-08-25 16:22:36.296685268 +0000
+@@ -54,7 +54,7 @@
+ ${kernelobj}: system.h types.h version.h externs.h globals.h segment.h thread.h sort.h
+ ${kernelobj}: ${Include}/equates.h ${Include}/scheme.h
+ ${mainobj}: ${Include}/scheme.h
+-${kernelobj}: ../zlib/zconf.h ../zlib/zlib.h
++${kernelobj}:
+ gc-ocd.o gc-oce.o: gc.c
+ 
+ ../zlib/zlib.h ../zlib/zconf.h: ../zlib/configure.log
+diff -ru ChezScheme-9.5.2.orig/c/Mf-i3s2 ChezScheme-9.5.2/c/Mf-i3s2
+--- ChezScheme-9.5.2.orig/c/Mf-i3s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-i3s2	2019-08-25 16:24:13.152327983 +0000
+@@ -16,7 +16,7 @@
+ m = i3s2
+ Cpu = I386
+ 
+-mdclib = -lnsl -ldl -lm -lcurses -lrt -luuid
++mdclib = -lnsl -ldl -lm -lcurses -lrt -luuid -lz
+ C = ${CC} ${CFLAGS} -m32 -Wpointer-arith -Wextra -Werror -O ${CPPFLAGS}
+ o = o
+ mdsrc = i3le.c
+@@ -26,12 +26,12 @@
+ .SUFFIXES: .c .o
+ 
+ .c.o:
+-	$C -c -DSOLARIS -D${Cpu} -I${Include} -I../zlib $*.c
++	$C -c -DSOLARIS -D${Cpu} -I${Include} $*.c
+ 
+ include Mf-base
+ 
+-${Kernel}: ${kernelobj} ../zlib/libz.a
+-	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
++${Kernel}: ${kernelobj}
++	/bin/ld -r -o ${Kernel} ${kernelobj}
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+diff -ru ChezScheme-9.5.2.orig/c/Mf-ta6s2 ChezScheme-9.5.2/c/Mf-ta6s2
+--- ChezScheme-9.5.2.orig/c/Mf-ta6s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-ta6s2	2019-08-25 16:23:58.255504663 +0000
+@@ -16,7 +16,7 @@
+ m = ta6s2
+ Cpu = X86_64
+ 
+-mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt -luuid
++mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt -luuid -lz
+ C = ${CC} ${CPPFLAGS} -m64 -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT ${CFLAGS}
+ o = o
+ mdsrc = i3le.c
+@@ -26,15 +26,12 @@
+ .SUFFIXES: .c .o
+ 
+ .c.o:
+-	$C -c -DSOLARIS -D${Cpu} -I${Include} -I../zlib $*.c
++	$C -c -DSOLARIS -D${Cpu} -I${Include} $*.c
+ 
+ include Mf-base
+ 
+-${Kernel}: ${kernelobj} ../zlib/libz.a
+-	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
++${Kernel}: ${kernelobj}
++	/bin/ld -r -o ${Kernel} ${kernelobj}
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+-
+-../zlib/configure.log:
+-	(cd ../zlib; CFLAGS=-m64 ./configure --64)
+Only in ChezScheme-9.5.2/c: Mf-ta6s2.~1~
+Only in ChezScheme-9.5.2/c: Mf-ta6s2.~2~
+diff -ru ChezScheme-9.5.2.orig/c/Mf-ti3s2 ChezScheme-9.5.2/c/Mf-ti3s2
+--- ChezScheme-9.5.2.orig/c/Mf-ti3s2	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/c/Mf-ti3s2	2019-08-25 16:24:36.560269634 +0000
+@@ -16,7 +16,7 @@
+ m = ti3s2
+ Cpu = I386
+ 
+-mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt -luuid
++mdclib = -lnsl -ldl -lm -lpthread -lcurses -lrt -luuid -lz
+ C = ${CC} ${CPPFLAGS} -m32 -Wpointer-arith -Wextra -Werror -O2 -D_REENTRANT ${CFLAGS}
+ o = o
+ mdsrc = i3le.c
+@@ -26,15 +26,12 @@
+ .SUFFIXES: .c .o
+ 
+ .c.o:
+-	$C -c -DSOLARIS -D${Cpu} -I${Include} -I../zlib $*.c
++	$C -c -DSOLARIS -D${Cpu} -I${Include} $*.c
+ 
+ include Mf-base
+ 
+-${Kernel}: ${kernelobj} ../zlib/libz.a
+-	/bin/ld -r -o ${Kernel} ${kernelobj} ../zlib/libz.a
++${Kernel}: ${kernelobj}
++	/bin/ld -r -o ${Kernel} ${kernelobj}
+ 
+ ${Scheme}: ${Kernel} ${Main}
+ 	$C -o ${Scheme} ${Kernel} ${Main} ${mdclib} ${LDFLAGS}
+-
+-../zlib/configure.log:
+-	(cd ../zlib; CFLAGS=-m32 ./configure)
+Only in ChezScheme-9.5.2/c: stats.c.~1~
+diff -ru ChezScheme-9.5.2.orig/configure ChezScheme-9.5.2/configure
+--- ChezScheme-9.5.2.orig/configure	2019-03-21 18:05:24.000000000 +0000
++++ ChezScheme-9.5.2/configure	2019-08-25 16:22:51.538238461 +0000
+@@ -331,11 +331,6 @@
+     (curl  -L -o v1.9.tar.gz https://github.com/nanopass/nanopass-framework-scheme/archive/v1.9.tar.gz && tar -zxf v1.9.tar.gz && mv nanopass-framework-scheme-1.9 nanopass && rm v1.9.tar.gz) || exit 1
+   fi
+ 
+-  if [ ! -f 'zlib/configure' ] ; then
+-    rmdir zlib > /dev/null 2>&1
+-    (curl -L -o v1.2.11.tar.gz https://github.com/madler/zlib/archive/v1.2.11.tar.gz && tar -xzf v1.2.11.tar.gz && mv zlib-1.2.11 zlib && rm v1.2.11.tar.gz) || exit 1
+-  fi
+-
+   if [ ! -f 'stex/Mf-stex' ] ; then
+     rmdir stex > /dev/null 2>&1
+     (curl -L -o v1.2.1.tar.gz https://github.com/dybvig/stex/archive/v1.2.1.tar.gz && tar -zxf v1.2.1.tar.gz && mv stex-1.2.1 stex && rm v1.2.1.tar.gz) || exit 1


### PR DESCRIPTION
This adds Chez Scheme 9.5.2.

The patches are from a pull request I currently have open upstream (cisco/ChezScheme#455)
The files/ directory are the files used to bootstrap on solaris x86 (I've included all of them, though we only use ta6s2, threaded solaris on amd64).  

The files will need to be generated for each future update, on a platform for which Chez ships bootstrap files (how to do so is documented in their build documentation).  The files are somewhat large, and ill-suited to version control, so it'd probably be better to put them in a separate tarball we could host and fetch, but I don't have the means to do that in the pull request.