### PR TITLE
update ignore file to ignore python3.5 compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ components/*.mk
 components/**/build
 
 tools/python/pkglint/*.pyc
+tools/python/pkglint/__pycache__
 tools/parfait
 tools/pkglint
 tools/time-*o


### PR DESCRIPTION
Since switching to python 3 the python compiled files show up again as changes. Which if you have a shell like zsh that displays any uncommited changes to a git repo breaks that functionality. I have added the compiled path in the new format to gitignore so we need not to worrx about it anymore like back when pkg was built with python2