### PR TITLE
[PARKED] libusb-1 : solaris: fix handling of control transfers

### DIFF
--- a/components/library/libusb-1/patches/08-release-transfer-lock.patch
+++ b/components/library/libusb-1/patches/08-release-transfer-lock.patch
@@ -1,10 +1,43 @@
---- libusb-1.0.22/libusb/os/sunos_usb.c.~5~	2018-05-22 08:57:25.153943880 +0000
-+++ libusb-1.0.22/libusb/os/sunos_usb.c	2018-05-22 09:02:19.631926413 +0000
-@@ -1375,6 +1375,7 @@
- 	usbi_dbg("Done: ctrl data bytes %d", ret);
+From d256f7df30bfad3efc700cf080d82b540f70bc34 Mon Sep 17 00:00:00 2001
+From: Daniele Pezzini <hyouko@gmail.com>
+Date: Mon, 10 Sep 2018 23:50:22 +0200
+Subject: [PATCH] solaris: fix handling of control transfers
+
+SunOS backend is 'completing' control transfers before a) libusb knows they're completed and b) libusb references the device to keep it alive for the completion, with the result that the device is unreferenced for the completion of the transfer before being referenced for it, and, if it's not already referenced in excess, it is destroyed, and the next call that tries to access that device... boom (segfault).
+So, don't trigger the completion of the transfer, but only signal it.
+---
+ libusb/os/sunos_usb.c | 17 +++++++----------
+ 1 file changed, 7 insertions(+), 10 deletions(-)
+
+diff --git a/libusb/os/sunos_usb.c b/libusb/os/sunos_usb.c
+index 7150a3e..fc62897 100644
+--- a/libusb/os/sunos_usb.c
++++ b/libusb/os/sunos_usb.c
+@@ -1354,17 +1354,14 @@ solaris_submit_ctrl_on_default(struct libusb_transfer *transfer)
+ 			wLength, READ, (int *)&transfer->status);
+ 	}
  
- 	/* sync transfer handling */
-+	usbi_mutex_unlock(&LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)->lock);
- 	ret = usbi_handle_transfer_completion(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer),
- 	    transfer->status);
+-	if (ret >= 0) {
+-		transfer->actual_length = ret;
+-		LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)->transferred = ret;
+-	}
+-	usbi_dbg("Done: ctrl data bytes %d", ret);
+-
+-	/* sync transfer handling */
+-	ret = usbi_handle_transfer_completion(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer),
+-	    transfer->status);
++	if (ret < 0)
++		return (LIBUSB_ERROR_IO);
  
+-	return (ret);
++	usbi_dbg("Done: ctrl data bytes %d", ret);
++	transfer->actual_length = ret;
++	LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer)->transferred = ret;
++	usbi_signal_transfer_completion(LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer));
++	return LIBUSB_SUCCESS;
+ }
+ 
+ int
+-- 
+2.18.0
+


### PR DESCRIPTION
This PR stems from a detailed discussion at https://github.com/networkupstools/nut/issues/300 and patches proposed by @zykh (Daniele Pezzini) to fix some legacy Solarish libusb pathological behaviors which precluded me from actually using it with an USB-connected UPS with NUT: 

* https://github.com/networkupstools/nut/files/2369269/0001-solaris-fix-handling-of-control-transfers.patch.txt

> try to build libusb-1 with this patch instead of OpenIndiana's patch n. 08 -- it should solve the problems with control transfers. Now, I have also problems with some interrupts, though... will look at it...

This patch was applied in the PR below. An additional recommendation, which I did not (have to) follow yet was for :

* https://github.com/networkupstools/nut/files/2373155/0002-solaris-fix-handling-of-errors-in-control-transfers.patch.txt

> Try adding also this patch on top of my last one -- libusb should at least error out now, when read()/write() fail in control transfers (not reporting the exact error yet, though... this is something for when I'll have more time) ... and we should now be able to set datastale in a more timely fashion. I haven't yet had time to look at the problems I experience with interrupts...

> I have not had time yet to do a deeper review of libusb's Solaris code, though I worked around my own problem with an ugly patch (apparently there are problems with aio_*() functions, though, at a first look, libusb uses them in the right way... so perhaps it's something outside libusb and more deeply hidden in Solaris itself...).

The latest known status of this was that on one hand, Daniele did not recommend to PR the fix as fully usable everywhere (he did face some issues to unravel, I do not know how that panned out in the past year, and I had some adventures with hotplug activities), and on another it let me build a libusb that worked for me a lot better (and worked at all) unlike the original component.

So at the very least, I'd like to put the code out here so the improvement is not lost as a needle in the haystack, and might be more exposed to illumos/solarish ecosystem specialists to evaluate and/or improve further.

Also CCing @citrus-it because the practical deployment I did was on OmniOS CE, using the libusb library built on/for/with-recipes-from OpenIndiana.