### PR TITLE
Update logrotate to 3.15.1

### DIFF
--- a/components/sysutils/logrotate/Makefile
+++ b/components/sysutils/logrotate/Makefile
@@ -13,45 +13,30 @@
 # Copyright 2019 Michal Nowak
 #
 
+BUILD_BITS=		64
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		logrotate
-COMPONENT_VERSION=	3.15.0
+COMPONENT_VERSION=	3.15.1
 COMPONENT_PROJECT_URL=	https://github.com/logrotate/logrotate
 COMPONENT_SUMMARY=	Logrotate - Rotates and compresses log files
+COMPONENT_FMRI=		system/file/logrotate
+COMPONENT_CLASSIFICATION=	System/Administration and Configuration
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:724da48020bb801ba02728bde4c5bdce2daae46ac360d163e40ebf6914bb9927
+	sha256:9eed6d9254f3e2313e15a44b4d1e5f209d35a4483b2c563c823050ec91ac67b8
 COMPONENT_ARCHIVE_URL=	https://github.com/logrotate/logrotate/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE_FILE=	COPYING
 COMPONENT_LICENSE=	GPLv2
-COMPONENT_FMRI=		system/file/logrotate
-COMPONENT_CLASSIFICATION=	System/Administration and Configuration
+COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
-CONFIGURE_SBINDIR.64= $(CONFIGURE_SBINDIR.32)
-
-COMPONENT_PREP_ACTION =        ( cd $(@D)  && \
-				$(TOUCH) NEWS README AUTHORS ChangeLog && \
-				libtoolize --copy --force && \
-				aclocal -I. && \
-				automake -c -f -a && \
-				autoconf )
-
 # Tests otherwise fail
 unexport SHELLOPTS
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/popt

--- a/components/sysutils/logrotate/manifests/sample-manifest.p5m
+++ b/components/sysutils/logrotate/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/sysutils/logrotate/patches/02.man.patch
+++ b/components/sysutils/logrotate/patches/02.man.patch
@@ -1,11 +1,11 @@
---- logrotate-3.13.0/logrotate.8.orig	Sun Nov  5 16:53:03 2017
-+++ logrotate-3.13.0/logrotate.8	Sun Nov  5 16:54:00 2017
+--- logrotate-3.15.1/logrotate.8	2019-08-30 16:47:26.350676696 +0000
++++ logrotate-3.15.1/logrotate.8.new	2019-08-30 16:49:12.846286545 +0000
 @@ -1,4 +1,4 @@
--.TH LOGROTATE 8 "3.15.0" "Linux" "System Administrator's Manual"
-+.TH LOGROTATE 1 "3.15.0" "System Administrator's Manual"
+-.TH LOGROTATE 8 "3.15.1" "Linux" "System Administrator's Manual"
++.TH LOGROTATE 1 "3.15.1" "System Administrator's Manual"
+ 
  .SH NAME
- logrotate \(hy rotates, compresses, and mails system logs
- .SH SYNOPSIS
+ 
 @@ -622,6 +622,7 @@
  .BR chmod (2),
  .BR gunzip (1),

--- a/components/sysutils/logrotate/patches/03.logrotate-default.patch
+++ b/components/sysutils/logrotate/patches/03.logrotate-default.patch
@@ -12,8 +12,8 @@
      minsize 1M
      rotate 1
  }
---- logrotate-3.15.0/examples/btmp	2018-05-25 14:31:21.000000000 +0000
-+++ logrotate-3.15.0/examples/btmp.new	2019-03-07 18:43:23.191396552 +0000
+--- logrotate-3.15.1/examples/btmp	2019-08-30 15:04:51.000000000 +0000
++++ logrotate-3.15.1/examples/btmp.new	2019-08-30 16:52:24.045593850 +0000
 @@ -1,7 +1,7 @@
 -# no packages own btmp -- we'll rotate it here
 -/var/log/btmp {
@@ -21,7 +21,7 @@
 +/var/adm/utmpx {
      missingok
      monthly
--    create 0600 root utmp
-+    create 0600 adm adm
+-    create 0660 root utmp
++    create 0660 adm adm
      rotate 1
  }


### PR DESCRIPTION
Release notes: https://github.com/logrotate/logrotate/releases/tag/3.15.1

**Testing**
- test suite passed