### PR TITLE
Update libexpat to 2.2.7, fix CVE-2018-20843

### DIFF
--- a/components/library/libexpat/Makefile
+++ b/components/library/libexpat/Makefile
@@ -22,13 +22,15 @@
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2017, Aurelien Larcher
-# Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2019, Michal Nowak
 #
+
+BUILD_BITS=		32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libexpat
-COMPONENT_VERSION=	2.2.6
+COMPONENT_VERSION=	2.2.7
 COMPONENT_VERSION_U=	$(shell echo $(COMPONENT_VERSION) | tr . _)
 COMPONENT_FMRI=		library/expat
 COMPONENT_SUMMARY=	libexpat - XML parser library
@@ -37,19 +39,19 @@ COMPONENT_CLASSIFICATION=	System/Libraries
 COMPONENT_PROJECT_URL=	https://libexpat.github.io
 COMPONENT_SRC_NAME=	expat
 COMPONENT_SRC=		$(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.lz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
+	sha256:db3712bf611b660fa8be7eb259447beffccf198840ebe0f3fe918fcd999a9d41
 COMPONENT_ARCHIVE_URL= \
-    https://github.com/libexpat/libexpat/releases/download/R_$(COMPONENT_VERSION_U)/$(COMPONENT_ARCHIVE)
+	https://github.com/libexpat/libexpat/releases/download/R_$(COMPONENT_VERSION_U)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	expat license
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CFLAGS += $(CPP_LARGEFILES)
 
+# Deliver only 64-bit binary
+CONFIGURE_OPTIONS.64+= --bindir=/usr/bin
 CONFIGURE_OPTIONS+= --disable-static
 
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
@@ -64,13 +66,6 @@ COMPONENT_TEST_TRANSFORMS= \
 	'-e "/FAIL/p" '  \
 	'-e "/XPASS/p" ' \
 	'-e "/ERROR/p" ' \
-
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/library/libexpat/expat.p5m
+++ b/components/library/libexpat/expat.p5m
@@ -11,7 +11,7 @@
 
 #
 # Copyright 2017 Aurelien Larcher
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,20 +23,18 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# Deliver only 64-bit binary
-file usr/bin/$(MACH64)/xmlwf path=usr/bin/xmlwf
+file path=usr/bin/xmlwf
 file path=usr/include/expat.h
 file path=usr/include/expat_config.h
 file path=usr/include/expat_external.h
-link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.8
-link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.8
-file path=usr/lib/$(MACH64)/libexpat.so.1.6.8
+link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.9
+link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.9
+file path=usr/lib/$(MACH64)/libexpat.so.1.6.9
 file path=usr/lib/$(MACH64)/pkgconfig/expat.pc
-link path=usr/lib/libexpat.so target=libexpat.so.1.6.8
-link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.8
-file path=usr/lib/libexpat.so.1.6.8
+link path=usr/lib/libexpat.so target=libexpat.so.1.6.9
+link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.9
+file path=usr/lib/libexpat.so.1.6.9
 file path=usr/lib/pkgconfig/expat.pc
+#file path=usr/share/doc/expat/AUTHORS
+#file path=usr/share/doc/expat/changelog
 file path=usr/share/man/man1/xmlwf.1
-
-legacy pkg=SUNWlexpt desc="libexpat - XML parser library" \
-    name="libexpat - XML parser library"

--- a/components/library/libexpat/manifests/sample-manifest.p5m
+++ b/components/library/libexpat/manifests/sample-manifest.p5m
@@ -22,18 +22,17 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/xmlwf
 file path=usr/bin/xmlwf
 file path=usr/include/expat.h
 file path=usr/include/expat_config.h
 file path=usr/include/expat_external.h
-link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.8
-link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.8
-file path=usr/lib/$(MACH64)/libexpat.so.1.6.8
+link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.9
+link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.9
+file path=usr/lib/$(MACH64)/libexpat.so.1.6.9
 file path=usr/lib/$(MACH64)/pkgconfig/expat.pc
-link path=usr/lib/libexpat.so target=libexpat.so.1.6.8
-link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.8
-file path=usr/lib/libexpat.so.1.6.8
+link path=usr/lib/libexpat.so target=libexpat.so.1.6.9
+link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.9
+file path=usr/lib/libexpat.so.1.6.9
 file path=usr/lib/pkgconfig/expat.pc
 file path=usr/share/doc/expat/AUTHORS
 file path=usr/share/doc/expat/changelog

--- a/components/library/libexpat/patches/01-manpage.patch
+++ b/components/library/libexpat/patches/01-manpage.patch
@@ -1,0 +1,12 @@
+diff -wpruN '--exclude=*.orig' a~/doc/Makefile.in a/doc/Makefile.in
+--- a~/doc/Makefile.in	1970-01-01 00:00:00
++++ a/doc/Makefile.in	1970-01-01 00:00:00
+@@ -317,7 +317,7 @@ target_alias = @target_alias@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-@WITH_DOCBOOK_TRUE@dist_man_MANS = xmlwf.1
++dist_man_MANS = xmlwf.1
+ EXTRA_DIST = \
+     expat.png \
+     reference.html \


### PR DESCRIPTION
Changes: https://github.com/libexpat/libexpat/blob/R_2_2_7/expat/Changes

ABI is clean: https://abi-laboratory.pro/index.php?view=timeline&l=expat

**Testing**
- internal tests passed