### PR TITLE
mesa: fix dependency on x11-protocols; modernize Makefile

### DIFF
--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -14,11 +14,12 @@
 # Copyright 2015 Ken Mays
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= mesa
 COMPONENT_VERSION= 13.0.6
-COMPONENT_REVISION= 5
+COMPONENT_REVISION= 6
 COMPONENT_SUMMARY= The Mesa 3-D Graphics Library
 COMPONENT_SRC= mesa-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= mesa-$(COMPONENT_VERSION).tar.xz
@@ -28,9 +29,8 @@ COMPONENT_ARCHIVE_URL= \
   https://mesa.freedesktop.org/archive/older-versions/13.x/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = http://www.mesa3d.org/
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PATCH_LEVEL=0
 
@@ -54,6 +54,9 @@ CONFIGURE_SCRIPT = $(@D)/configure
 
 # Missing files in build dir for configure without this.
 COMPONENT_PRE_CONFIGURE_ACTION =        (cp -a $(SOURCE_DIR)/* $(@D) )
+
+# Identify source_file files in hard links for manifest generator.
+PKG_HARDLINKS +=	usr/lib/xorg/modules/dri/radeon_dri.so
 
 # Add include paths and linker paths needed for DRM modules
 CPPFLAGS = -I/usr/X11/include/drm -D__EXTENSIONS__
@@ -91,15 +94,8 @@ CONFIGURE_ENV+=CPPFLAGS="$(CPPFLAGS)"
 
 COMPONENT_BUILD_ARGS =
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
 # Build dependencies
-REQUIRED_PACKAGES += x11/header/dri2proto
-REQUIRED_PACKAGES += x11/header/dri3proto
-REQUIRED_PACKAGES += x11/header/glproto
-REQUIRED_PACKAGES += x11/header/presentproto
+REQUIRED_PACKAGES += x11/header/x11-protocols
 REQUIRED_PACKAGES += x11/library/libpthread-stubs
 REQUIRED_PACKAGES += system/header/header-drm
 

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -108,14 +108,14 @@ file path=usr/lib/pkgconfig/glesv1_cm.pc
 file path=usr/lib/pkgconfig/glesv2.pc
 file path=usr/lib/pkgconfig/osmesa.pc
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/i915_dri.so \
-    target=swrast_dri.so
+    target=radeon_dri.so
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/i965_dri.so \
-    target=swrast_dri.so
+    target=radeon_dri.so
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/r200_dri.so \
-    target=swrast_dri.so
-hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/radeon_dri.so \
-    target=swrast_dri.so
-file path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so
+    target=radeon_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/radeon_dri.so
+hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so \
+    target=radeon_dri.so
 hardlink path=usr/lib/xorg/modules/dri/i915_dri.so target=radeon_dri.so
 hardlink path=usr/lib/xorg/modules/dri/i965_dri.so target=radeon_dri.so
 hardlink path=usr/lib/xorg/modules/dri/r200_dri.so target=radeon_dri.so

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -196,8 +196,8 @@ hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/r200_dri.so \
 file path=usr/lib/xorg/modules/dri/$(MACH64)/radeon_dri.so
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so \
     target=radeon_dri.so
-hardlink path=usr/lib/xorg/modules/dri/i915_dri.so target=r200_dri.so
-hardlink path=usr/lib/xorg/modules/dri/i965_dri.so target=r200_dri.so
-file path=usr/lib/xorg/modules/dri/r200_dri.so
-hardlink path=usr/lib/xorg/modules/dri/radeon_dri.so target=r200_dri.so
-hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=r200_dri.so
+hardlink path=usr/lib/xorg/modules/dri/i915_dri.so target=radeon_dri.so
+hardlink path=usr/lib/xorg/modules/dri/i965_dri.so target=radeon_dri.so
+hardlink path=usr/lib/xorg/modules/dri/r200_dri.so target=radeon_dri.so
+file path=usr/lib/xorg/modules/dri/radeon_dri.so
+hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=radeon_dri.so


### PR DESCRIPTION
This is the best outcome I could gain to reproduce the old sample-manifest.