### PR TITLE
evolution-data-server: fix build

### DIFF
--- a/components/desktop/gnome3/evolution-data-server/Makefile
+++ b/components/desktop/gnome3/evolution-data-server/Makefile
@@ -22,6 +22,10 @@
 #
 # Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
 #
+
+BUILD_BITS= 64
+BUILD_STYLE= cmake
+
 include ../../../../make-rules/shared-macros.mk
 
 # Despite its name, evolution-data-server is no longer just a backend for the
@@ -32,6 +36,7 @@ COMPONENT_NAME=		evolution-data-server
 COMPONENT_MJR_VERSION=	3.24
 COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
+COMPONENT_REVISION=	1
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
 COMPONENT_SUMMARY=      The GNOME backend for contacts, tasks, and calendar information
@@ -44,9 +49,7 @@ COMPONENT_FMRI=	library/desktop/evolution-data-server
 COMPONENT_LICENSE=	LGPLv2
 COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/cmake.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
@@ -69,16 +72,6 @@ CMAKE_OPTIONS += -DWITH_OPENLDAP=OFF
 CMAKE_OPTIONS += -DWITH_SUNLDAP=ON
 CMAKE_OPTIONS += -DENABLE_VALA_BINDINGS=ON
 CMAKE_OPTIONS += -DSYSCONF_INSTALL_DIR="/etc"
-
-# Parallel build fails
-#COMPONENT_BUILD_ARGS=
-
-# common targets
-build:          $(BUILD_64)
-
-install:        $(INSTALL_64)
-
-test:           $(TEST_64)
 
 # Tests are not reliable. Some tests which failed sporadically were removed,
 # but some other still sometimes fail. Test framework also fails when 

--- a/components/desktop/gnome3/evolution-data-server/patches/07-correct-rpath.patch
+++ b/components/desktop/gnome3/evolution-data-server/patches/07-correct-rpath.patch
@@ -18,3 +18,13 @@
  
  if(WIN32)
  	# On Win32 there is no "rpath" mechanism. We install the private
+--- evolution-data-server-3.24.0/cmake/modules/GObjectIntrospection.cmake.~1~	2017-03-20 11:47:25.000000000 +0000
++++ evolution-data-server-3.24.0/cmake/modules/GObjectIntrospection.cmake	2019-12-20 17:26:31.713993742 +0000
+@@ -227,7 +228,6 @@
+ 		${_gir_extra_libdirs}
+ 		${_gir_identifies_prefixes}
+ 		${_gir_deps}
+-		--library-path=${LIB_INSTALL_DIR}
+ 		${_extra_library_path}
+ 		--pkg-export ${pkg_export_prefix}-${gir_library_version}
+ 		--c-include=${c_include}

--- a/components/desktop/gnome3/evolution-data-server/test/results-all.master
+++ b/components/desktop/gnome3/evolution-data-server/test/results-all.master
@@ -1,6 +1,6 @@
 Test project $(@D)
  1/84 Test  #1: ebookbackendgoogle-phonenumber ............***Not Run   
- 2/84 Test  #2: test-migration ............................***Exception: Other  
+ 2/84 Test  #2: test-migration ............................Child aborted***Exception:   
  3/84 Test  #3: test-ebook-add-contact ....................   Passed    
  4/84 Test  #4: test-ebook-get-contact ....................   Passed    
  5/84 Test  #5: test-ebook-commit-contact .................   Passed    
@@ -33,7 +33,7 @@ Test project $(@D)
 32/84 Test #32: test-book-client-revision-view ............   Passed    
 33/84 Test #33: test-book-client-view-operations ..........   Passed    
 34/84 Test #34: test-book-client-suppress-notifications ...   Passed    
-35/84 Test #35: test-book-client-cursor-create ............   Passed   
+35/84 Test #35: test-book-client-cursor-create ............   Passed    
 36/84 Test #36: test-contact-types ........................   Passed    
 37/84 Test #37: test-vcard-parsing ........................   Passed    
 38/84 Test #38: test-untyped-phones .......................   Passed    
@@ -69,24 +69,24 @@ Test project $(@D)
 68/84 Test #68: test-cal-client-get-view ..................   Passed    
 69/84 Test #69: test-cal-client-revision-view .............   Passed    
 70/84 Test #70: test-cal-client-get-free-busy .............   Passed    
-71/84 Test #71: test-sqlite-get-contact ...................***Exception: Other  
+71/84 Test #71: test-sqlite-get-contact ...................SIGTRAP***Exception:   
 72/84 Test #72: test-sqlite-create-cursor .................   Passed    
 73/84 Test #73: test-sqlite-cursor-move-by-posix ..........   Passed    
 74/84 Test #74: test-sqlite-cursor-move-by-en-US ..........   Passed    
 75/84 Test #75: test-sqlite-cursor-move-by-fr-CA ..........   Passed    
 76/84 Test #76: test-sqlite-cursor-move-by-de-DE ..........   Passed    
-77/84 Test #77: test-sqlite-cursor-set-target .............***Exception: Other  
+77/84 Test #77: test-sqlite-cursor-set-target .............SIGTRAP***Exception:   
 78/84 Test #78: test-sqlite-cursor-calculate ..............   Passed    
 79/84 Test #79: test-sqlite-cursor-set-sexp ...............   Passed    
 80/84 Test #80: test-sqlite-cursor-change-locale ..........   Passed    
 81/84 Test #81: test-cal-backend-sexp .....................   Passed    
 82/84 Test #82: test-intervaltree .........................   Passed    
 83/84 Test #83: e-source-registry-test ....................   Passed    
-84/84 Test #84: test-fixture ..............................   Passed   
+84/84 Test #84: test-fixture ..............................   Passed    
 Total Test time (real) = 
 The following tests FAILED:
 	  1 - ebookbackendgoogle-phonenumber (Not Run)
-	  2 - test-migration (OTHER_FAULT)
-	 71 - test-sqlite-get-contact (OTHER_FAULT)
-	 77 - test-sqlite-cursor-set-target (OTHER_FAULT)
+	  2 - test-migration (Child aborted)
+	 71 - test-sqlite-get-contact (SIGTRAP)
+	 77 - test-sqlite-cursor-set-target (SIGTRAP)
 Errors while running CTest


### PR DESCRIPTION
g-ir-scanner tends to translate libpath to rpath, efficiently adding /usr/lib/amd64 to rpath and thus breaking the build.