### PR TITLE
Update sudo to 1.8.28, CVE-2019-14287

### DIFF
--- a/components/sysutils/sudo/Makefile
+++ b/components/sysutils/sudo/Makefile
@@ -23,10 +23,12 @@
 # Copyright (c) 2019, Michal Nowak
 #
 
+BUILD_BITS=		64
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		sudo
-SRC_VERSION=		1.8.27
+SRC_VERSION=		1.8.28
 SRC_PATCH_VERSION=	0
 SRC_DOT_PATCH_VERSION=	$(shell [ $(SRC_PATCH_VERSION) -gt 0 ] && echo .$(SRC_PATCH_VERSION))
 SRC_P_PATCH_VERSION=	$(shell [ $(SRC_PATCH_VERSION) -gt 0 ] && echo p$(SRC_PATCH_VERSION))
@@ -35,7 +37,7 @@ COMPONENT_SUMMARY=	sudo - tool to allow certain tasks to be run as root by ordin
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(SRC_VERSION)$(SRC_P_PATCH_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:7beb68b94471ef56d8a1036dbcdc09a7b58a949a68ffce48b83f837dd33e2ec0
+	sha256:9129fa745a08caff0ce2042d2162b38eb9bf73bf43fcb248ac8b3a750c1f13a1
 COMPONENT_ARCHIVE_URL=	https://www.sudo.ws/sudo/dist/$(COMPONENT_ARCHIVE)
 COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).sig	
 COMPONENT_PROJECT_URL=  https://www.sudo.ws/
@@ -43,12 +45,7 @@ COMPONENT_FMRI=		security/sudo
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_LICENSE=	ISC-like, BSD, zlib license
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
-
-CONFIGURE_BINDIR.64 = $(CONFIGURE_BINDIR.32)
-CONFIGURE_SBINDIR.64 = $(CONFIGURE_SBINDIR.32)
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_ENV +=	MAKE=$(GMAKE)
 
@@ -75,17 +72,6 @@ COMPONENT_INSTALL_TARGETS = install
 
 # Avoid calling "chown 0" on installed files
 COMPONENT_INSTALL_ARGS += INSTALL_OWNER=
-
-# Enable aslr for this component
-ASLR_MODE = $(ASLR_ENABLE)
-
-# common targets
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/zlib

--- a/components/sysutils/sudo/manifests/sample-manifest.p5m
+++ b/components/sysutils/sudo/manifests/sample-manifest.p5m
@@ -29,13 +29,13 @@ file path=usr/bin/sudo
 link path=usr/bin/sudoedit target=sudo
 file path=usr/bin/sudoreplay
 file path=usr/include/sudo_plugin.h
-file path=usr/lib/$(MACH64)/sudo/group_file.so
 link path=usr/lib/$(MACH64)/sudo/libsudo_util.so target=libsudo_util.so.0.0.0
 link path=usr/lib/$(MACH64)/sudo/libsudo_util.so.0 target=libsudo_util.so.0.0.0
 file path=usr/lib/$(MACH64)/sudo/libsudo_util.so.0.0.0
-file path=usr/lib/$(MACH64)/sudo/sudo_noexec.so
-file path=usr/lib/$(MACH64)/sudo/sudoers.so
-file path=usr/lib/$(MACH64)/sudo/system_group.so
+file path=usr/lib/$(MACH64)/sudo/sudo/group_file.so
+file path=usr/lib/$(MACH64)/sudo/sudo/sudo_noexec.so
+file path=usr/lib/$(MACH64)/sudo/sudo/sudoers.so
+file path=usr/lib/$(MACH64)/sudo/sudo/system_group.so
 file path=usr/sbin/visudo
 file path=usr/share/doc/sudo/CONTRIBUTORS
 file path=usr/share/doc/sudo/ChangeLog
@@ -56,6 +56,7 @@ file path=usr/share/doc/sudo/schema.iPlanet
 file path=usr/share/doc/sudo/schema.olcSudo
 link path=usr/share/locale/ast.UTF-8 target=ast
 file path=usr/share/locale/ast/LC_MESSAGES/sudo.mo
+file path=usr/share/locale/ast/LC_MESSAGES/sudoers.mo
 link path=usr/share/locale/ca.UTF-8 target=ca
 file path=usr/share/locale/ca/LC_MESSAGES/sudo.mo
 file path=usr/share/locale/ca/LC_MESSAGES/sudoers.mo
@@ -152,6 +153,7 @@ file path=usr/share/locale/zh_CN/LC_MESSAGES/sudo.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/sudoers.mo
 link path=usr/share/locale/zh_TW.UTF-8 target=zh_TW
 file path=usr/share/locale/zh_TW/LC_MESSAGES/sudo.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/sudoers.mo
 file path=usr/share/man/man1/cvtsudoers.1
 file path=usr/share/man/man1m/sudo.1m
 file path=usr/share/man/man1m/sudo_plugin.1m

--- a/components/sysutils/sudo/sudo.p5m
+++ b/components/sysutils/sudo/sudo.p5m
@@ -19,7 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2019, Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -40,13 +40,13 @@ file path=usr/bin/sudo mode=4511
 link path=usr/bin/sudoedit target=sudo
 file path=usr/bin/sudoreplay mode=0511
 file path=usr/include/sudo_plugin.h
-file path=usr/lib/$(MACH64)/sudo/group_file.so
 link path=usr/lib/$(MACH64)/sudo/libsudo_util.so target=libsudo_util.so.0.0.0
 link path=usr/lib/$(MACH64)/sudo/libsudo_util.so.0 target=libsudo_util.so.0.0.0
 file path=usr/lib/$(MACH64)/sudo/libsudo_util.so.0.0.0
-file path=usr/lib/$(MACH64)/sudo/sudo_noexec.so
-file path=usr/lib/$(MACH64)/sudo/sudoers.so
-file path=usr/lib/$(MACH64)/sudo/system_group.so
+file path=usr/lib/$(MACH64)/sudo/sudo/group_file.so
+file path=usr/lib/$(MACH64)/sudo/sudo/sudo_noexec.so
+file path=usr/lib/$(MACH64)/sudo/sudo/sudoers.so
+file path=usr/lib/$(MACH64)/sudo/sudo/system_group.so
 file path=usr/sbin/visudo mode=0511
 file path=usr/share/doc/sudo/CONTRIBUTORS
 file path=usr/share/doc/sudo/ChangeLog
@@ -67,6 +67,7 @@ file path=usr/share/doc/sudo/schema.iPlanet
 file path=usr/share/doc/sudo/schema.olcSudo
 link path=usr/share/locale/ast.UTF-8 target=ast
 file path=usr/share/locale/ast/LC_MESSAGES/sudo.mo
+file path=usr/share/locale/ast/LC_MESSAGES/sudoers.mo
 link path=usr/share/locale/ca.UTF-8 target=ca
 file path=usr/share/locale/ca/LC_MESSAGES/sudo.mo
 file path=usr/share/locale/ca/LC_MESSAGES/sudoers.mo
@@ -163,6 +164,7 @@ file path=usr/share/locale/zh_CN/LC_MESSAGES/sudo.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/sudoers.mo
 link path=usr/share/locale/zh_TW.UTF-8 target=zh_TW
 file path=usr/share/locale/zh_TW/LC_MESSAGES/sudo.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/sudoers.mo
 file path=usr/share/man/man1/cvtsudoers.1
 file path=usr/share/man/man1m/sudo.1m
 file path=usr/share/man/man1m/sudo_plugin.1m

--- a/components/sysutils/sudo/test/results-64.master
+++ b/components/sysutils/sudo/test/results-64.master
@@ -6,7 +6,7 @@ done
 make[2]: Entering directory '$(@D)/lib/util'
 parse_gids_test: 6 tests run, 0 errors, 100% success rate
 strsplit_test: 29 tests run, 0 errors, 100% success rate
-atofoo_test: 23 tests run, 0 errors, 100% success rate
+atofoo_test: 27 tests run, 0 errors, 100% success rate
 hltq_test: 19 tests run, 0 errors, 100% success rate
 sudo_conf/test1: OK
 sudo_conf/test2: OK
@@ -205,6 +205,7 @@ cvtsudoers/test23: OK
 cvtsudoers/test24: OK
 cvtsudoers/test25: OK
 cvtsudoers/test26: OK
+cvtsudoers/test26 (stderr): OK
 cvtsudoers/test27: OK
 cvtsudoers/test28: OK
 cvtsudoers/test29: OK
@@ -212,6 +213,7 @@ cvtsudoers/test3: OK
 cvtsudoers/test30: OK
 cvtsudoers/test31: OK
 cvtsudoers/test32: OK
+cvtsudoers/test32 (stderr): OK
 cvtsudoers/test33: OK
 cvtsudoers/test4: OK
 cvtsudoers/test5: OK
@@ -219,13 +221,13 @@ cvtsudoers/test6: OK
 cvtsudoers/test7: OK
 cvtsudoers/test8: OK
 cvtsudoers/test9: OK
-cvtsudoers: 33/33 tests passed; 0/33 tests failed
+cvtsudoers: 35/35 tests passed; 0/35 tests failed
 make[2]: Leaving directory '$(@D)/plugins/sudoers'
 make[2]: Entering directory '$(@D)/plugins/system_group'
 make[2]: Nothing to be done for 'check'.
 make[2]: Leaving directory '$(@D)/plugins/system_group'
 make[2]: Entering directory '$(@D)/src'
-check_ttyname: OK (/dev/pts/4)
+check_ttyname: OK (/dev/pts/2)
 check_noexec: OK (execl)
 check_noexec: OK (system)
 check_noexec: OK (wordexp) [2]


### PR DESCRIPTION
Changes: https://www.sudo.ws/stable.html#1.8.28

One change specifically relevant to us: "Sudo will now only set PAM_TTY to the empty string when no terminal is present on Solaris and Linux. This workaround is only needed on those systems which may have PAM modules that misbehave when PAM_TTY is not set."

**Testing**
- test suite did not regress