### PR TITLE
Update GNU grep to 3.4

### DIFF
--- a/components/text/ggrep/Makefile
+++ b/components/text/ggrep/Makefile
@@ -20,14 +20,15 @@
 
 #
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2020, Michal Nowak
 #
+
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		grep
-COMPONENT_VERSION=	3.3
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	3.4
 COMPONENT_FMRI=		text/gnu-grep
 COMPONENT_SUMMARY= 	GNU grep utilities
 COMPONENT_CLASSIFICATION= Applications/System Utilities
@@ -35,21 +36,18 @@ COMPONENT_PROJECT_URL=	http://gnu.org/software/grep/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:b960541c499619efd6afe1fa795402e4733c8e11ebf9fafccc0bb4bccdc5b514
+	sha256:58e6751c41a7c25bfc6e9363a41786cff3ba5709cf11d5ad903cf7cce31cc3fb
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/grep/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE= GPLv3, FDLv1.3
+COMPONENT_LICENSE=	GPLv3, FDLv1.3
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_PREP_ACTION = ( cd $(@D) && \
+				aclocal -I m4 && \
+				autoheader && \
+				automake --add-missing --copy --force )
 
 PATH=$(PATH.gnu)
-
-# Enable aslr for this component
-ASLR_MODE = $(ASLR_ENABLE)
-
-# 64-bit migration
-CONFIGURE_BINDIR.64 = $(CONFIGURE_BINDIR.32)
 
 # Needed for "gmake test" to work.
 # SHELLOPTS is exported via make-rules/shared-macros.mk,
@@ -62,22 +60,15 @@ unexport SHELLOPTS
 
 # Test transforms retain only relevant results output.
 COMPONENT_TEST_TRANSFORMS += \
-        '-n ' \
-        '-e "/TOTAL/p" ' \
-        '-e "/SKIP/p" ' \
-        '-e "/PASS/p" ' \
-        '-e "/FAIL/p" ' \
-        '-e "/ERROR/p" '
+	'-n ' \
+	'-e "/TOTAL/p" ' \
+	'-e "/SKIP/p" ' \
+	'-e "/PASS/p" ' \
+	'-e "/FAIL/p" ' \
+	'-e "/ERROR/p" '
 
-# common targets
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-# 1 test fails - multibyte-white-space (something with illumos locales?)
-# 
-test:		$(TEST_64)
-
+# Since version 3.4, GNU grep is needed for build.
+REQUIRED_PACKAGES += text/gnu-grep
 # Testsuite requirements
 REQUIRED_PACKAGES += locale/tr
 REQUIRED_PACKAGES += locale/ru-extra

--- a/components/text/ggrep/patches/01-tests-git---no-gpg-sign.patch
+++ b/components/text/ggrep/patches/01-tests-git---no-gpg-sign.patch
@@ -1,0 +1,13 @@
+'git commit --no-gpg-sign' makes sure that global Git configuration won't interfere.
+
+--- grep-3.4/gnulib-tests/test-vc-list-files-git.sh	2020-01-01 18:12:27.000000000 +0000
++++ grep-3.4/gnulib-tests/test-vc-list-files-git.sh.new	2020-01-03 08:01:26.999850260 +0000
+@@ -33,7 +33,7 @@ mkdir $tmpdir && cd $tmpdir &&
+   git config user.email "you@example.com" &&
+   git config user.name "Your Name" &&
+   git add . > /dev/null &&
+-  git commit -q -a -m log &&
++  git commit -q -a -m log --no-gpg-sign &&
+   printf '%s\n' b c d/a > expected &&
+   $BOURNE_SHELL "$abs_aux_dir/vc-list-files" > actual &&
+   compare expected actual &&

--- a/components/text/ggrep/patches/02-fix-libdir.patch
+++ b/components/text/ggrep/patches/02-fix-libdir.patch
@@ -1,0 +1,13 @@
+We need 64-bit lib path.
+
+--- grep-3.4/m4/lib-prefix.m4.old	2020-01-03 09:10:56.037530527 +0000
++++ grep-3.4/m4/lib-prefix.m4	2020-01-03 09:11:00.143439526 +0000
+@@ -235,7 +235,7 @@ changequote([,])dnl
+     [acl_cv_libdirstems],
+     [dnl Try 'lib' first, because that's the default for libdir in GNU, see
+      dnl <https://www.gnu.org/prep/standards/html_node/Directory-Variables.html>.
+-     acl_libdirstem=lib
++     acl_libdirstem=lib/64
+      acl_libdirstem2=
+      acl_libdirstem3=
+      case "$host_os" in

--- a/components/text/ggrep/test/results-64.master
+++ b/components/text/ggrep/test/results-64.master
@@ -3,7 +3,7 @@ PASS: backref-alt
 PASS: backref-multibyte-slow
 PASS: backref-word
 PASS: backslash-s-and-repetition-operators
-PASS: backslash-s-vs-invalid-multitype
+PASS: backslash-s-vs-invalid-multibyte
 SKIP: big-hole
 SKIP: big-match
 PASS: bogus-wctob
@@ -22,6 +22,7 @@ PASS: count-newline
 PASS: dfa-coverage
 PASS: dfa-heap-overrun
 PASS: dfa-infloop
+PASS: dfa-invalid-utf8
 PASS: dfaexec-multibyte
 PASS: empty
 PASS: empty-line
@@ -58,7 +59,9 @@ PASS: max-count-overread
 PASS: max-count-vs-context
 PASS: mb-dot-newline
 SKIP: mb-non-UTF8-overrun
+SKIP: mb-non-UTF8-perf-Fw
 SKIP: mb-non-UTF8-performance
+SKIP: mb-non-UTF8-word-boundary
 PASS: multibyte-white-space
 PASS: multiple-begin-or-end-line
 PASS: null-byte
@@ -108,9 +111,9 @@ PASS: word-multibyte
 PASS: write-error-msg
 PASS: yesno
 PASS: z-anchor-newline
-# TOTAL: 110
-# PASS:  97
-# SKIP:  11
+# TOTAL: 113
+# PASS:  98
+# SKIP:  13
 # XFAIL: 2
 # FAIL:  0
 # XPASS: 0
@@ -172,6 +175,7 @@ PASS: test-getopt-gnu
 PASS: test-getopt-posix
 PASS: test-getprogname
 PASS: test-gettimeofday
+PASS: test-hard-locale
 PASS: test-hash
 PASS: test-i-ring
 PASS: test-iconv-h
@@ -210,6 +214,7 @@ PASS: test-memrchr
 PASS: test-nanosleep
 PASS: test-netinet_in
 PASS: test-nl_langinfo.sh
+PASS: test-nl_langinfo-mt
 PASS: test-open
 PASS: test-openat-safer
 PASS: test-openat
@@ -217,15 +222,23 @@ PASS: test-pathmax
 PASS: test-perror.sh
 PASS: test-perror2
 PASS: test-pipe
+PASS: test-pthread
+PASS: test-pthread-thread
+PASS: test-pthread_sigmask1
+PASS: test-pthread_sigmask2
 PASS: test-quotearg-simple
 PASS: test-raise
 PASS: test-read
 PASS: test-realloc-gnu
 PASS: test-regex
+PASS: test-sched
 PASS: test-select
 PASS: test-select-in.sh
 PASS: test-select-out.sh
 PASS: test-setenv
+PASS: test-setlocale_null
+PASS: test-setlocale_null-mt-one
+PASS: test-setlocale_null-mt-all
 PASS: test-setlocale1.sh
 PASS: test-setlocale2.sh
 PASS: test-setsockopt
@@ -262,6 +275,8 @@ PASS: test-sys_time
 PASS: test-sys_types
 PASS: test-sys_uio
 PASS: test-init.sh
+PASS: test-thread_self
+PASS: test-thread_create
 PASS: test-time
 PASS: test-dup-safer
 PASS: test-unistd
@@ -288,8 +303,8 @@ PASS: test-wcwidth
 PASS: test-xalloc-die.sh
 PASS: test-xstrtoimax.sh
 PASS: test-xstrtol.sh
-# TOTAL: 173
-# PASS:  166
+# TOTAL: 185
+# PASS:  178
 # SKIP:  7
 # XFAIL: 0
 # FAIL:  0


### PR DESCRIPTION
**Release notes**: https://lists.gnu.org/archive/html/info-gnu/2020-01/msg00001.html

libsigsegv detection won't work unless lib patch fixed (to what it was in GNU grep 3.3).

**Testing**: Test suite passed.