### PR TITLE
Update open-vm-tools to 11.0.5

### DIFF
--- a/components/sysutils/open-vm-tools/Makefile
+++ b/components/sysutils/open-vm-tools/Makefile
@@ -14,12 +14,12 @@
 # Copyright 2019 Michal Nowak
 #
 
-PREFERRED_BITS=		64
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		open-vm-tools
-COMPONENT_VERSION=	10.3.10
+COMPONENT_VERSION=	11.0.5
 COMPONENT_SUMMARY=	open-vm-tools is a set of services and modules that enable several features in VMware products for better management of, and seamless user interactions with, guests.
 COMPONENT_PROJECT_URL=	https://github.com/vmware/open-vm-tools
 COMPONENT_FMRI=		system/virtualization/open-vm-tools
@@ -27,13 +27,13 @@ COMPONENT_CLASSIFICATION= Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-stable-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/vmware/$(COMPONENT_NAME)/archive/stable-$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:6e39e643edcd85bae04ba8db608bd500d14ff3771e6e89b171ffb31020fed945
+COMPONENT_ARCHIVE_HASH=	sha256:f4300d8ccf665a3ff435476bc372a3f189a98c2b830730608d4286226802bd97
 COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_POST_UNPACK_ACTION = \
 	($(MV) $(SOURCE_DIR)/open-vm-tools/* $(SOURCE_DIR) && \
@@ -42,7 +42,7 @@ COMPONENT_POST_UNPACK_ACTION = \
 COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -v -i -f )	
 
 COMPONENT_PRE_CONFIGURE_ACTION = \
-  ($(CLONEY) $(SOURCE_DIR) $(@D) ) 
+	($(CLONEY) $(SOURCE_DIR) $(@D) )
 
 CFLAGS += -std=gnu99
 
@@ -64,7 +64,6 @@ CFLAGS += -Wno-unused-variable
 
 LDFLAGS += -lnsl
 
-CONFIGURE_OPTIONS += --disable-grabbitmqproxy
 CONFIGURE_OPTIONS += --disable-multimon
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --disable-tests
@@ -78,13 +77,6 @@ CONFIGURE_OPTIONS += --sysconfdir=/etc
 
 # Need C++ compatible xdr headers
 CONFIGURE_OPTIONS += RPCGENFLAGS="-C"
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-# there are no tests defined
-test:		  $(NO_TESTS)
 
 # Build dependencies
 REQUIRED_PACKAGES += developer/documentation-tool/doxygen

--- a/components/sysutils/open-vm-tools/manifests/sample-manifest.p5m
+++ b/components/sysutils/open-vm-tools/manifests/sample-manifest.p5m
@@ -29,6 +29,7 @@ file path=etc/vmware-tools/resume-vm-default
 file path=etc/vmware-tools/scripts/vmware/network
 file path=etc/vmware-tools/statechange.subr
 file path=etc/vmware-tools/suspend-vm-default
+file path=etc/vmware-tools/tools.conf.example
 file path=etc/vmware-tools/vm-support
 file path=etc/xdg/autostart/vmware-user.desktop
 link path=sbin/mount.vmblock \

--- a/components/sysutils/open-vm-tools/open-vm-tools.p5m
+++ b/components/sysutils/open-vm-tools/open-vm-tools.p5m
@@ -12,7 +12,7 @@
 #
 # Copyright 2016 Adam Stevko
 # Copyright 2017 Andreas Grueninger, Grueninger GmbH, (grueni). All rights reserved.
-# Copyright 2018 Michal Nowak
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -39,6 +39,7 @@ file path=etc/vmware-tools/resume-vm-default      mode=0555
 file path=etc/vmware-tools/scripts/vmware/network mode=0555
 file path=etc/vmware-tools/statechange.subr       mode=0555
 file path=etc/vmware-tools/suspend-vm-default     mode=0555
+file path=etc/vmware-tools/tools.conf.example     mode=0555
 file path=etc/vmware-tools/vm-support             mode=0555
 
 file path=usr/bin/vmhgfs-fuse
@@ -50,12 +51,10 @@ file path=usr/bin/vmware-rpctool
 file path=usr/bin/vmware-toolbox-cmd
 file path=usr/bin/vmware-vmblock-fuse
 file path=usr/bin/vmware-xferlogs
-
 file path=usr/include/vmGuestLib/includeCheck.h
 file path=usr/include/vmGuestLib/vmGuestLib.h
 file path=usr/include/vmGuestLib/vmSessionId.h
 file path=usr/include/vmGuestLib/vm_basic_types.h
-
 link path=usr/lib/$(MACH64)/libguestlib.so target=libguestlib.so.0.0.0
 link path=usr/lib/$(MACH64)/libguestlib.so.0 target=libguestlib.so.0.0.0
 file path=usr/lib/$(MACH64)/libguestlib.so.0.0.0
@@ -73,7 +72,6 @@ file path=usr/lib/$(MACH64)/open-vm-tools/plugins/vmsvc/libtimeSync.so
 file path=usr/lib/$(MACH64)/open-vm-tools/plugins/vmsvc/libvmbackup.so
 
 file path=usr/lib/$(MACH64)/pkgconfig/vmguestlib.pc
-
 file path=usr/sbin/mount.vmblock
 
 file path=usr/share/open-vm-tools/messages/de/toolboxcmd.vmsg

--- a/components/sysutils/open-vm-tools/patches/04-nicInfo.patch
+++ b/components/sysutils/open-vm-tools/patches/04-nicInfo.patch
@@ -1,9 +1,9 @@
---- open-vm-tools-stable-10.1.15/lib/nicInfo/nicInfoPosix.c.orig	2017-12-05 10:16:50.182094452 +0000
-+++ open-vm-tools-stable-10.1.15/lib/nicInfo/nicInfoPosix.c	2017-12-05 10:18:32.310179456 +0000
-@@ -34,8 +34,10 @@
- #include <sys/socket.h>
+--- open-vm-tools-stable-11.0.5/lib/nicInfo/nicInfoPosix.c	2020-01-15 23:24:15.000000000 +0000
++++ open-vm-tools-stable-11.0.5/lib/nicInfo/nicInfoPosix.c	2020-01-17 08:01:40.647940115 +0000
+@@ -35,8 +35,10 @@
  #include <sys/stat.h>
  #include <errno.h>
+ #include <limits.h>
 +#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__sun)
  #if defined(__FreeBSD__) || defined(__APPLE__)
  # include <sys/sysctl.h>

--- a/components/sysutils/open-vm-tools/patches/15-vm_basic_types-h.patch
+++ b/components/sysutils/open-vm-tools/patches/15-vm_basic_types-h.patch
@@ -1,15 +1,15 @@
---- open-vm-tools-stable-10.3.0/lib/include/vm_basic_types.h.~1~	Fri Jul 13 14:54:23 2018
-+++ open-vm-tools-stable-10.3.0/lib/include/vm_basic_types.h	Sun Aug 19 14:51:28 2018
-@@ -272,7 +272,7 @@
+--- open-vm-tools-stable-11.0.0/lib/include/vm_basic_types.h	2019-09-20 22:28:29.000000000 +0000
++++ open-vm-tools-stable-11.0.0/lib/include/vm_basic_types.h	2019-09-21 12:46:23.631047124 +0000
+@@ -294,7 +294,7 @@ typedef char           Bool;
  #endif
  
  #if !defined(USING_AUTOCONF)
 -#   if defined(__FreeBSD__) || defined(sun)
 +#   if defined(__FreeBSD__) || defined(__sun)
- #      ifdef KLD_MODULE
- #         include <sys/types.h>
- #      else
-@@ -1058,7 +1058,7 @@
+ #      ifndef KLD_MODULE
+ #         if __FreeBSD_version >= 500043
+ #            if !defined(VMKERNEL)
+@@ -959,7 +959,7 @@ typedef void * UserVA;
   * Linux it's an int.
   * Use this like this: printf("The pid is %" FMTPID ".\n", pid);
   */
@@ -18,7 +18,7 @@
  #   ifdef VM_X86_64
  #      define FMTPID "d"
  #   else
-@@ -1073,7 +1073,7 @@
+@@ -974,7 +974,7 @@ typedef void * UserVA;
   * is a ulong, but on other platforms it's an unsigned int.
   * Use this like this: printf("The uid is %" FMTUID ".\n", uid);
   */
@@ -27,7 +27,7 @@
  #   ifdef VM_X86_64
  #      define FMTUID "u"
  #   else
-@@ -1088,7 +1088,7 @@
+@@ -989,7 +989,7 @@ typedef void * UserVA;
   * Linux it's an int.
   * Use this like this: printf("The mode is %" FMTMODE ".\n", mode);
   */

--- a/components/sysutils/open-vm-tools/patches/70-dilos.patch
+++ b/components/sysutils/open-vm-tools/patches/70-dilos.patch
@@ -20,7 +20,7 @@ Index: open-vm-tools-2013.04.16-1098359/open-vm-tools/lib/procMgr/procMgrSolaris
 
     ppw = &pw;
 -   if ((ppw = getpwuid_r(0, &pw, buffer, sizeof buffer)) == NULL) {
-+   if (getpwuid_r(0, &pw, buffer, sizeof buffer, &ppw) == NULL) {
++   if (!getpwuid_r(0, &pw, buffer, sizeof buffer, &ppw)) {
        return FALSE;
     }
 
@@ -38,7 +38,7 @@ Index: open-vm-tools-2013.04.16-1098359/open-vm-tools/lib/procMgr/procMgrSolaris
 
     ppw = &pw;
 -   if ((ppw = getpwuid_r(0, &pw, buffer, sizeof buffer)) == NULL) {
-+   if (getpwuid_r(0, &pw, buffer, sizeof buffer, &ppw) == NULL) {
++   if (!getpwuid_r(0, &pw, buffer, sizeof buffer, &ppw)) {
        return FALSE;
     }
 
@@ -47,7 +47,7 @@ Index: open-vm-tools-2013.04.16-1098359/open-vm-tools/lib/procMgr/procMgrSolaris
 
     ppw = &pw;
 -   if ((ppw = getpwuid_r(Id_GetEUid(), &pw, buffer, sizeof buffer)) == NULL) {
-+   if (getpwuid_r(Id_GetEUid(), &pw, buffer, sizeof buffer, &ppw) == NULL) {
++   if (!getpwuid_r(Id_GetEUid(), &pw, buffer, sizeof buffer, &ppw)) {
        return FALSE;
     }
 


### PR DESCRIPTION
**Release notes**
- https://github.com/vmware/open-vm-tools/blob/stable-11.0.0/ReleaseNotes.md
- https://github.com/vmware/open-vm-tools/blob/stable-11.0.5/ReleaseNotes.md

**Blog**
- https://blogs.vmware.com/vsphere/2019/09/vmware-tools-11-0-out-now.html

I'd appreciate if some more versed in C checked my changes to the `70-dilos.patch` (compilation used to fail dou to comparison of pointer and integer, probably because illumos changed the `NULL` definition).

**Testing**
- tested on VMware ESXi 6.7