### PR TITLE
Update libgsasl to 1.8.1

### DIFF
--- a/components/library/libgsasl/Makefile
+++ b/components/library/libgsasl/Makefile
@@ -10,29 +10,28 @@
 
 #
 # Copyright (c) 2014 Alexander Pyhalov. All rights reserved
+# Copyright (c) 2020 Michal Nowak
 #
+
+BUILD_BITS=		32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libgsasl
-COMPONENT_VERSION=	1.8.0
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	1.8.1
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/gsasl/
 COMPONENT_SUMMARY=	Implementation of the Simple Authentication and Security Layer framework 
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	\
-	sha256:3adfb49f9c92a719dea855fd1840d698cde55d4648d332a69032ba8bea207720
-COMPONENT_FMRI=		library/libgsasl
-COMPONENT_CLASSIFICATION=	System/Libraries
-COMPONENT_LICENSE= GPLv3
-COMPONENT_LICENSE_FILE= COPYING
-    
 COMPONENT_ARCHIVE_URL=	ftp://ftp.gnu.org/gnu/gsasl/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:19e2f90525c531010918c50bb1febef0d7115d620150cc66153b9ce73ff814e6
+COMPONENT_FMRI=		library/libgsasl
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_LICENSE=	GPLv3
+COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
@@ -41,13 +40,7 @@ CFLAGS+= -I/usr/include/idn
 CONFIGURE_OPTIONS.32 += --sysconfdir=/etc
 CONFIGURE_OPTIONS.32 += --libexecdir=/usr/lib
 CONFIGURE_OPTIONS.64 += --libexecdir=/usr/lib/$(MACH64)
-
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
+CONFIGURE_OPTIONS += --disable-static
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/libidn

--- a/components/library/libgsasl/libgsasl.p5m
+++ b/components/library/libgsasl/libgsasl.p5m
@@ -10,6 +10,7 @@
 
 #
 # Copyright 2014 Alexander Pyhalov. All rights reserved.
+# Copyright 2020 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,24 +25,29 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/include/gsasl-compat.h
 file path=usr/include/gsasl-mech.h
 file path=usr/include/gsasl.h
-link path=usr/lib/$(MACH64)/libgsasl.so target=libgsasl.so.7.9.6
-link path=usr/lib/$(MACH64)/libgsasl.so.7 target=libgsasl.so.7.9.6
-file path=usr/lib/$(MACH64)/libgsasl.so.7.9.6
+link path=usr/lib/$(MACH64)/libgsasl.so target=libgsasl.so.7.9.7
+link path=usr/lib/$(MACH64)/libgsasl.so.7 target=libgsasl.so.7.9.7
+file path=usr/lib/$(MACH64)/libgsasl.so.7.9.7
 file path=usr/lib/$(MACH64)/pkgconfig/libgsasl.pc
-link path=usr/lib/libgsasl.so target=libgsasl.so.7.9.6
-link path=usr/lib/libgsasl.so.7 target=libgsasl.so.7.9.6
-file path=usr/lib/libgsasl.so.7.9.6
+link path=usr/lib/libgsasl.so target=libgsasl.so.7.9.7
+link path=usr/lib/libgsasl.so.7 target=libgsasl.so.7.9.7
+file path=usr/lib/libgsasl.so.7.9.7
 file path=usr/lib/pkgconfig/libgsasl.pc
+file path=usr/share/locale/da/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/de/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/en@boldquot/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/en@quot/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/eo/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/es/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/fi/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/fr/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/ga/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/hu/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/id/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/it/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/nl/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/pl/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/ro/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/sk/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/sr/LC_MESSAGES/libgsasl.mo

--- a/components/library/libgsasl/manifests/sample-manifest.p5m
+++ b/components/library/libgsasl/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -25,26 +25,29 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/include/gsasl-compat.h
 file path=usr/include/gsasl-mech.h
 file path=usr/include/gsasl.h
-file path=usr/lib/$(MACH64)/libgsasl.a
-link path=usr/lib/$(MACH64)/libgsasl.so target=libgsasl.so.7.9.6
-link path=usr/lib/$(MACH64)/libgsasl.so.7 target=libgsasl.so.7.9.6
-file path=usr/lib/$(MACH64)/libgsasl.so.7.9.6
+link path=usr/lib/$(MACH64)/libgsasl.so target=libgsasl.so.7.9.7
+link path=usr/lib/$(MACH64)/libgsasl.so.7 target=libgsasl.so.7.9.7
+file path=usr/lib/$(MACH64)/libgsasl.so.7.9.7
 file path=usr/lib/$(MACH64)/pkgconfig/libgsasl.pc
-file path=usr/lib/libgsasl.a
-link path=usr/lib/libgsasl.so target=libgsasl.so.7.9.6
-link path=usr/lib/libgsasl.so.7 target=libgsasl.so.7.9.6
-file path=usr/lib/libgsasl.so.7.9.6
+link path=usr/lib/libgsasl.so target=libgsasl.so.7.9.7
+link path=usr/lib/libgsasl.so.7 target=libgsasl.so.7.9.7
+file path=usr/lib/libgsasl.so.7.9.7
 file path=usr/lib/pkgconfig/libgsasl.pc
+file path=usr/share/locale/da/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/de/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/en@boldquot/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/en@quot/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/eo/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/es/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/fi/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/fr/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/ga/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/hu/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/id/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/it/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/nl/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/pl/LC_MESSAGES/libgsasl.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/ro/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/sk/LC_MESSAGES/libgsasl.mo
 file path=usr/share/locale/sr/LC_MESSAGES/libgsasl.mo


### PR DESCRIPTION
**Release notes**: https://lists.gnu.org/archive/html/info-gnu/2020-01/msg00000.html

**Testing**: Internal test suite passed.