### PR TITLE
Update Ruby 2.3 to 2.3.8 (security)

### DIFF
--- a/components/ruby/ruby-23/Makefile
+++ b/components/ruby/ruby-23/Makefile
@@ -21,26 +21,23 @@
 
 #
 # Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020, Michal Nowak
 #
+
+BUILD_BITS=		32
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ruby
-COMPONENT_VERSION=	2.3.7
+COMPONENT_VERSION=	2.3.8
 COMPONENT_PROJECT_URL=	http://www.ruby-lang.org/
-COMPONENT_SRC=	\
-	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:c61f8f2b9d3ffff5567e186421fa191f0d5e7c2b189b426bb84498825d548edb
+	sha256:910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
+COMPONENT_ARCHIVE_URL=	https://cache.ruby-lang.org/pub/ruby/2.3/$(COMPONENT_ARCHIVE)
 
-COMPONENT_ARCHIVE_URL=	\
-	https://cache.ruby-lang.org/pub/ruby/2.3/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	utility/ruby
-
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/ips.mk
-include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/common.mk
 
 # COMPONENT_VERSION <major>.<minor>.<teeny>
 # is transformed into <major>.<minor> for RUBY_VER.
@@ -120,17 +117,7 @@ CFLAGS +=		-DFFI_NO_RAW_API
 CLEAN_PATHS +=		Solaris/gem.1 Solaris/rbconfig.sedscript.mod \
 			Solaris/ruby.1.sedscript.mod
 
-include $(WS_MAKE_RULES)/shared-targets.mk
-
-# common targets
-
-build:		$(BUILD_32)
-
-install:	$(INSTALL_32)
-
-# 16082 tests, 2239351 assertions, 0 failures, 1 errors, 50 skips
-# RuntimeError: Error in TestGem#test_self_install_in_rescue
-test:	$(TEST_32)
+# 16084 tests, 2236321 assertions, 2 failures, 1 errors, 49 skips
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += SUNWcs

--- a/components/ruby/ruby-23/patches/05-config.patch
+++ b/components/ruby/ruby-23/patches/05-config.patch
@@ -3,24 +3,23 @@ use "amd64" and "sparcv9" for the 64-bit cpu string.
 Changes were developed in-house, are Solaris specific,
 and are not suitable for upstream.
 
-diff -ru ruby-1.9.3-p484-orig//tool/config.guess ruby-1.9.3-p484/tool/config.guess
---- ruby-1.9.3-p484-orig//tool/config.guess	Sat Sep 25 18:25:34 2010
-+++ ruby-2.3.3/tool/config.guess	2016-11-29 21:28:28.580030490 +0300
-@@ -373,25 +373,18 @@
- 	echo sparc-hal-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
+--- ruby-2.3.8/tool/config.guess	2018-10-17 17:38:36.000000000 +0000
++++ ruby-2.3.8/tool/config.guess	2020-01-01 10:38:08.914901439 +0000
+@@ -383,25 +383,18 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAM
+ 	echo sparc-hal-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
  	exit ;;
      sun4*:SunOS:5.*:* | tadpole*:SunOS:5.*:*)
--	echo sparc-sun-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
-+        # Check CFLAGS for the 64-bit compile option to set the arch
-+        SUN_ARCH="sparc"
-+        echo $CFLAGS | /usr/gnu/bin/grep -q -w '\-m64' && SUN_ARCH="sparcv9"
-+        echo ${SUN_ARCH}-sun-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
+-	echo sparc-sun-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
++	# Check CFLAGS for the 64-bit compile option to set the arch
++	SUN_ARCH="sparc"
++	echo $CFLAGS | /usr/gnu/bin/grep -q -w '\-m64' && SUN_ARCH="sparcv9"
++	echo ${SUN_ARCH}-sun-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
  	exit ;;
      i86pc:AuroraUX:5.*:* | i86xen:AuroraUX:5.*:*)
- 	echo i386-pc-auroraux${UNAME_RELEASE}
+ 	echo i386-pc-auroraux"$UNAME_RELEASE"
  	exit ;;
      i86pc:SunOS:5.*:* | i86xen:SunOS:5.*:*)
--	eval $set_cc_for_build
+-	eval "$set_cc_for_build"
  	SUN_ARCH=i386
 -	# If there is a compiler, see if it is configured for 64-bit objects.
 -	# Note that the Sun cc does not turn __LP64__ into 1 like gcc does.
@@ -33,20 +32,19 @@ diff -ru ruby-1.9.3-p484-orig//tool/config.guess ruby-1.9.3-p484/tool/config.gue
 -		SUN_ARCH=x86_64
 -	    fi
 -	fi
-+        # Check CFLAGS for the 64-bit compile option to set the arch
-+        echo $CFLAGS | /usr/gnu/bin/grep -q -w '\-m64' && SUN_ARCH="amd64"
- 	echo ${SUN_ARCH}-pc-solaris2`echo ${UNAME_RELEASE}|sed -e 's/[^.]*//'`
++	# Check CFLAGS for the 64-bit compile option to set the arch
++	echo $CFLAGS | /usr/gnu/bin/grep -q -w '\-m64' && SUN_ARCH="amd64"
+ 	echo "$SUN_ARCH"-pc-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
  	exit ;;
      sun4*:SunOS:6*:*)
-diff -ru ruby-1.9.3-p484-orig//tool/config.sub ruby-1.9.3-p484/tool/config.sub
---- ruby-1.9.3-p484-orig//tool/config.sub	Sun Oct  3 08:06:23 2010
-+++ ruby-1.9.3-p484/tool/config.sub	Tue Feb 25 15:54:21 2014
-@@ -431,7 +431,7 @@
-		basic_machine=x86_64-pc
-		;;
-	amd64-*)
--		basic_machine=x86_64-`echo $basic_machine | sed 's/^[^-]*-//'`
+--- ruby-2.3.8/tool/config.sub	2018-10-17 17:38:36.000000000 +0000
++++ ruby-2.3.8/tool/config.sub	2020-01-01 10:39:05.436599128 +0000
+@@ -799,7 +799,7 @@ case $basic_machine in
+ 		basic_machine=x86_64-pc
+ 		;;
+ 	amd64-*)
+-		basic_machine=x86_64-`echo "$basic_machine" | sed 's/^[^-]*-//'`
 +		# don't change basic_machine
-		;;
-	amdahl)
-		basic_machine=580-amdahl
+ 		;;
+ 	amiga | amiga-*)
+ 		basic_machine=m68k-unknown


### PR DESCRIPTION
Release notes: http://www.ruby-lang.org/en/news/2018/10/17/ruby-2-3-8-released/

**Testing**

Test suite has two failures and a one error (which is two failures more compared to v2.3.4):
```
Running tests:

[  549/16091] IMAPTest#test_imaps_with_ca_file = 0.01 s                                             
  1) Failure:
IMAPTest#test_imaps_with_ca_file [/export/home/newman/ws/oi-userland/components/ruby/ruby-23/build/i86/.ext/common/openssl/ssl.rb:404]:
Exception raised:
<#<OpenSSL::SSL::SSLError: SSL_accept returned=1 errno=0 state=error: sslv3 alert certificate expired>>.

[  551/16091] IMAPTest#test_starttls = 0.01 s           
  2) Failure:
IMAPTest#test_starttls [/export/home/newman/ws/oi-userland/components/ruby/ruby-23/ruby-2.3.8/test/net/imap/test_imap.rb:21]:
exceptions on 1 threads:
#<Thread:0x0c34da08@/export/home/newman/ws/oi-userland/components/ruby/ruby-23/ruby-2.3.8/test/net/imap/test_imap.rb:573 dead>:
/export/home/newman/ws/oi-userland/components/ruby/ruby-23/ruby-2.3.8/test/net/imap/test_imap.rb:589:in `accept': SSL_accept returned=1 errno=0 state=error: sslv3 alert certificate expired (OpenSSL::SSL::SSLError)
	from /export/home/newman/ws/oi-userland/components/ruby/ruby-23/ruby-2.3.8/test/net/imap/test_imap.rb:589:in `block in starttls_test'

[ 5636/16091] TestGem#test_self_install_in_rescue = 0.10 s                                                                                                            
  3) Error:
TestGem#test_self_install_in_rescue:
RuntimeError: Error
    /export/home/newman/ws/oi-userland/components/ruby/ruby-23/ruby-2.3.8/test/rubygems/test_gem.rb:103:in `test_self_install_in_rescue'

Leaked file descriptor: TestPsych#test_load_file_with_fallback: 19 : #<File:/tmp/empty20200101-13300-1488kzfyml>        
Closed file descriptor: TestPsych#test_line_width_invalid: 19
Leaked file descriptor: TestTempfile#test_create_traversal_dir: 19 : #<File:/tmp/......................exporthomenewmanwsoi-userlandcomponentsrubyruby-23buildi86foo20200101-13300-18g0h7j>
Closed file descriptor: TestTempfile#test_create_with_block: 19
```