### PR TITLE
Update Hexchat to 2.14

### DIFF
--- a/components/desktop/hexchat/Makefile
+++ b/components/desktop/hexchat/Makefile
@@ -10,47 +10,42 @@
 
 #
 # Copyright 2016 Marcel Telka <marcel@telka.sk>
+# Copyright 2020 Michal Nowak
 #
+
+BUILD_BITS=		32
+BUILD_STYLE=		meson
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		hexchat
-COMPONENT_VERSION=	2.12.4
-COMPONENT_REVISION=	3
+COMPONENT_VERSION=	2.14.3
 COMPONENT_PROJECT_URL=	https://hexchat.github.io/
 COMPONENT_SUMMARY=	HexChat IRC client
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:fa35913158bbc7d0d99de79371b6df3e8d21802f1d2c7c92f0e5db694acf2c3a
+	sha256:901a9d13db5a4da69b827f6093306bbd16863dc49016f7668bd3e4506512e882
 COMPONENT_ARCHIVE_URL=	https://dl.hexchat.net/hexchat/$(COMPONENT_ARCHIVE)
+
 # We need to use non-default User-Agent for the fetch, otherwise we are denied
 # to download the source file.
 COMPONENT_FETCH_USER_AGENT= fetch
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=           $(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
-# This is a workaround for hexchat-2.12.4 packaging bugs
-COMPONENT_PREP_ACTION =        ( cd $(@D) && autoreconf -vif )
+#CONFIGURE_OPTIONS += -Dwith-python=python-2.7
+CONFIGURE_OPTIONS += -Dwith-lua=false
+CONFIGURE_OPTIONS += -Dwith-appdata=false
+CONFIGURE_OPTIONS += -Dwith-plugin=false
 
-CONFIGURE_ENV += OBJC=$(CC)
-CONFIGURE_ENV += PERL=$(PERL)
-CONFIGURE_ENV += INTLTOOL_PERL=$(PERL)
-
-CONFIGURE_OPTIONS += --enable-python=python2.7
-# Avoid using luajit since static linking is broken
-CONFIGURE_OPTIONS += LUA="lua"
-
-build:          $(BUILD_32)
-
-install:        $(INSTALL_32)
-
-test:           $(NO_TESTS)
-
+REQUIRED_PACKAGES += runtime/perl-522
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
 REQUIRED_PACKAGES += library/desktop/gtk2
 REQUIRED_PACKAGES += library/desktop/pango
@@ -59,9 +54,6 @@ REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/libnotify
 REQUIRED_PACKAGES += library/libproxy
 REQUIRED_PACKAGES += library/security/openssl
-REQUIRED_PACKAGES += runtime/lua
-REQUIRED_PACKAGES += runtime/perl-522
-REQUIRED_PACKAGES += runtime/python-27
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += system/library/libdbus-glib
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/desktop/hexchat/hexchat.p5m
+++ b/components/desktop/hexchat/hexchat.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2016 Marcel Telka <marcel@telka.sk>
+# Copyright 2020 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/desktop/irc/hexchat@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,15 +24,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license COPYING license='GPLv2'
 
 file path=usr/bin/hexchat
-file path=usr/include/hexchat-plugin.h
-file path=usr/lib/hexchat/plugins/checksum.so
-file path=usr/lib/hexchat/plugins/fishlim.so
-file path=usr/lib/hexchat/plugins/lua.so
-file path=usr/lib/hexchat/plugins/perl.so
-file path=usr/lib/hexchat/plugins/python.so
-file path=usr/lib/pkgconfig/hexchat-plugin.pc
-file path=usr/share/appdata/hexchat.appdata.xml
-file path=usr/share/applications/hexchat.desktop
+file path=usr/share/applications/io.github.Hexchat.desktop
 file path=usr/share/dbus-1/services/org.hexchat.service.service
 file path=usr/share/icons/hicolor/48x48/apps/hexchat.png
 file path=usr/share/icons/hicolor/scalable/apps/hexchat.svg

--- a/components/desktop/hexchat/manifests/sample-manifest.p5m
+++ b/components/desktop/hexchat/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,15 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/hexchat
-file path=usr/include/hexchat-plugin.h
-file path=usr/lib/hexchat/plugins/checksum.so
-file path=usr/lib/hexchat/plugins/fishlim.so
-file path=usr/lib/hexchat/plugins/lua.so
-file path=usr/lib/hexchat/plugins/perl.so
-file path=usr/lib/hexchat/plugins/python.so
-file path=usr/lib/pkgconfig/hexchat-plugin.pc
-file path=usr/share/appdata/hexchat.appdata.xml
-file path=usr/share/applications/hexchat.desktop
+file path=usr/share/applications/io.github.Hexchat.desktop
 file path=usr/share/dbus-1/services/org.hexchat.service.service
 file path=usr/share/icons/hicolor/48x48/apps/hexchat.png
 file path=usr/share/icons/hicolor/scalable/apps/hexchat.svg

--- a/components/desktop/hexchat/patches/ctcp-version.patch
+++ b/components/desktop/hexchat/patches/ctcp-version.patch
@@ -1,6 +1,5 @@
-diff -urN hexchat-2.12.0.orig/src/common/util.c hexchat-2.12.0/src/common/util.c
---- hexchat-2.12.0.orig/src/common/util.c	2016-03-07 00:25:32.000000000 +0100
-+++ hexchat-2.12.0/src/common/util.c	2016-04-10 15:49:12.891503656 +0200
+--- hexchat-2.14.3/src/common/util.c	2019-12-21 07:43:47.702403000 +0000
++++ hexchat-2.14.3/src/common/util.c	2020-01-02 12:03:02.367758918 +0000
 @@ -61,6 +61,10 @@
  #endif
  #endif
@@ -12,16 +11,16 @@ diff -urN hexchat-2.12.0.orig/src/common/util.c hexchat-2.12.0/src/common/util.c
  char *
  file_part (char *file)
  {
-@@ -360,7 +364,7 @@
+@@ -360,7 +364,7 @@ strip_hidden_attribute (char *src, char
  	return len;
  }
  
--#if defined (USING_LINUX) || defined (USING_FREEBSD) || defined (__APPLE__) || defined (__CYGWIN__)
-+#if defined (USING_LINUX) || defined (USING_FREEBSD) || defined (__APPLE__) || defined (__CYGWIN__) || (defined (__SVR4) && defined (__sun))
+-#if defined (__linux__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__CYGWIN__)
++#if defined (__linux__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__CYGWIN__) || (defined (__SVR4) && defined (__sun))
  
  static void
  get_cpu_info (double *mhz, int *cpus)
-@@ -450,6 +454,37 @@
+@@ -450,6 +454,37 @@ get_cpu_info (double *mhz, int *cpus)
  	*mhz = (freq / 1000000);
  
  #endif
@@ -59,33 +58,21 @@ diff -urN hexchat-2.12.0.orig/src/common/util.c hexchat-2.12.0/src/common/util.c
  
  }
  #endif
-@@ -495,7 +530,7 @@
+@@ -495,7 +530,7 @@ get_sys_str (int with_cpu)
  char *
  get_sys_str (int with_cpu)
  {
--#if defined (USING_LINUX) || defined (USING_FREEBSD) || defined (__APPLE__) || defined (__CYGWIN__)
-+#if defined (USING_LINUX) || defined (USING_FREEBSD) || defined (__APPLE__) || defined (__CYGWIN__) || (defined (__SVR4) && defined (__sun))
+-#if defined (__linux__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__CYGWIN__)
++#if defined (__linux__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__CYGWIN__) || (defined (__SVR4) && defined (__sun))
  	double mhz;
  #endif
  	int cpus = 1;
-@@ -507,7 +542,7 @@
+@@ -507,7 +542,7 @@ get_sys_str (int with_cpu)
  
  	uname (&un);
  
--#if defined (USING_LINUX) || defined (USING_FREEBSD) || defined (__APPLE__) || defined (__CYGWIN__)
-+#if defined (USING_LINUX) || defined (USING_FREEBSD) || defined (__APPLE__) || defined (__CYGWIN__) || (defined (__SVR4) && defined (__sun))
+-#if defined (__linux__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__CYGWIN__)
++#if defined (__linux__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__CYGWIN__) || (defined (__SVR4) && defined (__sun))
  	get_cpu_info (&mhz, &cpus);
  	if (mhz && with_cpu)
  	{
---- hexchat-2.12.4/src/fe-gtk/Makefile.am.orig	2020-03-22 14:57:18.684986137 +0000
-+++ hexchat-2.12.4/src/fe-gtk/Makefile.am	2020-03-22 15:00:14.283254444 +0000
-@@ -7,7 +7,8 @@
- 
- AM_CPPFLAGS = $(GUI_CFLAGS) -DLOCALEDIR=\"$(localedir)\"
- 
--hexchat_LDADD = $(top_builddir)/src/common/libhexchatcommon.a $(GUI_LIBS)
-+LIBS+= -lssp -lssp_nonshared
-+hexchat_LDADD = $(top_builddir)/src/common/libhexchatcommon.a $(GUI_LIBS) -lkstat
- 
- EXTRA_DIST = \
- 	ascii.h banlist.h chanlist.h chanview.h chanview-tabs.c \

--- a/components/desktop/hexchat/patches/fix-de-gtk.patch
+++ b/components/desktop/hexchat/patches/fix-de-gtk.patch
@@ -1,0 +1,20 @@
+--- hexchat-2.14.3/src/fe-gtk/meson.build	2019-12-21 07:43:47.705736400 +0000
++++ hexchat-2.14.3/src/fe-gtk/meson.build.new	2020-01-02 12:54:22.246102942 +0000
+@@ -41,7 +41,7 @@ endif
+ 
+ hexchat_gtk_cflags = []
+ 
+-hexchat_gtk_ldflags = []
++hexchat_gtk_ldflags = ['-lkstat', '-lsocket', '-lnsl', '-lssp', '-lssp_nonshared']
+ 
+ if get_option('with-libnotify')
+   hexchat_gtk_sources += 'notifications/notification-libnotify.c'
+@@ -85,7 +85,7 @@ executable('hexchat',
+   dependencies: hexchat_gtk_deps,
+   c_args: hexchat_gtk_cflags,
+   link_args: hexchat_gtk_ldflags,
+-  pie: true,
++  pie: false,
+   install: true,
+   gui_app: true,
+ )

--- a/components/desktop/hexchat/patches/unknown-system.patch
+++ b/components/desktop/hexchat/patches/unknown-system.patch
@@ -1,0 +1,11 @@
+--- hexchat-2.14.3/plugins/sysinfo/meson.build	2019-12-21 07:43:47.652401700 +0000
++++ hexchat-2.14.3/plugins/sysinfo/meson.build.new	2020-01-02 12:27:17.764611458 +0000
+@@ -47,7 +47,7 @@ elif system == 'windows'
+     '../../src/common/sysinfo/win32/backend.c'
+   ]
+ else
+-  error('sysinfo: Unknown system?')
++  warning('sysinfo: Unknown system?')
+ endif
+ 
+ shared_module('sysinfo', sysinfo_sources,


### PR DESCRIPTION
Disabled plugins because they fail to build like this:
```
[73/86] Linking target plugins/checksum/checksum.so.
FAILED: plugins/checksum/checksum.so 
/usr/gcc/6/bin/gcc  -o plugins/checksum/checksum.so 'plugins/checksum/c016833@@checksum@sha/checksum.c.o' -z nodefs -shared -fPIC -Wl,--start-group -Wl,-soname,checksum.so -Wl,-z,now -m32 -O3 -m32 /usr/lib/libgio-2.0.so /usr/lib/libgobject-2.0.so /usr/lib/libglib-2.0.so -Wl,--end-group
Undefined			first referenced
 symbol  			    in file
__stack_chk_fail_local              plugins/checksum/c016833@@checksum@sha/checksum.c.o  (symbol scope specifies local binding)
ld: fatal: symbol referencing errors. No output written to plugins/checksum/checksum.so
```