### PR TITLE
Update GNU sed to 4.8

### DIFF
--- a/components/text/sed/Makefile
+++ b/components/text/sed/Makefile
@@ -22,13 +22,15 @@
 #
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2017, Aurelien Larcher.
-# Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2020, Michal Nowak
 #
+
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		sed
-COMPONENT_VERSION=	4.7
+COMPONENT_VERSION=	4.8
 COMPONENT_FMRI=		text/gnu-sed
 COMPONENT_SUMMARY=	GNU implementation of sed, the Unix stream editor
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
@@ -36,13 +38,11 @@ COMPONENT_PROJECT_URL=	https://www.gnu.org/software/sed/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:2885768cd0a29ff8d58a6280a270ff161f6a3deb5690b2be6c49f46d4c67bd6a
+	sha256:f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633
 COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/pub/gnu/sed/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3, FDLv1.3
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
@@ -65,16 +65,6 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "/PASS/p" ' \
 	'-e "/FAIL/p" ' \
 	'-e "/ERROR/p" '
-
-# Enable ASLR for this component
-ASLR_MODE = $(ASLR_ENABLE)
-
-# common targets
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
 
 # Test dependencies
 REQUIRED_PACKAGES += developer/debug/valgrind

--- a/components/text/sed/test/results-64.master
+++ b/components/text/sed/test/results-64.master
@@ -138,6 +138,7 @@ PASS: test-getopt-gnu
 PASS: test-getopt-posix
 PASS: test-getprogname
 PASS: test-gettimeofday
+PASS: test-hard-locale
 PASS: test-ignore-value
 PASS: test-inet_pton
 PASS: test-intprops
@@ -164,6 +165,8 @@ SKIP: test-mbrtowc-w32-2.sh
 SKIP: test-mbrtowc-w32-3.sh
 SKIP: test-mbrtowc-w32-4.sh
 SKIP: test-mbrtowc-w32-5.sh
+SKIP: test-mbrtowc-w32-6.sh
+SKIP: test-mbrtowc-w32-7.sh
 PASS: test-mbsinit.sh
 PASS: test-memchr
 PASS: test-memrchr
@@ -171,11 +174,16 @@ PASS: test-mkdir
 PASS: test-nanosleep
 PASS: test-netinet_in
 PASS: test-nl_langinfo.sh
+SKIP: test-nl_langinfo-mt
 PASS: test-open
 PASS: test-pathmax
 PASS: test-perror.sh
 PASS: test-perror2
 PASS: test-pipe
+PASS: test-pthread
+PASS: test-pthread-thread
+PASS: test-pthread_sigmask1
+SKIP: test-pthread_sigmask2
 PASS: test-quotearg-simple
 PASS: test-raise
 PASS: test-read-file
@@ -183,10 +191,14 @@ PASS: test-readlink
 PASS: test-regex
 PASS: test-rename
 PASS: test-rmdir
+PASS: test-sched
 PASS: test-select
 PASS: test-select-in.sh
 PASS: test-select-out.sh
 PASS: test-setenv
+PASS: test-setlocale_null
+SKIP: test-setlocale_null-mt-one
+SKIP: test-setlocale_null-mt-all
 PASS: test-setlocale1.sh
 PASS: test-setlocale2.sh
 PASS: test-setsockopt
@@ -216,6 +228,8 @@ PASS: test-sys_time
 PASS: test-sys_types
 PASS: test-sys_uio
 PASS: test-init.sh
+PASS: test-thread_self
+SKIP: test-thread_create
 PASS: test-time
 PASS: test-unistd
 PASS: test-unsetenv
@@ -232,11 +246,13 @@ SKIP: test-wcrtomb-w32-2.sh
 SKIP: test-wcrtomb-w32-3.sh
 SKIP: test-wcrtomb-w32-4.sh
 SKIP: test-wcrtomb-w32-5.sh
+SKIP: test-wcrtomb-w32-6.sh
+SKIP: test-wcrtomb-w32-7.sh
 PASS: test-wctype-h
 PASS: test-xalloc-die.sh
-# TOTAL: 162
-# PASS:  151
-# SKIP:  11
+# TOTAL: 178
+# PASS:  158
+# SKIP:  20
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0


### PR DESCRIPTION
**Changes**

```
** Bug fixes

  "sed -i" now creates temporary files with correct umask (limited to u=rwx).
  Previously sed would incorrectly set umask on temporary files, resulting
  in problems under certain fuse-like file systems.
  [bug introduced in sed 4.2.1]

** Improvements

  a year's worth of gnulib development, including improved DFA performance
```

**Testing**

Test suite passed.