### PR TITLE
Update sane-backends to 1.0.28

### DIFF
--- a/components/library/sane-backends/Makefile
+++ b/components/library/sane-backends/Makefile
@@ -19,11 +19,15 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
+
+BUILD_BITS=		32
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		sane-backends
-COMPONENT_VERSION=	1.0.27
+COMPONENT_VERSION=	1.0.28
 COMPONENT_FMRI=         image/scanner/xsane/sane-backends
 COMPONENT_SUMMARY=      SANE library and backends
 COMPONENT_CLASSIFICATION=System/Libraries
@@ -31,39 +35,38 @@ COMPONENT_PROJECT_URL=	http://www.sane-project.org/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9
-COMPONENT_ARCHIVE_URL=	http://fossies.org/linux/misc/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE=      GPLv2
+	sha256:31260f3f72d82ac1661c62c5a4468410b89fb2b4a811dabbfcc0350c1346de03
+COMPONENT_ARCHIVE_URL=	https://gitlab.com/sane-project/backends/uploads/9e718daff347826f4cfe21126c8d5091/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=      GPLv2+ and GPLv2+ with exceptions and Public Domain and IJG and LGPLv2+ and MIT
+COMPONENT_LICENSE_FILE=	LICENSE
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
-CFLAGS += -std=gnu89
-LDFLAGS+=-lnsl -lsocket
+LDFLAGS += -lnsl -lsocket
 
 # build with the distribution preferred libjpeg implementation
 CFLAGS   += $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
 CXXFLAGS += $(JPEG_CPPFLAGS) $(JPEG_CXXFLAGS)
 LDFLAGS  += $(JPEG_LDFLAGS)
 
-CONFIGURE_OPTIONS +=	--disable-locking
 CONFIGURE_OPTIONS +=	--sysconfdir=/etc
-CONFIGURE_OPTIONS +=	CFLAGS="$(CFLAGS)" 
+CONFIGURE_OPTIONS +=	--disable-locking
+CONFIGURE_OPTIONS +=	--enable-pthread
+CONFIGURE_OPTIONS +=	--with-gphoto2
+CONFIGURE_OPTIONS +=	--with-usb
+CONFIGURE_OPTIONS +=	--without-api-spec
 
-build:		$(BUILD_32)
-
-install:	$(INSTALL_32)
-
-test:		$(NO_TESTS)
+COMPONENT_TEST_ENV += PATH="$(PATH.gnu)"
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += image/library/libjpeg8-turbo
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += image/library/libtiff
 REQUIRED_PACKAGES += library/libgphoto2-2
 REQUIRED_PACKAGES += library/libusb-1
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += system/management/snmp/net-snmp

--- a/components/library/sane-backends/manifests/sample-manifest.p5m
+++ b/components/library/sane-backends/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -311,6 +311,11 @@ link path=usr/lib/sane/libsane-kvs20xx.so \
 file path=usr/lib/sane/libsane-kvs20xx.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-kvs20xx.so.1 \
     target=libsane-kvs20xx.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-kvs40xx.so \
+    target=libsane-kvs40xx.so.$(COMPONENT_VERSION)
+file path=usr/lib/sane/libsane-kvs40xx.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-kvs40xx.so.1 \
+    target=libsane-kvs40xx.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-leo.so target=libsane-leo.so.$(COMPONENT_VERSION)
 file path=usr/lib/sane/libsane-leo.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-leo.so.1 \
@@ -355,6 +360,11 @@ link path=usr/lib/sane/libsane-mustek_usb.so \
 file path=usr/lib/sane/libsane-mustek_usb.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-mustek_usb.so.1 \
     target=libsane-mustek_usb.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-mustek_usb2.so \
+    target=libsane-mustek_usb2.so.$(COMPONENT_VERSION)
+file path=usr/lib/sane/libsane-mustek_usb2.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-mustek_usb2.so.1 \
+    target=libsane-mustek_usb2.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-nec.so target=libsane-nec.so.$(COMPONENT_VERSION)
 file path=usr/lib/sane/libsane-nec.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-nec.so.1 \
@@ -400,6 +410,11 @@ link path=usr/lib/sane/libsane-ricoh.so \
 file path=usr/lib/sane/libsane-ricoh.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-ricoh.so.1 \
     target=libsane-ricoh.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-ricoh2.so \
+    target=libsane-ricoh2.so.$(COMPONENT_VERSION)
+file path=usr/lib/sane/libsane-ricoh2.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-ricoh2.so.1 \
+    target=libsane-ricoh2.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-rts8891.so \
     target=libsane-rts8891.so.$(COMPONENT_VERSION)
 file path=usr/lib/sane/libsane-rts8891.so.$(COMPONENT_VERSION)
@@ -584,6 +599,8 @@ file path=usr/share/doc/sane-backends/umax/umax.CHANGES
 file path=usr/share/doc/sane-backends/umax/umax.FAQ
 file path=usr/share/doc/sane-backends/umax/umax.TODO
 file path=usr/share/locale/bg/LC_MESSAGES/sane-backends.mo
+file path=usr/share/locale/ca/LC_MESSAGES/sane-backends.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/cs/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/da/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/de/LC_MESSAGES/sane-backends.mo
@@ -595,6 +612,7 @@ file path=usr/share/locale/es/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/fi/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/fr/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/gl/LC_MESSAGES/sane-backends.mo
+file path=usr/share/locale/he/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/hu/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/it/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/ja/LC_MESSAGES/sane-backends.mo
@@ -650,6 +668,7 @@ file path=usr/share/man/man5/sane-kodak.5
 file path=usr/share/man/man5/sane-kodakaio.5
 file path=usr/share/man/man5/sane-kvs1025.5
 file path=usr/share/man/man5/sane-kvs20xx.5
+file path=usr/share/man/man5/sane-kvs40xx.5
 file path=usr/share/man/man5/sane-leo.5
 file path=usr/share/man/man5/sane-lexmark.5
 file path=usr/share/man/man5/sane-ma1509.5
@@ -659,6 +678,7 @@ file path=usr/share/man/man5/sane-microtek.5
 file path=usr/share/man/man5/sane-microtek2.5
 file path=usr/share/man/man5/sane-mustek.5
 file path=usr/share/man/man5/sane-mustek_usb.5
+file path=usr/share/man/man5/sane-mustek_usb2.5
 file path=usr/share/man/man5/sane-nec.5
 file path=usr/share/man/man5/sane-net.5
 file path=usr/share/man/man5/sane-niash.5

--- a/components/library/sane-backends/sane-backends.p5m
+++ b/components/library/sane-backends/sane-backends.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -400,6 +401,11 @@ link path=usr/lib/sane/libsane-ricoh.so \
 file path=usr/lib/sane/libsane-ricoh.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-ricoh.so.1 \
     target=libsane-ricoh.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-ricoh2.so \
+    target=libsane-ricoh2.so.$(COMPONENT_VERSION)
+file path=usr/lib/sane/libsane-ricoh2.so.$(COMPONENT_VERSION)
+link path=usr/lib/sane/libsane-ricoh2.so.1 \
+    target=libsane-ricoh2.so.$(COMPONENT_VERSION)
 link path=usr/lib/sane/libsane-rts8891.so \
     target=libsane-rts8891.so.$(COMPONENT_VERSION)
 file path=usr/lib/sane/libsane-rts8891.so.$(COMPONENT_VERSION)
@@ -584,6 +590,8 @@ file path=usr/share/doc/sane-backends/umax/umax.CHANGES
 file path=usr/share/doc/sane-backends/umax/umax.FAQ
 file path=usr/share/doc/sane-backends/umax/umax.TODO
 file path=usr/share/locale/bg/LC_MESSAGES/sane-backends.mo
+file path=usr/share/locale/ca/LC_MESSAGES/sane-backends.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/cs/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/da/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/de/LC_MESSAGES/sane-backends.mo
@@ -595,6 +603,7 @@ file path=usr/share/locale/es/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/fi/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/fr/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/gl/LC_MESSAGES/sane-backends.mo
+file path=usr/share/locale/he/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/hu/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/it/LC_MESSAGES/sane-backends.mo
 file path=usr/share/locale/ja/LC_MESSAGES/sane-backends.mo


### PR DESCRIPTION
Changes: https://gitlab.com/sane-project/backends/-/releases

Minor glitch but not a regression: https://gitlab.com/sane-project/backends/issues/128

Update license tag according to https://gitlab.com/sane-project/backends/blob/master/LICENSE (the actual license string taken from Fedora).

**Testing**
- `scanimage --format=jpeg --output-file=my.jpeg --progress --verbose`
- scanning with `xsane` in various modes (color, grey, halftone, lineart), and resolutions (from 75 to 1200 dpi) to JPEG, PNM, and PDF
- internal tests passed