### PR TITLE
sudo: Fix sudoers config file to validate

### DIFF
--- a/components/sysutils/sudo/patches/03-valid-sudoers-config.patch
+++ b/components/sysutils/sudo/patches/03-valid-sudoers-config.patch
@@ -1,0 +1,10 @@
+https://bugzilla.sudo.ws/show_bug.cgi?id=902
+
+--- sudo-1.8.28p1/plugins/sudoers/sudoers.in	2019-10-10 18:32:33.000000000 +0000
++++ sudo-1.8.28p1/plugins/sudoers/sudoers.in.new	2019-10-16 19:40:32.874578851 +0000
+@@ -94,4 +94,4 @@ root ALL=(ALL) ALL
+ 
+ ## Read drop-in files from @sysconfdir@/sudoers.d
+ ## (the '#' here does not indicate a comment)
+-#includedir @sysconfdir@/sudoers.d
++# includedir @sysconfdir@/sudoers.d


### PR DESCRIPTION
https://hipster.openindiana.org/logs/oi-userland/latest/sysutils.sudo.publish.log:
```
make[4]: Entering directory '/jenkins/jobs/oi-userland/workspace/components/sysutils/sudo/build/amd64/plugins/sudoers'
Checking existing sudoers file for syntax errors.
visudo: /etc/sudoers.d: Permission denied
parse error in /jenkins/jobs/oi-userland/workspace/components/sysutils/sudo/build/prototype/i386/etc/sudoers near line 96
make[4]: *** [Makefile:387: pre-install] Error 1
```