### PR TITLE
Update PCRE2 to 10.33

### DIFF
--- a/components/library/pcre2/Makefile
+++ b/components/library/pcre2/Makefile
@@ -23,79 +23,78 @@
 # Copyright (c) 2018, Michal Nowak
 #
 
-PREFERRED_BITS=64
+BUILD_BITS=		32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pcre2
-COMPONENT_VERSION=	10.32
+COMPONENT_VERSION=	10.33
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:f29e89cc5de813f45786580101aaee3984a65818631d4ddbda7b32f699b87c2e
-COMPONENT_ARCHIVE_URL=	ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/$(COMPONENT_ARCHIVE)
-COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).sig
+	sha256:35514dff0ccdf02b55bd2e9fa586a1b9d01f62332c3356e379eabb75f789d8aa
+COMPONENT_ARCHIVE_URL=	https://ftp.pcre.org/pub/pcre/$(COMPONENT_ARCHIVE)
+COMPONENT_SUMMARY=	Version 2 of Perl-Compatible Regular Expressions
+COMPONENT_CLASSIFICATION=Development/C
 COMPONENT_PROJECT_URL=  http://pcre.org/
 COMPONENT_FMRI=		library/pcre2
 COMPONENT_CLASSIFICATION=	Development/C
 COMPONENT_LICENSE=	BSD
 COMPONENT_LICENSE_FILE=	LICENCE
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 TEST_TARGET= install $(TEST_32_and_64)
 
 # pick up -std=c99 in CFLAGS
-CFLAGS+=	-std=c99
+CFLAGS +=	-std=c99
 
 # turn on largefile support
-CFLAGS+=	$(CPP_LARGEFILES)
+CFLAGS +=	$(CPP_LARGEFILES)
 
 # Although -norunpath is set for CXXFLAGS, we need to put -norunpath
 # here, otherwise -norunpath doesn't get set when creating the shared
 # libraries (CC -G).
-CXX+=	$(studio_NORUNPATH)
+CXX +=	$(studio_NORUNPATH)
 
 CXXFLAGS+=	$(CC_PIC)
 
 # turn on support for large files
-CXXFLAGS+=	$(CPP_LARGEFILES)
+CXXFLAGS +=	$(CPP_LARGEFILES)
 
-CONFIGURE_ENV+=	"CPP=$(CC) $(CPPFLAGS) $(CFLAGS) -E"
-CONFIGURE_ENV+=	"CXXCPP=$(CXX) $(CPPFLAGS) $(CXXFLAGS) -E"
-CONFIGURE_ENV+=	"CXXLDFLAGS=$(LDFLAGS)"
-CONFIGURE_ENV+= "CXXLD=$(CXX) $(CXXFLAGS) $(LDFLAGS)"
-CONFIGURE_ENV+= "INSTALL=$(INSTALL)"
-CONFIGURE_ENV+= "MAKE=$(GMAKE)"
+CONFIGURE_ENV +=	"CPP=$(CC) $(CPPFLAGS) $(CFLAGS) -E"
+CONFIGURE_ENV +=	"CXXCPP=$(CXX) $(CPPFLAGS) $(CXXFLAGS) -E"
+CONFIGURE_ENV +=	"CXXLDFLAGS=$(LDFLAGS)"
+CONFIGURE_ENV +=	"CXXLD=$(CXX) $(CXXFLAGS) $(LDFLAGS)"
+CONFIGURE_ENV +=	"INSTALL=$(INSTALL)"
+CONFIGURE_ENV +=	"MAKE=$(GMAKE)"
 
-CONFIGURE_ENV.64+= "CXXLINKLIB=$(CXX) $(CCFLAGS) $(LDFLAGS)"
-CONFIGURE_ENV.64+= "MACH64=$(MACH64)"
+CONFIGURE_ENV.64 +=	"CXXLINKLIB=$(CXX) $(CCFLAGS) $(LDFLAGS)"
+CONFIGURE_ENV.64 +=	"MACH64=$(MACH64)"
 
-CONFIGURE_OPTIONS+=	--includedir=$(CONFIGURE_INCLUDEDIR)/pcre
-CONFIGURE_OPTIONS+=	--localstatedir=$(VARDIR)
-CONFIGURE_OPTIONS+=	--disable-static
-CONFIGURE_OPTIONS+=	--enable-rebuild-chartables
-CONFIGURE_OPTIONS+=	--enable-newline-is-any
-CONFIGURE_OPTIONS+=	--enable-pcre2grep-libz
-CONFIGURE_OPTIONS+=	--enable-pcre2grep-libbz2
-CONFIGURE_OPTIONS+=	--enable-pcre2-32
-CONFIGURE_OPTIONS+=	--with-link-size=4
-CONFIGURE_OPTIONS+=	--with-match-limit=10000000
-CONFIGURE_OPTIONS+=	--with-pic
+CONFIGURE_OPTIONS +=	--includedir=$(CONFIGURE_INCLUDEDIR)/pcre
+CONFIGURE_OPTIONS +=	--localstatedir=$(VARDIR)
+CONFIGURE_OPTIONS +=	--disable-static
+CONFIGURE_OPTIONS +=	--enable-rebuild-chartables
+CONFIGURE_OPTIONS +=	--enable-newline-is-any
+CONFIGURE_OPTIONS +=	--enable-pcre2grep-libz
+CONFIGURE_OPTIONS +=	--enable-pcre2grep-libbz2
+CONFIGURE_OPTIONS +=	--enable-pcre2-32
+CONFIGURE_OPTIONS +=	--with-link-size=4
+CONFIGURE_OPTIONS +=	--with-match-limit=10000000
+CONFIGURE_OPTIONS +=	--with-pic
 # Enable UTF8 support    (was --enable-utf8 in pcre(1) configure).
-CONFIGURE_OPTIONS+=	--enable-pcre2-8
+CONFIGURE_OPTIONS +=	--enable-pcre2-8
 # Enable Unicode support (was --enable-unicode-properties in pcre(1) configure).
-CONFIGURE_OPTIONS+=	--enable-unicode
+CONFIGURE_OPTIONS +=	--enable-unicode
 
-COMPONENT_BUILD_ENV+=	"LDFLAGS=$(LDFLAGS)"
-COMPONENT_BUILD_ENV+=	"INSTALL=$(INSTALL)"
-COMPONENT_BUILD_ENV+=	"MAKE=$(GMAKE)"
+COMPONENT_BUILD_ENV +=	"LDFLAGS=$(LDFLAGS)"
+COMPONENT_BUILD_ENV +=	"INSTALL=$(INSTALL)"
+COMPONENT_BUILD_ENV +=	"MAKE=$(GMAKE)"
 
-COMPONENT_BUILD_ARGS+=	-e
+COMPONENT_BUILD_ARGS +=	-e
 
-COMPONENT_INSTALL_ARGS+=	"INSTALL=$(INSTALL)"
+COMPONENT_INSTALL_ARGS +=	"INSTALL=$(INSTALL)"
 
 # Needed for "gmake test" to work successfully.
 # If SHELLOPTS is exported (as it is by the userland makefiles),
@@ -119,13 +118,6 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "/Leaving directory/d"' \
 	'-e "/Entering directory/d"' \
 	'-e "s|Testsuite summary for PCRE .*|Testsuite summary for PCRE|" '
-
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += compress/bzip2

--- a/components/library/pcre2/manifests/sample-manifest.p5m
+++ b/components/library/pcre2/manifests/sample-manifest.p5m
@@ -22,35 +22,35 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH32)/pcre2-config
-file path=usr/bin/$(MACH32)/pcre2grep
-file path=usr/bin/$(MACH32)/pcre2test
+file path=usr/bin/$(MACH64)/pcre2-config
+file path=usr/bin/$(MACH64)/pcre2grep
+file path=usr/bin/$(MACH64)/pcre2test
 file path=usr/bin/pcre2-config
 file path=usr/bin/pcre2grep
 file path=usr/bin/pcre2test
 file path=usr/include/pcre/pcre2.h
 file path=usr/include/pcre/pcre2posix.h
-link path=usr/lib/$(MACH64)/libpcre2-32.so target=libpcre2-32.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
-file path=usr/lib/$(MACH64)/libpcre2-32.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
-file path=usr/lib/$(MACH64)/libpcre2-8.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
-link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
-file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.1
+link path=usr/lib/$(MACH64)/libpcre2-32.so target=libpcre2-32.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-32.so.0 target=libpcre2-32.so.0.8.0
+file path=usr/lib/$(MACH64)/libpcre2-32.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.8.0
+file path=usr/lib/$(MACH64)/libpcre2-8.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.2
+link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.2
+file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.2
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-32.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-8.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-posix.pc
-link path=usr/lib/libpcre2-32.so target=libpcre2-32.so.0.7.1
-link path=usr/lib/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
-file path=usr/lib/libpcre2-32.so.0.7.1
-link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.7.1
-link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
-file path=usr/lib/libpcre2-8.so.0.7.1
-link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
-link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
-file path=usr/lib/libpcre2-posix.so.2.0.1
+link path=usr/lib/libpcre2-32.so target=libpcre2-32.so.0.8.0
+link path=usr/lib/libpcre2-32.so.0 target=libpcre2-32.so.0.8.0
+file path=usr/lib/libpcre2-32.so.0.8.0
+link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.8.0
+link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.8.0
+file path=usr/lib/libpcre2-8.so.0.8.0
+link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.2
+link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.2
+file path=usr/lib/libpcre2-posix.so.2.0.2
 file path=usr/lib/pkgconfig/libpcre2-32.pc
 file path=usr/lib/pkgconfig/libpcre2-8.pc
 file path=usr/lib/pkgconfig/libpcre2-posix.pc
@@ -123,6 +123,7 @@ file path=usr/share/doc/pcre2/html/pcre2_set_offset_limit.html
 file path=usr/share/doc/pcre2/html/pcre2_set_parens_nest_limit.html
 file path=usr/share/doc/pcre2/html/pcre2_set_recursion_limit.html
 file path=usr/share/doc/pcre2/html/pcre2_set_recursion_memory_management.html
+file path=usr/share/doc/pcre2/html/pcre2_set_substitute_callout.html
 file path=usr/share/doc/pcre2/html/pcre2_substitute.html
 file path=usr/share/doc/pcre2/html/pcre2_substring_copy_byname.html
 file path=usr/share/doc/pcre2/html/pcre2_substring_copy_bynumber.html
@@ -220,6 +221,7 @@ file path=usr/share/man/man3/pcre2_set_offset_limit.3
 file path=usr/share/man/man3/pcre2_set_parens_nest_limit.3
 file path=usr/share/man/man3/pcre2_set_recursion_limit.3
 file path=usr/share/man/man3/pcre2_set_recursion_memory_management.3
+file path=usr/share/man/man3/pcre2_set_substitute_callout.3
 file path=usr/share/man/man3/pcre2_substitute.3
 file path=usr/share/man/man3/pcre2_substring_copy_byname.3
 file path=usr/share/man/man3/pcre2_substring_copy_bynumber.3

--- a/components/library/pcre2/pcre2.p5m
+++ b/components/library/pcre2/pcre2.p5m
@@ -21,48 +21,47 @@
 
 #
 # Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2019, Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="Version 2 of Perl-Compatible Regular Expressions"
-set name=info.classification value=org.opensolaris.category.2008:Development/C
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# pcre2-config contains embedded paths, so swap these around.
-file usr/bin/pcre2-config path=usr/bin/$(MACH64)/pcre2-config
-file usr/bin/$(MACH32)/pcre2-config path=usr/bin/pcre2-config
-file path=usr/bin/$(MACH32)/pcre2grep
-file path=usr/bin/$(MACH32)/pcre2test
+file path=usr/bin/$(MACH64)/pcre2-config
+file path=usr/bin/$(MACH64)/pcre2grep
+file path=usr/bin/$(MACH64)/pcre2test
+file path=usr/bin/pcre2-config
 file path=usr/bin/pcre2grep
 file path=usr/bin/pcre2test
 file path=usr/include/pcre/pcre2.h
 file path=usr/include/pcre/pcre2posix.h
-link path=usr/lib/$(MACH64)/libpcre2-32.so target=libpcre2-32.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
-file path=usr/lib/$(MACH64)/libpcre2-32.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
-file path=usr/lib/$(MACH64)/libpcre2-8.so.0.7.1
-link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
-link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
-file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.1
+link path=usr/lib/$(MACH64)/libpcre2-32.so target=libpcre2-32.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-32.so.0 target=libpcre2-32.so.0.8.0
+file path=usr/lib/$(MACH64)/libpcre2-32.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-8.so target=libpcre2-8.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-8.so.0 target=libpcre2-8.so.0.8.0
+file path=usr/lib/$(MACH64)/libpcre2-8.so.0.8.0
+link path=usr/lib/$(MACH64)/libpcre2-posix.so target=libpcre2-posix.so.2.0.2
+link path=usr/lib/$(MACH64)/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.2
+file path=usr/lib/$(MACH64)/libpcre2-posix.so.2.0.2
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-32.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-8.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libpcre2-posix.pc
-link path=usr/lib/libpcre2-32.so target=libpcre2-32.so.0.7.1
-link path=usr/lib/libpcre2-32.so.0 target=libpcre2-32.so.0.7.1
-file path=usr/lib/libpcre2-32.so.0.7.1
-link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.7.1
-link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.7.1
-file path=usr/lib/libpcre2-8.so.0.7.1
-link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.1
-link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.1
-file path=usr/lib/libpcre2-posix.so.2.0.1
+link path=usr/lib/libpcre2-32.so target=libpcre2-32.so.0.8.0
+link path=usr/lib/libpcre2-32.so.0 target=libpcre2-32.so.0.8.0
+file path=usr/lib/libpcre2-32.so.0.8.0
+link path=usr/lib/libpcre2-8.so target=libpcre2-8.so.0.8.0
+link path=usr/lib/libpcre2-8.so.0 target=libpcre2-8.so.0.8.0
+file path=usr/lib/libpcre2-8.so.0.8.0
+link path=usr/lib/libpcre2-posix.so target=libpcre2-posix.so.2.0.2
+link path=usr/lib/libpcre2-posix.so.2 target=libpcre2-posix.so.2.0.2
+file path=usr/lib/libpcre2-posix.so.2.0.2
 file path=usr/lib/pkgconfig/libpcre2-32.pc
 file path=usr/lib/pkgconfig/libpcre2-8.pc
 file path=usr/lib/pkgconfig/libpcre2-posix.pc
@@ -135,6 +134,7 @@ file path=usr/share/doc/pcre2/html/pcre2_set_offset_limit.html
 file path=usr/share/doc/pcre2/html/pcre2_set_parens_nest_limit.html
 file path=usr/share/doc/pcre2/html/pcre2_set_recursion_limit.html
 file path=usr/share/doc/pcre2/html/pcre2_set_recursion_memory_management.html
+file path=usr/share/doc/pcre2/html/pcre2_set_substitute_callout.html
 file path=usr/share/doc/pcre2/html/pcre2_substitute.html
 file path=usr/share/doc/pcre2/html/pcre2_substring_copy_byname.html
 file path=usr/share/doc/pcre2/html/pcre2_substring_copy_bynumber.html
@@ -232,6 +232,7 @@ file path=usr/share/man/man3/pcre2_set_offset_limit.3
 file path=usr/share/man/man3/pcre2_set_parens_nest_limit.3
 file path=usr/share/man/man3/pcre2_set_recursion_limit.3
 file path=usr/share/man/man3/pcre2_set_recursion_memory_management.3
+file path=usr/share/man/man3/pcre2_set_substitute_callout.3
 file path=usr/share/man/man3/pcre2_substitute.3
 file path=usr/share/man/man3/pcre2_substring_copy_byname.3
 file path=usr/share/man/man3/pcre2_substring_copy_bynumber.3

--- a/components/library/pcre2/test/results-all.master
+++ b/components/library/pcre2/test/results-all.master
@@ -5,7 +5,7 @@
 PASS: RunTest
 PASS: RunGrepTest
 ============================================================================
-Testsuite summary for PCRE2 10.32
+Testsuite summary for PCRE2 10.33
 ============================================================================
 # TOTAL: 2
 # PASS:  2


### PR DESCRIPTION
Changelog: https://www.pcre.org/changelog.txt

Removed the 64-bit preference as we were partially reverting it in pcre2.p5m anyway. I checked that `pcre2-config`s provide expected output:

```
$ /usr/bin/pcre2-config --cflags --libs32
-I/usr/include/pcre
-lpcre2-32

$ /usr/bin/amd64/pcre2-config --cflags --libs32
-I/usr/include/pcre
-L/usr/lib/amd64 -lpcre2-32
```

**Testing**
- internal test suite passed
- `git grep -P` works