### PR TITLE
samba: readd patch for avahi propagation.

### DIFF
--- a/components/network/samba/Makefile
+++ b/components/network/samba/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME =		samba
 COMPONENT_FMRI =		service/network/samba
 COMPONENT_VERSION =		4.11.0
+COMPONENT_REVISION =		1
 COMPONENT_SRC =			$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL =		http://www.samba.org/
 COMPONENT_ARCHIVE =             $(COMPONENT_SRC).tar.gz

--- a/components/network/samba/patches/14-avahi-register.patch
+++ b/components/network/samba/patches/14-avahi-register.patch
@@ -1,0 +1,25 @@
+Set port numbers to something different than 0
+see https://www.illumos.org/issues/9782
+
+The patch can be dropped when upstream has included the fix for the issue.
+
+--- samba-4.9.5/source3/smbd/avahi_register.c	2019-03-12 09:19:04.000000000 +0000
++++ samba-4.9.5/source3/smbd/avahi_register.c	2019-03-18 17:58:47.199335371 +0000
+@@ -186,7 +186,7 @@
+ 			error = avahi_entry_group_add_service_strlst(
+ 				    state->entry_group, AVAHI_IF_UNSPEC,
+ 				    AVAHI_PROTO_UNSPEC, 0, hostname,
+-				    "_adisk._tcp", NULL, NULL, 0, adisk);
++				    "_adisk._tcp", NULL, NULL, 9, adisk);
+ 			avahi_string_list_free(adisk);
+ 			adisk = NULL;
+ 			if (error != AVAHI_OK) {
+@@ -212,7 +212,7 @@
+ 		error = avahi_entry_group_add_service_strlst(
+ 			    state->entry_group, AVAHI_IF_UNSPEC,
+ 			    AVAHI_PROTO_UNSPEC, 0, hostname,
+-			    "_device-info._tcp", NULL, NULL, 0,
++			    "_device-info._tcp", NULL, NULL, 9,
+ 			    dinfo);
+ 		avahi_string_list_free(dinfo);
+ 		if (error != AVAHI_OK) {


### PR DESCRIPTION
Sorry, but this readded patch is still necessary...
Hope you can add that before release 10.2019