### PR TITLE
Update libidn2 to 2.3.0

### DIFF
--- a/components/library/libidn2/Makefile
+++ b/components/library/libidn2/Makefile
@@ -14,15 +14,17 @@
 # Copyright 2019 Michal Nowak
 #
 
+BUILD_BITS=		32_and_64
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libidn2
-COMPONENT_VERSION=	2.2.0
+COMPONENT_VERSION=	2.3.0
 COMPONENT_SUMMARY=	An implementation of IDNA2008 internationalized domain names
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:fc734732b506d878753ec6606982bf7b936e868c25c30ddb0d83f7d7056381fe
+	sha256:e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5
 COMPONENT_ARCHIVE_URL= \
 	http://ftp.gnu.org/gnu/libidn/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://www.gnu.org/software/libidn/
@@ -30,9 +32,7 @@ COMPONENT_FMRI=		library/libidn2
 COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_LICENSE=	LGPLv3, GPLv2
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_OPTIONS += --sysconfdir=/etc
 CONFIGURE_OPTIONS += --enable-static=no
@@ -46,12 +46,6 @@ COMPONENT_TEST_TRANSFORMS += '-ne "/^===/p" '
 COMPONENT_TEST_TRANSFORMS += '-ne "/^\# /p" '
 
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
-
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/libunistring

--- a/components/library/libidn2/libidn2.p5m
+++ b/components/library/libidn2/libidn2.p5m
@@ -26,13 +26,13 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/bin/$(MACH64)/idn2
 file path=usr/bin/idn2
 file path=usr/include/idn2/idn2.h
-link path=usr/lib/$(MACH64)/libidn2.so target=libidn2.so.0.3.6
-link path=usr/lib/$(MACH64)/libidn2.so.0 target=libidn2.so.0.3.6
-file path=usr/lib/$(MACH64)/libidn2.so.0.3.6
+link path=usr/lib/$(MACH64)/libidn2.so target=libidn2.so.0.3.7
+link path=usr/lib/$(MACH64)/libidn2.so.0 target=libidn2.so.0.3.7
+file path=usr/lib/$(MACH64)/libidn2.so.0.3.7
 file path=usr/lib/$(MACH64)/pkgconfig/libidn2.pc
-link path=usr/lib/libidn2.so target=libidn2.so.0.3.6
-link path=usr/lib/libidn2.so.0 target=libidn2.so.0.3.6
-file path=usr/lib/libidn2.so.0.3.6
+link path=usr/lib/libidn2.so target=libidn2.so.0.3.7
+link path=usr/lib/libidn2.so.0 target=libidn2.so.0.3.7
+file path=usr/lib/libidn2.so.0.3.7
 file path=usr/lib/pkgconfig/libidn2.pc
 #file path=usr/share/info/dir
 file path=usr/share/info/libidn2.info

--- a/components/library/libidn2/manifests/sample-manifest.p5m
+++ b/components/library/libidn2/manifests/sample-manifest.p5m
@@ -25,13 +25,13 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/bin/$(MACH64)/idn2
 file path=usr/bin/idn2
 file path=usr/include/idn2/idn2.h
-link path=usr/lib/$(MACH64)/libidn2.so target=libidn2.so.0.3.6
-link path=usr/lib/$(MACH64)/libidn2.so.0 target=libidn2.so.0.3.6
-file path=usr/lib/$(MACH64)/libidn2.so.0.3.6
+link path=usr/lib/$(MACH64)/libidn2.so target=libidn2.so.0.3.7
+link path=usr/lib/$(MACH64)/libidn2.so.0 target=libidn2.so.0.3.7
+file path=usr/lib/$(MACH64)/libidn2.so.0.3.7
 file path=usr/lib/$(MACH64)/pkgconfig/libidn2.pc
-link path=usr/lib/libidn2.so target=libidn2.so.0.3.6
-link path=usr/lib/libidn2.so.0 target=libidn2.so.0.3.6
-file path=usr/lib/libidn2.so.0.3.6
+link path=usr/lib/libidn2.so target=libidn2.so.0.3.7
+link path=usr/lib/libidn2.so.0 target=libidn2.so.0.3.7
+file path=usr/lib/libidn2.so.0.3.7
 file path=usr/lib/pkgconfig/libidn2.pc
 file path=usr/share/info/dir
 file path=usr/share/info/libidn2.info

--- a/components/library/libidn2/test/results-all.master
+++ b/components/library/libidn2/test/results-all.master
@@ -3,17 +3,15 @@ PASS: test-lookup
 PASS: test-register
 PASS: test-strerror
 PASS: test-tounicode
-FAIL: test-glibc
 ============================================================================
 ============================================================================
-# TOTAL: 6
+# TOTAL: 5
 # PASS:  5
 # SKIP:  0
 # XFAIL: 0
-# FAIL:  1
+# FAIL:  0
 # XPASS: 0
 # ERROR: 0
-============================================================================
 ============================================================================
 PASS: libidn2_to_ascii_8z_fuzzer
 PASS: libidn2_to_unicode_8z8z_fuzzer


### PR DESCRIPTION
ABI checker is clean: https://abi-laboratory.pro/index.php?view=timeline&l=libidn2

**Testing**

öko.de still works with Curl and Wget.