### PR TITLE
htop: Add compressed ARC statistics

### DIFF
--- a/components/sysutils/htop/Makefile
+++ b/components/sysutils/htop/Makefile
@@ -24,21 +24,21 @@
 # Copyright 2019, Michal Nowak
 #
 
-PREFERRED_BITS=64
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		htop
 COMPONENT_VERSION=	2.2.0
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_FMRI=		diagnostic/htop
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SUMMARY=	htop - an interactive process viewer for Unix
 COMPONENT_PROJECT_URL=	https://hisham.hm/htop/
-COMPONENT_SRC=		htop-220-sunos_11-p2
+COMPONENT_SRC=		htop-220-sunos_11-p3
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:8cb90827a719ee0ca0aafce776ed0bc027565be448aea99ee70dae2fa65bd6f6
+	sha256:2f84ca37383879c90060309eb5c2aa7fb8b60c6bda18c75146cf0e68d9051c26
 # htop is broken without https://github.com/hishamhm/htop/pull/880 and
 # as upstream seems stalled on this (and other things), we opt for a source
 # which has illumos fixes included. Revert to the source below once merged:
@@ -47,22 +47,16 @@ COMPONENT_ARCHIVE_HASH= \
 # COMPONENT_ARCHIVE_URL= \
 # 	https://hisham.hm/htop/releases/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_URL= \
-	https://github.com/ninefathom/htop/archive/220-sunos_11-p2.tar.gz
+	https://github.com/ninefathom/htop/archive/220-sunos_11-p3.tar.gz
 COMPONENT_LICENSE=  GPLv2 
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
 COMPONENT_PREP_ACTION= ( cd $(@D); $(RM) config.h; sh autogen.sh )
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(NO_TESTS)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/ncurses


### PR DESCRIPTION
https://github.com/hishamhm/htop/issues/937
https://github.com/hishamhm/htop/pull/920
https://www.illumos.org/issues/11655

**Testing**
- in GZ and NGZ compressed ARC statistics look good