### PR TITLE
Add mpg123 1.25.12

### DIFF
--- a/components/multimedia/mpg123/Makefile
+++ b/components/multimedia/mpg123/Makefile
@@ -1,0 +1,59 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Alexander Pyhalov
+#
+
+BUILD_BITS= 32_and_64
+PREFERRED_BITS = 64
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= mpg123
+COMPONENT_VERSION= 1.25.12
+COMPONENT_SUMMARY= Fast console MPEG Audio Player and decoder library
+COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH= \
+  sha256:1ffec7c9683dfb86ea9040d6a53d6ea819ecdda215df347f79def08f1fe731d1
+COMPONENT_ARCHIVE_URL= \
+  http://mpg123.org/download/$(COMPONENT_ARCHIVE)
+COMPONENT_SIG_URL= $(COMPONENT_ARCHIVE_URL).sig
+COMPONENT_PROJECT_URL = http://mpg123.org/
+COMPONENT_FMRI = audio/mpg123
+COMPONENT_CLASSIFICATION = Applications/Sound and Video
+COMPONENT_LICENSE = LGPLv2,GPLv2
+COMPONENT_LICENSE_FILE = COPYING
+
+TEST_TARGET= $(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
+
+CFLAGS += -D__EXTENSIONS__
+
+CONFIGURE_OPTIONS += --disable-static
+CONFIGURE_OPTIONS += --enable-shared
+CONFIGURE_OPTIONS += --enable-int-quality
+CONFIGURE_OPTIONS += --enable-fifo
+CONFIGURE_OPTIONS += --enable-network
+CONFIGURE_OPTIONS += --enable-ipv6=yes
+CONFIGURE_OPTIONS += --with-optimization=3
+CONFIGURE_OPTIONS.32 += --with-cpu=sse
+CONFIGURE_OPTIONS.64 += --with-cpu=x86-64
+CONFIGURE_OPTIONS += --with-default-audio=pulse
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/audio/openal
+REQUIRED_PACKAGES += library/audio/pulseaudio
+REQUIRED_PACKAGES += library/sdl
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/multimedia/mpg123/manifests/sample-manifest.p5m
+++ b/components/multimedia/mpg123/manifests/sample-manifest.p5m
@@ -1,0 +1,65 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH32)/mpg123
+file path=usr/bin/$(MACH32)/mpg123-id3dump
+file path=usr/bin/$(MACH32)/mpg123-strip
+file path=usr/bin/$(MACH32)/out123
+file path=usr/bin/mpg123
+file path=usr/bin/mpg123-id3dump
+file path=usr/bin/mpg123-strip
+file path=usr/bin/out123
+file path=usr/include/fmt123.h
+file path=usr/include/mpg123.h
+file path=usr/include/out123.h
+link path=usr/lib/$(MACH64)/libmpg123.so target=libmpg123.so.0.44.10
+link path=usr/lib/$(MACH64)/libmpg123.so.0 target=libmpg123.so.0.44.10
+file path=usr/lib/$(MACH64)/libmpg123.so.0.44.10
+link path=usr/lib/$(MACH64)/libout123.so target=libout123.so.0.2.2
+link path=usr/lib/$(MACH64)/libout123.so.0 target=libout123.so.0.2.2
+file path=usr/lib/$(MACH64)/libout123.so.0.2.2
+file path=usr/lib/$(MACH64)/mpg123/output_dummy.so
+file path=usr/lib/$(MACH64)/mpg123/output_openal.so
+file path=usr/lib/$(MACH64)/mpg123/output_oss.so
+file path=usr/lib/$(MACH64)/mpg123/output_pulse.so
+file path=usr/lib/$(MACH64)/mpg123/output_sdl.so
+file path=usr/lib/$(MACH64)/mpg123/output_sun.so
+file path=usr/lib/$(MACH64)/pkgconfig/libmpg123.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libout123.pc
+link path=usr/lib/libmpg123.so target=libmpg123.so.0.44.10
+link path=usr/lib/libmpg123.so.0 target=libmpg123.so.0.44.10
+file path=usr/lib/libmpg123.so.0.44.10
+link path=usr/lib/libout123.so target=libout123.so.0.2.2
+link path=usr/lib/libout123.so.0 target=libout123.so.0.2.2
+file path=usr/lib/libout123.so.0.2.2
+file path=usr/lib/mpg123/output_dummy.so
+file path=usr/lib/mpg123/output_openal.so
+file path=usr/lib/mpg123/output_oss.so
+file path=usr/lib/mpg123/output_pulse.so
+file path=usr/lib/mpg123/output_sdl.so
+file path=usr/lib/mpg123/output_sun.so
+file path=usr/lib/pkgconfig/libmpg123.pc
+file path=usr/lib/pkgconfig/libout123.pc
+file path=usr/share/man/man1/mpg123.1
+file path=usr/share/man/man1/out123.1

--- a/components/multimedia/mpg123/mpg123.p5m
+++ b/components/multimedia/mpg123/mpg123.p5m
@@ -1,0 +1,61 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Alexander Pyhalov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/mpg123
+file path=usr/bin/mpg123-id3dump
+file path=usr/bin/mpg123-strip
+file path=usr/bin/out123
+file path=usr/include/fmt123.h
+file path=usr/include/mpg123.h
+file path=usr/include/out123.h
+link path=usr/lib/$(MACH64)/libmpg123.so target=libmpg123.so.0.44.10
+link path=usr/lib/$(MACH64)/libmpg123.so.0 target=libmpg123.so.0.44.10
+file path=usr/lib/$(MACH64)/libmpg123.so.0.44.10
+link path=usr/lib/$(MACH64)/libout123.so target=libout123.so.0.2.2
+link path=usr/lib/$(MACH64)/libout123.so.0 target=libout123.so.0.2.2
+file path=usr/lib/$(MACH64)/libout123.so.0.2.2
+file path=usr/lib/$(MACH64)/mpg123/output_dummy.so
+file path=usr/lib/$(MACH64)/mpg123/output_openal.so
+file path=usr/lib/$(MACH64)/mpg123/output_oss.so
+file path=usr/lib/$(MACH64)/mpg123/output_pulse.so
+file path=usr/lib/$(MACH64)/mpg123/output_sdl.so
+file path=usr/lib/$(MACH64)/mpg123/output_sun.so
+file path=usr/lib/$(MACH64)/pkgconfig/libmpg123.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libout123.pc
+link path=usr/lib/libmpg123.so target=libmpg123.so.0.44.10
+link path=usr/lib/libmpg123.so.0 target=libmpg123.so.0.44.10
+file path=usr/lib/libmpg123.so.0.44.10
+link path=usr/lib/libout123.so target=libout123.so.0.2.2
+link path=usr/lib/libout123.so.0 target=libout123.so.0.2.2
+file path=usr/lib/libout123.so.0.2.2
+file path=usr/lib/mpg123/output_dummy.so
+file path=usr/lib/mpg123/output_openal.so
+file path=usr/lib/mpg123/output_oss.so
+file path=usr/lib/mpg123/output_pulse.so
+file path=usr/lib/mpg123/output_sdl.so
+file path=usr/lib/mpg123/output_sun.so
+file path=usr/lib/pkgconfig/libmpg123.pc
+file path=usr/lib/pkgconfig/libout123.pc
+file path=usr/share/man/man1/mpg123.1
+file path=usr/share/man/man1/out123.1


### PR DESCRIPTION
As I understand, we can include mp3-related software in main repository.
This component is working (at least mpg123 itself), but perhaps I'll have to make some modifications to use the library (which is used by wine).