### PR TITLE
Update OpenVPN to 2.4.8

### DIFF
--- a/components/network/openvpn/Makefile
+++ b/components/network/openvpn/Makefile
@@ -11,19 +11,19 @@
 #
 # Copyright 2013 Adam Stevko. All rights reserved.
 # Copyright 2016 Jim Klimov
-# Copyright 2019 Michal Nowak
+# Copyright 2020 Michal Nowak
 #
 
-PREFERRED_BITS=		64
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		openvpn
-COMPONENT_VERSION=	2.4.7
+COMPONENT_VERSION=	2.4.8
 COMPONENT_SUMMARY=	OpenVPN is a full-featured open source SSL VPN solution
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH=	sha256:a42f53570f669eaf10af68e98d65b531015ff9e12be7a62d9269ea684652f648
+COMPONENT_ARCHIVE_HASH=	sha256:fb8ca66bb7807fff595fbdf2a0afd085c02a6aa47715c9aa3171002f9f1a3f91
 COMPONENT_PROJECT_URL=	http://openvpn.net
 COMPONENT_ARCHIVE_URL=	http://build.openvpn.net/downloads/releases/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		network/openvpn
@@ -31,9 +31,7 @@ COMPONENT_CLASSIFICATION=	Applications/Internet
 COMPONENT_LICENSE=	GPLv2
 COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CFLAGS +=	$(CPP_LARGEFILES)
 LDFLAGS +=	$(LD_Z_DEFS) $(LD_Z_TEXT) -lpthread
@@ -46,12 +44,6 @@ CONFIGURE_OPTIONS += --enable-shared
 COMPONENT_POST_INSTALL_ACTION += \
 	$(MKDIR) $(PROTO_DIR)/$(USRSHAREDOCDIR)/openvpn/sample/ ; \
 	$(CP) -a $(SOURCE_DIR)/sample/sample-{config-files,keys,scripts} $(PROTO_DIR)/$(USRSHAREDOCDIR)/openvpn/sample/ ;
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
 
 # Build dependencies
 REQUIRED_PACKAGES += driver/network/header-tun


### PR DESCRIPTION
**Changes**: https://github.com/OpenVPN/openvpn/releases/tag/v2.4.8
```
Gert Doering: Fix IPv6 routes on tap interfaces on OpenSolaris/OpenIndiana
```

**Testing**: Test suite passed.