### PR TITLE
Fix mod_auth_mellon files

### DIFF
--- a/components/web/apache2-modules/mod_auth_mellon/Makefile
+++ b/components/web/apache2-modules/mod_auth_mellon/Makefile
@@ -21,17 +21,18 @@
 # Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
 #
 
-BUILD_BITS=64
+BUILD_BITS=		64
 
 include ../../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=	mod_auth_mellon
+COMPONENT_NAME=		mod_auth_mellon
 COMPONENT_VERSION=	0.14.2
-COMPONENT_FMRI=	web/server/apache-24/module/apache-mellon
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		web/server/apache-24/module/apache-mellon
 COMPONENT_SUMMARY=	SAML2.0 authentication module for Apache
 COMPONENT_CLASSIFICATION=	Web Services/Application and Web Servers
 COMPONENT_PROJECT_URL=	https://github.com/Uninett/mod_auth_mellon
-COMPONENT_SRC=	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:8290ba57394fb7c551b9902c32bded8711f9656e2d36e351618b952f2c162afc

--- a/components/web/apache2-modules/mod_auth_mellon/mod_auth_mellon.p5m
+++ b/components/web/apache2-modules/mod_auth_mellon/mod_auth_mellon.p5m
@@ -26,12 +26,7 @@ depend fmri=text/gnu-grep type=require
 
 # there is no install section in the Makefile
 # we use the files from the build folders
-file files/sample-mellon.conf path=$(ETCDIR)/apache2/2.4/samples-conf.d/mellon.conf
-file build/$(MACH64)/mellon_create_metadata.sh \
-    path=$(USRDIR)/apache2/2.4/bin/mellon_create_metadata.sh mode=0555 \
-    pkg.linted.userland.action001.0=true
-file build/$(MACH64)/.libs/mod_auth_mellon.so \
-    path=$(USRDIR)/apache2/2.4/libexec/mod_auth_mellon.so \
-    pkg.linted.userland.action001.2=true
-file build/$(MACH64)/README.md path=$(USRSHAREDIR)/doc/mellon/README.md
-
+file files/sample-mellon.conf path=etc/apache2/2.4/samples-conf.d/mellon.conf
+file build/$(MACH64)/mellon_create_metadata.sh path=usr/apache2/2.4/bin/mellon_create_metadata.sh mode=0555
+file build/$(MACH64)/.libs/mod_auth_mellon.so path=usr/apache2/2.4/libexec/mod_auth_mellon.so
+file build/$(MACH64)/README.md path=usr/share/doc/mellon/README.md


### PR DESCRIPTION
```
:; pkg contents apache-mellon
PATH
$(ETCDIR)/apache2/2.4/samples-conf.d/mellon.conf
$(USRDIR)/apache2/2.4/bin/mellon_create_metadata.sh
$(USRDIR)/apache2/2.4/libexec/mod_auth_mellon.so
$(USRSHAREDIR)/doc/mellon/README.md

e.g:
:; ls -al /etc//apache2/2.4/samples-conf.d/mellon.conf
ls: cannot access '/etc//apache2/2.4/samples-conf.d/mellon.conf': No such file or directory 
```

FYI @grueni.

**Testing**
```
$ for i in `pkg contents -H web/server/apache-24/module/apache-mellon`; do ll /$i; done
-r--r--r--   1 root     bin        24.5K Aug 27 17:12 /etc/apache2/2.4/samples-conf.d/mellon.conf
-r-xr-xr-x   1 root     bin        2.59K Aug 27 17:12 /usr/apache2/2.4/bin/mellon_create_metadata.sh*
-r--r--r--   1 root     bin         744K Aug 27 17:12 /usr/apache2/2.4/libexec/mod_auth_mellon.so
-r--r--r--   1 root     bin        37.5K Aug 27 17:12 /usr/share/doc/mellon/README.md
```