### PR TITLE
4/4 Remove libmpfr.so.4 compat link

### DIFF
--- a/components/library/mpfr/Makefile
+++ b/components/library/mpfr/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         mpfr
 COMPONENT_VERSION=      4.0.2
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=      The GNU Multiple Precision with IEEE Rounding Floating-Point Library
 COMPONENT_PROJECT_URL=	http://www.mpfr.org/
 COMPONENT_FMRI=		library/mpfr

--- a/components/library/mpfr/mpfr.p5m
+++ b/components/library/mpfr/mpfr.p5m
@@ -23,9 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# Compat link so gawk works before it's rebuild with MPFR 4
-link path=usr/lib/$(MACH64)/libmpfr.so.4 target=libmpfr.so.6
-
 file path=usr/include/mpfr/mpf2mpfr.h
 file path=usr/include/mpfr/mpfr.h
 link path=usr/lib/$(MACH64)/libmpfr.so target=libmpfr.so.6.0.2


### PR DESCRIPTION
Merge after https://github.com/OpenIndiana/oi-userland/pull/5305.

It contains commits from https://github.com/OpenIndiana/oi-userland/pull/4738, https://github.com/OpenIndiana/oi-userland/pull/5304, and https://github.com/OpenIndiana/oi-userland/pull/5305. Needs to be merged last from the series.