### PR TITLE
Update UPower to 0.99.11

### DIFF
--- a/components/sysutils/upower/Makefile
+++ b/components/sysutils/upower/Makefile
@@ -11,28 +11,31 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
+# Copyright 2020 Michal Nowak
 #
+
+BUILD_BITS=		32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME= upower
-COMPONENT_VERSION= 0.99.7
-COMPONENT_PROJECT_URL = http://upower.freedesktop.org/
-COMPONENT_CLASSIFICATION=System/Libraries
-COMPONENT_FMRI=system/upower
-COMPONENT_SUMMARY= A service for enumerating and querying data related to power devices
-COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
+COMPONENT_NAME=		upower
+COMPONENT_VERSION=	0.99.11
+COMPONENT_PROJECT_URL=	http://upower.freedesktop.org/
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_FMRI=		system/upower
+COMPONENT_SUMMARY=	A service for enumerating and querying data related to power devices
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:24bcc2f6ab25a2533bac70b587bcb019e591293076920f5b5e04bdedc140a401
+	sha256:64b5ffbfccd5bdb15d925777979a4dbee1a957f9eaeb158dc76175267eddbdef
 COMPONENT_ARCHIVE_URL= \
-  http://upower.freedesktop.org/releases/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE= GPLv2
-COMPONENT_LICENSE_FILE= COPYING
+	http://upower.freedesktop.org/releases/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	GPLv2
+COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
@@ -40,8 +43,6 @@ CPPFLAGS += $(CPP_LARGEFILES)
 
 COMPONENT_PREP_ACTION = (cd $(@D) && \
 				libtoolize --copy --force &&\
-				glib-gettextize -f &&\
-				intltoolize --force --copy &&\
 				aclocal -I . &&\
 				autoheader &&\
 				automake -c -f -a &&\
@@ -63,12 +64,6 @@ CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
 # gobject-introspection
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
-
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
-test: $(NO_TESTS)
 
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += system/library

--- a/components/sysutils/upower/manifests/sample-manifest.p5m
+++ b/components/sysutils/upower/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,7 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=etc/UPower/UPower.conf
-file path=etc/dbus-1/system.d/org.freedesktop.UPower.conf
 file path=usr/bin/upower
 file path=usr/include/libupower-glib/up-autocleanups.h
 file path=usr/include/libupower-glib/up-client.h
@@ -51,35 +50,23 @@ file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.KbdBacklight.xml
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.Wakeups.xml
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.xml
 file path=usr/share/dbus-1/system-services/org.freedesktop.UPower.service
+file path=usr/share/dbus-1/system.d/org.freedesktop.UPower.conf
 file path=usr/share/gir-1.0/UPowerGlib-1.0.gir
-file path=usr/share/gtk-doc/html/UPower/Device.html
-file path=usr/share/gtk-doc/html/UPower/KbdBacklight.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-client.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-device.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-history-item.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-stats-item.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-types.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-wakeup-item.html
-file path=usr/share/gtk-doc/html/UPower/UPower.7.html
+file path=usr/share/gtk-doc/html/UPower/UPower-up-version.html
 file path=usr/share/gtk-doc/html/UPower/UPower.devhelp2
-file path=usr/share/gtk-doc/html/UPower/UPower.html
+file path=usr/share/gtk-doc/html/UPower/api-index-full.html
+file path=usr/share/gtk-doc/html/UPower/ch01.html
+file path=usr/share/gtk-doc/html/UPower/deprecated-api-index.html
 file path=usr/share/gtk-doc/html/UPower/home.png
 file path=usr/share/gtk-doc/html/UPower/index.html
-file path=usr/share/gtk-doc/html/UPower/ix01.html
 file path=usr/share/gtk-doc/html/UPower/left-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/left.png
-file path=usr/share/gtk-doc/html/UPower/libupower-glib-helpers.html
-file path=usr/share/gtk-doc/html/UPower/libupower-glib.html
-file path=usr/share/gtk-doc/html/UPower/license.html
-file path=usr/share/gtk-doc/html/UPower/ref-dbus.html
+file path=usr/share/gtk-doc/html/UPower/object-tree.html
 file path=usr/share/gtk-doc/html/UPower/right-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/right.png
 file path=usr/share/gtk-doc/html/UPower/style.css
-file path=usr/share/gtk-doc/html/UPower/tools-fileformats.html
 file path=usr/share/gtk-doc/html/UPower/up-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/up.png
-file path=usr/share/gtk-doc/html/UPower/upower.1.html
-file path=usr/share/gtk-doc/html/UPower/upowerd.8.html
 file path=usr/share/locale/fr/LC_MESSAGES/upower.mo
 file path=usr/share/locale/it/LC_MESSAGES/upower.mo
 file path=usr/share/locale/pl/LC_MESSAGES/upower.mo

--- a/components/sysutils/upower/patches/04-upower-glib-crash.patch
+++ b/components/sysutils/upower/patches/04-upower-glib-crash.patch
@@ -1,13 +1,13 @@
 A lot of upower clients expect to get some answer from up_client_get_devices().
 So to avoid fixing all consumers we want to return empty device list to them.
 
---- upower-0.99.4/libupower-glib/up-client.c.1	2018-01-11 11:01:18.708705809 +0000
-+++ upower-0.99.4/libupower-glib/up-client.c	2018-01-11 11:01:49.927915101 +0000
-@@ -96,17 +96,17 @@
+--- upower-0.99.11/libupower-glib/up-client.c	2019-07-07 10:29:27.000000000 +0000
++++ upower-0.99.11/libupower-glib/up-client.c	2020-01-05 11:05:13.731804295 +0000
+@@ -115,17 +115,17 @@ up_client_get_devices2 (UpClient *client
  
  	g_return_val_if_fail (UP_IS_CLIENT (client), NULL);
  
-+	array = g_ptr_array_new ();
++	array = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 +
  	if (up_exported_daemon_call_enumerate_devices_sync (client->priv->proxy,
  							    &devices,
@@ -19,7 +19,7 @@ So to avoid fixing all consumers we want to return empty device list to them.
 +		return array;
  	}
  
--	array = g_ptr_array_new ();
+-	array = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 -
  	for (i = 0; devices[i] != NULL; i++) {
  		UpDevice *device;

--- a/components/sysutils/upower/upower.p5m
+++ b/components/sysutils/upower/upower.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2017 Alexander Pyhalov
+# Copyright 2020 Michal Nowak
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,7 +28,6 @@ file files/upower.xml path=lib/svc/manifest/system/upower.xml variant.opensolari
     pkg.depend.bypass-generate=.* 
 
 file path=etc/UPower/UPower.conf mode=0644 preserve=true
-file path=etc/dbus-1/system.d/org.freedesktop.UPower.conf
 file path=usr/bin/upower
 file path=usr/include/libupower-glib/up-autocleanups.h
 file path=usr/include/libupower-glib/up-client.h
@@ -55,35 +55,23 @@ file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.KbdBacklight.xml
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.Wakeups.xml
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.xml
 file path=usr/share/dbus-1/system-services/org.freedesktop.UPower.service
+file usr/share/dbus-1/system.d/org.freedesktop.UPower.conf path=etc/dbus-1/system.d/org.freedesktop.UPower.conf
 file path=usr/share/gir-1.0/UPowerGlib-1.0.gir
-file path=usr/share/gtk-doc/html/UPower/Device.html
-file path=usr/share/gtk-doc/html/UPower/KbdBacklight.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-client.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-device.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-history-item.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-stats-item.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-types.html
-file path=usr/share/gtk-doc/html/UPower/UPower-up-wakeup-item.html
-file path=usr/share/gtk-doc/html/UPower/UPower.7.html
+file path=usr/share/gtk-doc/html/UPower/UPower-up-version.html
 file path=usr/share/gtk-doc/html/UPower/UPower.devhelp2
-file path=usr/share/gtk-doc/html/UPower/UPower.html
+file path=usr/share/gtk-doc/html/UPower/api-index-full.html
+file path=usr/share/gtk-doc/html/UPower/ch01.html
+file path=usr/share/gtk-doc/html/UPower/deprecated-api-index.html
 file path=usr/share/gtk-doc/html/UPower/home.png
 file path=usr/share/gtk-doc/html/UPower/index.html
-file path=usr/share/gtk-doc/html/UPower/ix01.html
 file path=usr/share/gtk-doc/html/UPower/left-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/left.png
-file path=usr/share/gtk-doc/html/UPower/libupower-glib-helpers.html
-file path=usr/share/gtk-doc/html/UPower/libupower-glib.html
-file path=usr/share/gtk-doc/html/UPower/license.html
-file path=usr/share/gtk-doc/html/UPower/ref-dbus.html
+file path=usr/share/gtk-doc/html/UPower/object-tree.html
 file path=usr/share/gtk-doc/html/UPower/right-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/right.png
 file path=usr/share/gtk-doc/html/UPower/style.css
-file path=usr/share/gtk-doc/html/UPower/tools-fileformats.html
 file path=usr/share/gtk-doc/html/UPower/up-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/up.png
-file path=usr/share/gtk-doc/html/UPower/upower.1.html
-file path=usr/share/gtk-doc/html/UPower/upowerd.8.html
 file path=usr/share/locale/fr/LC_MESSAGES/upower.mo
 file path=usr/share/locale/it/LC_MESSAGES/upower.mo
 file path=usr/share/locale/pl/LC_MESSAGES/upower.mo


### PR DESCRIPTION
**Changelog**: https://abi-laboratory.pro/index.php?view=changelog&l=upower&v=0.99.11

`up_client_get_devices` got deprecated in favor of `up_client_get_devices2`, MATE 1.24 will require UPower >= 0.99.8.

Intltool was dropped in favor of Gettext, changes in `COMPONENT_PREP_ACTION` were required.

**Testing**
- `upower` lists and monitors devices
- MATE Power Manager and Statistics work