### PR TITLE
Update nano to 4.4

### DIFF
--- a/components/editor/nano/Makefile
+++ b/components/editor/nano/Makefile
@@ -16,7 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		nano
-COMPONENT_VERSION=	4.3
+COMPONENT_VERSION=	4.4
 COMPONENT_FMRI=		editor/nano
 COMPONENT_SUMMARY=	GNU implementation of nano, a text editor emulating pico
 COMPONENT_CLASSIFICATION=System/Text Tools
@@ -24,7 +24,7 @@ COMPONENT_PROJECT_URL=	https://www.nano-editor.org/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:00d3ad1a287a85b4bf83e5f06cedd0a9f880413682bebd52b4b1e2af8cfc0d81
+	sha256:2af222e0354848ffaa3af31b5cd0a77917e9cb7742cd073d762f3c32f0f582c7
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/pub/gnu/nano/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3
 


### PR DESCRIPTION
```
2019.08.25 - GNU nano 4.4 "Hagelslag"

• At startup, the cursor can be put on the first or last occurrence
  of a string by preceding the filename with +/string or +?string.
• When automatic hard-wrapping occurs (--breaklonglines), any leading
  quoting characters will be automatically copied to the new line.
• M-6 works again also when the cursor is at end of buffer.
```