### PR TITLE
Update Python 3.5 to 3.5.8 (security)

### DIFF
--- a/components/python/python35/Makefile
+++ b/components/python/python35/Makefile
@@ -24,25 +24,27 @@
 # Copyright (c) 2019, Michal Nowak
 #
 
-PREFERRED_BITS=	64
+BUILD_BITS=	64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Python
-COMPONENT_VERSION=	3.5.7
+COMPONENT_VERSION=	3.5.8
 COMPONENT_PROJECT_URL=	https://www.python.org
+COMPONENT_SUMMARY=	The Python interpreter, libraries and utilities
+COMPONENT_CLASSIFICATION= Development/Python
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:285892899bf4d5737fd08482aa6171c6b2564a45b9102dfacfb72826aebdc7dc
+	sha256:55a345c78ee3afbc2e60678442aad7bcc384ddea5bb95f8d66edc4868d4847d4
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/ftp/python/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).asc
+COMPONENT_LICENSE=	PSFv2
 
 CONFIGURE_FIX_LIBTOOL_RPATH = no
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(TEST_64)
+
+include $(WS_MAKE_RULES)/common.mk
 
 # Need to preserve timestamp for Grammar files.  If the pickle files are older,
 # Python will try to rebuild them.
@@ -113,10 +115,6 @@ COMPONENT_BUILD_ARGS =
 # 64-bit shared objects need to go to 64-bit directory
 COMPONENT_INSTALL_ARGS += DESTSHARED=$(CONFIGURE_PREFIX)/lib/python3.5/lib-dynload
 
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
 # Using "-uall,-network" ensures all tests are run except the network tests.
 # The network tests contain many expected failures when run behind a firewall.
 # The "-v" ensures verbose mode.  You can set TESTOPTS_PYTHON_TEST to a
@@ -136,8 +134,6 @@ COMPONENT_TEST_TARGETS = test < /dev/null
 # with "tests OK." and end with "Re-running failed tests..." for comparison.
 COMPONENT_TEST_TRANSFORMER =	$(NAWK)
 COMPONENT_TEST_TRANSFORMS = "'/tests OK/ { results = 1 }; /^Re-running failed tests in verbose mode/ { results = 0 } { if (results) print }'"
-
-test:		$(TEST_64)
 
 # Required for dump(1)
 REQUIRED_PACKAGES += developer/object-file

--- a/components/python/python35/manifests/sample-manifest.p5m
+++ b/components/python/python35/manifests/sample-manifest.p5m
@@ -30,9 +30,9 @@ link path=usr/bin/pydoc3 target=pydoc3.5
 file path=usr/bin/pydoc3.5
 link path=usr/bin/python3 target=python3.5
 link path=usr/bin/python3-config target=python3.5-config
-file path=usr/bin/python3.5
+hardlink path=usr/bin/python3.5 target=python3.5m
 link path=usr/bin/python3.5-config target=python3.5m-config
-hardlink path=usr/bin/python3.5m target=python3.5
+file path=usr/bin/python3.5m
 file path=usr/bin/python3.5m-config
 link path=usr/bin/pyvenv target=pyvenv-3.5
 file path=usr/bin/pyvenv-3.5
@@ -1090,6 +1090,7 @@ file path=usr/lib/python3.5/test/capath/5ed36f99.0
 file path=usr/lib/python3.5/test/capath/6e88d7b8.0
 file path=usr/lib/python3.5/test/capath/99d0fa06.0
 file path=usr/lib/python3.5/test/capath/ce7b8643.0
+file path=usr/lib/python3.5/test/capath/efa5f9c3.0
 file path=usr/lib/python3.5/test/cfgparser.1
 file path=usr/lib/python3.5/test/cfgparser.2
 file path=usr/lib/python3.5/test/cfgparser.3

--- a/components/python/python35/patches/32-test-pkgutil-fix.patch
+++ b/components/python/python35/patches/32-test-pkgutil-fix.patch
@@ -1,0 +1,42 @@
+There's a namespace clash, where /usr/lib/python3.5/vendor-packages/pkg gets
+loaded to 'pkg'. Renaming pkg->pak fixes that.
+
+--- Python-3.5.8/Lib/test/test_pkgutil.py	2019-12-20 12:31:25.259726249 +0000
++++ Python-3.5.8/Lib/test/test_pkgutil.py.new	2019-12-20 12:31:18.225892234 +0000
+@@ -368,22 +368,22 @@ class NestedNamespacePackageTest(unittes
+         pkgutil_boilerplate = (
+             'import pkgutil; '
+             '__path__ = pkgutil.extend_path(__path__, __name__)')
+-        self.create_module('a.pkg.__init__', pkgutil_boilerplate)
+-        self.create_module('b.pkg.__init__', pkgutil_boilerplate)
+-        self.create_module('a.pkg.subpkg.__init__', pkgutil_boilerplate)
+-        self.create_module('b.pkg.subpkg.__init__', pkgutil_boilerplate)
+-        self.create_module('a.pkg.subpkg.c', 'c = 1')
+-        self.create_module('b.pkg.subpkg.d', 'd = 2')
++        self.create_module('a.pak.__init__', pkgutil_boilerplate)
++        self.create_module('b.pak.__init__', pkgutil_boilerplate)
++        self.create_module('a.pak.subpkg.__init__', pkgutil_boilerplate)
++        self.create_module('b.pak.subpkg.__init__', pkgutil_boilerplate)
++        self.create_module('a.pak.subpkg.c', 'c = 1')
++        self.create_module('b.pak.subpkg.d', 'd = 2')
+         sys.path.insert(0, os.path.join(self.basedir, 'a'))
+         sys.path.insert(0, os.path.join(self.basedir, 'b'))
+-        import pkg
+-        self.addCleanup(unload, 'pkg')
+-        self.assertEqual(len(pkg.__path__), 2)
+-        import pkg.subpkg
+-        self.addCleanup(unload, 'pkg.subpkg')
+-        self.assertEqual(len(pkg.subpkg.__path__), 2)
+-        from pkg.subpkg.c import c
+-        from pkg.subpkg.d import d
++        import pak
++        self.addCleanup(unload, 'pak')
++        self.assertEqual(len(pak.__path__), 2)
++        import pak.subpkg
++        self.addCleanup(unload, 'pak.subpkg')
++        self.assertEqual(len(pak.subpkg.__path__), 2)
++        from pak.subpkg.c import c
++        from pak.subpkg.d import d
+         self.assertEqual(c, 1)
+         self.assertEqual(d, 2)
+ 

--- a/components/python/python35/python-35.p5m
+++ b/components/python/python35/python-35.p5m
@@ -35,15 +35,17 @@
 <transform file path=usr/lib/python3.5/lib-dynload/.*\.so -> \
     add pkg.linted.userland.action001.2 true>
 <transform file path=.*/(idle_)?tests?/.* -> default facet.optional.test true>
+
 set name=pkg.fmri \
     value=pkg:/runtime/python-35@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="The Python interpreter, libraries and utilities"
-set name=info.classification \
-    value=org.opensolaris.category.2008:Development/Python
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-#
+
+license python35.license license='$(COMPONENT_LICENSE)'
+
 link path=usr/bin/2to3 target=2to3-3.5 mediator=python mediator-version=3.5
 file path=usr/bin/2to3-3.5
 link path=usr/bin/idle target=idle3.5 mediator=python mediator-version=3.5
@@ -1154,6 +1156,7 @@ file path=usr/lib/python3.5/test/capath/5ed36f99.0
 file path=usr/lib/python3.5/test/capath/6e88d7b8.0
 file path=usr/lib/python3.5/test/capath/99d0fa06.0
 file path=usr/lib/python3.5/test/capath/ce7b8643.0
+file path=usr/lib/python3.5/test/capath/efa5f9c3.0
 file path=usr/lib/python3.5/test/cfgparser.1
 file path=usr/lib/python3.5/test/cfgparser.2
 file path=usr/lib/python3.5/test/cfgparser.3
@@ -1445,6 +1448,7 @@ file path=usr/lib/python3.5/test/subprocessdata/qgrep.py
 file path=usr/lib/python3.5/test/subprocessdata/sigchild_ignore.py
 file path=usr/lib/python3.5/test/support/__init__.py
 file path=usr/lib/python3.5/test/support/script_helper.py
+file path=usr/lib/python3.5/test/talos-2019-0758.pem
 file path=usr/lib/python3.5/test/test___all__.py
 file path=usr/lib/python3.5/test/test___future__.py
 file path=usr/lib/python3.5/test/test__locale.py
@@ -1814,8 +1818,7 @@ file path=usr/lib/python3.5/test/test_linecache.py
 file path=usr/lib/python3.5/test/test_list.py
 file path=usr/lib/python3.5/test/test_listcomps.py
 file path=usr/lib/python3.5/test/test_locale.py
-file path=usr/lib/python3.5/test/test_logging.py \
-    pkg.depend.bypass-generate=.*/win32evtlog.*
+file path=usr/lib/python3.5/test/test_logging.py pkg.depend.bypass-generate=.*/win32evtlog.*
 file path=usr/lib/python3.5/test/test_long.py
 file path=usr/lib/python3.5/test/test_longexp.py
 file path=usr/lib/python3.5/test/test_lzma.py
@@ -2146,6 +2149,8 @@ file path=usr/lib/python3.5/uuid.py
 file path=usr/lib/python3.5/venv/__init__.py
 file path=usr/lib/python3.5/venv/__main__.py
 file path=usr/lib/python3.5/venv/scripts/common/activate
+#file path=usr/lib/python3.5/venv/scripts/posix/activate.csh
+#file path=usr/lib/python3.5/venv/scripts/posix/activate.fish
 file path=usr/lib/python3.5/warnings.py
 file path=usr/lib/python3.5/wave.py
 file path=usr/lib/python3.5/weakref.py
@@ -2184,8 +2189,5 @@ file path=usr/lib/python3.5/xmlrpc/client.py
 file path=usr/lib/python3.5/xmlrpc/server.py
 file path=usr/lib/python3.5/zipapp.py
 file path=usr/lib/python3.5/zipfile.py
-link path=usr/share/man/man1/python3.1 target=python3.5.1 mediator=python \
-    mediator-version=3.5
+link path=usr/share/man/man1/python3.1 target=python3.5.1 mediator=python mediator-version=3.5
 file path=usr/share/man/man1/python3.5.1
-#
-license python35.license license=PSFv2

--- a/components/python/python35/python35.license
+++ b/components/python/python35/python35.license
@@ -1,5 +1,63 @@
 From the LICENSE file:
 
+A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+as a successor of a language called ABC.  Guido remains Python's
+principal author, although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for
+National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+in Reston, Virginia where he released several versions of the
+software.
+
+In May 2000, Guido and the Python core development team moved to
+BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
+year, the PythonLabs team moved to Digital Creations, which became
+Zope Corporation.  In 2001, the Python Software Foundation (PSF, see
+https://www.python.org/psf/) was formed, a non-profit organization
+created specifically to own Python-related Intellectual Property.
+Zope Corporation was a sponsoring member of the PSF.
+
+All Python releases are Open Source (see http://www.opensource.org for
+the Open Source Definition).  Historically, most, but not all, Python
+releases have also been GPL-compatible; the table below summarizes
+the various releases.
+
+    Release         Derived     Year        Owner       GPL-
+                    from                                compatible? (1)
+
+    0.9.0 thru 1.2              1991-1995   CWI         yes
+    1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes
+    1.6             1.5.2       2000        CNRI        no
+    2.0             1.6         2000        BeOpen.com  no
+    1.6.1           1.6         2001        CNRI        yes (2)
+    2.1             2.0+1.6.1   2001        PSF         no
+    2.0.1           2.0+1.6.1   2001        PSF         yes
+    2.1.1           2.1+2.0.1   2001        PSF         yes
+    2.1.2           2.1.1       2002        PSF         yes
+    2.1.3           2.1.2       2002        PSF         yes
+    2.2 and above   2.1.1       2001-now    PSF         yes
+
+Footnotes:
+
+(1) GPL-compatible doesn't mean that we're distributing Python under
+    the GPL.  All Python licenses, unlike the GPL, let you distribute
+    a modified version without making your changes open source.  The
+    GPL-compatible licenses make it possible to combine Python with
+    other software that is released under the GPL; the others don't.
+
+(2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+    because its license has a choice of law clause.  According to
+    CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+    is "not incompatible" with the GPL.
+
+Thanks to the many outside volunteers who have worked under Guido's
+direction to make these releases possible.
+
+
 B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
 ===============================================================
 
@@ -16,10 +74,10 @@ grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
 analyze, test, perform and/or display publicly, prepare derivative works,
 distribute, and otherwise use Python alone or in any derivative version,
 provided, however, that PSF's License Agreement and PSF's notice of copyright,
-i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-2011, 2012, 2013, 2014, 2015, 2016, 2017 Python Software Foundation; All Rights
-Reserved" are retained in Python alone or in any derivative version prepared by
-Licensee.
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009,
+2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Python Software
+Foundation; All Rights Reserved" are retained in Python alone or in any
+derivative version prepared by Licensee.
 
 3. In the event Licensee prepares a derivative work that is based on
 or incorporates Python or any part thereof, and wants to make
@@ -52,7 +110,412 @@ products or services of Licensee, or any third party.
 agrees to be bound by the terms and conditions of this License
 Agreement.
 
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+Individual or Organization ("Licensee") accessing and otherwise using
+this software in source or binary form and its associated
+documentation ("the Software").
+
+2. Subject to the terms and conditions of this BeOpen Python License
+Agreement, BeOpen hereby grants Licensee a non-exclusive,
+royalty-free, world-wide license to reproduce, analyze, test, perform
+and/or display publicly, prepare derivative works, distribute, and
+otherwise use the Software alone or in any derivative version,
+provided, however, that the BeOpen Python License is retained in the
+Software, alone or in any derivative version prepared by Licensee.
+
+3. BeOpen is making the Software available to Licensee on an "AS IS"
+basis.  BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+5. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+6. This License Agreement shall be governed by and interpreted in all
+respects by the law of the State of California, excluding conflict of
+law provisions.  Nothing in this License Agreement shall be deemed to
+create any relationship of agency, partnership, or joint venture
+between BeOpen and Licensee.  This License Agreement does not grant
+permission to use BeOpen trademarks or trade names in a trademark
+sense to endorse or promote products or services of Licensee, or any
+third party.  As an exception, the "BeOpen Python" logos available at
+http://www.pythonlabs.com/logos.html may be used according to the
+permissions granted on that web page.
+
+7. By copying, installing or otherwise using the software, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+1. This LICENSE AGREEMENT is between the Corporation for National
+Research Initiatives, having an office at 1895 Preston White Drive,
+Reston, VA 20191 ("CNRI"), and the Individual or Organization
+("Licensee") accessing and otherwise using Python 1.6.1 software in
+source or binary form and its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, CNRI
+hereby grants Licensee a nonexclusive, royalty-free, world-wide
+license to reproduce, analyze, test, perform and/or display publicly,
+prepare derivative works, distribute, and otherwise use Python 1.6.1
+alone or in any derivative version, provided, however, that CNRI's
+License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+1995-2001 Corporation for National Research Initiatives; All Rights
+Reserved" are retained in Python 1.6.1 alone or in any derivative
+version prepared by Licensee.  Alternately, in lieu of CNRI's License
+Agreement, Licensee may substitute the following text (omitting the
+quotes): "Python 1.6.1 is made available subject to the terms and
+conditions in CNRI's License Agreement.  This Agreement together with
+Python 1.6.1 may be located on the Internet using the following
+unique, persistent identifier (known as a handle): 1895.22/1013.  This
+Agreement may also be obtained from a proxy server on the Internet
+using the following URL: http://hdl.handle.net/1895.22/1013".
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python 1.6.1 or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python 1.6.1.
+
+4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+basis.  CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. This License Agreement shall be governed by the federal
+intellectual property law of the United States, including without
+limitation the federal copyright law, and, to the extent such
+U.S. federal law does not apply, by the law of the Commonwealth of
+Virginia, excluding Virginia's conflict of law provisions.
+Notwithstanding the foregoing, with regard to derivative works based
+on Python 1.6.1 that incorporate non-separable material that was
+previously distributed under the GNU General Public License (GPL), the
+law of the Commonwealth of Virginia shall govern this License
+Agreement only as to issues arising under or with respect to
+Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in this
+License Agreement shall be deemed to create any relationship of
+agency, partnership, or joint venture between CNRI and Licensee.  This
+License Agreement does not grant permission to use CNRI trademarks or
+trade name in a trademark sense to endorse or promote products or
+services of Licensee, or any third party.
+
+8. By clicking on the "ACCEPT" button where indicated, or by copying,
+installing or otherwise using Python 1.6.1, Licensee agrees to be
+bound by the terms and conditions of this License Agreement.
+
+        ACCEPT
+
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+--------------------------------------------------
+
+Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+The Netherlands.  All rights reserved.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
 From the Doc/license.rst file:
+
+.. highlightlang:: none
+
+.. _history-and-license:
+
+*******************
+History and License
+*******************
+
+
+History of the software
+=======================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting
+Mathematisch Centrum (CWI, see https://www.cwi.nl/) in the Netherlands as a
+successor of a language called ABC.  Guido remains Python's principal author,
+although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for National
+Research Initiatives (CNRI, see https://www.cnri.reston.va.us/) in Reston,
+Virginia where he released several versions of the software.
+
+In May 2000, Guido and the Python core development team moved to BeOpen.com to
+form the BeOpen PythonLabs team.  In October of the same year, the PythonLabs
+team moved to Digital Creations (now Zope Corporation; see
+http://www.zope.com/).  In 2001, the Python Software Foundation (PSF, see
+https://www.python.org/psf/) was formed, a non-profit organization created
+specifically to own Python-related Intellectual Property.  Zope Corporation is a
+sponsoring member of the PSF.
+
+All Python releases are Open Source (see https://opensource.org/ for the Open
+Source Definition). Historically, most, but not all, Python releases have also
+been GPL-compatible; the table below summarizes the various releases.
+
++----------------+--------------+------------+------------+-----------------+
+| Release        | Derived from | Year       | Owner      | GPL compatible? |
++================+==============+============+============+=================+
+| 0.9.0 thru 1.2 | n/a          | 1991-1995  | CWI        | yes             |
++----------------+--------------+------------+------------+-----------------+
+| 1.3 thru 1.5.2 | 1.2          | 1995-1999  | CNRI       | yes             |
++----------------+--------------+------------+------------+-----------------+
+| 1.6            | 1.5.2        | 2000       | CNRI       | no              |
++----------------+--------------+------------+------------+-----------------+
+| 2.0            | 1.6          | 2000       | BeOpen.com | no              |
++----------------+--------------+------------+------------+-----------------+
+| 1.6.1          | 1.6          | 2001       | CNRI       | no              |
++----------------+--------------+------------+------------+-----------------+
+| 2.1            | 2.0+1.6.1    | 2001       | PSF        | no              |
++----------------+--------------+------------+------------+-----------------+
+| 2.0.1          | 2.0+1.6.1    | 2001       | PSF        | yes             |
++----------------+--------------+------------+------------+-----------------+
+| 2.1.1          | 2.1+2.0.1    | 2001       | PSF        | yes             |
++----------------+--------------+------------+------------+-----------------+
+| 2.1.2          | 2.1.1        | 2002       | PSF        | yes             |
++----------------+--------------+------------+------------+-----------------+
+| 2.1.3          | 2.1.2        | 2002       | PSF        | yes             |
++----------------+--------------+------------+------------+-----------------+
+| 2.2 and above  | 2.1.1        | 2001-now   | PSF        | yes             |
++----------------+--------------+------------+------------+-----------------+
+
+.. note::
+
+   GPL-compatible doesn't mean that we're distributing Python under the GPL.  All
+   Python licenses, unlike the GPL, let you distribute a modified version without
+   making your changes open source. The GPL-compatible licenses make it possible to
+   combine Python with other software that is released under the GPL; the others
+   don't.
+
+Thanks to the many outside volunteers who have worked under Guido's direction to
+make these releases possible.
+
+
+Terms and conditions for accessing or otherwise using Python
+============================================================
+
+
+PSF LICENSE AGREEMENT FOR PYTHON |release|
+------------------------------------------
+
+.. parsed-literal::
+
+   1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
+      the Individual or Organization ("Licensee") accessing and otherwise using Python
+      |release| software in source or binary form and its associated documentation.
+
+   2. Subject to the terms and conditions of this License Agreement, PSF hereby
+      grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+      analyze, test, perform and/or display publicly, prepare derivative works,
+      distribute, and otherwise use Python |release| alone or in any derivative
+      version, provided, however, that PSF's License Agreement and PSF's notice of
+      copyright, i.e., "Copyright © 2001-2019 Python Software Foundation; All Rights
+      Reserved" are retained in Python |release| alone or in any derivative version
+      prepared by Licensee.
+
+   3. In the event Licensee prepares a derivative work that is based on or
+      incorporates Python |release| or any part thereof, and wants to make the
+      derivative work available to others as provided herein, then Licensee hereby
+      agrees to include in any such work a brief summary of the changes made to Python
+      |release|.
+
+   4. PSF is making Python |release| available to Licensee on an "AS IS" basis.
+      PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
+      EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
+      WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
+      USE OF PYTHON |release| WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+   5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON |release|
+      FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+      MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON |release|, OR ANY DERIVATIVE
+      THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+   6. This License Agreement will automatically terminate upon a material breach of
+      its terms and conditions.
+
+   7. Nothing in this License Agreement shall be deemed to create any relationship
+      of agency, partnership, or joint venture between PSF and Licensee.  This License
+      Agreement does not grant permission to use PSF trademarks or trade name in a
+      trademark sense to endorse or promote products or services of Licensee, or any
+      third party.
+
+   8. By copying, installing or otherwise using Python |release|, Licensee agrees
+      to be bound by the terms and conditions of this License Agreement.
+
+
+BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+-------------------------------------------
+
+BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+
+.. parsed-literal::
+
+   1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an office at
+      160 Saratoga Avenue, Santa Clara, CA 95051, and the Individual or Organization
+      ("Licensee") accessing and otherwise using this software in source or binary
+      form and its associated documentation ("the Software").
+
+   2. Subject to the terms and conditions of this BeOpen Python License Agreement,
+      BeOpen hereby grants Licensee a non-exclusive, royalty-free, world-wide license
+      to reproduce, analyze, test, perform and/or display publicly, prepare derivative
+      works, distribute, and otherwise use the Software alone or in any derivative
+      version, provided, however, that the BeOpen Python License is retained in the
+      Software, alone or in any derivative version prepared by Licensee.
+
+   3. BeOpen is making the Software available to Licensee on an "AS IS" basis.
+      BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
+      EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
+      WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
+      USE OF THE SOFTWARE WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+   4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE SOFTWARE FOR
+      ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF USING,
+      MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY DERIVATIVE THEREOF, EVEN IF
+      ADVISED OF THE POSSIBILITY THEREOF.
+
+   5. This License Agreement will automatically terminate upon a material breach of
+      its terms and conditions.
+
+   6. This License Agreement shall be governed by and interpreted in all respects
+      by the law of the State of California, excluding conflict of law provisions.
+      Nothing in this License Agreement shall be deemed to create any relationship of
+      agency, partnership, or joint venture between BeOpen and Licensee.  This License
+      Agreement does not grant permission to use BeOpen trademarks or trade names in a
+      trademark sense to endorse or promote products or services of Licensee, or any
+      third party.  As an exception, the "BeOpen Python" logos available at
+      http://www.pythonlabs.com/logos.html may be used according to the permissions
+      granted on that web page.
+
+   7. By copying, installing or otherwise using the software, Licensee agrees to be
+      bound by the terms and conditions of this License Agreement.
+
+
+CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+---------------------------------------
+
+.. parsed-literal::
+
+   1. This LICENSE AGREEMENT is between the Corporation for National Research
+      Initiatives, having an office at 1895 Preston White Drive, Reston, VA 20191
+      ("CNRI"), and the Individual or Organization ("Licensee") accessing and
+      otherwise using Python 1.6.1 software in source or binary form and its
+      associated documentation.
+
+   2. Subject to the terms and conditions of this License Agreement, CNRI hereby
+      grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+      analyze, test, perform and/or display publicly, prepare derivative works,
+      distribute, and otherwise use Python 1.6.1 alone or in any derivative version,
+      provided, however, that CNRI's License Agreement and CNRI's notice of copyright,
+      i.e., "Copyright © 1995-2001 Corporation for National Research Initiatives; All
+      Rights Reserved" are retained in Python 1.6.1 alone or in any derivative version
+      prepared by Licensee.  Alternately, in lieu of CNRI's License Agreement,
+      Licensee may substitute the following text (omitting the quotes): "Python 1.6.1
+      is made available subject to the terms and conditions in CNRI's License
+      Agreement.  This Agreement together with Python 1.6.1 may be located on the
+      Internet using the following unique, persistent identifier (known as a handle):
+      1895.22/1013.  This Agreement may also be obtained from a proxy server on the
+      Internet using the following URL: http://hdl.handle.net/1895.22/1013."
+
+   3. In the event Licensee prepares a derivative work that is based on or
+      incorporates Python 1.6.1 or any part thereof, and wants to make the derivative
+      work available to others as provided herein, then Licensee hereby agrees to
+      include in any such work a brief summary of the changes made to Python 1.6.1.
+
+   4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS" basis.  CNRI
+      MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF EXAMPLE,
+      BUT NOT LIMITATION, CNRI MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY
+      OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF
+      PYTHON 1.6.1 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+   5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 1.6.1 FOR
+      ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+      MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1, OR ANY DERIVATIVE
+      THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+   6. This License Agreement will automatically terminate upon a material breach of
+      its terms and conditions.
+
+   7. This License Agreement shall be governed by the federal intellectual property
+      law of the United States, including without limitation the federal copyright
+      law, and, to the extent such U.S. federal law does not apply, by the law of the
+      Commonwealth of Virginia, excluding Virginia's conflict of law provisions.
+      Notwithstanding the foregoing, with regard to derivative works based on Python
+      1.6.1 that incorporate non-separable material that was previously distributed
+      under the GNU General Public License (GPL), the law of the Commonwealth of
+      Virginia shall govern this License Agreement only as to issues arising under or
+      with respect to Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in
+      this License Agreement shall be deemed to create any relationship of agency,
+      partnership, or joint venture between CNRI and Licensee.  This License Agreement
+      does not grant permission to use CNRI trademarks or trade name in a trademark
+      sense to endorse or promote products or services of Licensee, or any third
+      party.
+
+   8. By clicking on the "ACCEPT" button where indicated, or by copying, installing
+      or otherwise using Python 1.6.1, Licensee agrees to be bound by the terms and
+      conditions of this License Agreement.
+
+
+CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+--------------------------------------------------
+
+.. parsed-literal::
+
+   Copyright © 1991 - 1995, Stichting Mathematisch Centrum Amsterdam, The
+   Netherlands.  All rights reserved.
+
+   Permission to use, copy, modify, and distribute this software and its
+   documentation for any purpose and without fee is hereby granted, provided that
+   the above copyright notice appear in all copies and that both that copyright
+   notice and this permission notice appear in supporting documentation, and that
+   the name of Stichting Mathematisch Centrum or CWI not be used in advertising or
+   publicity pertaining to distribution of the software without specific, written
+   prior permission.
+
+   STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+   SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+   EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE FOR ANY SPECIAL, INDIRECT
+   OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+   DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+   ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+   SOFTWARE.
+
 
 Licenses and Acknowledgements for Incorporated Software
 =======================================================
@@ -133,14 +596,14 @@ Project, http://www.wide.ad.jp/. ::
       without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
-   GAI_ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
    ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
-   FOR GAI_ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-   HOWEVER CAUSED AND ON GAI_ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN GAI_ANY WAY
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
    SUCH DAMAGE.
 
@@ -453,6 +916,143 @@ notice::
     ***************************************************************/
 
 
+OpenSSL
+-------
+
+The modules :mod:`hashlib`, :mod:`posix`, :mod:`ssl`, :mod:`crypt` use
+the OpenSSL library for added performance if made available by the
+operating system. Additionally, the Windows and Mac OS X installers for
+Python may include a copy of the OpenSSL libraries, so we include a copy
+of the OpenSSL license here::
+
+
+  LICENSE ISSUES
+  ==============
+
+  The OpenSSL toolkit stays under a dual license, i.e. both the conditions of
+  the OpenSSL License and the original SSLeay license apply to the toolkit.
+  See below for the actual license texts. Actually both licenses are BSD-style
+  Open Source licenses. In case of any license issues related to OpenSSL
+  please contact openssl-core@openssl.org.
+
+  OpenSSL License
+  ---------------
+
+    /* ====================================================================
+     * Copyright (c) 1998-2008 The OpenSSL Project.  All rights reserved.
+     *
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions
+     * are met:
+     *
+     * 1. Redistributions of source code must retain the above copyright
+     *    notice, this list of conditions and the following disclaimer.
+     *
+     * 2. Redistributions in binary form must reproduce the above copyright
+     *    notice, this list of conditions and the following disclaimer in
+     *    the documentation and/or other materials provided with the
+     *    distribution.
+     *
+     * 3. All advertising materials mentioning features or use of this
+     *    software must display the following acknowledgment:
+     *    "This product includes software developed by the OpenSSL Project
+     *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+     *
+     * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+     *    endorse or promote products derived from this software without
+     *    prior written permission. For written permission, please contact
+     *    openssl-core@openssl.org.
+     *
+     * 5. Products derived from this software may not be called "OpenSSL"
+     *    nor may "OpenSSL" appear in their names without prior written
+     *    permission of the OpenSSL Project.
+     *
+     * 6. Redistributions of any form whatsoever must retain the following
+     *    acknowledgment:
+     *    "This product includes software developed by the OpenSSL Project
+     *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+     *
+     * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+     * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+     * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+     * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+     * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+     * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+     * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+     * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+     * OF THE POSSIBILITY OF SUCH DAMAGE.
+     * ====================================================================
+     *
+     * This product includes cryptographic software written by Eric Young
+     * (eay@cryptsoft.com).  This product includes software written by Tim
+     * Hudson (tjh@cryptsoft.com).
+     *
+     */
+
+ Original SSLeay License
+ -----------------------
+
+    /* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+     * All rights reserved.
+     *
+     * This package is an SSL implementation written
+     * by Eric Young (eay@cryptsoft.com).
+     * The implementation was written so as to conform with Netscapes SSL.
+     *
+     * This library is free for commercial and non-commercial use as long as
+     * the following conditions are aheared to.  The following conditions
+     * apply to all code found in this distribution, be it the RC4, RSA,
+     * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+     * included with this distribution is covered by the same copyright terms
+     * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+     *
+     * Copyright remains Eric Young's, and as such any Copyright notices in
+     * the code are not to be removed.
+     * If this package is used in a product, Eric Young should be given attribution
+     * as the author of the parts of the library used.
+     * This can be in the form of a textual message at program startup or
+     * in documentation (online or textual) provided with the package.
+     *
+     * Redistribution and use in source and binary forms, with or without
+     * modification, are permitted provided that the following conditions
+     * are met:
+     * 1. Redistributions of source code must retain the copyright
+     *    notice, this list of conditions and the following disclaimer.
+     * 2. Redistributions in binary form must reproduce the above copyright
+     *    notice, this list of conditions and the following disclaimer in the
+     *    documentation and/or other materials provided with the distribution.
+     * 3. All advertising materials mentioning features or use of this software
+     *    must display the following acknowledgement:
+     *    "This product includes cryptographic software written by
+     *     Eric Young (eay@cryptsoft.com)"
+     *    The word 'cryptographic' can be left out if the rouines from the library
+     *    being used are not cryptographic related :-).
+     * 4. If you include any Windows specific code (or a derivative thereof) from
+     *    the apps directory (application code) you must include an acknowledgement:
+     *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+     *
+     * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+     * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+     * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+     * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+     * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+     * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+     * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+     * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+     * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+     * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+     * SUCH DAMAGE.
+     *
+     * The licence and distribution terms for any publically available version or
+     * derivative of this code cannot be changed.  i.e. this code cannot simply be
+     * copied and put under another distribution licence
+     * [including the GNU Public Licence.]
+     */
+
+
 expat
 -----
 
@@ -613,504 +1213,3 @@ library unless the build is configured ``--with-system-libmpdec``::
    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
    SUCH DAMAGE.
-
----------------------------------------------------------------------------
-
-Additional attribution text found in the source:
-
-::::::::::::::
-Lib/bsddb/__init__.py
-::::::::::::::
-#  Copyright (c) 1999-2001, Digital Creations, Fredericksburg, VA, USA
-#  and Andrew Kuchling. All rights reserved.
-#
-#  Redistribution and use in source and binary forms, with or without
-#  modification, are permitted provided that the following conditions are
-#  met:
-#
-#    o Redistributions of source code must retain the above copyright
-#      notice, this list of conditions, and the disclaimer that follows.
-#
-#    o Redistributions in binary form must reproduce the above copyright
-#      notice, this list of conditions, and the following disclaimer in
-#      the documentation and/or other materials provided with the
-#      distribution.
-#
-#    o Neither the name of Digital Creations nor the names of its
-#      contributors may be used to endorse or promote products derived
-#      from this software without specific prior written permission.
-#
-#  THIS SOFTWARE IS PROVIDED BY DIGITAL CREATIONS AND CONTRIBUTORS *AS
-#  IS* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-#  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-#  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL DIGITAL
-#  CREATIONS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-#  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-#  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-#  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-#  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-#  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-#  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-#  DAMAGE.
-::::::::::::::
-Lib/compiler/transformer.py
-::::::::::::::
-# Original version written by Greg Stein (gstein@lyra.org)
-#                         and Bill Tutt (rassilon@lima.mudlib.org)
-# February 1997.
-#
-# Modifications and improvements for Python 2.0 by Jeremy Hylton and
-# Mark Hammond
-#
-# Some fixes to try to have correct line number on almost all nodes
-# (except Module, Discard and Stmt) added by Sylvain Thenault
-#
-# Portions of this file are:
-# Copyright (C) 1997-1998 Greg Stein. All Rights Reserved.
-#
-# This module is provided under a BSD-ish license. See
-#   http://www.opensource.org/licenses/bsd-license.html
-# and replace OWNER, ORGANIZATION, and YEAR as appropriate.
-::::::::::::::
-Lib/lib-tk/turtle.py
-::::::::::::::
-# Copyright (C) 2006 - 2010  Gregor Lingl
-# email: glingl@aon.at
-#
-# This software is provided 'as-is', without any express or implied
-# warranty.  In no event will the authors be held liable for any damages
-# arising from the use of this software.
-#
-# Permission is granted to anyone to use this software for any purpose,
-# including commercial applications, and to alter it and redistribute it
-# freely, subject to the following restrictions:
-#
-# 1. The origin of this software must not be misrepresented; you must not
-#    claim that you wrote the original software. If you use this software
-#    in a product, an acknowledgment in the product documentation would be
-#    appreciated but is not required.
-# 2. Altered source versions must be plainly marked as such, and must not be
-#    misrepresented as being the original software.
-# 3. This notice may not be removed or altered from any source distribution.
-::::::::::::::
-Lib/logging/__init__.py
-::::::::::::::
-# Copyright 2001-2016 by Vinay Sajip. All Rights Reserved.
-#
-# Permission to use, copy, modify, and distribute this software and its
-# documentation for any purpose and without fee is hereby granted,
-# provided that the above copyright notice appear in all copies and that
-# both that copyright notice and this permission notice appear in
-# supporting documentation, and that the name of Vinay Sajip
-# not be used in advertising or publicity pertaining to distribution
-# of the software without specific, written prior permission.
-# VINAY SAJIP DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
-# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL
-# VINAY SAJIP BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR
-# ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
-# IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-::::::::::::::
-Lib/multiprocessing/__init__.py
-::::::::::::::
-# Copyright (c) 2006-2008, R Oudkerk
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-#
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-# 3. Neither the name of author nor the names of any contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-::::::::::::::
-Lib/optparse.py
-::::::::::::::
-Copyright (c) 2001-2006 Gregory P. Ward.  All rights reserved.
-Copyright (c) 2002-2006 Python Software Foundation.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-  * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-
-  * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-
-  * Neither the name of the author nor the names of its
-    contributors may be used to endorse or promote products derived from
-    this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-::::::::::::::
-Lib/platform.py
-::::::::::::::
-    Copyright (c) 1999-2000, Marc-Andre Lemburg; mailto:mal@lemburg.com
-    Copyright (c) 2000-2010, eGenix.com Software GmbH; mailto:info@egenix.com
-
-    Permission to use, copy, modify, and distribute this software and its
-    documentation for any purpose and without fee or royalty is hereby granted,
-    provided that the above copyright notice appear in all copies and that
-    both that copyright notice and this permission notice appear in
-    supporting documentation or portions thereof, including modifications,
-    that you make.
-
-    EGENIX.COM SOFTWARE GMBH DISCLAIMS ALL WARRANTIES WITH REGARD TO
-    THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-    FITNESS, IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL,
-    INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
-    FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
-    NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
-    WITH THE USE OR PERFORMANCE OF THIS SOFTWARE !
-::::::::::::::
-Lib/profile.py
-::::::::::::::
-# Copyright Disney Enterprises, Inc.  All Rights Reserved.
-# Licensed to PSF under a Contributor Agreement
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied.  See the License for the specific language
-# governing permissions and limitations under the License.
-::::::::::::::
-Lib/sqlite3/__init__.py
-::::::::::::::
-# Copyright (C) 2005 Gerhard H?ring <gh@ghaering.de>
-#
-# This file is part of pysqlite.
-#
-# This software is provided 'as-is', without any express or implied
-# warranty.  In no event will the authors be held liable for any damages
-# arising from the use of this software.
-#
-# Permission is granted to anyone to use this software for any purpose,
-# including commercial applications, and to alter it and redistribute it
-# freely, subject to the following restrictions:
-#
-# 1. The origin of this software must not be misrepresented; you must not
-#    claim that you wrote the original software. If you use this software
-#    in a product, an acknowledgment in the product documentation would be
-#    appreciated but is not required.
-# 2. Altered source versions must be plainly marked as such, and must not be
-#    misrepresented as being the original software.
-# 3. This notice may not be removed or altered from any source distribution.
-::::::::::::::
-Lib/tarfile.py
-::::::::::::::
-# Copyright (C) 2002 Lars Gust?bel <lars@gustaebel.de>
-# All rights reserved.
-#
-# Permission  is  hereby granted,  free  of charge,  to  any person
-# obtaining a  copy of  this software  and associated documentation
-# files  (the  "Software"),  to   deal  in  the  Software   without
-# restriction,  including  without limitation  the  rights to  use,
-# copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies  of  the  Software,  and to  permit  persons  to  whom the
-# Software  is  furnished  to  do  so,  subject  to  the  following
-# conditions:
-#
-# The above copyright  notice and this  permission notice shall  be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS  IS", WITHOUT WARRANTY OF ANY  KIND,
-# EXPRESS OR IMPLIED, INCLUDING  BUT NOT LIMITED TO  THE WARRANTIES
-# OF  MERCHANTABILITY,  FITNESS   FOR  A  PARTICULAR   PURPOSE  AND
-# NONINFRINGEMENT.  IN  NO  EVENT SHALL  THE  AUTHORS  OR COPYRIGHT
-# HOLDERS  BE LIABLE  FOR ANY  CLAIM, DAMAGES  OR OTHER  LIABILITY,
-# WHETHER  IN AN  ACTION OF  CONTRACT, TORT  OR OTHERWISE,  ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-::::::::::::::
-Lib/unittest.py
-::::::::::::::
-Copyright (c) 1999-2003 Steve Purcell
-This module is free software, and you may redistribute it and/or modify
-it under the same terms as Python itself, so long as this copyright message
-and disclaimer are retained in their original form.
-
-IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
-SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OF
-THIS CODE, EVEN IF THE AUTHOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-
-THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE.  THE CODE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
-AND THERE IS NO OBLIGATION WHATSOEVER TO PROVIDE MAINTENANCE,
-SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-::::::::::::::
-Modules/_localemodule.c
-::::::::::::::
-Copyright (C) 1997, 2002, 2003 Martin von Loewis
-
-Permission to use, copy, modify, and distribute this software and its
-documentation for any purpose and without fee is hereby granted,
-provided that the above copyright notice appear in all copies.
-
-This software comes with no warranty. Use at your own risk.
-::::::::::::::
-Modules/parsermodule.c
-::::::::::::::
- *  Copyright 1995-1996 by Fred L. Drake, Jr. and Virginia Polytechnic
- *  Institute and State University, Blacksburg, Virginia, USA.
- *  Portions copyright 1991-1995 by Stichting Mathematisch Centrum,
- *  Amsterdam, The Netherlands.  Copying is permitted under the terms
- *  associated with the main Python distribution, with the additional
- *  restriction that this additional notice be included and maintained
- *  on all distributed copies.
-::::::::::::::
-Modules/timing.h
-::::::::::::::
-/*
- * Copyright (c) 1993 George V. Neville-Neil
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. The name, George Neville-Neil may not be used to endorse or promote
- *    products derived from this software without specific prior
- *    written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- */
-::::::::::::::
-Parser/spark.py
-::::::::::::::
-#  Copyright (c) 1998-2002 John Aycock
-#
-#  Permission is hereby granted, free of charge, to any person obtaining
-#  a copy of this software and associated documentation files (the
-#  "Software"), to deal in the Software without restriction, including
-#  without limitation the rights to use, copy, modify, merge, publish,
-#  distribute, sublicense, and/or sell copies of the Software, and to
-#  permit persons to whom the Software is furnished to do so, subject to
-#  the following conditions:
-#
-#  The above copyright notice and this permission notice shall be
-#  included in all copies or substantial portions of the Software.
-#
-#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-#  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-#  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-#  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-#  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-#  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-::::::::::::::
-Python/getopt.c
-::::::::::::::
- * Copyright 1992-1994, David Gottner
- *
- *                    All Rights Reserved
- *
- * Permission to use, copy, modify, and distribute this software and its
- * documentation for any purpose and without fee is hereby granted,
- * provided that the above copyright notice, this permission notice and
- * the following disclaimer notice appear unmodified in all copies.
- *
- * I DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.  IN NO EVENT SHALL I
- * BE LIABLE FOR ANY SPECIAL, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
- * DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA, OR PROFITS, WHETHER
- * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
- * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * Nevertheless, I would like to know about bugs in this library or
- * suggestions for improvment.  Send bug reports and feedback to
- * davegottner@delphi.com.
-::::::::::::::
-Tools/pybench/LICENSE
-::::::::::::::
-pybench License
----------------
-
-This copyright notice and license applies to all files in the pybench
-directory of the pybench distribution.
-
-Copyright (c), 1997-2006, Marc-Andre Lemburg (mal@lemburg.com)
-Copyright (c), 2000-2006, eGenix.com Software GmbH (info@egenix.com)
-
-                   All Rights Reserved.
-
-Permission to use, copy, modify, and distribute this software and its
-documentation for any purpose and without fee or royalty is hereby
-granted, provided that the above copyright notice appear in all copies
-and that both that copyright notice and this permission notice appear
-in supporting documentation or portions thereof, including
-modifications, that you make.
-
-THE AUTHOR MARC-ANDRE LEMBURG DISCLAIMS ALL WARRANTIES WITH REGARD TO
-THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS, IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL,
-INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
-FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
-NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
-WITH THE USE OR PERFORMANCE OF THIS SOFTWARE !
-::::::::::::::
-Tools/pynche/X/xlicense.txt
-::::::::::::::
-X Window System License - X11R6.4
-
-Copyright (c) 1998 The Open Group
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE OPEN GROUP BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-Except as contained in this notice, the name of The Open Group shall
-not be used in advertising or otherwise to promote the sale, use or
-other dealings in this Software without prior written authorization
-from The Open Group.
-
-X Window System is a trademark of The Open Group
-::::::::::::::
-install-sh
-::::::::::::::
-#!/bin/sh
-#
-# install - install a program, script, or datafile
-#
-# This originates from X11R5 (mit/util/scripts/install.sh), which was
-# later released in X11R6 (xc/config/util/install.sh) with the
-# following copyright and license.
-#
-# Copyright (C) 1994 X Consortium
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to
-# deal in the Software without restriction, including without limitation the
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-# sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-# X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
-# AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNEC-
-# TION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-# Except as contained in this notice, the name of the X Consortium shall not
-# be used in advertising or otherwise to promote the sale, use or other deal-
-# ings in this Software without prior written authorization from the X Consor-
-# tium.
-::::::::::::::
-Include/dynamic_annotations.h
-Python/dynamic_annotations.c
-::::::::::::::
-/* Copyright (c) 2008-2009, Google Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- *
- *     * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *     * Neither the name of Google Inc. nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * ---
- * Author: Kostya Serebryany
- */
-::::::::::::::
-Lib/statistics.py
-::::::::::::::
-##  Module statistics.py
-##
-##  Copyright (c) 2013 Steven D'Aprano <steve+python@pearwood.info>.
-##
-##  Licensed under the Apache License, Version 2.0 (the "License");
-##  you may not use this file except in compliance with the License.
-##  You may obtain a copy of the License at
-##
-##  http://www.apache.org/licenses/LICENSE-2.0
-##
-##  Unless required by applicable law or agreed to in writing, software
-##  distributed under the License is distributed on an "AS IS" BASIS,
-##  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-##  See the License for the specific language governing permissions and
-##  limitations under the License.

--- a/components/python/python35/test/results-64.master
+++ b/components/python/python35/test/results-64.master
@@ -1,7 +1,7 @@
 373 tests OK.
 8 tests failed:
-    test_cmd_line_script test_concurrent_futures test_import test_mmap
-    test_selectors test_socket test_strftime test_zipimport
+    test_cmd_line_script test_import test_mmap test_re test_selectors
+    test_socket test_strftime test_zipimport
 18 tests skipped:
     test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
     test_smtpnet test_socketserver test_startfile test_timeout

--- a/components/python/python35/tkinter-35.p5m
+++ b/components/python/python35/tkinter-35.p5m
@@ -23,14 +23,14 @@
 set name=pkg.fmri \
     value=pkg:/library/python/tkinter-35@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="Python 3.5 bindings to tcl/tk"
-set name=info.classification \
-    value=org.opensolaris.category.2008:Development/Python
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-#
-file path=usr/lib/python3.5/lib-dynload/_tkinter.cpython-35m.so \
-    pkg.linted.userland.action001.2=true
+
+license python35.license license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python3.5/lib-dynload/_tkinter.cpython-35m.so pkg.linted.userland.action001.2=true
 file path=usr/lib/python3.5/tkinter/__init__.py
 file path=usr/lib/python3.5/tkinter/__main__.py
 file path=usr/lib/python3.5/tkinter/colorchooser.py
@@ -64,5 +64,3 @@ file path=usr/lib/python3.5/tkinter/test/test_ttk/test_widgets.py
 file path=usr/lib/python3.5/tkinter/test/widget_tests.py
 file path=usr/lib/python3.5/tkinter/tix.py
 file path=usr/lib/python3.5/tkinter/ttk.py
-#
-license python35.license license=PSFv2


### PR DESCRIPTION
Release notes: https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-8-final

**Testing**

One new failure in `test_re`:

```
======================================================================
FAIL: test_locale_caching (test.test_re.ReTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/userland/ws/oi-userland/components/python/python35/Python-3.5.8/Lib/test/test_re.py", line 1614, in test_locale_caching
    self.check_en_US_utf8()
  File "/userland/ws/oi-userland/components/python/python35/Python-3.5.8/Lib/test/test_re.py", line 1631, in check_en_US_utf8
    self.assertIsNone(re.match(b'\xc5', b'\xe5', re.L|re.I))
AssertionError: <_sre.SRE_Match object; span=(0, 1), match=b'\xe5'> is not None
``