### PR TITLE
Font renames

### DIFF
--- a/components/fonts/arphic-ukai/Makefile
+++ b/components/fonts/arphic-ukai/Makefile
@@ -19,6 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		arphic-ukai
 COMPONENT_VERSION=	0.2.20080216.1
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=	CJK Unicode TrueType font Ming style
 COMPONENT_PROJECT_URL=	https://www.freedesktop.org/wiki/Software/CJKUnifonts
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/fonts/arphic-ukai/arphic-ukai.p5m
+++ b/components/fonts/arphic-ukai/arphic-ukai.p5m
@@ -24,6 +24,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=system/library/fontconfig
 
+# Rename
+depend type=optional fmri=system/font/arphic-ukai@0.2.20080216.1-2018.0.0.1
+
 link path=etc/X11/fontpath.d/$(COMPONENT_NAME):pri=99 \
     target=../../../usr/share/fonts/TrueType/$(COMPONENT_NAME)
 

--- a/components/fonts/arphic-ukai/history
+++ b/components/fonts/arphic-ukai/history
@@ -1,0 +1,1 @@
+system/font/arphic-ukai@0.2.20080216.1-2018.0.0.1 system/font/truetype/arphic-ukai

--- a/components/fonts/arphic-uming/Makefile
+++ b/components/fonts/arphic-uming/Makefile
@@ -19,6 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		arphic-uming
 COMPONENT_VERSION=	0.2.20080216.1
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=	CJK Unicode TrueType font Ming style
 COMPONENT_PROJECT_URL=	https://www.freedesktop.org/wiki/Software/CJKUnifonts
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/fonts/arphic-uming/arphic-uming.p5m
+++ b/components/fonts/arphic-uming/arphic-uming.p5m
@@ -24,6 +24,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=system/library/fontconfig
 
+# Rename
+depend type=optional fmri=system/font/arphic-uming@0.2.20080216.1-2018.0.0.1
+
 link path=etc/X11/fontpath.d/$(COMPONENT_NAME):pri=99 \
     target=../../../usr/share/fonts/TrueType/$(COMPONENT_NAME)
 

--- a/components/fonts/arphic-uming/history
+++ b/components/fonts/arphic-uming/history
@@ -1,0 +1,1 @@
+system/font/arphic-uming@0.2.20080216.1-2018.0.0.1 system/font/truetype/arphic-uming

--- a/components/fonts/baekmuk/Makefile
+++ b/components/fonts/baekmuk/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         baekmuk
 COMPONENT_VERSION=      2.2
-COMPONENT_REVISION=     2
+COMPONENT_REVISION=     3
 COMPONENT_PROJECT_URL=  http://kldp.net/projects/baekmuk/
 COMPONENT_SUMMARY=      Baekmuk family Korean TrueType fonts
 COMPONENT_SRC_NAME=     baekmuk-ttf

--- a/components/fonts/baekmuk/baekmuk.p5m
+++ b/components/fonts/baekmuk/baekmuk.p5m
@@ -24,6 +24,10 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=system/library/fontconfig
 
+# Renames
+depend type=optional fmri=system/font/baekmuk-ttf@2.2-2018.0.0.2
+depend type=optional fmri=system/font/baekmuk@2.2-2018.0.0.2
+
 file path=usr/share/fonts/TrueType/baekmuk/batang.ttf
 file path=usr/share/fonts/TrueType/baekmuk/dotum.ttf
 file path=usr/share/fonts/TrueType/baekmuk/fonts.dir

--- a/components/fonts/baekmuk/history
+++ b/components/fonts/baekmuk/history
@@ -1,1 +1,2 @@
-system/font/baekmuk-ttf@2.2-2018.0.0.1 system/font/baekmuk
+system/font/baekmuk-ttf@2.2-2018.0.0.2 system/font/truetype/baekmuk
+system/font/baekmuk@2.2-2018.0.0.2 system/font/truetype/baekmuk

--- a/components/fonts/bitstream-vera/Makefile
+++ b/components/fonts/bitstream-vera/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         bitstream-vera
 COMPONENT_VERSION=      1.10
-COMPONENT_REVISION=     1
+COMPONENT_REVISION=     2
 COMPONENT_SUMMARY=      The Bitstream Vera fonts
 COMPONENT_PROJECT_URL=  https://dejavu-fonts.org/
 COMPONENT_SRC_NAME=     ttf-bitstream-vera

--- a/components/fonts/bitstream-vera/bitstream-vera.p5m
+++ b/components/fonts/bitstream-vera/bitstream-vera.p5m
@@ -24,6 +24,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=system/library/fontconfig
 
+# Rename
+depend type=optional fmri=system/font/bitstream-vera@1.10-2018.0.0.2
+
 # Added link
 link path=etc/X11/fontpath.d/bitstream-vera:pri=42 target=../../../usr/share/fonts/TrueType/bitstream-vera
 

--- a/components/fonts/bitstream-vera/history
+++ b/components/fonts/bitstream-vera/history
@@ -1,0 +1,1 @@
+system/font/bitstream-vera@1.10-2018.0.0.2 system/font/truetype/bitstream-vera 

--- a/components/fonts/dejavu/Makefile
+++ b/components/fonts/dejavu/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         dejavu
 COMPONENT_VERSION=      2.37
-COMPONENT_REVISION=     2
+COMPONENT_REVISION=     3
 COMPONENT_SUMMARY=      The DejaVu fonts
 COMPONENT_PROJECT_URL=  https://dejavu-fonts.github.io/
 COMPONENT_SRC_NAME=     dejavu-fonts-ttf

--- a/components/fonts/dejavu/dejavu.p5m
+++ b/components/fonts/dejavu/dejavu.p5m
@@ -24,6 +24,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=system/library/fontconfig
 
+# Rename
+depend type=optional fmri=system/font/dejavu@2.37-2018.0.0.3
+
 # Added links
 link path=etc/X11/fontpath.d/dejavu:pri=42 target=../../../usr/share/fonts/TrueType/dejavu
 link path=etc/fonts/conf.d/20-unhint-small-dejavu-sans-mono.conf target=../conf.avail/20-unhint-small-dejavu-sans-mono.conf

--- a/components/fonts/dejavu/history
+++ b/components/fonts/dejavu/history
@@ -1,0 +1,1 @@
+system/font/dejavu@2.37-2018.0.0.3 system/font/truetype/dejavu

--- a/components/fonts/freefont/Makefile
+++ b/components/fonts/freefont/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=        freefont
 COMPONENT_VERSION=     20120503
 IPS_COMPONENT_VERSION= 0.$(COMPONENT_VERSION)
-COMPONENT_REVISION=    2
+COMPONENT_REVISION=    3
 COMPONENT_PROJECT_URL= https://savannah.gnu.org/projects/freefont/
 COMPONENT_SUMMARY=     Free UCS TrueType Fonts
 COMPONENT_SRC=         freefont-$(COMPONENT_VERSION)

--- a/components/fonts/freefont/freefont.p5m
+++ b/components/fonts/freefont/freefont.p5m
@@ -22,6 +22,10 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Renames
+depend type=optional fmri=system/font/freefont-ttf@0.20120503-2018.0.0.2
+depend type=optional fmri=system/font/freefont@0.20120503-2018.0.0.2
+
 file path=usr/share/fonts/TrueType/freefont/FreeMono.ttf
 file path=usr/share/fonts/TrueType/freefont/FreeMonoBold.ttf
 file path=usr/share/fonts/TrueType/freefont/FreeMonoBoldOblique.ttf

--- a/components/fonts/freefont/history
+++ b/components/fonts/freefont/history
@@ -1,1 +1,2 @@
-system/font/freefont-ttf@0.20120503-2018.0.0.1 system/font/freefont
+system/font/freefont-ttf@0.20120503-2018.0.0.2 system/font/truetype/freefont
+system/font/freefont@0.20120503-2018.0.0.2 system/font/truetype/freefont

--- a/components/fonts/gentium/Makefile
+++ b/components/fonts/gentium/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=  	gentium
 COMPONENT_VERSION=      1.102
+COMPONENT_VERSION=      1
 COMPONENT_SUMMARY=      Gentium Basic extended Unicode fonts
 COMPONENT_SRC=  	GentiumBasic_1102
 COMPONENT_ARCHIVE=      $(COMPONENT_NAME)-$(COMPONENT_VERSION).zip

--- a/components/fonts/gentium/gentium.p5m
+++ b/components/fonts/gentium/gentium.p5m
@@ -22,6 +22,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Rename
+depend type=optional fmri=system/font/gentium@1.102-2018.0.0.1
+
 file path=usr/share/fonts/TrueType/gentium/GenBasB.ttf
 file path=usr/share/fonts/TrueType/gentium/GenBasBI.ttf
 file path=usr/share/fonts/TrueType/gentium/GenBasI.ttf

--- a/components/fonts/gentium/history
+++ b/components/fonts/gentium/history
@@ -1,0 +1,1 @@
+system/font/gentium@1.102-2018.0.0.1 system/font/truetype/gentium

--- a/components/fonts/google-droid/Makefile
+++ b/components/fonts/google-droid/Makefile
@@ -19,6 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		google-droid
 COMPONENT_VERSION=	20141010
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=	CJK Unicode TrueType font Ming style
 COMPONENT_PROJECT_URL=	https://www.droidfonts.com/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/fonts/google-droid/google-droid.p5m
+++ b/components/fonts/google-droid/google-droid.p5m
@@ -22,6 +22,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Rename
+depend type=optional fmri=system/font/google-droid@20141010-2018.0.0.1
+
 link path=etc/X11/fontpath.d/google-droid:pri=42 \
 target=../../../usr/share/fonts/TrueType/google-droid
 

--- a/components/fonts/google-droid/history
+++ b/components/fonts/google-droid/history
@@ -1,0 +1,1 @@
+system/font/google-droid@20141010-2018.0.0.1 system/font/truetype/google-droid 

--- a/components/fonts/texgyre/Makefile
+++ b/components/fonts/texgyre/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		texgyre
 COMPONENT_VERSION=	2.501
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=	The TeX Gyre (TG) Collection of Fonts
 COMPONENT_PROJECT_URL=	http://www.gust.org.pl/projects/e-foundry/tex-gyre
 COMPONENT_SRC=		tg2_501otf

--- a/components/fonts/texgyre/history
+++ b/components/fonts/texgyre/history
@@ -1,0 +1,1 @@
+system/font/texgyre@2.501-2018.0.0.1 system/font/opentype/texgyre

--- a/components/fonts/texgyre/texgyre.p5m
+++ b/components/fonts/texgyre/texgyre.p5m
@@ -22,6 +22,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Rename
+depend type=optional fmri=system/font/texgyre@2.501-2018.0.0.1
+
 file path=usr/share/fonts/OpenType/texgyre/fonts.dir
 file path=usr/share/fonts/OpenType/texgyre/fonts.scale
 file path=usr/share/fonts/OpenType/texgyre/texgyreadventor-bold.otf

--- a/components/fonts/unfonts-ko-core/Makefile
+++ b/components/fonts/unfonts-ko-core/Makefile
@@ -30,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=        unfonts-ko-core
 COMPONENT_VERSION=     1.0.2-080608
 IPS_COMPONENT_VERSION= 1.0.2
+COMPONENT_REVISION=    1
 COMPONENT_SUMMARY=     Un-Fonts Korean TrueType fonts
 COMPONENT_PROJECT_URL= https://kldp.net/unfonts/
 COMPONENT_SRC=         un-fonts

--- a/components/fonts/unfonts-ko-core/history
+++ b/components/fonts/unfonts-ko-core/history
@@ -1,0 +1,1 @@
+system/font/unfonts-ko-core@1.0.2-2018.0.0.1 system/font/truetype/unfonts-ko-core  

--- a/components/fonts/unfonts-ko-core/unfonts-ko-core.p5m
+++ b/components/fonts/unfonts-ko-core/unfonts-ko-core.p5m
@@ -24,6 +24,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=system/library/fontconfig
 
+# Rename
+depend type=optional fmri=pkg:/system/font/unfonts-ko-core@1.0.2-2018.0.0.1
+
 file path=usr/share/fonts/TrueType/unfonts-ko-core/UnBatang.ttf
 file path=usr/share/fonts/TrueType/unfonts-ko-core/UnBatangBold.ttf
 file path=usr/share/fonts/TrueType/unfonts-ko-core/UnDinaru.ttf

--- a/components/fonts/unfonts-ko-extra/Makefile
+++ b/components/fonts/unfonts-ko-extra/Makefile
@@ -30,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=        unfonts-ko-extra
 COMPONENT_VERSION=     1.0.2-080608
 IPS_COMPONENT_VERSION= 1.0.2
+COMPONENT_REVISION=    1
 COMPONENT_SUMMARY=     Un-Fonts Korean TrueType fonts (extra)
 COMPONENT_PROJECT_URL= https://kldp.net/unfonts/
 COMPONENT_SRC=         un-fonts

--- a/components/fonts/unfonts-ko-extra/history
+++ b/components/fonts/unfonts-ko-extra/history
@@ -1,0 +1,1 @@
+system/font/unfonts-ko-extra@1.0.2-2018.0.0.1 system/font/truetype/unfonts-ko-extra

--- a/components/fonts/unfonts-ko-extra/unfonts-ko-extra.p5m
+++ b/components/fonts/unfonts-ko-extra/unfonts-ko-extra.p5m
@@ -24,6 +24,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=system/library/fontconfig
 
+# Rename
+depend type=optional fmri=system/font/unfonts-ko-extra@1.0.2-2018.0.0.1
+
 file path=usr/share/fonts/TrueType/unfonts-ko-extra/UnBom.ttf
 file path=usr/share/fonts/TrueType/unfonts-ko-extra/UnJamoBatang.ttf
 file path=usr/share/fonts/TrueType/unfonts-ko-extra/UnJamoDotum.ttf

--- a/components/fonts/wqy-zenhei/Makefile
+++ b/components/fonts/wqy-zenhei/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=       wqy-zenhei
 COMPONENT_VERSION=    0.9.45
-COMPONENT_REVISION=   1
+COMPONENT_REVISION=   2
 COMPONENT_SUMMARY=    The WenQuanYi (Spring of Letters) Zenhei TrueType font
 COMPONENT_PROJECT_URL=https://sourceforge.net/projects/wqy/
 COMPONENT_SRC=	      $(COMPONENT_NAME)

--- a/components/fonts/wqy-zenhei/history
+++ b/components/fonts/wqy-zenhei/history
@@ -1,0 +1,1 @@
+system/font/wqy-zenhei@0.9.45-2018.0.0.2 system/font/truetype/wqy-zenhei 

--- a/components/fonts/wqy-zenhei/wqy-zenhei.p5m
+++ b/components/fonts/wqy-zenhei/wqy-zenhei.p5m
@@ -22,6 +22,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Rename
+depend type=optional fmri=system/font/wqy-zenhei@0.9.45-2018.0.0.2
+
 link path=etc/fonts/conf.d/44-wqy-zenhei.conf target=../conf.avail/44-wqy-zenhei.conf
 
 file path=etc/fonts/conf.avail/43-wqy-zenhei-sharp.conf

--- a/components/meta-packages/gnome-fonts/Makefile
+++ b/components/meta-packages/gnome-fonts/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnome-fonts
 COMPONENT_VERSION=	2.30.1
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	GNOME Unicode and Korean TrueType fonts
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	system/font/gnome-fonts

--- a/components/meta-packages/gnome-fonts/gnome-fonts.p5m
+++ b/components/meta-packages/gnome-fonts/gnome-fonts.p5m
@@ -19,5 +19,5 @@ set name=description value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-depend fmri=system/font/freefont type=require
-depend fmri=system/font/baekmuk type=require
+depend fmri=system/font/truetype/freefont type=require
+depend fmri=system/font/truetype/baekmuk type=require


### PR DESCRIPTION
This fixes some renames due to mispublished packages with fmri system/font/foo instead of system/font/truetype/foo.
In all the case the component revision taken for the rename was the last in the repository plus one.
This also fixes the gnome-fonts package which refers to mispublished fmris instead of the correct ones.
