### PR TITLE
Update GNU findutils to 4.7.0

### DIFF
--- a/components/sysutils/findutils/Makefile
+++ b/components/sysutils/findutils/Makefile
@@ -21,59 +21,49 @@
 
 #
 # Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Michal Nowak
 #
-PREFERRED_BITS=64
+
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         findutils
-COMPONENT_VERSION=      4.6.0
+COMPONENT_VERSION=      4.7.0
 COMPONENT_SUMMARY=      GNU findutils
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/findutils/
 COMPONENT_FMRI=         file/gnu-findutils
 COMPONENT_CLASSIFICATION=Applications/System Utilities
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:ded4c9f73731cd48fec3b6bdaccce896473b6d8e337e9612e16cf1431bb1169d
+	sha256:c5fefbdf9858f7e4feb86f036e1247a54c79fc2d8e4b7064d5aaa1f47dfa789a
 COMPONENT_ARCHIVE_URL= \
-  http://ftp.gnu.org/pub/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+	http://ftp.gnu.org/pub/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=      GPLv2
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_PREFIX = $(GNUDIR)
-
-# Fixes coredump in the tests/test-localename test.
-CONFIGURE_OPTIONS += ac_cv_func_newlocale=no
 
 # Disable the leaf optimisation feature, because the st_nlinks directory
 # field is incorrect on ZFS file systems.
 CONFIGURE_OPTIONS +=	--disable-leaf-optimisation
 
-ASLR_MODE = $(ASLR_ENABLE)
-
 # Run all the tests even if there is a failure
 COMPONENT_TEST_ARGS += -k
-COMPONENT_TEST_ENV +=	PATH="$(GNUBIN):$(PATH)"
+COMPONENT_TEST_ENV +=	PATH="$(PATH.gnu)"
 COMPONENT_TEST_TRANSFORMS += \
 	'-n ' \
 	'-e "/^PASS:/p" ' \
 	'-e "/^FAIL:/p" ' \
 	'-e "/^SKIP:/p" ' \
 	'-e "/^\# /p" '
+
 # Needed for "gmake test" to work successfully.
 # Otherwise we see errors such as:
 # FAIL: exec-nogaps.old-O3, sh: SHELLOPTS: readonly variable
 unexport SHELLOPTS
-
-build:          $(BUILD_64)
-
-install:        $(INSTALL_64)
-
-test:           $(TEST_64)
 
 # Test dependencies:
 REQUIRED_PACKAGES += developer/versioning/cvs

--- a/components/sysutils/findutils/findutils.p5m
+++ b/components/sysutils/findutils/findutils.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2018 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,15 +31,12 @@ link path=usr/share/man/man1/gfind.1 \
 link path=usr/share/man/man1/gxargs.1 \
     target=../../../gnu/share/man/man1/xargs.1 facet.compat.gnulinks=all
 
-# locate and updatedb are not being delivered, in favor of an external
-# solution to the problem.
+# locate and updatedb are not being delivered, in favor of utilities of
+# the same name from the file/mlocate package.
 file path=usr/gnu/bin/find
 #file path=usr/gnu/bin/locate
 #file path=usr/gnu/bin/updatedb
 file path=usr/gnu/bin/xargs
-#file path=usr/gnu/lib/$(MACH64)/charset.alias
-file path=usr/gnu/libexec/bigram mode=0555
-file path=usr/gnu/libexec/code mode=0555
 file path=usr/gnu/libexec/frcode mode=0555
 #file path=usr/gnu/share/info/dir
 file path=usr/gnu/share/info/find-maint.info
@@ -75,7 +73,6 @@ file path=usr/gnu/share/locale/pt/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/pt_BR/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/ro/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/ru/LC_MESSAGES/findutils.mo
-file path=usr/gnu/share/locale/rw/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/sk/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/sl/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/sr/LC_MESSAGES/findutils.mo

--- a/components/sysutils/findutils/manifests/sample-manifest.p5m
+++ b/components/sysutils/findutils/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,9 +26,6 @@ file path=usr/gnu/bin/find
 file path=usr/gnu/bin/locate
 file path=usr/gnu/bin/updatedb
 file path=usr/gnu/bin/xargs
-file path=usr/gnu/lib/$(MACH64)/charset.alias
-file path=usr/gnu/libexec/bigram
-file path=usr/gnu/libexec/code
 file path=usr/gnu/libexec/frcode
 file path=usr/gnu/share/info/dir
 file path=usr/gnu/share/info/find-maint.info
@@ -65,7 +62,6 @@ file path=usr/gnu/share/locale/pt/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/pt_BR/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/ro/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/ru/LC_MESSAGES/findutils.mo
-file path=usr/gnu/share/locale/rw/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/sk/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/sl/LC_MESSAGES/findutils.mo
 file path=usr/gnu/share/locale/sr/LC_MESSAGES/findutils.mo

--- a/components/sysutils/findutils/patches/01-test-set-ls.patch
+++ b/components/sysutils/findutils/patches/01-test-set-ls.patch
@@ -1,0 +1,13 @@
+https://savannah.gnu.org/bugs/?56831
+
+--- findutils-4.7.0/tests/find/printf_inode.sh	2019-08-30 10:21:17.198324425 +0000
++++ findutils-4.7.0/tests/find/printf_inode.sh.new	2019-08-30 10:21:47.966762636 +0000
+@@ -27,7 +27,7 @@ make_canonical() {
+ > file || framework_failure_
+ 
+ # Let ls(1) create the expected output.
+-ls -i file | make_canonical > exp || framework_failure_
++/usr/gnu/bin/ls -i file | make_canonical > exp || framework_failure_
+ 
+ for executable in oldfind find; do
+   rm -f out out2

--- a/components/sysutils/findutils/test/results-64.master
+++ b/components/sysutils/findutils/test/results-64.master
@@ -1,3 +1,15 @@
+PASS: check-regexprops
+PASS: test_splitstring
+# TOTAL: 2
+# PASS:  2
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+# of expected passes		951
+# of expected passes		96
+# of expected passes		28
 PASS: test-accept
 PASS: test-alloca-opt
 PASS: test-areadlink
@@ -40,6 +52,7 @@ PASS: test-fflush
 PASS: test-fflush2.sh
 PASS: test-fgetc
 PASS: test-float
+PASS: test-fnmatch-h
 PASS: test-fnmatch
 PASS: test-fopen-safer
 PASS: test-fopen
@@ -73,7 +86,9 @@ PASS: test-getdtablesize
 PASS: test-getgroups
 PASS: test-gethostname
 PASS: test-getline
-PASS: test-getopt
+PASS: test-getopt-gnu
+PASS: test-getopt-posix
+PASS: test-getprogname
 PASS: test-gettimeofday
 PASS: test-hash
 PASS: test-i-ring
@@ -91,11 +106,15 @@ PASS: test-isnanf-nolibm
 PASS: test-isnanl-nolibm
 PASS: test-iswblank
 PASS: test-langinfo
+PASS: test-limits-h
 PASS: test-listen
 PASS: test-locale
 PASS: test-localeconv
 PASS: test-localename
+PASS: test-rwlock1
 PASS: test-lock
+PASS: test-once1
+PASS: test-once2
 PASS: test-lseek.sh
 PASS: test-lstat
 PASS: test-malloc-gnu
@@ -105,6 +124,7 @@ PASS: test-mbrtowc1.sh
 PASS: test-mbrtowc2.sh
 SKIP: test-mbrtowc3.sh
 PASS: test-mbrtowc4.sh
+PASS: test-mbrtowc5.sh
 SKIP: test-mbrtowc-w32-1.sh
 SKIP: test-mbrtowc-w32-2.sh
 SKIP: test-mbrtowc-w32-3.sh
@@ -128,6 +148,7 @@ PASS: test-modf
 PASS: test-nanosleep
 PASS: test-netinet_in
 PASS: test-nl_langinfo.sh
+PASS: test-nstrftime
 PASS: test-open
 PASS: test-openat-safer
 PASS: test-openat
@@ -137,6 +158,8 @@ PASS: test-perror.sh
 PASS: test-perror2
 PASS: test-pipe
 PASS: test-priv-set
+PASS: test-pthread_sigmask1
+PASS: test-pthread_sigmask2
 PASS: test-quotearg-simple
 PASS: test-raise
 PASS: test-read
@@ -170,7 +193,6 @@ PASS: test-stdlib
 PASS: test-strcasestr
 PASS: test-strerror
 PASS: test-strerror_r
-PASS: test-strftime
 PASS: test-string
 PASS: test-strings
 PASS: test-strnlen
@@ -204,6 +226,7 @@ PASS: test-unlink
 PASS: test-unlinkat
 PASS: test-unsetenv
 PASS: test-update-copyright.sh
+PASS: test-usleep
 PASS: test-vasnprintf
 PASS: test-vc-list-files-git.sh
 PASS: test-vc-list-files-cvs.sh
@@ -223,35 +246,29 @@ PASS: test-xalloc-die.sh
 PASS: test-xstrtol.sh
 PASS: test-xstrtoumax.sh
 PASS: test-yesno.sh
-# TOTAL: 225
-# PASS:  212
+# TOTAL: 236
+# PASS:  223
 # SKIP:  13
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0
 # ERROR: 0
-PASS: check-regexprops
-PASS: test_splitstring
-# TOTAL: 2
-# PASS:  2
-# SKIP:  0
+FAIL: tests/misc/help-version.sh
+SKIP: tests/find/many-dir-entries-vs-OOM.sh
+PASS: tests/find/name-lbracket-literal.sh
+PASS: tests/find/printf_escapechars.sh
+PASS: tests/find/printf_escape_c.sh
+PASS: tests/find/printf_inode.sh
+PASS: tests/find/execdir-fd-leak.sh
+PASS: tests/find/exec-plus-last-file.sh
+PASS: tests/find/refuse-noop.sh
+PASS: tests/find/debug-missing-arg.sh
+PASS: tests/xargs/verbose-quote.sh
+PASS: tests/find/type_list.sh
+# TOTAL: 12
+# PASS:  10
+# SKIP:  1
 # XFAIL: 0
-# FAIL:  0
+# FAIL:  1
 # XPASS: 0
 # ERROR: 0
-# of expected passes		949
-PASS: sv-bug-32043.sh
-PASS: test_escapechars.sh
-PASS: test_escape_c.sh
-PASS: test_inode.sh
-PASS: sv-34079.sh
-PASS: sv-34976-execdir-fd-leak.sh
-# TOTAL: 6
-# PASS:  6
-# SKIP:  0
-# XFAIL: 0
-# FAIL:  0
-# XPASS: 0
-# ERROR: 0
-# of expected passes		96
-# of expected passes		34


### PR DESCRIPTION
Release notes: https://lists.gnu.org/archive/html/info-gnu/2019-08/msg00009.html

**Testing**
- there's a one failure in a binary we don't ship: https://savannah.gnu.org/bugs/?56832
- otherwise tests passed
- will keep locally for some time: looks good