### PR TITLE
Update check to 0.13.0, fix libxcb tests

### DIFF
--- a/components/developer/check/Makefile
+++ b/components/developer/check/Makefile
@@ -11,12 +11,15 @@
 
 #
 # Copyright 2014-2017 Aurelien Larcher.  All rights reserved.
+# Copyright 2020, Michal Nowak
 #
+
+BUILD_BITS=		32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		check
-COMPONENT_VERSION=	0.12.0
+COMPONENT_VERSION=	0.13.0
 COMPONENT_FMRI=		developer/check
 COMPONENT_SUMMARY=	Unit Testing Framework for C
 COMPONENT_PROJECT_URL=	https://libcheck.github.io/check
@@ -24,14 +27,12 @@ COMPONENT_CLASSIFICATION=Development/C
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:464201098bee00e90f5c4bdfa94a5d3ead8d641f9025b560a27755a83b824234
+	sha256:c4336b31447acc7e3266854f73ec188cdb15554d0edd44739631da174a569909
 COMPONENT_ARCHIVE_URL=\
 	https://github.com/libcheck/check/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	LGPLv2
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CFLAGS+=-std=gnu99
 
@@ -55,13 +56,6 @@ COMPONENT_TEST_TRANSFORMS += \
         '-e "/PASS:/p" ' \
         '-e "/FAIL:/p" ' \
         '-e "/ERROR:/p" '
-
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-# All tests pass
-test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/developer/check/check.p5m
+++ b/components/developer/check/check.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2014-2015 Aurelien Larcher
+# Copyright 2020, Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -39,26 +40,4 @@ file path=usr/share/doc/check/COPYING.LESSER
 file path=usr/share/doc/check/ChangeLog
 file path=usr/share/doc/check/NEWS
 file path=usr/share/doc/check/README
-file path=usr/share/doc/check/example/Makefile.am
-file path=usr/share/doc/check/example/README
-file path=usr/share/doc/check/example/configure.ac
-file path=usr/share/doc/check/example/src/Makefile.am
-file path=usr/share/doc/check/example/src/main.c
-file path=usr/share/doc/check/example/src/money.1.c
-file path=usr/share/doc/check/example/src/money.1.h
-file path=usr/share/doc/check/example/src/money.2.h
-file path=usr/share/doc/check/example/src/money.3.c
-file path=usr/share/doc/check/example/src/money.4.c
-file path=usr/share/doc/check/example/src/money.5.c
-file path=usr/share/doc/check/example/src/money.6.c
-file path=usr/share/doc/check/example/src/money.c
-file path=usr/share/doc/check/example/src/money.h
-file path=usr/share/doc/check/example/tests/Makefile.am
-file path=usr/share/doc/check/example/tests/check_money.1.c
-file path=usr/share/doc/check/example/tests/check_money.2.c
-file path=usr/share/doc/check/example/tests/check_money.3.c
-file path=usr/share/doc/check/example/tests/check_money.6.c
-file path=usr/share/doc/check/example/tests/check_money.7.c
-file path=usr/share/doc/check/example/tests/check_money.c
-file path=usr/share/info/check.info
 file path=usr/share/man/man1/checkmk.1

--- a/components/developer/check/manifests/sample-manifest.p5m
+++ b/components/developer/check/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -39,27 +39,4 @@ file path=usr/share/doc/check/COPYING.LESSER
 file path=usr/share/doc/check/ChangeLog
 file path=usr/share/doc/check/NEWS
 file path=usr/share/doc/check/README
-file path=usr/share/doc/check/example/Makefile.am
-file path=usr/share/doc/check/example/README
-file path=usr/share/doc/check/example/configure.ac
-file path=usr/share/doc/check/example/src/Makefile.am
-file path=usr/share/doc/check/example/src/main.c
-file path=usr/share/doc/check/example/src/money.1.c
-file path=usr/share/doc/check/example/src/money.1.h
-file path=usr/share/doc/check/example/src/money.2.h
-file path=usr/share/doc/check/example/src/money.3.c
-file path=usr/share/doc/check/example/src/money.4.c
-file path=usr/share/doc/check/example/src/money.5.c
-file path=usr/share/doc/check/example/src/money.6.c
-file path=usr/share/doc/check/example/src/money.c
-file path=usr/share/doc/check/example/src/money.h
-file path=usr/share/doc/check/example/tests/Makefile.am
-file path=usr/share/doc/check/example/tests/check_money.1.c
-file path=usr/share/doc/check/example/tests/check_money.2.c
-file path=usr/share/doc/check/example/tests/check_money.3.c
-file path=usr/share/doc/check/example/tests/check_money.6.c
-file path=usr/share/doc/check/example/tests/check_money.7.c
-file path=usr/share/doc/check/example/tests/check_money.c
-file path=usr/share/info/check.info
-file path=usr/share/info/dir
 file path=usr/share/man/man1/checkmk.1

--- a/components/x11/libxcb/Makefile
+++ b/components/x11/libxcb/Makefile
@@ -27,6 +27,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME=        libxcb
 COMPONENT_VERSION=     1.13
+COMPONENT_REVISION=    1
 COMPONENT_FMRI=        x11/library/libxcb
 COMPONENT_SUMMARY=     The X protocol C-language Binding (XCB): Libraries
 COMPONENT_PROJECT_URL= http://xcb.freedesktop.org
@@ -65,6 +66,8 @@ CONFIGURE_OPTIONS+= --enable-xv
 CONFIGURE_OPTIONS+= --enable-xvmc 
 CONFIGURE_OPTIONS+= --with-queue-size=32768 
 CONFIGURE_OPTIONS+= --with-pic
+
+unexport SHELLOPTS
 
 # Build dependencies
 REQUIRED_PACKAGES += developer/check

--- a/components/x11/libxcb/patches/01-check-0.13.0-fix.patch
+++ b/components/x11/libxcb/patches/01-check-0.13.0-fix.patch
@@ -1,0 +1,43 @@
+https://gitlab.freedesktop.org/xorg/lib/libxcb/issues/43
+https://gitlab.freedesktop.org/xorg/lib/libxcb/merge_requests/6
+
+From a667ec3e0cf5d9cd1d1715e3fff3328e353fae84 Mon Sep 17 00:00:00 2001
+From: "A. Wilcox" <AWilcox@Wilcox-Tech.com>
+Date: Mon, 23 Dec 2019 21:49:29 -0600
+Subject: [PATCH] tests: Support Check 0.13.0 API
+
+---
+ tests/check_all.c    | 4 ++--
+ tests/check_suites.h | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/check_all.c b/tests/check_all.c
+index 4393422..f201dec 100644
+--- a/tests/check_all.c
++++ b/tests/check_all.c
+@@ -1,10 +1,10 @@
+ #include <stdlib.h>
+ #include "check_suites.h"
+ 
+-void suite_add_test(Suite *s, TFun tf, const char *name)
++void suite_add_test(Suite *s, const TTest *tt, const char *name)
+ {
+ 	TCase *tc = tcase_create(name);
+-	tcase_add_test(tc, tf);
++	tcase_add_test(tc, tt);
+ 	suite_add_tcase(s, tc);
+ }
+ 
+diff --git a/tests/check_suites.h b/tests/check_suites.h
+index 499f1af..595923a 100644
+--- a/tests/check_suites.h
++++ b/tests/check_suites.h
+@@ -1,4 +1,4 @@
+ #include <check.h>
+ 
+-void suite_add_test(Suite *s, TFun tf, const char *name);
++void suite_add_test(Suite *s, const TTest *tt, const char *name);
+ Suite *public_suite(void);
+-- 
+2.24.1
+


### PR DESCRIPTION
**Release notes**: https://github.com/libcheck/check/releases/tag/0.13.0

**Testing**: `libxcb` and `PulseAudio` test suites require `check`, they both did not regress with updated check.