### PR TITLE
Update GNU Texinfo to 6.7

### DIFF
--- a/components/text/texinfo/Makefile
+++ b/components/text/texinfo/Makefile
@@ -24,21 +24,21 @@
 # Copyright (c) 2019, Michal Nowak
 #
 
+BUILD_BITS=		64
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		texinfo
-COMPONENT_VERSION=	6.6
+COMPONENT_VERSION=	6.7
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/texinfo/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:9bb9ca00da53f26a7e5725eee49689cd4a1e18d25d5b061ac8b2053018d93d66
+	sha256:988403c1542d15ad044600b909997ba3079b10e03224c61188117f3676b02caa
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/texinfo/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		text/texinfo
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 INFOPATH := /usr/share/info
 INFOPATH := $(INFOPATH):/usr/sfw/share/info
@@ -64,13 +64,6 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "s|^make.*: Entering directory.*$$|XXX_CC_XXX|g" ' \
 	'-e "s|^make.*: .*is up to date.*$$|XXX_CC_XXX|g" ' \
 	'-e "/^XXX_CC_XXX$$/d" '
-
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
 
 REQUIRED_PACKAGES += runtime/perl-522
 # Auto-generated dependencies

--- a/components/text/texinfo/manifests/sample-manifest.p5m
+++ b/components/text/texinfo/manifests/sample-manifest.p5m
@@ -22,15 +22,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/info
-file path=usr/bin/$(MACH64)/install-info
-link path=usr/bin/$(MACH64)/makeinfo target=texi2any
-file path=usr/bin/$(MACH64)/pdftexi2dvi
-file path=usr/bin/$(MACH64)/pod2texi
-file path=usr/bin/$(MACH64)/texi2any
-file path=usr/bin/$(MACH64)/texi2dvi
-file path=usr/bin/$(MACH64)/texi2pdf
-file path=usr/bin/$(MACH64)/texindex
 file path=usr/bin/info
 file path=usr/bin/install-info
 link path=usr/bin/makeinfo target=texi2any
@@ -52,13 +43,10 @@ file path=usr/share/locale/ca/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/cs/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/cs/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/da/LC_MESSAGES/texinfo.mo
-file path=usr/share/locale/da/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/de.us-ascii/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/de/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/de/LC_MESSAGES/texinfo_document.mo
-file path=usr/share/locale/de_AT/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/el/LC_MESSAGES/texinfo.mo
-file path=usr/share/locale/el/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/eo/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/eo/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/es/LC_MESSAGES/texinfo.mo
@@ -92,6 +80,7 @@ file path=usr/share/locale/ru/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/rw/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/sl/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/sv/LC_MESSAGES/texinfo.mo
+file path=usr/share/locale/sv/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/tr/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/uk/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/uk/LC_MESSAGES/texinfo_document.mo

--- a/components/text/texinfo/test/results-all.master
+++ b/components/text/texinfo/test/results-all.master
@@ -90,7 +90,7 @@ PASS: t/echo-area-no-completions.sh
 PASS: t/multiple-completions.sh
 PASS: t/help.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
 # TOTAL: 85
 # PASS:  85
@@ -162,7 +162,7 @@ PASS: ii-0055-test
 PASS: ii-0056-test
 PASS: ii-0057-test
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
 # TOTAL: 57
 # PASS:  57
@@ -178,7 +178,7 @@ Making check in tp
 Making check in .
 /usr/gnu/bin/make  check-TESTS
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
 # TOTAL: 0
 # PASS:  0
@@ -196,7 +196,6 @@ PASS: test_scripts/formatting_ignore_and_comments_output.sh
 PASS: test_scripts/formatting_test_redefine_need.sh
 PASS: test_scripts/formatting_split_nocopying_split_dev_null.sh
 PASS: test_scripts/formatting_simplest_test_css.sh
-PASS: test_scripts/sectioning_equivalent_nodes_test_renamed_nodes.sh
 PASS: test_scripts/sectioning_sectioning_directions.sh
 PASS: test_scripts/indices_nodes_before_top_and_sections_html_chapter.sh
 PASS: test_scripts/indices_nodes_before_top_and_sections_html_chapter_nodes.sh
@@ -288,13 +287,11 @@ SKIP: test_scripts/tex_html_math_not_closed.sh
 SKIP: test_scripts/tex_html_tex_not_closed.sh
 SKIP: test_scripts/tex_html_tex_in_copying.sh
 SKIP: test_scripts/tex_html_formatting_singular.sh
-PASS: t/stdout.sh
-PASS: t/stdout_split.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
-# TOTAL: 99
-# PASS:  86
+# TOTAL: 96
+# PASS:  83
 # SKIP:  13
 # XFAIL: 0
 # FAIL:  0
@@ -306,7 +303,7 @@ Making check in many_input_files
 SKIP: tex_l2h.sh
 SKIP: tex_t4ht.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
 # TOTAL: 2
 # PASS:  0
@@ -320,7 +317,7 @@ Making check in Pod-Simple-Texinfo
 /usr/gnu/bin/make  check-TESTS
 PASS: prove.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
 # TOTAL: 1
 # PASS:  1
@@ -334,7 +331,7 @@ Making check in texindex
 /usr/gnu/bin/make  check-TESTS
 PASS: tests/ti-helpversion.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
 # TOTAL: 1
 # PASS:  1
@@ -348,7 +345,7 @@ Making check in util
 /usr/gnu/bin/make  check-TESTS
 PASS: tests/texi2dvi_helpversion.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.6
+Testsuite summary for GNU Texinfo 6.7
 ============================================================================
 # TOTAL: 1
 # PASS:  1

--- a/components/text/texinfo/texinfo.p5m
+++ b/components/text/texinfo/texinfo.p5m
@@ -37,11 +37,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 depend type=require fmri=runtime/python-27
 
-<transform file path=usr.*/man/.+$ -> default mangler.man.stability volatile>
-
 file usr/share/info/dir path=var/info/usr_share_info_dir mode=0644 preserve=true
-legacy pkg=SUNWtexi desc="GNU texinfo (texinfo)" \
-    name="GNU texinfo - Texinfo utilities (texinfo)"
 license texinfo.copyright license='GPLv3,FDLv1.3'
 license texi2html.copyright license=texi2html
 
@@ -50,15 +46,6 @@ file files/svc-texinfo-update path=lib/svc/method/svc-texinfo-update \
     disable_fmri=svc:/application/texinfo-update:default
 file files/texi2html.pl path=usr/bin/texi2html
 
-file path=usr/bin/$(MACH64)/info
-file path=usr/bin/$(MACH64)/install-info
-link path=usr/bin/$(MACH64)/makeinfo target=texi2any
-file path=usr/bin/$(MACH64)/pdftexi2dvi
-file path=usr/bin/$(MACH64)/pod2texi
-file path=usr/bin/$(MACH64)/texi2any
-file path=usr/bin/$(MACH64)/texi2dvi
-file path=usr/bin/$(MACH64)/texi2pdf
-file path=usr/bin/$(MACH64)/texindex
 file path=usr/bin/info
 file path=usr/bin/install-info
 link path=usr/bin/makeinfo target=texi2any
@@ -81,13 +68,10 @@ file path=usr/share/locale/ca/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/cs/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/cs/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/da/LC_MESSAGES/texinfo.mo
-file path=usr/share/locale/da/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/de.us-ascii/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/de/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/de/LC_MESSAGES/texinfo_document.mo
-file path=usr/share/locale/de_AT/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/el/LC_MESSAGES/texinfo.mo
-file path=usr/share/locale/el/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/eo/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/eo/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/es/LC_MESSAGES/texinfo.mo
@@ -121,6 +105,7 @@ file path=usr/share/locale/ru/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/rw/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/sl/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/sv/LC_MESSAGES/texinfo.mo
+file path=usr/share/locale/sv/LC_MESSAGES/texinfo_document.mo
 file path=usr/share/locale/tr/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/uk/LC_MESSAGES/texinfo.mo
 file path=usr/share/locale/uk/LC_MESSAGES/texinfo_document.mo


### PR DESCRIPTION
Release notes: https://lists.gnu.org/archive/html/bug-texinfo/2019-09/msg00018.html

**Testing**
- test suite passed
- GCC 4.9, 3.4, and illumos-gcc build fine.
- `info info` works