### PR TITLE
Update GnuPG to 2.2.19

### DIFF
--- a/components/sysutils/gnupg/Makefile
+++ b/components/sysutils/gnupg/Makefile
@@ -23,20 +23,20 @@
 # Copyright (c) 2019, Michal Nowak
 #
 
+BUILD_BITS=		64
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnupg
-COMPONENT_VERSION=	2.2.17
+COMPONENT_VERSION=	2.2.19
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	http://www.gnupg.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:afa262868e39b651a2db4c071fba90415154243e83a830ca00516f9a807fd514
+	sha256:242554c0e06f3a83c420b052f750b65ead711cc3fddddb5e7274fcdbb4e9dec0
 COMPONENT_ARCHIVE_URL=	ftp://ftp.gnupg.org/gcrypt/gnupg/$(COMPONENT_ARCHIVE)
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
@@ -86,9 +86,7 @@ CONFIGURE_OPTIONS  +=		--with-readline=$(CONFIGURE_PREFIX)
 
 MAN8LIST = addgnupghome applygnupgdefaults
 
-build:		$(BUILD_32)
-
-install:	$(INSTALL_32)
+install:	$(INSTALL_64)
 	( cd $(PROTOUSRSHARELOCALEDIR) ; \
 	    $(CP) -R 'en@boldquot' en )
 	( cd $(PROTOUSRSHAREMANDIR) ; \
@@ -99,8 +97,6 @@ install:	$(INSTALL_32)
 	    if test -f $$f.8 ; then \
 	    $(MV) -f $$f.8 $$f.1m ; fi ; \
 	    done )
-
-test:		$(TEST_32)
 
 # Missing dependencies for pinentry
 REQUIRED_PACKAGES += library/desktop/gtk2


### PR DESCRIPTION
Move from 32 to 64-bit.

**Release notes**
- 2.2.18: https://dev.gnupg.org/T4684
- 2.2.19: https://dev.gnupg.org/T4768

**Testing**
- internal tests look good
- needs some testing in my environments