### PR TITLE
remove gstreamer/plugin/good from mate_install

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	36
+COMPONENT_REVISION=	37
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -56,7 +56,6 @@ depend type=require fmri=image/dcraw
 depend type=require fmri=image/scanner/xsane/sane-backends
 depend type=require fmri=library/audio/gstreamer
 depend type=require fmri=library/audio/gstreamer/plugin/base
-depend type=require fmri=library/audio/gstreamer/plugin/good
 depend type=require fmri=library/desktop/desktop-file-utils
 depend type=require fmri=library/desktop/gtk3
 depend type=require fmri=library/desktop/gtk3/gtk-backend-cups


### PR DESCRIPTION
`library/audio/gstreamer/plugin/good` can be removed from the `mate_install` meta-package, since no other current components from MATE or `desktop_common` depend upon it.

Note that there are external dependencies (like SFW libreoffice) that still depend upon `library/audio/gstreamer/plugin/good`, but nothing in current MATE does.

See PR #5066 for more discussion.