### PR TITLE
Revert "12118 system/library/install has gone" workaround

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -557,9 +557,6 @@ $(BUILD_DIR)/$(MACH)/publish.transforms: $(BUILD_DIR)/$(MACH)/.overlay
 	echo "<transform depend fmri=pkg:/system/storage/parted@.* -> drop>" >> $(BUILD_DIR)/$(MACH)/publish.transforms
 	echo "<transform depend fmri=pkg:/system/zones/brand/lx@.* -> drop>" >> $(BUILD_DIR)/$(MACH)/publish.transforms
 
-	# Temporary fix for https://www.illumos.org/issues/12118
-	echo "<transform depend fmri=system/library/install -> drop>" >> $(BUILD_DIR)/$(MACH)/publish.transforms
-
 	# Needed for MTA replacement
 	echo "<transform depend type=require fmri=pkg:/service/network/smtp/sendmail@.* -> emit depend type=require fmri=pkg:/system/mta>" >> $(BUILD_DIR)/$(MACH)/publish.transforms
 	echo "<transform depend type=require fmri=pkg:/service/network/smtp/sendmail@.* -> drop>" >> $(BUILD_DIR)/$(MACH)/publish.transforms


### PR DESCRIPTION
This reverts commit f2f6c9b64ad326201e78f2e65747f544c49ba11c as 12118 was integrated as https://github.com/illumos/illumos-gate/commit/07493f32b693ae8ddef96861c721ea94eb66b126.