### PR TITLE
update to samba-4.11.5

### DIFF
--- a/components/network/samba/Makefile
+++ b/components/network/samba/Makefile
@@ -24,26 +24,25 @@
 # Copyright 2019 Rouven Weiler
 #
 
-BUILD_BITS=			64
-BUILD_STYLE=			waf
+BUILD_BITS =			64
+BUILD_STYLE =			waf
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		samba
 COMPONENT_FMRI =		service/network/samba
-COMPONENT_VERSION =		4.11.4
-COMPONENT_REVISION=		1
+COMPONENT_VERSION =		4.11.5
 COMPONENT_SRC =			$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL =		http://www.samba.org/
 COMPONENT_ARCHIVE =             $(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH = 	sha256:b95471ba450757109dce65acfe75dafc719c5cc5d464fc65ee442433a461db24
+COMPONENT_ARCHIVE_HASH = 	sha256:f3e299ff62e424c0c259a2e60ca30979c8a65244d7ef6b54667902dac639d93f
 COMPONENT_ARCHIVE_URL =		http://us1.samba.org/samba/ftp/stable/$(COMPONENT_ARCHIVE)
 COMPONENT_SUMMARY =		samba - A Windows SMB/CIFS fileserver for UNIX
 COMPONENT_LICENSE =		GPLv3
 COMPONENT_LICENSE_FILE = 	$(COMPONENT_NAME).license
 COMPONENT_CLASSIFICATION =	System/File System
 
-TEST_TARGET=		$(NO_TESTS)
+TEST_TARGET =		$(NO_TESTS)
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -63,12 +62,12 @@ CFLAGS +=	$($(COMPILER)_C99_ENABLE) -D_POSIX_PTHREAD_SEMANTICS
 CPPFLAGS +=	$(CPP_LARGEFILES) $(CPP_XPG6MODE) 
 CPPFLAGS +=	-I/usr/include/openldap
 
-LDFLAGS.64 +=	-L/usr/lib/samba/$(MACH64) -R/usr/lib/samba/$(MACH64)
-LDFLAGS.64 +=	-L/usr/lib/samba/private/$(MACH64) -R/usr/lib/samba/private/$(MACH64)
-LDFLAGS.64 +=	-L/usr/gnu/lib/$(MACH64) -R/usr/gnu/lib/$(MACH64)
+LDFLAGS +=	-L/usr/lib/samba/$(MACH64) -R/usr/lib/samba/$(MACH64)
+LDFLAGS +=	-L/usr/lib/samba/private/$(MACH64) -R/usr/lib/samba/private/$(MACH64)
+LDFLAGS +=	-L$(GNULIB.$(BITS)) -R$(GNULIB.$(BITS))
 
-LDFLAGS +=      -lrt -lsec -lcrypt -lmd5 -lsocket -lnsl -lsendfile $(LD_FLAGS.$(BITS))
-LDFLAGS +=      -lldap_r -lsendfile -lavahi-common -lavahi-core $(LDFLAGS.$(BITS))
+LDFLAGS +=      -lrt -lsec -lcrypt -lmd5 -lsocket -lnsl -lsendfile
+LDFLAGS +=      -lldap_r -lsendfile -lavahi-common -lavahi-core 
 
 LD_OPTIONS +=	-B direct
 
@@ -80,6 +79,7 @@ CONFIGURE_PREFIX =	/usr/lib/samba
 CONFIGURE_ENV +=	CPP="$(CC) -E"
 CONFIGURE_ENV +=	CPPFLAGS="$(CPPFLAGS)"
 CONFIGURE_ENV +=	CUPS_CONFIG=$(USRBINDIR)/cups-config
+CONFIGURE_ENV +=	PATH=$(GNUBIN.$(BITS)):$(USRBINDIR.$(BITS)):$(PATH.gnu)
 CONFIGURE_ENV +=	PERL=$(PERL)
 CONFIGURE_ENV +=	PYTHONARCHDIR=$(PYTHON_VENDOR_PACKAGES)/samba
 
@@ -120,8 +120,6 @@ CONFIGURE_OPTIONS +=	--python=$(PYTHON)
 #
 # set everything for target build.
 #
-COMPONENT_BUILD_ARGS += $(WAF_BUILD_OPTIONS) 
-
 COMPONENT_POST_INSTALL_ACTION += \
 	$(MKDIR) $(PROTO_DIR)$(ETCDIR)/samba ; \
 	(sed -f $(COMPONENT_DIR)/Solaris/smbconf.sed \

--- a/components/network/samba/samba.p5m
+++ b/components/network/samba/samba.p5m
@@ -19,7 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2019 Rouven Weiler
+# Copyright 2020 Rouven Weiler
 #
 
 #


### PR DESCRIPTION
I was trying to update to version 4.11.5 but got a weird compile issue...
There is a "-m32" in the compiler command, although the Makefile tells to use 64 bits...
Can someone please help me, as I do not know where to start...

`[2770/3882] Compiling source4/lib/registry/tools/regshell.c
17:19:42 runner ['/usr/gcc/6/bin/gcc', '-m64', '-D_SAMBA_BUILD_=4', '-DHAVE_CONFIG_H=1', '-m64', '-O3', '-std=c99', '-D_POSIX_PTHREAD_SEMANTICS', '-MMD', '-D_GNU_SOURCE=1', '-D_XOPEN_SOURCE_EXTENDED=1', '-DHAVE_CONFIG_H=1', '-fPIC', '-D__STDC_WANT_LIB_EXT1__=1', '-D_LARGEFILE_SOURCE', '-D_FILE_OFFSET_BITS=64', '-D_REENTRANT', '-DSTATIC_regshell_MODULES=NULL', '-DSTATIC_regshell_MODULES_PROTO=extern void __regshell_dummy_module_proto(void)', '-m32', '-Isource4/lib/registry', '-I../../source4/lib/registry', '-Iinclude/public', '-I../../include/public', '-Isource4', '-I../../source4', '-Ilib', '-I../../lib', '-Isource4/lib', '-I../../source4/lib', '-Isource4/include', '-I../../source4/include', '-Iinclude', '-I../../include', '-Ilib/replace', '-I../../lib/replace', '-I.', '-I../..', '-Ilib/crypto', '-I../../lib/crypto', '-Ilibrpc', '-I../../librpc', '-Isource4/param', '-I../../source4/param', '-Isource4/heimdal/lib/asn1', '-I../../source4/heimdal/lib/asn1', '-Isource4/heimdal_build', '-I../../source4/heimdal_build', '-Isource4/lib/cmdline', '-I../../source4/lib/cmdline', '-Isource3', '-I../../source3', '-Isource3/include', '-I../../source3/include', '-Isource3/lib', '-I../../source3/lib', '-Isource4/heimdal/lib/com_err', '-I../../source4/heimdal/lib/com_err', '-Isource4/heimdal/lib/krb5', '-I../../source4/heimdal/lib/krb5', '-Isource4/heimdal/lib/gssapi', '-I../../source4/heimdal/lib/gssapi', '-Ibin/default/source4/heimdal/lib/asn1', '-Isource4/heimdal/lib/asn1', '-Ilib/tdb/include', '-I../../lib/tdb/include', '-Ilib/tevent', '-I../../lib/tevent', '-Ilib/talloc', '-I../../lib/talloc', '-Ilib/popt', '-I../../lib/popt', '-Ilibcli/netlogon', '-I../../libcli/netlogon', '-Isource4/libcli', '-I../../source4/libcli', '-Ilib/util/charset', '-I../../lib/util/charset', '-Isource4/auth', '-I../../source4/auth', '-Ilibcli/auth', '-I../../libcli/auth', '-Isource4/heimdal/lib/hcrypto', '-I../../source4/heimdal/lib/hcrypto', '-Isource4/heimdal/lib', '-I../../source4/heimdal/lib', '-Isource4/heimdal/include', '-I../../source4/heimdal/include', '-Ilib/ldb/include', '-I../../lib/ldb/include', '-Ilib/ldb', '-I../../lib/ldb', '-Ilib/dbwrap', '-I../../lib/dbwrap', '-Ilibds/common', '-I../../libds/common', '-Isource4/auth/kerberos', '-I../../source4/auth/kerberos', '-Iauth/credentials', '-I../../auth/credentials', '-Isource4/lib/socket', '-I../../source4/lib/socket', '-Isource4/auth/gensec', '-I../../source4/auth/gensec', '-Isource4/cluster', '-I../../source4/cluster', '-Isource4/heimdal/lib/wind', '-I../../source4/heimdal/lib/wind', '-Ilib/async_req', '-I../../lib/async_req', '-Isource4/dsdb', '-I../../source4/dsdb', '-Iauth', '-I../../auth', '-Isource4/heimdal/lib/hx509', '-I../../source4/heimdal/lib/hx509', '-Ilibcli/util', '-I../../libcli/util', '-Isource4/lib/http', '-I../../source4/lib/http', '-Ilib/param', '-I../../lib/param', '-Ilibcli/smb', '-I../../libcli/smb', '-Ithird_party/popt', '-I../../third_party/popt', '-Ilibcli/smbreadline', '-I../../libcli/smbreadline', '-Ilib/ldb-samba', '-I../../lib/ldb-samba', '-Ithird_party/zlib', '-I../../third_party/zlib', '-Ilibcli/security', '-I../../libcli/security', '-Ilib/socket', '-I../../lib/socket', '-Ilibcli/nbt', '-I../../libcli/nbt', '-Isource3/librpc', '-I../../source3/librpc', '-Isource4/lib/messaging', '-I../../source4/lib/messaging', '-Isource3/param', '-I../../source3/param', '-Iauth/gensec', '-I../../auth/gensec', '-Ilib/tdr', '-I../../lib/tdr', '-Isource4/heimdal/lib/gssapi/gssapi', '-I../../source4/heimdal/lib/gssapi/gssapi', '-Isource4/heimdal/lib/gssapi/spnego', '-I../../source4/heimdal/lib/gssapi/spnego', '-Isource4/heimdal/lib/gssapi/krb5', '-I../../source4/heimdal/lib/gssapi/krb5', '-Isource4/heimdal/lib/gssapi/mech', '-I../../source4/heimdal/lib/gssapi/mech', '-Ilibcli/cldap', '-I../../libcli/cldap', '-Isource4/heimdal/lib/roken', '-I../../source4/heimdal/lib/roken', '-Isource4/libcli/ldap', '-I../../source4/libcli/ldap', '-Ilib/smbconf', '-I../../lib/smbconf', '-Insswitch/libwbclient', '-I../../nsswitch/libwbclient', '-Insswitch', '-I../../nsswitch', '-Ilib/audit_logging', '-I../../lib/audit_logging', '-Ilib/tsocket', '-I../../lib/tsocket', '-Ilib/compression', '-I../../lib/compression', '-Isource4/lib/stream', '-I../../source4/lib/stream', '-Ilibcli/registry', '-I../../libcli/registry', '-Iauth/kerberos', '-I../../auth/kerberos', '-Ilib/addns', '-I../../lib/addns', '-Ilibcli/drsuapi', '-I../../libcli/drsuapi', '-Isource4/lib/tls', '-I../../source4/lib/tls', '-Isource4/lib/events', '-I../../source4/lib/events', '-Isource4/heimdal/lib/hcrypto/libtommath', '-I../../source4/heimdal/lib/hcrypto/libtommath', '-Ilibcli/dns', '-I../../libcli/dns', '-Isource4/heimdal/base', '-I../../source4/heimdal/base', '-Iauth/ntlmssp', '-I../../auth/ntlmssp', '-Ilibcli/ldap', '-I../../libcli/ldap', '-Ilib/krb5_wrap', '-I../../lib/krb5_wrap', '-Ilib/tdb', '-I../../lib/tdb', '-Isource4/librpc', '-I../../source4/librpc', '-Ilibcli/lsarpc', '-I../../libcli/lsarpc', '-Ilib/pthreadpool', '-I../../lib/pthreadpool', '-Isource4/libcli/smb2', '-I../../source4/libcli/smb2', '-Idynconfig', '-I../../dynconfig', '-I/usr/include/p11-kit-1', '-I/usr/include/ncurses/ncurses', '-I/usr/include/ncurses', '-I/usr/include/jansson', '-D__EXTENSIONS__', '-D_XPG6', '../../source4/lib/registry/tools/regshell.c', '-c', '-o/export/home/github.com/oi-userland.git/components/network/samba/build/amd64/bin/default/source4/lib/registry/tools/regshell.c.15.o', '-D_LARGEFILE64_SOURCE', '-D_XOPEN_SOURCE=600', '-D__EXTENSIONS__=1', '-D_XPG6', '-I/usr/include/openldap']
`