### PR TITLE
xlock: Sync with solaris-userland (security)

### DIFF
--- a/components/x11/xlock/Makefile
+++ b/components/x11/xlock/Makefile
@@ -11,51 +11,43 @@
 
 #
 # Copyright 2015 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=           xlock
-COMPONENT_VERSION=        7.5
-COMPONENT_REVISION=       1
-COMPONENT_FMRI=           x11/xlock
+COMPONENT_NAME=		xlock
+COMPONENT_VERSION=	7.5
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		x11/xlock
 COMPONENT_CLASSIFICATION= System/X11
-COMPONENT_SUMMARY=        xlock - screen lock program
-COMPONENT_SRC=            src
-COMPONENT_PROJECT_URL=    https://hg.java.net/hg/solaris-x11~x-s12-clone
-COMPONENT_LICENSE=        MIT License
+COMPONENT_SUMMARY=	xlock - screen lock program
+COMPONENT_SRC=		src
+COMPONENT_PROJECT_URL=	https://github.com/oracle/solaris-userland/tree/master/components/x11/app/xlock/sun-src
+COMPONENT_LICENSE=	MIT License
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/justmake.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+COMPONENT_BUILD_ENV += $(COMPONENT_COMMON_ENV)
+COMPONENT_INSTALL_ENV += INSTALL="$(INSTALL) -D"
+COMPONENT_INSTALL_ENV += PREFIX=$(USRDIR)
 
 COMPONENT_COMMON_ENV = CC=$(CC)
 COMPONENT_COMMON_ENV+= CFLAGS="$(CFLAGS)"
 COMPONENT_COMMON_ENV+= LDFLAGS="$(LDFLAGS)"
 
-XLOCK_BINDIR.32= $(USRBINDIR)
-XLOCK_BINDIR.64= $(USRBINDIR64)
-
-COMPONENT_BUILD_ENV+= $(COMPONENT_COMMON_ENV)
-COMPONENT_BUILD_ARGS= VPATH=$(SOURCE_DIR) -f $(SOURCE_DIR)/Makefile
-COMPONENT_INSTALL_ENV+= INSTALL=$(INSTALL)
-COMPONENT_INSTALL_ENV+= DESTDIR=$(PROTO_DIR)
-COMPONENT_INSTALL_ENV+= PREFIX=$(USRDIR)
-COMPONENT_INSTALL_ENV+= bindir=$(XLOCK_BINDIR.$(BITS))
-COMPONENT_INSTALL_ENV+= datadir=$(USRSHAREDIR)
-COMPONENT_INSTALL_ENV+= mandir=$(USRSHAREMANDIR)
-
 $(SOURCE_DIR)/.prep: $(MAKEFILE_PREREQ)
 	$(TOUCH) $@
 
-build: $(BUILD_32_and_64)
+build: $(BUILD_64)
 
-install: $(INSTALL_32_and_64)
+install: $(INSTALL_64)
 
 test: $(NO_TESTS)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libx11

--- a/components/x11/xlock/manifests/sample-manifest.p5m
+++ b/components/x11/xlock/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,7 +22,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/xlock
 file path=usr/bin/xlock
 file path=usr/share/X11/app-defaults/XLock
 file path=usr/share/man/man1/xlock.1

--- a/components/x11/xlock/src/Makefile
+++ b/components/x11/xlock/src/Makefile
@@ -2,7 +2,7 @@
 #
 # xlock Makefile
 #
-# Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -34,7 +34,7 @@ SRCS=${C_SRCS} ${HDRS} ${IMAGES} xlock.man XLock.ad
 OBJS=${C_SRCS:.c=.o}
 LIBS=-lX11 -lm -lpam -lbsm -lsocket
 # Base lint flags
-LINTFLAGS = -fd -s -errtags=yes -Xc99
+LINTFLAGS = -fd -s -errtags=yes -std=c11 -xlang=c11
 # 64-bit checks
 LINTFLAGS += -m64 -L/usr/lib/64 -errchk=longptr64,sizematch
 LINTFLAGS += -erroff=E_CAST_INT_TO_SMALL_INT -erroff=E_CAST_UINT_TO_SIGNED_INT
@@ -44,11 +44,17 @@ LINTFLAGS += -errsecurity=extended
 LINTFLAGS += -erroff=E_SEC_RAND_WARN
 
 # Get default XFILESEARCHPATH from libXt & use it in resource.c
-DEF_FILESEARCHPATH=`pkg-config --variable=xfilesearchpath xt` 
+DEF_FILESEARCHPATH_RAW = $(shell pkg-config --variable=xfilesearchpath xt)
+DEF_FILESEARCHPATH = $(strip \
+	$(subst $$(datadir),$(datadir), \
+	$(subst $$(libdir),$(libdir), \
+	$(subst $$(sysconfdir),$(sysconfdir), $(DEF_FILESEARCHPATH_RAW)))))
+bindir=$(PREFIX)/bin
 datadir=$(PREFIX)/share
 libdir=$(PREFIX)/lib
+mandir=$(PREFIX)/share/man
 sysconfdir=/etc
-#resource.o lint := CPPFLAGS += -DDEF_FILESEARCHPATH=\"$(DEF_FILESEARCHPATH)\"
+CPPFLAGS += -DDEF_FILESEARCHPATH=\"$(DEF_FILESEARCHPATH)\"
 
 xlock: ${OBJS}
 	@print $(DEF_FILESEARCHPATH) | perl -n -e \
@@ -56,11 +62,8 @@ xlock: ${OBJS}
 	${CC} -o $@ ${OBJS} ${CFLAGS} ${LDFLAGS} ${LIBS}
 
 install: xlock xlock.1 XLock.ad
-	mkdir -p $(DESTDIR)$(bindir)
 	$(INSTALL) -m 0555 xlock $(DESTDIR)$(bindir)/xlock
-	mkdir -p $(DESTDIR)$(mandir)/man1
 	$(INSTALL) -m 0444 xlock.1 $(DESTDIR)$(mandir)/man1/xlock.1
-	mkdir -p $(DESTDIR)$(datadir)/X11/app-defaults
 	$(INSTALL) -m 0444 XLock.ad $(DESTDIR)$(datadir)/X11/app-defaults/XLock
 
 lint: ${C_SRCS}

--- a/components/x11/xlock/xlock.license
+++ b/components/x11/xlock/xlock.license
@@ -13,7 +13,7 @@
  other special, indirect and consequential damages.
  
  /*
- * Copyright (c) 1988, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1988, 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/components/x11/xlock/xlock.p5m
+++ b/components/x11/xlock/xlock.p5m
@@ -11,19 +11,24 @@
 
 #
 # Copyright 2016 Aurelien Larcher
+# Copyright 2019 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+#set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# XLock app-defaults specifies font:
+# -b&h-lucida-medium-r-normal-sans-24-*-*-*-*-*-iso8859-1
+depend type=require fmri=pkg:/system/font/xorg/iso8859-1
+
 link path=usr/X11/bin/xlock target=../../bin/xlock
 
-file path=usr/bin/$(MACH64)/xlock owner=root mode=4555
 file path=usr/bin/xlock owner=root mode=4555
 file path=usr/share/X11/app-defaults/XLock
 file path=usr/share/man/man1/xlock.1


### PR DESCRIPTION
Hinted by @alanc. Likely a security issue.

Synced with the whole solaris-userland component sources as we didn't sync them for some time.

**Testing**
- `xlock` locks and unlocks when run with user permissions