### PR TITLE
fix dependencies on x11-protocols; modernize Makefile

### DIFF
--- a/components/x11/lndir/Makefile
+++ b/components/x11/lndir/Makefile
@@ -13,12 +13,14 @@
 # Copyright 2016 Alexander Pyhalov
 #
 
+BUILD_BITS = 32
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=           lndir
-COMPONENT_VERSION=        1.0.3
-COMPONENT_FMRI=           file/lndir
-COMPONENT_CLASSIFICATION= Applications/System Utilities
+COMPONENT_NAME=				lndir
+COMPONENT_VERSION=			1.0.3
+COMPONENT_REVISION=			1
+COMPONENT_FMRI=				file/lndir
+COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SUMMARY=  lndir - create a shadow directory of symbolic links to another directory tree
 COMPONENT_SRC=      $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=  $(COMPONENT_SRC).tar.bz2
@@ -30,20 +32,13 @@ COMPONENT_PROJECT_URL = https://www.x.org/
 COMPONENT_LICENSE=      MIT License
 COMPONENT_LICENSE_FILE= COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=/usr/gnu/bin:/usr/bin
 
-build: $(BUILD_32)
-
-install: $(INSTALL_32)
-
-test: $(NO_TESTS)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/x11/xcb-util-image/Makefile
+++ b/components/x11/xcb-util-image/Makefile
@@ -20,10 +20,13 @@
 #
 # Copyright (c) 2013-2015, Aurelien Larcher. All rights reserved.
 #
+
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		xcb-util-image
 COMPONENT_VERSION=	0.4.0
+COMPONENT_REVISION= 1
 COMPONENT_FMRI=     	x11/library/xcb-util-image
 COMPONENT_CLASSIFICATION= Development/X11
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -35,18 +38,11 @@ COMPONENT_LICENSE=      MIT
 COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
 COMPONENT_SUMMARY=      The X protocol C-language Binding (XCB): Port of XImage and XShmImage functions.
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
-
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
-test: $(NO_TESTS)
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/x11/xf86-input-acecad/Makefile
+++ b/components/x11/xf86-input-acecad/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-input-acecad
 COMPONENT_VERSION= 1.5.0
-COMPONENT_REVISIION= 1
+COMPONENT_REVISIION= 2
 COMPONENT_SUMMARY= xf86-input-acecad - Acecad Flair input driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -31,9 +32,8 @@ COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-input-acecad
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION =        ( cd $(@D) && \
                                         libtoolize --automake --copy --force && \
@@ -42,14 +42,8 @@ COMPONENT_PREP_ACTION =        ( cd $(@D) && \
                                         automake -a -f -c &&\
                                         autoconf )
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/kbproto
-REQUIRED_PACKAGES += x11/header/inputproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += x11/server/xorg
 
 # Auto-generated dependencies

--- a/components/x11/xf86-input-keyboard/Makefile
+++ b/components/x11/xf86-input-keyboard/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-input-keyboard
 COMPONENT_VERSION= 1.9.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= \
   xf86-input-keyboard - Keyboard input driver for the Xorg X server
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-input-keyboard
@@ -32,9 +33,8 @@ COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -43,15 +43,10 @@ COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           automake -a -f -c &&\
                           autoconf )
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/inputproto
+REQUIRED_PACKAGES += system/header/header-usb
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += x11/server/xorg
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += system/header/header-usb

--- a/components/x11/xf86-input-mouse/Makefile
+++ b/components/x11/xf86-input-mouse/Makefile
@@ -13,10 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-input-mouse
 COMPONENT_VERSION= 1.9.3
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= xf86-input-mouse - Mouse input driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -30,18 +32,11 @@ COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-input-mouse
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
-
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/inputproto
-REQUIRED_PACKAGES += x11/server/xorg
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/x11/xf86-input-synaptics/Makefile
+++ b/components/x11/xf86-input-synaptics/Makefile
@@ -13,10 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-input-synaptics
 COMPONENT_VERSION= 1.9.1
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= xf86-input-synaptics - Synaptics touchpad driver for X.Org
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-input-synaptics
@@ -30,21 +32,19 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_BINDIR.32=/usr/lib/xorg
 CONFIGURE_BINDIR.64=/usr/lib/xorg/$(MACH64)
 
-build: $(BUILD_32_and_64)
+# Build dependencies
+REQUIRED_PACKAGES += x11/header/x11-protocols
+REQUIRED_PACKAGES += x11/library/libpthread-stubs
 
-install: $(INSTALL_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libx11
 REQUIRED_PACKAGES += x11/library/libxi
 REQUIRED_PACKAGES += x11/library/libxtst
-REQUIRED_PACKAGES += x11/library/libpthread-stubs
-REQUIRED_PACKAGES += x11/header/inputproto

--- a/components/x11/xf86-input-vmmouse/Makefile
+++ b/components/x11/xf86-input-vmmouse/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-input-vmmouse
 COMPONENT_VERSION= 13.1.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-input-vmmouse - VMWare guest mouse input driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -31,9 +32,8 @@ COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-input-vmmouse
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 HAL_CALLOUTS_DIR.32=/usr/lib/hal
 HAL_CALLOUTS_DIR.64=/usr/lib/hal/$(MACH64)
@@ -49,13 +49,11 @@ CONFIGURE_OPTIONS += --with-hal-fdi-dir=/etc/hal/fdi/policy/10osvendor
 CONFIGURE_OPTIONS += --without-libudev
 CONFIGURE_OPTIONS += --with-udev-rules-dir=no
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
+# Build dependencies
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += x11/header/inputproto
 REQUIRED_PACKAGES += x11/library/libpthread-stubs
 REQUIRED_PACKAGES += x11/library/libxi
 REQUIRED_PACKAGES += x11/library/libx11

--- a/components/x11/xf86-video-ast/Makefile
+++ b/components/x11/xf86-video-ast/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-ast
 COMPONENT_VERSION= 1.1.5
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-ast - ASPEED AST driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -27,10 +28,8 @@ COMPONENT_ARCHIVE_URL= \
   http://xorg.freedesktop.org/archive/individual/driver/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 
-include $(WS_TOP)/make-rules/prep.mk
-
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION =        ( cd $(@D) && \
 					aclocal -I. && \
@@ -55,13 +54,8 @@ LD_OPTIONS+= \
 	$(AST_LIBRARIES)
 
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += diagnostic/scanpci

--- a/components/x11/xf86-video-ati/Makefile
+++ b/components/x11/xf86-video-ati/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-ati
 COMPONENT_VERSION= 6.14.6
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_SUMMARY= xf86-video-ati - ATI Radeon video driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -27,12 +28,9 @@ COMPONENT_ARCHIVE_URL= \
   http://xorg.freedesktop.org/archive/individual/driver/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 
-include $(WS_MAKE_RULES)/prep.mk
-
+TEST_TARGET = $(NO_TESTS)
 CONFIGURE_DEFAULT_DIRS = no
-
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = \
  ( cd $(@D) && \
@@ -82,15 +80,8 @@ CONFIGURE_OPTIONS += --disable-kms
 COMPONENT_BUILD_ARGS += $(COMPONENT_COMMON_ARGS)
 COMPONENT_INSTALL_ARGS += $(COMPONENT_COMMON_ARGS)
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/fontsproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xf86-video-cirrus/Makefile
+++ b/components/x11/xf86-video-cirrus/Makefile
@@ -14,11 +14,12 @@
 # Copyright 2017 Michal Nowak
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-cirrus
 COMPONENT_VERSION= 1.5.3
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-cirrus - Cirrus Logic video driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -32,9 +33,8 @@ COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-cirrus
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION =        ( cd $(@D) && \
                                         libtoolize --automake --copy --force && \
@@ -56,17 +56,12 @@ LD_OPTIONS= \
         -R$(X11_SERVERMODS_DIR)$(SERVERMOD_SUBDIR) \
         -R$(X11_SERVERLIBS_DIR)$(SERVERMOD_SUBDIR)
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
+# Build dependencies
 REQUIRED_PACKAGES += developer/build/autoconf/xorg-macros
 REQUIRED_PACKAGES += developer/build/pkg-config
-REQUIRED_PACKAGES += x11/server/xorg
-REQUIRED_PACKAGES += x11/header/fontsproto
-REQUIRED_PACKAGES += x11/header/randrproto
-REQUIRED_PACKAGES += x11/header/renderproto
-REQUIRED_PACKAGES += x11/header/videoproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/xproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
+
+# Auto-generated dependencies
 REQUIRED_PACKAGES += diagnostic/scanpci
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += x11/server/xorg

--- a/components/x11/xf86-video-dummy/Makefile
+++ b/components/x11/xf86-video-dummy/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-dummy
 COMPONENT_VERSION= 0.3.8
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= \
   xf86-video-dummy - virtual/offscreen frame buffer driver for the Xorg X server
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
@@ -32,9 +33,8 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -57,13 +57,8 @@ LD_OPTIONS= \
         -R$(X11_SERVERLIBS_DIR)$(SERVERMOD_SUBDIR) \
         -lfb
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/x11/xf86-video-intel/Makefile
+++ b/components/x11/xf86-video-intel/Makefile
@@ -14,11 +14,12 @@
 # Copyright 2016 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-intel
 COMPONENT_VERSION= 2.99.917
-COMPONENT_REVISION= 6
+COMPONENT_REVISION= 7
 COMPONENT_SUMMARY= xf86-video-intel - Intel integrated graphics chipset driver for the Xorg X server
 COMPONENT_GIT_DATE= 20171018
 COMPONENT_GIT_HASH= 4798e18b2b2c8b0a05dc967e6140fd9962bc1a73
@@ -30,12 +31,9 @@ COMPONENT_ARCHIVE_URL= \
   https://cgit.freedesktop.org/xorg/driver/xf86-video-intel/snapshot/$(COMPONENT_SRC).tar.xz
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 
-include $(WS_TOP)/make-rules/prep.mk
-
 CONFIGURE_DEFAULT_DIRS = no
-
-include $(WS_TOP)/make-rules/configure.mk
-include $(WS_TOP)/make-rules/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 LDFLAGS += -lm -lsocket
 
@@ -103,15 +101,8 @@ CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
 COMPONENT_BUILD_ARGS += $(COMPONENT_COMMON_ARGS)
 COMPONENT_INSTALL_ARGS += $(COMPONENT_COMMON_ARGS)
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/dri2proto
-REQUIRED_PACKAGES += x11/header/dri3proto
-REQUIRED_PACKAGES += x11/header/presentproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += x11/library/libpthread-stubs
 REQUIRED_PACKAGES += system/header/header-drm
 

--- a/components/x11/xf86-video-mach64/Makefile
+++ b/components/x11/xf86-video-mach64/Makefile
@@ -13,10 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-mach64
 COMPONENT_VERSION= 6.9.6
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= xf86-video-mach64 - MACH64 driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -26,9 +28,8 @@ COMPONENT_ARCHIVE_URL= \
   http://xorg.freedesktop.org/archive/individual/driver/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION =        ( cd $(@D) && \
                                         libtoolize --automake --copy --force && \
@@ -58,15 +59,8 @@ CONFIGURE_OPTIONS += --enable-xaa
 COMPONENT_BUILD_ARGS += $(COMPONENT_COMMON_ARGS)
 COMPONENT_INSTALL_ARGS += $(COMPONENT_COMMON_ARGS)
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/fontsproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xf86-video-mga/Makefile
+++ b/components/x11/xf86-video-mga/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-mga
 COMPONENT_VERSION= 1.6.5
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-mga - Matrox MGA driver for the Xorg X server
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-mga
@@ -31,9 +32,8 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -58,14 +58,8 @@ CONFIGURE_OPTIONS += --disable-dri
 
 CONFIGURE_OPTIONS += XORG_LIBS="$(DRIVER_LD_FLAGS)"
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xf86-video-nv/Makefile
+++ b/components/x11/xf86-video-nv/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-nv
 COMPONENT_VERSION= 2.1.21
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-nv - NVIDIA video driver for the Xorg X server
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-nv
 COMPONENT_CLASSIFICATION= Drivers/Display
@@ -31,9 +32,8 @@ COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -57,14 +57,8 @@ LD_OPTIONS= \
         -lexa -lfb -lint10 -lshadowfb -lXfont -lvbe -lvgahw -lfbdevhw \
 	-lpciaccess -lpixman-1 -lm
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += diagnostic/scanpci

--- a/components/x11/xf86-video-openchrome/Makefile
+++ b/components/x11/xf86-video-openchrome/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-openchrome
 COMPONENT_VERSION= 0.6.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-openchrome - OpenChrome driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -31,9 +32,8 @@ COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-openchrome
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -72,15 +72,8 @@ COMPONENT_BUILD_ENV += \
 # Disable as 32bit module is not installed in the right directory. 
 #CONFIGURE_LIBDIR.$(BITS) =   $(X11_SERVERLIBS_DIR)$(SERVERMOD_SUBDIR)
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
-REQUIRED_PACKAGES += x11/header/fontsproto
-REQUIRED_PACKAGES += x11/header/glproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xf86-video-r128/Makefile
+++ b/components/x11/xf86-video-r128/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-r128
 COMPONENT_VERSION= 6.10.2
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-r128 - ATI Rage 128 video driver for the Xorg X server
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-r128
@@ -31,10 +32,8 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -57,15 +56,8 @@ LD_OPTIONS = \
 # - Disable DRI since the kernel module isn't ported
 CONFIGURE_OPTIONS += --disable-dri
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xf86-video-savage/Makefile
+++ b/components/x11/xf86-video-savage/Makefile
@@ -13,11 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-savage
 COMPONENT_VERSION= 2.3.9
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-savage - S3 Savage video driver for the Xorg X server
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-savage
@@ -31,9 +32,8 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -59,15 +59,8 @@ LD_OPTIONS= -M$(COMPONENT_DIR)/mapfile.externs \
 # - Disable DRI since the kernel module isn't ported
 CONFIGURE_OPTIONS += --disable-dri
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xf86-video-trident/Makefile
+++ b/components/x11/xf86-video-trident/Makefile
@@ -15,9 +15,10 @@
 
 include ../../../make-rules/shared-macros.mk
 
+BUILD_BITS = 32_and_64
 COMPONENT_NAME= xf86-video-trident
 COMPONENT_VERSION= 1.3.8
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-trident - Trident video driver for the Xorg X server
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-trident
@@ -31,9 +32,8 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -57,14 +57,8 @@ LD_OPTIONS= \
         -lexa -lfb -lint10 -lpciaccess -lpixman-1 -lshadow -lvbe -lvgahw \
         -lm
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += diagnostic/scanpci

--- a/components/x11/xf86-video-vbox/Makefile
+++ b/components/x11/xf86-video-vbox/Makefile
@@ -13,12 +13,13 @@
 # Copyright 2017 Aurelien Larcher
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-vbox
 # Use version string from Xorg module
 COMPONENT_VERSION= 1.0.1
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= xf86-video-vbox - VirtualBox UMS driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_GIT_HASH)
 COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.xz
@@ -33,9 +34,8 @@ COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-vboxvideo
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -66,15 +66,8 @@ LD_OPTIONS+= \
 
 CONFIGURE_OPTIONS+= --with-xorg-module-dir=$(X11_SERVERMODS_DIR)$(SERVERMOD_SUBDIR)
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
-REQUIRED_PACKAGES += x11/header/fontsproto
-REQUIRED_PACKAGES += x11/header/glproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xf86-video-vesa/Makefile
+++ b/components/x11/xf86-video-vesa/Makefile
@@ -13,10 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-vesa
 COMPONENT_VERSION= 2.4.0
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= xf86-video-vesa - VESA driver for the Xorg X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -30,9 +32,8 @@ COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-vesa
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION =        ( cd $(@D) && \
                                         libtoolize --automake --copy --force && \
@@ -53,14 +54,8 @@ LD_OPTIONS= \
         -R$(X11_SERVERMODS_DIR)$(SERVERMOD_SUBDIR) \
         -lfb -lpciaccess -lshadow -lvbe
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/xextproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += diagnostic/scanpci

--- a/components/x11/xf86-video-vmware/Makefile
+++ b/components/x11/xf86-video-vmware/Makefile
@@ -13,10 +13,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xf86-video-vmware
 COMPONENT_VERSION= 13.3.0
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= xf86-video-vmware - VMWare driver for the Xorg X server
 COMPONENT_PROJECT_URL = http://xorg.freedesktop.org
 COMPONENT_FMRI = x11/server/xorg/driver/xorg-video-vmware
@@ -30,9 +32,8 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_LICENSE = MIT
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && \
                           libtoolize --automake --copy --force && \
@@ -53,13 +54,8 @@ LD_OPTIONS= \
         -R$(X11_SERVERMODS_DIR)$(SERVERMOD_SUBDIR) \
         -lfb -lpixman-1 -lshadowfb -lvgahw -lpciaccess
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/xproto
-REQUIRED_PACKAGES += x11/header/fontsproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += system/header/header-drm
 
 # Auto-generated dependencies

--- a/components/x11/xorg-server/Makefile
+++ b/components/x11/xorg-server/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= xorg-server
 COMPONENT_VERSION= 1.19.7
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= Xorg - X11R7 X server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -124,10 +124,7 @@ COMPONENT_POST_INSTALL_ACTION += ( $(ENV) $(COMPONENT_BUILD_ENV) $(CONFIGURE_ENV
 # Build dependencies
 REQUIRED_PACKAGES += x11/documentation/xorg-docs
 REQUIRED_PACKAGES += x11/documentation/xorg-sgml-doctools
-REQUIRED_PACKAGES += x11/header/dri2proto
-REQUIRED_PACKAGES += x11/header/dri3proto
-REQUIRED_PACKAGES += x11/header/glproto
-REQUIRED_PACKAGES += x11/header/xf86driproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += x11/font-util
 REQUIRED_PACKAGES += x11/library/libxres
 REQUIRED_PACKAGES += x11/library/xcb-util


### PR DESCRIPTION
Without these changes publishing always tries to install missing packages.
I left out mesa because the sample-manifest changes slightly when I check in my environment. Albeit I think the differences aren't relevant I am reluctant to publish them:
╰─➤  diff sample-manifest.p5m sample-manifest.p5m.old
13c13
< # Copyright 2018 <contributor>
---
> # Copyright 2017 <contributor>
111c111
<     target=radeon_dri.so
---
>     target=swrast_dri.so
113c113
<     target=radeon_dri.so
---
>     target=swrast_dri.so
115,123c115,123
<     target=radeon_dri.so
< file path=usr/lib/xorg/modules/dri/$(MACH64)/radeon_dri.so
< hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so \
<     target=radeon_dri.so
< hardlink path=usr/lib/xorg/modules/dri/i915_dri.so target=r200_dri.so
< hardlink path=usr/lib/xorg/modules/dri/i965_dri.so target=r200_dri.so
< file path=usr/lib/xorg/modules/dri/r200_dri.so
< hardlink path=usr/lib/xorg/modules/dri/radeon_dri.so target=r200_dri.so
< hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=r200_dri.so
---
>     target=swrast_dri.so
> hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/radeon_dri.so \
>     target=swrast_dri.so
> file path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so
> hardlink path=usr/lib/xorg/modules/dri/i915_dri.so target=radeon_dri.so
> hardlink path=usr/lib/xorg/modules/dri/i965_dri.so target=radeon_dri.so
> hardlink path=usr/lib/xorg/modules/dri/r200_dri.so target=radeon_dri.so
> file path=usr/lib/xorg/modules/dri/radeon_dri.so
> hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=radeon_dri.so
