### PR TITLE
Update zstd to 1.4.4

### DIFF
--- a/components/archiver/zstd/Makefile
+++ b/components/archiver/zstd/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE=		cmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zstd
-COMPONENT_VERSION=	1.4.3
+COMPONENT_VERSION=	1.4.4
 COMPONENT_SUMMARY=	Zstandard, or zstd for short, is a fast lossless compression algorithm, targeting real-time compression scenarios
 COMPONENT_PROJECT_URL=	https://facebook.github.io/zstd/
 COMPONENT_FMRI=		compress/zstd
@@ -26,7 +26,7 @@ COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/facebook/zstd/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	sha256:e88ec8d420ff228610b77fba4fbf22b9f8b9d3f223a40ef59c9c075fcdad5767
+COMPONENT_ARCHIVE_HASH=	sha256:59ef70ebb757ffe74a7b3fe9c305e2ba3350021a918d168a046c6300aeea9315
 COMPONENT_LICENSE=	BSD,GPLv2.0
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 

--- a/components/archiver/zstd/manifests/sample-manifest.p5m
+++ b/components/archiver/zstd/manifests/sample-manifest.p5m
@@ -22,6 +22,12 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+link path=usr/bin/$(MACH64)/unzstd target=zstd
+file path=usr/bin/$(MACH64)/zstd
+link path=usr/bin/$(MACH64)/zstdcat target=zstd
+file path=usr/bin/$(MACH64)/zstdgrep
+file path=usr/bin/$(MACH64)/zstdless
+link path=usr/bin/$(MACH64)/zstdmt target=zstd
 link path=usr/bin/unzstd target=zstd
 file path=usr/bin/zstd
 link path=usr/bin/zstdcat target=zstd

--- a/components/archiver/zstd/zstd.p5m
+++ b/components/archiver/zstd/zstd.p5m
@@ -25,6 +25,12 @@ depend fmri=text/gnu-grep type=require
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+link path=usr/bin/$(MACH64)/unzstd target=zstd
+file path=usr/bin/$(MACH64)/zstd
+link path=usr/bin/$(MACH64)/zstdcat target=zstd
+file path=usr/bin/$(MACH64)/zstdgrep
+file path=usr/bin/$(MACH64)/zstdless
+link path=usr/bin/$(MACH64)/zstdmt target=zstd
 link path=usr/bin/unzstd target=zstd
 file path=usr/bin/zstd
 link path=usr/bin/zstdcat target=zstd


### PR DESCRIPTION
Release notes: https://github.com/facebook/zstd/releases/tag/v1.4.4

No ABI changes: https://abi-laboratory.pro/index.php?view=timeline&l=zstd

**Testing**
- internal test suite passed
- manual un/compression, cat, and grep executables work