### PR TITLE
libpeas: avoid dependency on Python 3.4

### DIFF
--- a/components/library/libpeas/Makefile
+++ b/components/library/libpeas/Makefile
@@ -23,6 +23,7 @@
 # Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
 #
 
+BUILD_BITS = 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libpeas
@@ -30,7 +31,7 @@ COMPONENT_SUMMARY=	A gobject-based plugins engine for GNOME
 COMPONENT_DESCRIPTION=	libpeas is a gobject-based plugins engine, and is targeted\
  at giving every application the chance to assume its own extensibility.
 COMPONENT_VERSION=	1.20.0
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=  https://wiki.gnome.org/Projects/Libpeas
 COMPONENT_MAJOR_MINOR=        $(basename $(COMPONENT_VERSION))
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -43,23 +44,21 @@ COMPONENT_FMRI=	library/desktop/libpeas
 COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_ENV.32 += PYTHON2=$(PYTHON.2.7.32)
 CONFIGURE_ENV.64 += PYTHON2=$(PYTHON.2.7.64)
-CONFIGURE_ENV.32 += PYTHON=$(PYTHON.3.4.32)
-CONFIGURE_ENV.64 += PYTHON=$(PYTHON.3.4.64)
-CONFIGURE_ENV.32 += PYTHON3_CONFIG=/usr/bin/python3.4-config
-CONFIGURE_ENV.64 += PYTHON3_CONFIG=/usr/bin/$(MACH64)/python3.4-config
+# Note, there's no 32-bit Python 3.5
+CONFIGURE_ENV.64 += PYTHON=$(PYTHON.3.5.64)
+CONFIGURE_ENV.64 += PYTHON3_CONFIG=/usr/bin/python3.5-config
 
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --enable-gtk
 CONFIGURE_OPTIONS += --enable-lua5.2
 CONFIGURE_OPTIONS += --disable-luajit
 CONFIGURE_OPTIONS += --enable-python2
-CONFIGURE_OPTIONS += --enable-python3
+CONFIGURE_OPTIONS.32 += --disable-python3
+CONFIGURE_OPTIONS.64 += --enable-python3
 CONFIGURE_OPTIONS += --enable-shared
 CONFIGURE_OPTIONS += --with-pic
 
@@ -85,11 +84,8 @@ COMPONENT_TEST_TRANSFORMS += \
         '-e "/PASS:/p" ' \
         '-e "/FAIL:/p" '
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
-test: $(TEST_32_and_64)
+# Build dependencies
+REQUIRED_PACKAGES += developer/ui-designer/glade
 
 REQUIRED_PACKAGES += developer/documentation-tool/gtk-doc
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
@@ -100,6 +96,6 @@ REQUIRED_PACKAGES += library/lua/lgi-52
 REQUIRED_PACKAGES += library/python/pygobject-3
 REQUIRED_PACKAGES += runtime/lua
 REQUIRED_PACKAGES += runtime/python-27
-REQUIRED_PACKAGES += runtime/python-34
+REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += text/xmlto

--- a/components/library/libpeas/libpeas-python3loader.p5m
+++ b/components/library/libpeas/libpeas-python3loader.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Alexander Pyhalov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/libpeas-python3loader@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="libpeas python 3 loader plugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/$(MACH64)/libpeas-1.0/loaders/libpython3loader.so
+file path=usr/lib/$(MACH64)/peas-demo/plugins/pythonhello/pythonhello.plugin
+file path=usr/lib/$(MACH64)/peas-demo/plugins/pythonhello/pythonhello.py

--- a/components/library/libpeas/libpeas-pythonloader.p5m
+++ b/components/library/libpeas/libpeas-pythonloader.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Alexander Pyhalov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/libpeas-pythonloader@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="libpeas python 2 loader plugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/$(MACH64)/libpeas-1.0/loaders/libpythonloader.so
+file path=usr/lib/libpeas-1.0/loaders/libpythonloader.so
+

--- a/components/library/libpeas/libpeas.p5m
+++ b/components/library/libpeas/libpeas.p5m
@@ -22,6 +22,12 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 depend type=require fmri=library/lua/lgi-52
 
+depend type=conditional fmri=$(COMPONENT_FMRI)/libpeas-pythonloader \
+    predicate=runtime/python-27
+
+depend type=conditional fmri=$(COMPONENT_FMRI)/libpeas-python3loader \
+    predicate=runtime/python-35
+
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/$(MACH64)/peas-demo
@@ -46,8 +52,6 @@ link path=usr/lib/$(MACH64)/libpeas-1.0.so target=libpeas-1.0.so.0.2000.0
 link path=usr/lib/$(MACH64)/libpeas-1.0.so.0 target=libpeas-1.0.so.0.2000.0
 file path=usr/lib/$(MACH64)/libpeas-1.0.so.0.2000.0
 file path=usr/lib/$(MACH64)/libpeas-1.0/loaders/liblua52loader.so
-file path=usr/lib/$(MACH64)/libpeas-1.0/loaders/libpython3loader.so
-file path=usr/lib/$(MACH64)/libpeas-1.0/loaders/libpythonloader.so
 link path=usr/lib/$(MACH64)/libpeas-gtk-1.0.so \
     target=libpeas-gtk-1.0.so.0.2000.0
 link path=usr/lib/$(MACH64)/libpeas-gtk-1.0.so.0 \
@@ -56,8 +60,6 @@ file path=usr/lib/$(MACH64)/libpeas-gtk-1.0.so.0.2000.0
 file path=usr/lib/$(MACH64)/peas-demo/plugins/helloworld/helloworld.plugin
 file path=usr/lib/$(MACH64)/peas-demo/plugins/helloworld/libhelloworld.so
 file path=usr/lib/$(MACH64)/peas-demo/plugins/luahello/luahello.plugin
-file path=usr/lib/$(MACH64)/peas-demo/plugins/pythonhello/pythonhello.plugin
-file path=usr/lib/$(MACH64)/peas-demo/plugins/pythonhello/pythonhello.py
 file path=usr/lib/$(MACH64)/peas-demo/plugins/secondtime/libsecondtime.so
 file path=usr/lib/$(MACH64)/peas-demo/plugins/secondtime/secondtime.plugin
 file path=usr/lib/$(MACH64)/pkgconfig/libpeas-1.0.pc
@@ -68,16 +70,12 @@ link path=usr/lib/libpeas-1.0.so target=libpeas-1.0.so.0.2000.0
 link path=usr/lib/libpeas-1.0.so.0 target=libpeas-1.0.so.0.2000.0
 file path=usr/lib/libpeas-1.0.so.0.2000.0
 file path=usr/lib/libpeas-1.0/loaders/liblua52loader.so
-file path=usr/lib/libpeas-1.0/loaders/libpython3loader.so
-file path=usr/lib/libpeas-1.0/loaders/libpythonloader.so
 link path=usr/lib/libpeas-gtk-1.0.so target=libpeas-gtk-1.0.so.0.2000.0
 link path=usr/lib/libpeas-gtk-1.0.so.0 target=libpeas-gtk-1.0.so.0.2000.0
 file path=usr/lib/libpeas-gtk-1.0.so.0.2000.0
 file path=usr/lib/peas-demo/plugins/helloworld/helloworld.plugin
 file path=usr/lib/peas-demo/plugins/helloworld/libhelloworld.so
 file path=usr/lib/peas-demo/plugins/luahello/luahello.plugin
-file path=usr/lib/peas-demo/plugins/pythonhello/pythonhello.plugin
-file path=usr/lib/peas-demo/plugins/pythonhello/pythonhello.py
 file path=usr/lib/peas-demo/plugins/secondtime/libsecondtime.so
 file path=usr/lib/peas-demo/plugins/secondtime/secondtime.plugin
 file path=usr/lib/pkgconfig/libpeas-1.0.pc

--- a/components/library/libpeas/manifests/sample-manifest.p5m
+++ b/components/library/libpeas/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2018 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -66,7 +66,6 @@ link path=usr/lib/libpeas-1.0.so target=libpeas-1.0.so.0.2000.0
 link path=usr/lib/libpeas-1.0.so.0 target=libpeas-1.0.so.0.2000.0
 file path=usr/lib/libpeas-1.0.so.0.2000.0
 file path=usr/lib/libpeas-1.0/loaders/liblua52loader.so
-file path=usr/lib/libpeas-1.0/loaders/libpython3loader.so
 file path=usr/lib/libpeas-1.0/loaders/libpythonloader.so
 link path=usr/lib/libpeas-gtk-1.0.so target=libpeas-gtk-1.0.so.0.2000.0
 link path=usr/lib/libpeas-gtk-1.0.so.0 target=libpeas-gtk-1.0.so.0.2000.0
@@ -74,8 +73,6 @@ file path=usr/lib/libpeas-gtk-1.0.so.0.2000.0
 file path=usr/lib/peas-demo/plugins/helloworld/helloworld.plugin
 file path=usr/lib/peas-demo/plugins/helloworld/libhelloworld.so
 file path=usr/lib/peas-demo/plugins/luahello/luahello.plugin
-file path=usr/lib/peas-demo/plugins/pythonhello/pythonhello.plugin
-file path=usr/lib/peas-demo/plugins/pythonhello/pythonhello.py
 file path=usr/lib/peas-demo/plugins/secondtime/libsecondtime.so
 file path=usr/lib/peas-demo/plugins/secondtime/secondtime.plugin
 file path=usr/lib/pkgconfig/libpeas-1.0.pc


### PR DESCRIPTION
We still need to rebuild pluma, eom, rhythmbox and do something with totem to avoid shipping libpeas Python 2.7 module by default.