### PR TITLE
Update GNU make to 4.3

### DIFF
--- a/components/developer/make/Makefile
+++ b/components/developer/make/Makefile
@@ -21,35 +21,31 @@
 
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, Michal Nowak
 #
+
+BUILD_BITS=		32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		make
-COMPONENT_VERSION=	4.2.1
+COMPONENT_VERSION=	4.3
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/make/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.lz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7
+	sha256:de1a441c4edf952521db30bfca80baae86a0ff1acd0a00402999344f04c45e82
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/make/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	utility/gnu-make
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_OPTIONS  +=		--program-prefix=g
 CONFIGURE_OPTIONS  +=		--infodir=$(CONFIGURE_INFODIR)
 
-ASLR_MODE = $(ASLR_ENABLE)
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "/.*Clearing work.*/d" '
 
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/guile

--- a/components/developer/make/make.p5m
+++ b/components/developer/make/make.p5m
@@ -32,7 +32,6 @@ set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.arc-caseid value=PSARC/2000/488
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
 
 license make.license license="GPLv3, FDLv1.3"
 
@@ -58,6 +57,7 @@ file path=usr/share/info/make.info
 file path=usr/share/info/make.info-1
 file path=usr/share/info/make.info-2
 file path=usr/share/locale/be/LC_MESSAGES/make.mo
+file path=usr/share/locale/bg/LC_MESSAGES/make.mo
 file path=usr/share/locale/cs/LC_MESSAGES/make.mo
 file path=usr/share/locale/da/LC_MESSAGES/make.mo
 file path=usr/share/locale/de/LC_MESSAGES/make.mo
@@ -75,10 +75,13 @@ file path=usr/share/locale/ko/LC_MESSAGES/make.mo
 file path=usr/share/locale/lt/LC_MESSAGES/make.mo
 file path=usr/share/locale/nl/LC_MESSAGES/make.mo
 file path=usr/share/locale/pl/LC_MESSAGES/make.mo
+file path=usr/share/locale/pt/LC_MESSAGES/make.mo
 file path=usr/share/locale/pt_BR/LC_MESSAGES/make.mo
 file path=usr/share/locale/ru/LC_MESSAGES/make.mo
+file path=usr/share/locale/sr/LC_MESSAGES/make.mo
 file path=usr/share/locale/sv/LC_MESSAGES/make.mo
 file path=usr/share/locale/tr/LC_MESSAGES/make.mo
 file path=usr/share/locale/uk/LC_MESSAGES/make.mo
 file path=usr/share/locale/vi/LC_MESSAGES/make.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/make.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/make.mo

--- a/components/developer/make/manifests/sample-manifest.p5m
+++ b/components/developer/make/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,6 +30,7 @@ file path=usr/share/info/make.info
 file path=usr/share/info/make.info-1
 file path=usr/share/info/make.info-2
 file path=usr/share/locale/be/LC_MESSAGES/make.mo
+file path=usr/share/locale/bg/LC_MESSAGES/make.mo
 file path=usr/share/locale/cs/LC_MESSAGES/make.mo
 file path=usr/share/locale/da/LC_MESSAGES/make.mo
 file path=usr/share/locale/de/LC_MESSAGES/make.mo
@@ -47,11 +48,14 @@ file path=usr/share/locale/ko/LC_MESSAGES/make.mo
 file path=usr/share/locale/lt/LC_MESSAGES/make.mo
 file path=usr/share/locale/nl/LC_MESSAGES/make.mo
 file path=usr/share/locale/pl/LC_MESSAGES/make.mo
+file path=usr/share/locale/pt/LC_MESSAGES/make.mo
 file path=usr/share/locale/pt_BR/LC_MESSAGES/make.mo
 file path=usr/share/locale/ru/LC_MESSAGES/make.mo
+file path=usr/share/locale/sr/LC_MESSAGES/make.mo
 file path=usr/share/locale/sv/LC_MESSAGES/make.mo
 file path=usr/share/locale/tr/LC_MESSAGES/make.mo
 file path=usr/share/locale/uk/LC_MESSAGES/make.mo
 file path=usr/share/locale/vi/LC_MESSAGES/make.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/make.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/make.mo
 file path=usr/share/man/man1/gmake.1

--- a/components/developer/make/test/results-all.master
+++ b/components/developer/make/test/results-all.master
@@ -1,0 +1,167 @@
+make[1]: Entering directory '$(@D)'
+Making check in lib
+make[2]: Entering directory '$(@D)/lib'
+/usr/gnu/bin/make  check-recursive
+make[3]: Entering directory '$(@D)/lib'
+make[4]: Entering directory '$(@D)/lib'
+make[4]: Nothing to be done for 'check-am'.
+make[4]: Leaving directory '$(@D)/lib'
+make[3]: Leaving directory '$(@D)/lib'
+make[2]: Leaving directory '$(@D)/lib'
+Making check in po
+make[2]: Entering directory '$(@D)/po'
+make[2]: Nothing to be done for 'check'.
+make[2]: Leaving directory '$(@D)/po'
+Making check in doc
+make[2]: Entering directory '$(@D)/doc'
+make[2]: Nothing to be done for 'check'.
+make[2]: Leaving directory '$(@D)/doc'
+make[2]: Entering directory '$(@D)'
+/usr/gnu/bin/make  check-local
+make[3]: Entering directory '$(@D)'
+cd tests && perl  ./run_make_tests.pl -srcdir $(SOURCE_DIR) -make ../make 
+------------------------------------------------------------------------------
+        Running tests for GNU make on SunOS build-userland 5.11 i86pc
+                                 GNU Make 4.3
+------------------------------------------------------------------------------
+
+Finding tests...
+
+features/archives ....................................... ok     (12 passed)
+features/comments ....................................... ok     (1 passed)
+features/conditionals ................................... ok     (5 passed)
+features/default_names .................................. ok     (3 passed)
+features/double_colon ................................... ok     (14 passed)
+features/echoing ........................................ ok     (4 passed)
+features/errors ......................................... ok     (7 passed)
+features/escape ......................................... ok     (10 passed)
+features/exec ........................................... ok     (16 passed)
+features/export ......................................... ok     (12 passed)
+features/grouped_targets ................................ ok     (12 passed)
+features/include ........................................ ok     (19 passed)
+features/jobserver ...................................... ok     (6 passed)
+features/load ........................................... ok     (5 passed)
+features/loadapi ........................................ ok     (3 passed)
+features/mult_rules ..................................... ok     (2 passed)
+features/mult_targets ................................... ok     (2 passed)
+features/order_only ..................................... ok     (10 passed)
+features/output-sync .................................... ok     (15 passed)
+features/override ....................................... ok     (4 passed)
+features/parallelism .................................... ok     (13 passed)
+features/patspecific_vars ............................... ok     (10 passed)
+features/patternrules ................................... ok     (12 passed)
+features/quoting ........................................ ok     (1 passed)
+features/recursion ...................................... ok     (3 passed)
+features/reinvoke ....................................... ok     (5 passed)
+features/rule_glob ...................................... ok     (3 passed)
+features/se_explicit .................................... ok     (12 passed)
+features/se_implicit .................................... ok     (13 passed)
+features/se_statpat ..................................... ok     (4 passed)
+features/shell_assignment ............................... ok     (4 passed)
+features/statipattrules ................................. ok     (8 passed)
+features/suffixrules .................................... ok     (9 passed)
+features/targetvars ..................................... ok     (27 passed)
+features/utf8 ........................................... ok     (1 passed)
+features/varnesting ..................................... ok     (2 passed)
+features/vpath .......................................... ok     (2 passed)
+features/vpath2 ......................................... ok     (1 passed)
+features/vpath3 ......................................... ok     (1 passed)
+features/vpathgpath ..................................... ok     (1 passed)
+features/vpathplus ...................................... ok     (4 passed)
+functions/abspath ....................................... ok     (1 passed)
+functions/addprefix ..................................... ok     (1 passed)
+functions/addsuffix ..................................... ok     (2 passed)
+functions/andor ......................................... ok     (2 passed)
+functions/basename ...................................... ok     (1 passed)
+functions/call .......................................... ok     (3 passed)
+functions/dir ........................................... ok     (1 passed)
+functions/error ......................................... ok     (5 passed)
+functions/eval .......................................... ok     (9 passed)
+functions/file .......................................... ok     (15 passed)
+functions/filter-out .................................... ok     (5 passed)
+functions/findstring .................................... ok     (1 passed)
+functions/flavor ........................................ ok     (1 passed)
+functions/foreach ....................................... ok     (6 passed)
+functions/guile ......................................... ok     (8 passed)
+functions/if ............................................ ok     (1 passed)
+functions/join .......................................... ok     (1 passed)
+functions/notdir ........................................ ok     (1 passed)
+functions/origin ........................................ ok     (1 passed)
+functions/realpath ...................................... ok     (3 passed)
+functions/shell ......................................... ok     (8 passed)
+functions/sort .......................................... ok     (2 passed)
+functions/strip ......................................... ok     (2 passed)
+functions/substitution .................................. ok     (3 passed)
+functions/suffix ........................................ ok     (1 passed)
+functions/value ......................................... ok     (1 passed)
+functions/warning ....................................... ok     (5 passed)
+functions/wildcard ...................................... ok     (8 passed)
+functions/word .......................................... ok     (16 passed)
+misc/bs-nl .............................................. ok     (28 passed)
+misc/close_stdout ....................................... ok     (1 passed)
+misc/fopen-fail ......................................... ok     (1 passed)
+misc/general1 ........................................... ok     (1 passed)
+misc/general2 ........................................... ok     (1 passed)
+misc/general3 ........................................... ok     (14 passed)
+misc/general4 ........................................... ok     (9 passed)
+misc/utf8 ............................................... ok     (1 passed)
+options/dash-B .......................................... ok     (8 passed)
+options/dash-C .......................................... ok     (2 passed)
+options/dash-I .......................................... ok     (3 passed)
+options/dash-W .......................................... ok     (10 passed)
+options/dash-e .......................................... ok     (1 passed)
+options/dash-f .......................................... ok     (4 passed)
+options/dash-k .......................................... ok     (3 passed)
+options/dash-l .......................................... ok     (1 passed)
+options/dash-n .......................................... ok     (6 passed)
+options/dash-q .......................................... ok     (11 passed)
+options/dash-s .......................................... ok     (11 passed)
+options/dash-t .......................................... ok     (2 passed)
+options/eval ............................................ ok     (5 passed)
+options/general ......................................... ok     (2 passed)
+options/print-directory ................................. ok     (4 passed)
+options/symlinks ........................................ ok     (10 passed)
+options/warn-undefined-variables ........................ ok     (2 passed)
+targets/DEFAULT ......................................... ok     (1 passed)
+targets/DELETE_ON_ERROR ................................. ok     (2 passed)
+targets/FORCE ........................................... ok     (1 passed)
+targets/INTERMEDIATE .................................... ok     (8 passed)
+targets/ONESHELL ........................................ ok     (5 passed)
+targets/PHONY ........................................... ok     (1 passed)
+targets/POSIX ........................................... ok     (4 passed)
+targets/SECONDARY ....................................... ok     (12 passed)
+targets/SILENT .......................................... ok     (3 passed)
+targets/clean ........................................... ok     (2 passed)
+variables/CURDIR ........................................ ok     (1 passed)
+variables/DEFAULT_GOAL .................................. ok     (5 passed)
+variables/EXTRA_PREREQS ................................. ok     (13 passed)
+variables/GNUMAKEFLAGS .................................. ok     (3 passed)
+variables/INCLUDE_DIRS .................................. ok     (2 passed)
+variables/LIBPATTERNS ................................... ok     (2 passed)
+variables/MAKE .......................................... ok     (1 passed)
+variables/MAKECMDGOALS .................................. ok     (3 passed)
+variables/MAKEFILES ..................................... ok     (2 passed)
+variables/MAKEFLAGS ..................................... ok     (3 passed)
+variables/MAKELEVEL ..................................... ok     (1 passed)
+variables/MAKE_RESTARTS ................................. ok     (3 passed)
+variables/MFILE_LIST .................................... ok     (2 passed)
+variables/SHELL ......................................... ok     (8 passed)
+variables/automatic ..................................... ok     (7 passed)
+variables/define ........................................ ok     (16 passed)
+variables/flavors ....................................... ok     (11 passed)
+variables/negative ...................................... ok     (4 passed)
+variables/private ....................................... ok     (10 passed)
+variables/special ....................................... ok     (6 passed)
+variables/undefine ...................................... ok     (4 passed)
+vms/library ............................................. N/A
+
+699 Tests in 126 Categories Complete ... No Failures :-)
+
+
+=====================================================================================
+ Regression PASSED: GNU Make 4.3 (i386-pc-solaris2.11) built with /usr/gcc/6/bin/gcc 
+=====================================================================================
+
+make[3]: Leaving directory '$(@D)'
+make[2]: Leaving directory '$(@D)'
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
**Release notes**: https://lists.gnu.org/archive/html/info-gnu/2020-01/msg00004.html
```
* WARNING: Backward-incompatibility!
  Number signs (#) appearing inside a macro reference or function invocation
  no longer introduce comments and should not be escaped with backslashes:
  thus a call such as:
    foo := $(shell echo '#')
  is legal.  Previously the number sign needed to be escaped, for example:
    foo := $(shell echo '\#')
  Now this latter will resolve to "\#".  If you want to write makefiles
  portable to both versions, assign the number sign to a variable:
    H := \#
    foo := $(shell echo '$H')
  This was claimed to be fixed in 3.81, but wasn't, for some reason.
  To detect this change search for 'nocomment' in the .FEATURES variable.

* WARNING: Backward-incompatibility!
  Previously appending using '+=' to an empty variable would result in a value
  starting with a space.  Now the initial space is only added if the variable
  already contains some value.  Similarly, appending an empty string does not
  add a trailing space.
```

**Testing**
- test suite passed
- given the incompatibilities, we should, as a test, rebuild userland to see if there are potential problems and scan userland for incompatibilities