### PR TITLE
Backout 7661 so we can bring in urgent 11755 & 11757

### DIFF
--- a/components/openindiana/illumos-gate/patches/0003-11757-installboot-install-vbr-only-when-stage2-is-installed.patch
+++ b/components/openindiana/illumos-gate/patches/0003-11757-installboot-install-vbr-only-when-stage2-is-installed.patch
@@ -1,0 +1,133 @@
+diff --git a/usr/src/cmd/boot/installboot/i386/installboot.c b/usr/src/cmd/boot/installboot/i386/installboot.c
+index 3ed4e595775ac9c2e02397aaba5850856f0d92ba..4175ac431087184a23175b388e75a02b126bb889 100644
+--- a/usr/src/cmd/boot/installboot/i386/installboot.c
++++ b/usr/src/cmd/boot/installboot/i386/installboot.c
+@@ -106,6 +106,7 @@
+  */
+ 
+ static bool	write_mbr = false;
++static bool	write_vbr = false;
+ static bool	force_mbr = false;
+ static bool	force_update = false;
+ static bool	do_getinfo = false;
+@@ -220,7 +221,7 @@ install_stage1_cb(void *data, struct partlist *plist)
+ 		perror("write");
+ 	} else {
+ 		(void) fprintf(stdout, gettext("stage1 written to "
+-		    "%s %d sector 0 (abs %d)\n"),
++		    "%s %d sector 0 (abs %d)\n\n"),
+ 		    device->devtype == IB_DEV_MBR? "partition" : "slice",
+ 		    device->stage.id, device->stage.start);
+ 	}
+@@ -260,7 +261,7 @@ install_stage2_cb(void *data, struct partlist *plist)
+ 		return;
+ 	}
+ 	(void) fprintf(stdout, gettext("bootblock written for %s,"
+-	    " %d sectors starting at %d (abs %lld)\n"), plist->pl_devname,
++	    " %d sectors starting at %d (abs %lld)\n\n"), plist->pl_devname,
+ 	    (bblock->buf_size / SECTOR_SIZE) + 1, offset / SECTOR_SIZE, abs);
+ }
+ 
+@@ -411,7 +412,7 @@ install_esp_cb(void *data, struct partlist *plist)
+ 		ret = write_out(fd, bblock->buf, bblock->buf_size, 0);
+ 		if (ret == BC_SUCCESS) {
+ 			(void) fprintf(stdout,
+-			    gettext("bootblock written to %s\n"), file);
++			    gettext("bootblock written to %s\n\n"), file);
+ 		} else {
+ 			(void) fprintf(stdout,
+ 			    gettext("error while writing %s\n"), file);
+@@ -446,14 +447,16 @@ compare_mbr_cb(struct partlist *plist)
+ }
+ 
+ /*
+- * VBR setup is always done.
++ * VBR setup is done in pair with stage2.
+  */
+ static bool
+ compare_stage1_cb(struct partlist *plist)
+ {
+-	(void) printf("%s will be written to %s\n", plist->pl_src_name,
+-	    plist->pl_devname);
+-	return (true);
++	if (write_vbr) {
++		(void) printf("%s will be written to %s\n", plist->pl_src_name,
++		    plist->pl_devname);
++	}
++	return (write_vbr);
+ }
+ 
+ /*
+@@ -472,12 +475,19 @@ compare_einfo_cb(struct partlist *plist)
+ 		return (false);	/* source is missing, cannot update */
+ 
+ 	bblock = plist->pl_stage;
+-	if (bblock == NULL || bblock->extra == NULL || bblock->extra_size == 0)
++	if (bblock == NULL ||
++	    bblock->extra == NULL ||
++	    bblock->extra_size == 0) {
++		if (plist->pl_type == IB_BBLK_STAGE2)
++			write_vbr = true;
+ 		return (true);
++	}
+ 
+ 	einfo = find_einfo(bblock->extra, bblock->extra_size);
+ 	if (einfo == NULL) {
+ 		BOOT_DEBUG("No extended information available on disk\n");
++		if (plist->pl_type == IB_BBLK_STAGE2)
++			write_vbr = true;
+ 		return (true);
+ 	}
+ 
+@@ -503,12 +513,16 @@ compare_einfo_cb(struct partlist *plist)
+ 		    gettext("WARNING: target device %s has a "
+ 		    "versioned bootblock that is going to be overwritten by a "
+ 		    "non versioned one\n"), plist->pl_devname);
++		if (plist->pl_type == IB_BBLK_STAGE2)
++			write_vbr = true;
+ 		return (true);
+ 	}
+ 
+ 	if (force_update) {
+ 		BOOT_DEBUG("Forcing update of %s bootblock\n",
+ 		    plist->pl_devname);
++		if (plist->pl_type == IB_BBLK_STAGE2)
++			write_vbr = true;
+ 		return (true);
+ 	}
+ 
+@@ -519,13 +533,15 @@ compare_einfo_cb(struct partlist *plist)
+ 
+ 	rv = einfo_should_update(einfo, &bblock_hs, update_str);
+ 	if (rv == false) {
+-		(void) fprintf(stderr, gettext("\nBootblock version installed "
++		(void) fprintf(stderr, gettext("Bootblock version installed "
+ 		    "on %s is more recent or identical to\n%s\n"
+-		    "Use -F to override or install without the -u option.\n"),
++		    "Use -F to override or install without the -u option.\n\n"),
+ 		    plist->pl_devname, plist->pl_src_name);
+ 	} else {
+ 		(void) printf("%s is newer than one in %s\n",
+ 		    plist->pl_src_name, plist->pl_devname);
++		if (plist->pl_type == IB_BBLK_STAGE2)
++			write_vbr = true;
+ 	}
+ 	return (rv);
+ }
+@@ -2137,8 +2153,6 @@ handle_install(char *progname, int argc, char **argv)
+ 			    pl->pl_cb.compare(pl)) {
+ 				if (pl->pl_cb.install != NULL)
+ 					pl->pl_cb.install(&data, pl);
+-			} else {
+-				printf("\n");
+ 			}
+ 			STAILQ_REMOVE(data.plist, pl, partlist, pl_next);
+ 			partlist_free(pl);
+@@ -2275,6 +2289,7 @@ handle_mirror(char *progname, int argc, char **argv)
+ 		goto cleanup_src;
+ 	}
+ 
++	write_vbr = true;
+ 	write_mbr = true;
+ 	force_mbr = true;
+ 

--- a/components/openindiana/illumos-gate/patches/0004-backout-7661.patch
+++ b/components/openindiana/illumos-gate/patches/0004-backout-7661.patch
@@ -1,0 +1,684 @@
+--- b/usr/src/Makefile.master
++++ a/usr/src/Makefile.master
+@@ -26,7 +26,6 @@
+ # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+ # Copyright 2015 Gary Mills
+ # Copyright 2015 Igor Kozhukhov <ikozhukhov@gmail.com>
+-# Copyright 2016 RackTop Systems.
+ # Copyright 2016 Toomas Soome <tsoome@me.com>
+ # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ # Copyright 2019, Joyent, Inc.
+@@ -194,11 +193,8 @@
+ PERL=		/usr/bin/perl
+ PERL_VERSION=	5.10.0
+ PERL_PKGVERS=	-510
++PERL_ARCH =		i86pc-solaris-64int
++$(SPARC_BLD)PERL_ARCH =	sun4-solaris-64int
+-PERL_MACH=	i86pc
+-$(SPARC_BLD)PERL_MACH=	sun4
+-PERL_VARIANT=
+-PERL_ARCH=	$(PERL_MACH)-solaris$(PERL_VARIANT)-64int
+-PERL_ARCH64=	$(PERL_MACH)-solaris$(PERL_VARIANT)-64
+ PYTHON_VERSION=	2.7
+ PYTHON_PKGVERS=	-27
+ PYTHON_SUFFIX=
+@@ -798,18 +794,13 @@
+ $(__GNUC)CCNEEDED	= -L$(GCCLIBDIR) -lstdc++ -lgcc_s
+ $(__GNUC)CCEXTNEEDED	= $(CCNEEDED)
+ 
+-CCNEEDED64		= -lCrun
+-CCEXTNEEDED64		= -lCrun -lCstd
+-$(__GNUC64)CCNEEDED64	= -L$(GCCLIBDIR) -lstdc++ -lgcc_s
+-$(__GNUC64)CCEXTNEEDED	= $(CCNEEDED64)
+-
+ LINK.c=		$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+ LINK64.c=	$(CC) $(CFLAGS64) $(CPPFLAGS) $(LDFLAGS)
+ NORUNPATH=	-norunpath -nolib
+ LINK.cc=	$(CCC) $(CCFLAGS) $(CPPFLAGS) $(NORUNPATH) \
+ 		$(LDFLAGS) $(CCNEEDED)
+ LINK64.cc=	$(CCC) $(CCFLAGS64) $(CPPFLAGS) $(NORUNPATH) \
++		$(LDFLAGS) $(CCNEEDED)
+-		$(LDFLAGS) $(CCNEEDED64)
+ 
+ #
+ # lint macros
+@@ -852,7 +843,6 @@
+ #
+ # For now at least, we cross-compile amd64 on i386 machines.
+ NATIVE_MACH=	$(MACH:amd64=i386)
+-NATIVE_MACH64=	$(MACH64)
+ 
+ # Define native compilation macros
+ #
+@@ -917,13 +907,6 @@
+ NATIVELD=		$($(NATIVE_MACH)_LD)
+ NATIVELINT=		$($(NATIVE_MACH)_LINT)
+ 
+-NATIVECC64=		$($(NATIVE_MACH64)_CC)
+-NATIVECCC64=		$($(NATIVE_MACH64)_CCC)
+-NATIVECPP64=		$($(NATIVE_MACH64)_CPP)
+-NATIVEAS64=		$($(NATIVE_MACH64)_AS)
+-NATIVELD64=		$($(NATIVE_MACH64)_LD)
+-NATIVELINT64=		$($(NATIVE_MACH64)_LINT)
+-
+ #
+ # Makefile.master.64 overrides these settings
+ #
+@@ -934,13 +917,6 @@
+ LD=			$(NATIVELD)
+ LINT=			$(NATIVELINT)
+ 
+-CC64=			$(NATIVECC64)
+-CCC64=			$(NATIVECCC64)
+-CPP64=			$(NATIVECPP64)
+-AS64=			$(NATIVEAS64)
+-LD64=			$(NATIVELD64)
+-LINT64=			$(NATIVELINT64)
+-
+ # Pass -Y flag to cpp (method of which is release-dependent)
+ CCYFLAG=		-Y I,
+ 
+--- b/usr/src/Makefile.master.64
++++ a/usr/src/Makefile.master.64
+@@ -21,7 +21,6 @@
+ #
+ # Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
+ # Copyright 2014 Garrett D'Amore <garrett@damore.org>
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ # rebind basic build macros to 64-bit versions
+@@ -57,19 +56,25 @@
+ #
+ # Override Makefile.master's settings of CC, CCC, AS and LINT
+ #
++CC=		$($(MACH64)_CC)
++CCC=		$($(MACH64)_CCC)
++CPP=		$($(MACH64)_CPP)
++AS=		$($(MACH64)_AS)
++LD=		$($(MACH64)_LD)
++LINT=		$($(MACH64)_LINT)
+-CC=		$(CC64)
+-CCC=		$(CCC64)
+-CPP=		$(CPP64)
+-AS=		$(AS64)
+-LD=		$(LD64)
+-LINT=		$(LINT64)
+ 
++BUILD.SO=	$(CC) $(CFLAGS) -o $@ $(GSHARED) $(DYNFLAGS) \
++		$(PICS) $(EXTPICS) -L $(ROOTLIBDIR64) $(LDLIBS)
+-BUILD.SO=	$(BUILD64.SO)
+-BUILDCCC.SO=	$(BUILDCCC64.SO)
+ 
+ #
+ # ld(1) requires the -64 option to create a 64-bit filter solely from a mapfile
+ #
+ MAPFILECLASS=	-64
+ 
++CCNEEDED =		-lCrun
++$(__GNUC64)CCNEEDED =	-L$(GCCLIBDIR) -lstdc++
++$(__GNUC64)CCNEEDED +=	-lgcc_s
++
++BUILDCCC.SO=    $(CCC) $(CCFLAGS) -o $@ $(GSHARED) $(DYNFLAGS) \
++		$(PICS) $(EXTPICS) $(LDLIBS) $(CCNEEDED)
+ MAPFILE.NGB =	$(MAPFILE.NGB_$(MACH64))
+--- b/usr/src/cmd/perl/Makefile.perl
++++ a/usr/src/cmd/perl/Makefile.perl
+@@ -9,8 +9,8 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+ # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ include $(SRC)/lib/Makefile.lib
+@@ -22,29 +22,16 @@
+ PERLDIR = $(ADJUNCT_PROTO)/usr/perl5/$(PERL_VERSION)
+ PERLLIBDIR = $(PERLDIR)/lib/$(PERL_ARCH)
+ PERLINCDIR = $(PERLLIBDIR)/CORE
+-PERLLIBDIR64 = $(PERLDIR)/lib/$(PERL_ARCH64)
+-PERLINCDIR64 = $(PERLLIBDIR64)/CORE
+ 
+ PERLMOD = $(MODULE).pm
+ PERLEXT = $(MACH)/$(MODULE).so
+-PERLEXT64 = $(MACH64)/$(MODULE).so
+ 
+ ROOTPERLDIR = $(ROOT)/usr/perl5/$(PERL_VERSION)
+ ROOTPERLLIBDIR = $(ROOTPERLDIR)/lib/$(PERL_ARCH)
+ ROOTPERLMODDIR = $(ROOTPERLLIBDIR)/Sun/Solaris
+ ROOTPERLEXTDIR = $(ROOTPERLLIBDIR)/auto/Sun/Solaris/$(MODULE)
+-ROOTPERLLIBDIR64 = $(ROOTPERLDIR)/lib/$(PERL_ARCH64)
+-ROOTPERLMODDIR64 = $(ROOTPERLLIBDIR64)/Sun/Solaris
+-ROOTPERLEXTDIR64 = $(ROOTPERLLIBDIR64)/auto/Sun/Solaris/$(MODULE)
+ 
+ ROOTPERLMOD = $(ROOTPERLMODDIR)/$(MODULE).pm
+ ROOTPERLEXT = $(ROOTPERLEXTDIR)/$(MODULE).so
+-ROOTPERLMOD64 = $(ROOTPERLMODDIR64)/$(MODULE).pm
+-ROOTPERLEXT64 = $(ROOTPERLEXTDIR64)/$(MODULE).so
+-
+-XSUBPP = $(PERLDIR)/bin/$(MACH)/perl $(PERLDIR)/lib/ExtUtils/xsubpp \
+-	-typemap $(PERLDIR)/lib/ExtUtils/typemap
+-XSUBPP64 = $(PERLDIR)/bin/$(MACH64)/perl $(PERLDIR)/lib/ExtUtils/xsubpp \
+-	-typemap $(PERLDIR)/lib/ExtUtils/typemap
+ 
+ CSTD = $(CSTD_GNU99)
+--- b/usr/src/cmd/perl/Makefile.targ
++++ a/usr/src/cmd/perl/Makefile.targ
+@@ -9,66 +9,45 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+ # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright (c) 2016 Racktop Systems.
+ # Copyright (c) 2018, Joyent, Inc.
+ 
++# Link against libc as perl solaris specs
+-# Link against libc as per solaris specs
+ $(PERLEXT):= LDLIBS += -lc
+-$(PERLEXT64):= LDLIBS += -lc
+ 
+ # Allow for undefined symbols satisfied by perl
+ $(PERLEXT):= ZDEFS =
+-$(PERLEXT64):= ZDEFS =
+ 
+ $(ROOTPERLEXT) := FILEMODE = 0555
+ $(ROOTPERLMOD) := FILEMODE = 0444
+-$(ROOTPERLEXT64) := FILEMODE = 0555
+-$(ROOTPERLMOD64) := FILEMODE = 0444
+ 
+ # CFLAGS for perl, specifically.
+ PCFLAGS= -DPERL_EUPXS_ALWAYS_EXPORT -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 \
+ 	-DPERL_USE_SAFE_PUTENV -D_TS_ERRNO
+-PCFLAGS64= -DPERL_EUPXS_ALWAYS_EXPORT -D_LARGEFILE_SOURCE64 \
+-	 -DPERL_USE_SAFE_PUTENV -D_TS_ERRNO
+ 
+ SMATCH=off
+ 
++$(MACH):
+-$(MACH) $(MACH64):
+ 	$(INS.dir)
+ 
+ $(PERLEXT): $(MACH)/$(MODULE).o
+ 	$(BUILD.SO) $(MACH)/$(MODULE).o
+ 
+-$(PERLEXT64): $(MACH64)/$(MODULE).o
+-	$(BUILD64.SO) $(MACH64)/$(MODULE).o
+-
+ $(MACH)/$(MODULE).o: $(MACH)/$(MODULE).c
+ 	$(COMPILE.c) $(PCFLAGS) $(C_PICFLAGS) -I$(PERLINCDIR) $< -o $@
+ 
++$(MACH)/$(MODULE).c: $(MACH) $(MODULE).xs 
++	$(PERLDIR)/bin/xsubpp $(XSUBPPFLAGS) $(MODULE).xs >$@
+-$(MACH64)/$(MODULE).o: $(MACH64)/$(MODULE).c
+-	$(COMPILE64.c) $(PCFLAGS64) $(C_PICFLAGS) -I$(PERLINCDIR64) $< -o $@
+-
+-$(MACH)/$(MODULE).c: $(MACH) $(MODULE).xs
+-	$(XSUBPP) $(XSUBPPFLAGS) $(MODULE).xs >$@
+ 
++$(ROOTPERLMODDIR):
+-$(MACH64)/$(MODULE).c: $(MACH64) $(MODULE).xs
+-	$(XSUBPP64) $(XSUBPPFLAGS64) $(MODULE).xs >$@
+-
+-$(ROOTPERLMODDIR) $(ROOTPERLMODDIR64):
+ 	$(INS.dir)
+ 
+ $(ROOTPERLMOD): $(ROOTPERLMODDIR) $(MODULE).pm
+ 	$(RM) $@; $(INS) -s -m $(FILEMODE) -f $^
+ 
++$(ROOTPERLEXTDIR):
+-$(ROOTPERLMOD64): $(ROOTPERLMODDIR64) $(MODULE).pm
+-	$(RM) $@; $(INS) -s -m $(FILEMODE) -f $^
+-
+-$(ROOTPERLEXTDIR) $(ROOTPERLEXTDIR64):
+ 	$(INS.dir)
+ 
+ $(ROOTPERLEXT): $(ROOTPERLEXTDIR) $(MACH)/$(MODULE).so
+ 	$(RM) $@; $(INS) -s -m $(FILEMODE) -f $^
+-
+-$(ROOTPERLEXT64): $(ROOTPERLEXTDIR64) $(MACH64)/$(MODULE).so
+-	$(RM) $@; $(INS) -s -m $(FILEMODE) -f $^
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/BSM/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/BSM/Makefile
+@@ -9,15 +9,14 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+-# Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = _BSMparse
+ 
+ include $(SRC)/cmd/perl/Makefile.perl
+ 
++# Install module into arch independant directory
+-# Install module into arch independent directory
+ ROOTPERLMODDIR = $(ROOTPERLDIR)/lib/Sun/Solaris/BSM
+ 
+ include $(SRC)/cmd/perl/Makefile.targ
+@@ -29,3 +28,4 @@
+ install: $(ROOTPERLMOD)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/Intrs/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/Intrs/Makefile
+@@ -9,8 +9,7 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+-# Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = Intrs
+@@ -25,11 +24,9 @@
+ 
+ .KEEP_STATE:
+ 
++all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL32)all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL64)all: $(PERLEXT64) $(PERLMOD)
+ 
++install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL32)install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL64)install: $(ROOTPERLEXT64) $(ROOTPERLMOD64)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+-	$(RM) -r $(MACH) $(MACH64)
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/Kstat/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/Kstat/Makefile
+@@ -10,8 +10,7 @@
+ #
+ # Copyright 2014 Gary Mills
+ #
++# Copyright (c) 2014 Racktop Systems.
+-# Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = Kstat
+@@ -34,11 +33,9 @@
+ 
+ .KEEP_STATE:
+ 
++all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL32)all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL64)all: $(PERLEXT64) $(PERLMOD)
+ 
++install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL32)install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL64)install: $(ROOTPERLEXT64) $(ROOTPERLMOD64)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+-	$(RM) -r $(MACH) $(MACH64)
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/Lgrp/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/Lgrp/Makefile
+@@ -9,8 +9,7 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+-# Copyright 2014, OmniTI Computer Consulting. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = Lgrp
+@@ -29,11 +28,9 @@
+ 
+ .KEEP_STATE:
+ 
++all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL32)all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL64)all: $(PERLEXT64) $(PERLMOD)
+ 
++install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL32)install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL64)install: $(ROOTPERLEXT64) $(ROOTPERLMOD64)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+-	$(RM) -r $(MACH) $(MACH64)
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/Pg/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/Pg/Makefile
+@@ -9,15 +9,14 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+-# Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = Pg
+ 
+ include $(SRC)/cmd/perl/Makefile.perl
+ 
++# Install module into arch independant directory
+-# Install module into arch independent directory
+ ROOTPERLMODDIR = $(ROOTPERLDIR)/lib/Sun/Solaris
+ 
+ include $(SRC)/cmd/perl/Makefile.targ
+@@ -29,3 +28,4 @@
+ install: $(ROOTPERLMOD)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/Project/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/Project/Makefile
+@@ -9,8 +9,7 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+-# Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = Project
+@@ -29,11 +28,9 @@
+ 
+ .KEEP_STATE:
+ 
++all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL32)all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL64)all: $(PERLEXT64) $(PERLMOD)
+ 
++install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL32)install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL64)install: $(ROOTPERLEXT64) $(ROOTPERLMOD64)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+-	$(RM) -r $(MACH) $(MACH64)
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/Task/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/Task/Makefile
+@@ -9,8 +9,7 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+-# Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = Task
+@@ -25,11 +24,9 @@
+ 
+ .KEEP_STATE:
+ 
++all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL32)all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL64)all: $(PERLEXT64) $(PERLMOD)
+ 
++install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL32)install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL64)install: $(ROOTPERLEXT64) $(ROOTPERLMOD64)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+-	$(RM) -r $(MACH) $(MACH64)
+--- b/usr/src/cmd/perl/contrib/Sun/Solaris/Utils/Makefile
++++ a/usr/src/cmd/perl/contrib/Sun/Solaris/Utils/Makefile
+@@ -9,8 +9,8 @@
+ # http://www.illumos.org/license/CDDL.
+ #
+ #
++# Copyright (c) 2014 Racktop Systems.
+ # Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ MODULE = Utils
+@@ -25,11 +25,9 @@
+ 
+ .KEEP_STATE:
+ 
++all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL32)all: $(PERLEXT) $(PERLMOD)
+-$(BUILDPERL64)all: $(PERLEXT64) $(PERLMOD)
+ 
++install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL32)install: $(ROOTPERLEXT) $(ROOTPERLMOD)
+-$(BUILDPERL64)install: $(ROOTPERLEXT64) $(ROOTPERLMOD64)
+ 
+ clean clobber:
++	$(RM) -r $(MACH)
+-	$(RM) -r $(MACH) $(MACH64)
+--- b/usr/src/lib/Makefile.lib
++++ a/usr/src/lib/Makefile.lib
+@@ -21,7 +21,6 @@
+ # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ # Copyright 2015 Gary Mills
+ # Copyright 2015 Igor Kozhukhov <ikozhukhov@gmail.com>
+-# Copyright 2016 RackTop Systems.
+ # Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ # Copyright 2019, Joyent, Inc.
+ #
+@@ -147,12 +146,8 @@
+ BUILD.AR=	$(AR) $(ARFLAGS) $@ $(AROBJS)
+ BUILD.SO=	$(CC) $(CFLAGS) -o $@ $(GSHARED) $(DYNFLAGS) \
+ 		$(PICS) $(EXTPICS) $(LDLIBS)
+-BUILD64.SO=	$(CC64) $(CFLAGS64) -o $@ $(GSHARED) $(DYNFLAGS) \
+-		$(PICS) $(EXTPICS) -L $(ROOTLIBDIR64) $(LDLIBS)
+ BUILDCCC.SO=	$(CCC) $(CCFLAGS) -o $@ $(GSHARED) $(DYNFLAGS) \
+ 		$(PICS) $(EXTPICS) $(LDLIBS)
+-BUILDCCC64.SO=	$(CCC64) $(CCFLAGS64) -o $@ $(GSHARED) $(DYNFLAGS) \
+-		$(PICS) $(EXTPICS) $(LDLIBS) $(CCNEEDED64)
+ 
+ # default dynamic library symlink
+ INS.liblink=	-$(RM) $@; $(SYMLINK) $(LIBLINKPATH)$(LIBLINKS)$(VERS) $@
+--- b/usr/src/pkg/Makefile
++++ a/usr/src/pkg/Makefile
+@@ -23,7 +23,6 @@
+ # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+ # Copyright 2015 Igor Kozhukhov <ikozhukhov@gmail.com>
+-# Copyright 2016 RackTop Systems.
+ # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+ #
+ 
+@@ -188,11 +187,8 @@
+ 	PKGVERS_BRANCH=$(PKGVERS_BRANCH) \
+ 	PKGVERS=$(PKGVERS) \
+ 	PERL_ARCH=$(PERL_ARCH) \
+-	PERL_ARCH64=$(PERL_ARCH64) \
+ 	PERL_VERSION=$(PERL_VERSION) \
+ 	PERL_PKGVERS=$(PERL_PKGVERS) \
+-	BUILDPERL32=$(BUILDPERL32) \
+-	BUILDPERL64=$(BUILDPERL64) \
+ 	PYTHON_VERSION=$(PYTHON_VERSION) \
+ 	PYTHON3_VERSION=$(PYTHON3_VERSION) \
+ 	PYTHON_PKGVERS=$(PYTHON_PKGVERS) \
+--- b/usr/src/pkg/manifests/runtime-perl-module-sun-solaris.mf
++++ a/usr/src/pkg/manifests/runtime-perl-module-sun-solaris.mf
+@@ -21,11 +21,11 @@
+ 
+ #
+ # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
++# Copyright (c) 2014 Racktop Systems.
+ # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
++<transform file path=.*\.(pm|bs) -> default mode 0444>
+-<transform file path=.*\.pm -> default mode 0444>
+ <transform file path=.*\.so -> default mode 0555>
+ set name=pkg.fmri \
+     value=pkg:/runtime/perl$(PERL_PKGVERS)/module/sun-solaris@0.5.11,$(PKGVERS_BUILTON)-$(PKGVERS_BRANCH)
+@@ -37,98 +37,41 @@
+ dir path=usr/perl5
+ dir path=usr/perl5/$(PERL_VERSION)
+ dir path=usr/perl5/$(PERL_VERSION)/lib
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Intrs
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Kstat
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Project
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Task
++dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Utils
+-$(BUILDPERL32)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)
+-$(BUILDPERL32)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun
+-$(BUILDPERL32)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris
+-$(BUILDPERL32)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto
+-$(BUILDPERL32)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun
+-$(BUILDPERL32)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris
+-$(BUILDPERL32)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Intrs
+-$(BUILDPERL32)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Kstat
+-$(BUILDPERL32)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp
+-$(BUILDPERL32)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Project
+-$(BUILDPERL32)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Task
+-$(BUILDPERL32)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Utils
+-$(BUILDPERL64)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)
+-$(BUILDPERL64)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun/Solaris
+-$(BUILDPERL64)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto
+-$(BUILDPERL64)dir path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Intrs
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Kstat
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Lgrp
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Project
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Task
+-$(BUILDPERL64)dir \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Utils
+ dir path=usr/perl5/$(PERL_VERSION)/lib/Sun
+ dir path=usr/perl5/$(PERL_VERSION)/lib/Sun/Solaris
+ dir path=usr/perl5/$(PERL_VERSION)/lib/Sun/Solaris/BSM
+ dir path=usr/share/man
+ dir path=usr/share/man/man3perl
++file path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Intrs.pm
++file path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Kstat.pm
++file path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Lgrp.pm
++file path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Project.pm
++file path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Task.pm
++file path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Utils.pm
++file \
+-$(BUILDPERL32)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Intrs.pm
+-$(BUILDPERL32)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Kstat.pm
+-$(BUILDPERL32)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Lgrp.pm
+-$(BUILDPERL32)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Project.pm
+-$(BUILDPERL32)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Task.pm
+-$(BUILDPERL32)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/Sun/Solaris/Utils.pm
+-$(BUILDPERL32)file \
+     path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Intrs/Intrs.so
++file \
+-$(BUILDPERL32)file \
+     path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Kstat/Kstat.so
++file \
+-$(BUILDPERL32)file \
+     path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp/Lgrp.so
++file \
+-$(BUILDPERL32)file \
+     path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Project/Project.so
++file \
+-$(BUILDPERL32)file \
+     path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Task/Task.so
++file \
+-$(BUILDPERL32)file \
+     path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/auto/Sun/Solaris/Utils/Utils.so
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun/Solaris/Intrs.pm
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun/Solaris/Kstat.pm
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun/Solaris/Lgrp.pm
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun/Solaris/Project.pm
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun/Solaris/Task.pm
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/Sun/Solaris/Utils.pm
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Intrs/Intrs.so
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Kstat/Kstat.so
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Lgrp/Lgrp.so
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Project/Project.so
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Task/Task.so
+-$(BUILDPERL64)file \
+-    path=usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH64)/auto/Sun/Solaris/Utils/Utils.so
+ file path=usr/perl5/$(PERL_VERSION)/lib/Sun/Solaris/BSM/_BSMparse.pm
+ file path=usr/perl5/$(PERL_VERSION)/lib/Sun/Solaris/Pg.pm
+ file path=usr/share/man/man3perl/Kstat.3perl
+@@ -138,4 +81,3 @@
+ license cr_Sun license=cr_Sun
+ license usr/src/cmd/perl/THIRDPARTYLICENSE \
+     license=usr/src/cmd/perl/THIRDPARTYLICENSE
+-depend fmri=runtime/perl$(PERL_PKGVERS) type=require
+--- b/usr/src/pkg/manifests/system-extended-system-utilities.mf
++++ a/usr/src/pkg/manifests/system-extended-system-utilities.mf
+@@ -22,7 +22,6 @@
+ #
+ # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ # Copyright 2012 Nexenta Systems, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ #
+ 
+ set name=pkg.fmri value=pkg:/system/extended-system-utilities@$(PKGVERS)
+@@ -293,4 +292,3 @@
+ link path=usr/share/man/man1/unpack.1 target=pack.1
+ link path=usr/share/man/man1/zcat.1 target=compress.1
+ depend fmri=runtime/perl$(PERL_PKGVERS) type=require
+-depend fmri=runtime/perl$(PERL_PKGVERS)/module/sun-solaris type=require
+--- b/usr/src/tools/env/illumos.sh
++++ a/usr/src/tools/env/illumos.sh
+@@ -22,7 +22,6 @@
+ # Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ # Copyright 2012 Joshua M. Clulow <josh@sysmgr.org>
+ # Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
+-# Copyright 2016 RackTop Systems.
+ # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+ # Copyright 2019, Joyent, Inc.
+ #
+@@ -96,14 +95,9 @@
+ # contains your new defaults OR your .env file sets them.
+ # These are how you would override for building on OmniOS r151028, for example.
+ #export PERL_VERSION=5.28
++#export PERL_ARCH=i86pc-solaris-thread-multi-64int
+-#export PERL_VARIANT=-thread-multi
+ #export PERL_PKGVERS=
+ 
+-# To disable building of the 32-bit or 64-bit perl modules (or both),
+-# uncomment these lines:
+-#export BUILDPERL32='#'
+-#export BUILDPERL64='#'
+-
+ # If your distro uses certain versions of Python, make sure either
+ # Makefile.master contains your new defaults OR your .env file sets them.
+ #export PYTHON_VERSION=2.7

--- a/components/openindiana/illumos-gate/patches/0005-11755-loader-command_lsmod-does-show-garbage-on-screen.patch
+++ b/components/openindiana/illumos-gate/patches/0005-11755-loader-command_lsmod-does-show-garbage-on-screen.patch
@@ -1,0 +1,23 @@
+diff --git a/usr/src/boot/sys/boot/common/module.c b/usr/src/boot/sys/boot/common/module.c
+index ca4090fc24f5292a947bd5b8cd83458250a77c32..643625c34749d3201445895b03f60176a4cad074 100644
+--- a/usr/src/boot/sys/boot/common/module.c
++++ b/usr/src/boot/sys/boot/common/module.c
+@@ -263,7 +263,7 @@ command_lsmod(int argc, char *argv[])
+ 				break;
+ 			if (strcmp(fp->f_type, "hash") == 0) {
+ 				pager_output("    contents: ");
+-				strncpy(lbuf, PTOV(fp->f_addr), fp->f_size);
++				strlcpy(lbuf, PTOV(fp->f_addr), sizeof (lbuf));
+ 				if (pager_output(lbuf))
+ 					break;
+ 			}
+diff --git a/usr/src/boot/Makefile.version b/usr/src/boot/Makefile.version
+index faf491c1af6a546f3729c06d162eb37e1c73e835..67889d27d9d9843f3ee6f6e37d6a8b252ce8b808 100644
+--- a/usr/src/boot/Makefile.version
++++ b/usr/src/boot/Makefile.version
+@@ -33,4 +33,4 @@ LOADER_VERSION = 1.1
+ # Use date like formatting here, YYYY.MM.DD.XX, without leading zeroes.
+ # The version is processed from left to right, the version number can only
+ # be increased.
+-BOOT_VERSION = $(LOADER_VERSION)-2019.09.20.1
++BOOT_VERSION = $(LOADER_VERSION)-2019.09.27.1


### PR DESCRIPTION
Need to backout 7661 which fails with:
```
==== Build noise differences (DEBUG) ====

78a79
> The following command caused the error:
83a85,86
> dmake: Warning: Command failed for target `perl'
> dmake: Warning: Target `install' not remade because of errors
84a88,89
> sh: line 1: /usr/perl5/5.22/bin/amd64/perl: not found
> sh: line 1: /usr/perl5/5.22/bin/i386/perl: not found
```

So that an urgent fix for 11755 & 11757 can come in.

I am compiling this right now.

@tsoome @AndWac 