### PR TITLE
rdesktop: Add build require library/audio/libao

### DIFF
--- a/components/desktop/rdesktop/Makefile
+++ b/components/desktop/rdesktop/Makefile
@@ -59,6 +59,7 @@ CONFIGURE_OPTIONS+=	--enable-credssp
 CONFIGURE_OPTIONS+=	--with-ipv6
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += library/audio/libao
 REQUIRED_PACKAGES += library/audio/pulseaudio
 REQUIRED_PACKAGES += library/gmp
 REQUIRED_PACKAGES += library/gnutls-3


### PR DESCRIPTION
Fix https://hipster.openindiana.org/jenkins/job/oi-userland/4863/:
```
/jenkins/jobs/oi-userland/workspace/components/desktop/rdesktop/build/manifest-i386-rdesktop.depend has unresolved dependency '
    depend type=require fmri=__TBD pkg.debug.depend.file=libao.so.4 \
        pkg.debug.depend.reason=usr/bin/rdesktop pkg.debug.depend.type=elf \
        pkg.debug.depend.path=lib/64 \
        pkg.debug.depend.path=usr/gcc/6/lib/amd64 \
        pkg.debug.depend.path=usr/lib/64 \
        pkg.debug.depend.path=usr/lib/amd64/gnutls-3'.
gmake[2]: *** [/jenkins/jobs/oi-userland/workspace/make-rules/ips.mk:441: /jenkins/jobs/oi-userland/workspace/components/desktop/rdesktop/build/.resolved-i386] Error 1
gmake[2]: Target 'publish' not remade because of errors.
gmake[2]: Leaving directory '/jenkins/jobs/oi-userland/workspace/components/desktop/rdesktop'
```