### PR TITLE
Update libsigsegv to 2.12

### DIFF
--- a/components/library/libsigsegv/Makefile
+++ b/components/library/libsigsegv/Makefile
@@ -20,28 +20,30 @@
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2017, Aurelien Larcher
+# Copyright (c) 2020, Michal Nowak
 #
+
+BUILD_BITS=		32_and_64
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libsigsegv
-COMPONENT_VERSION=	2.11
-COMPONENT_FMRI= library/libsigsegv
-COMPONENT_SUMMARY=  libsigsegv - handling page faults in user mode
+COMPONENT_VERSION=	2.12
+COMPONENT_FMRI=		library/libsigsegv
+COMPONENT_SUMMARY=	libsigsegv - handling page faults in user mode
 COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/libsigsegv/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:dd7c2eb2ef6c47189406d562c1dc0f96f2fc808036834d596075d58377e37a18
+	sha256:3ae1af359eebaa4ffc5896a1aee3568c052c99879316a1ab57f8fe1789c390b6
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/libsigsegv/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE=  GPLv2
+COMPONENT_LICENSE=	GPLv2
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
-CONFIGURE_OPTIONS  +=		--disable-static
-CONFIGURE_OPTIONS  +=		--enable-shared
+CONFIGURE_OPTIONS  +=	--disable-static
+CONFIGURE_OPTIONS  +=	--enable-shared
 
 # Test failure
 unexport SHELLOPTS
@@ -55,13 +57,6 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "/PASS/p" ' \
 	'-e "/FAIL/p" ' \
 	'-e "/ERROR/p" '
-
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/library/libsigsegv/libsigsegv.p5m
+++ b/components/library/libsigsegv/libsigsegv.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Aurelien Larcher
+# Copyright 2020 Michal Nowak
 #
 
 # pull the manpages out of the component dir
@@ -26,12 +27,12 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/sigsegv.h
-link path=usr/lib/$(MACH64)/libsigsegv.so target=libsigsegv.so.2.0.4
-link path=usr/lib/$(MACH64)/libsigsegv.so.2 target=libsigsegv.so.2.0.4
-file path=usr/lib/$(MACH64)/libsigsegv.so.2.0.4
-link path=usr/lib/libsigsegv.so target=libsigsegv.so.2.0.4
-link path=usr/lib/libsigsegv.so.2 target=libsigsegv.so.2.0.4
-file path=usr/lib/libsigsegv.so.2.0.4
+link path=usr/lib/$(MACH64)/libsigsegv.so target=libsigsegv.so.2.0.5
+link path=usr/lib/$(MACH64)/libsigsegv.so.2 target=libsigsegv.so.2.0.5
+file path=usr/lib/$(MACH64)/libsigsegv.so.2.0.5
+link path=usr/lib/libsigsegv.so target=libsigsegv.so.2.0.5
+link path=usr/lib/libsigsegv.so.2 target=libsigsegv.so.2.0.5
+file path=usr/lib/libsigsegv.so.2.0.5
 file path=usr/share/man/man3/sigsegv.3
 file path=usr/share/man/man3/sigsegv_deinstall_handler.3
 file path=usr/share/man/man3/sigsegv_dispatch.3

--- a/components/library/libsigsegv/manifests/sample-manifest.p5m
+++ b/components/library/libsigsegv/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,9 +23,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/sigsegv.h
-link path=usr/lib/$(MACH64)/libsigsegv.so target=libsigsegv.so.2.0.4
-link path=usr/lib/$(MACH64)/libsigsegv.so.2 target=libsigsegv.so.2.0.4
-file path=usr/lib/$(MACH64)/libsigsegv.so.2.0.4
-link path=usr/lib/libsigsegv.so target=libsigsegv.so.2.0.4
-link path=usr/lib/libsigsegv.so.2 target=libsigsegv.so.2.0.4
-file path=usr/lib/libsigsegv.so.2.0.4
+link path=usr/lib/$(MACH64)/libsigsegv.so target=libsigsegv.so.2.0.5
+link path=usr/lib/$(MACH64)/libsigsegv.so.2 target=libsigsegv.so.2.0.5
+file path=usr/lib/$(MACH64)/libsigsegv.so.2.0.5
+link path=usr/lib/libsigsegv.so target=libsigsegv.so.2.0.5
+link path=usr/lib/libsigsegv.so.2 target=libsigsegv.so.2.0.5
+file path=usr/lib/libsigsegv.so.2.0.5


### PR DESCRIPTION
**Release notes**: https://savannah.gnu.org/forum/forum.php?forum_id=9057
**Testing**: Test suite passed. Dependent packages still build.