### PR TITLE
[totem-update] new component library/desktop/cogl

### DIFF
--- a/components/library/cogl/COPYING
+++ b/components/library/cogl/COPYING
@@ -1,0 +1,107 @@
+Most of Cogl is licensed under the terms of the MIT license.
+
+A few exceptions are:
+- We have a copy of the GLU tesselator in cogl-path/tesselator which
+  is licensed under the SGI Free Software License B, version 2.0
+
+  This license is essentially identical to the MIT license with
+  the option to refer to a web address for a copy of the notice
+  in documentation.
+- cogl-point-in-poly.c is under a 3 clause BSD license
+- stb_image.c is public domain.
+
+Please see individual files for details.
+
+deps/glib is licensed under the LGPL (please see individual files for
+details and deps/glib/COPYING for a copy of the LGPL license) This
+code is only referenced when building Cogl with the --standalone
+configure option.
+
+--
+The MIT License
+
+Copyright (C) 2007,2008 OpenedHand
+Copyright (C) 2009-2014 Intel Corporation.
+Copyright (C) 2010,2012 Red Hat, Inc.
+Copyright (C) 1999-2005 Brian Paul   All Rights Reserved.
+Copyright (C) 2011,2012 Collabora Ltd.
+Copyright (c) 2008-2011 Kristian Høgsberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+--
+SGI FREE SOFTWARE LICENSE B (Version 2.0, Sept. 18, 2008)
+
+Copyright (C) 1991-2000 Silicon Graphics, Inc. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice including the dates of first publication and
+either this permission notice or a reference to
+http://oss.sgi.com/projects/FreeB/
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+SILICON GRAPHICS, INC. BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Except as contained in this notice, the name of Silicon Graphics, Inc.
+shall not be used in advertising or otherwise to promote the sale, use or
+other dealings in this Software without prior written authorization from
+Silicon Graphics, Inc.
+
+
+--
+The BSD license used in cogl-point-in-poly.c:
+
+Copyright (c) 1970-2003 Wm. Randolph Frianklin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimers.
+2. Redistributions in binary form must reproduce the above
+   copyright notice in the documentation and/or other materials
+   provided with the distribution.
+3. The name of W. Randolph Franklin may not be used to endorse or
+   promote products derived from this Software without specific
+   prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/components/library/cogl/Makefile
+++ b/components/library/cogl/Makefile
@@ -1,0 +1,83 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Tim Mooney.  All rights reserved.
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		cogl
+COMPONENT_VERSION=	1.22.4
+COMPONENT_FMRI=		library/desktop/cogl
+COMPONENT_SUMMARY=	a library for using 3D graphics hardware for rendering
+COMPONENT_CLASSIFICATION= System/Multimedia Libraries
+COMPONENT_PROJECT_URL=	https://developer.gnome.org/cogl/
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH=	\
+  sha256:5217bf94cbca3df63268a3b79d017725382b9e592b891d1e7dc6212590ce0de0
+COMPONENT_ARCHIVE_URL= \
+  http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/1.22/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	MIT, SGI Free Software License B version 2.0, 3-clause BSD, public domain
+COMPONENT_LICENSE_FILE=	COPYING
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_PRE_CONFIGURE_ACTION += ( $(CLONEY) $(SOURCE_DIR) $(@D) && \
+					mkdir -p $(@D)/mesa/GL && \
+					ln -s /usr/include/mesa/*.h $(@D)/mesa/GL )
+
+PATH=$(PATH.gnu)
+
+CONFIGURE_SCRIPT=	$(@D)/configure
+
+CFLAGS+=	-I$(@D)/mesa
+CXXFLAGS+=	-I$(@D)/mesa
+LDFLAGS.32 =	-L/usr/lib/mesa -L/usr/X11/lib -R/usr/X11/lib -lX11
+LDFLAGS.64 =	-L/usr/lib/mesa/$(MACH64) -L/usr/X11/lib/$(MACH64) -R/usr/X11/lib/$(MACH64) -lX11
+
+CONFIGURE_OPTIONS+=	--sysconfdir=/etc
+CONFIGURE_OPTIONS+=	--disable-static
+CONFIGURE_OPTIONS+=	--enable-gtk-doc
+CONFIGURE_OPTIONS+=	--enable-xlib-egl-platform=yes
+CONFIGURE_OPTIONS+=	--enable-cogl-gst=yes
+
+# Tell g-ir-scanner about compiler
+COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
+COMPONENT_BUILD_ENV += CC="$(CC)"
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)
+
+# build dependency
+REQUIRED_PACKAGES += developer/documentation-tool/gtk-doc
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/audio/gstreamer1
+REQUIRED_PACKAGES += library/audio/gstreamer1/plugin/base
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
+REQUIRED_PACKAGES += library/desktop/pango
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11
+REQUIRED_PACKAGES += x11/library/libxdamage
+REQUIRED_PACKAGES += x11/library/libxext
+REQUIRED_PACKAGES += x11/library/libxfixes
+REQUIRED_PACKAGES += x11/library/libxrandr

--- a/components/library/cogl/cogl.p5m
+++ b/components/library/cogl/cogl.p5m
@@ -1,0 +1,398 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Tim Mooney.  All rights reserved
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# filter dependency on libEGL.so.1 , similar to webkitgtk
+<transform file -> add pkg.depend.bypass-generate libEGL\.so\.1>
+<transform dir path=usr/share/locale/([^/]+)(\..+){0,1}(/.+){0,1} -> default facet.locale.%<\1> true>
+<transform file path=usr/share/gtk-doc/html/.* ->  default facet.doc.html true>
+
+file path=usr/include/cogl/cogl-gst/cogl-gst-video-sink.h
+file path=usr/include/cogl/cogl-gst/cogl-gst.h
+file path=usr/include/cogl/cogl-pango/cogl-pango.h
+file path=usr/include/cogl/cogl-path/cogl-path-enum-types.h
+file path=usr/include/cogl/cogl-path/cogl-path-types.h
+file path=usr/include/cogl/cogl-path/cogl-path.h
+file path=usr/include/cogl/cogl-path/cogl1-path-functions.h
+file path=usr/include/cogl/cogl-path/cogl2-path-functions.h
+file path=usr/include/cogl/cogl/cogl-atlas-texture.h
+file path=usr/include/cogl/cogl/cogl-attribute-buffer.h
+file path=usr/include/cogl/cogl/cogl-attribute.h
+file path=usr/include/cogl/cogl/cogl-auto-texture.h
+file path=usr/include/cogl/cogl/cogl-bitmap.h
+file path=usr/include/cogl/cogl/cogl-buffer.h
+file path=usr/include/cogl/cogl/cogl-clip-state.h
+file path=usr/include/cogl/cogl/cogl-clutter-xlib.h
+file path=usr/include/cogl/cogl/cogl-clutter.h
+file path=usr/include/cogl/cogl/cogl-color.h
+file path=usr/include/cogl/cogl/cogl-context.h
+file path=usr/include/cogl/cogl/cogl-defines.h
+file path=usr/include/cogl/cogl/cogl-deprecated.h
+file path=usr/include/cogl/cogl/cogl-depth-state.h
+file path=usr/include/cogl/cogl/cogl-display.h
+file path=usr/include/cogl/cogl/cogl-egl-defines.h
+file path=usr/include/cogl/cogl/cogl-egl.h
+file path=usr/include/cogl/cogl/cogl-enum-types.h
+file path=usr/include/cogl/cogl/cogl-error.h
+file path=usr/include/cogl/cogl/cogl-euler.h
+file path=usr/include/cogl/cogl/cogl-fence.h
+file path=usr/include/cogl/cogl/cogl-fixed.h
+file path=usr/include/cogl/cogl/cogl-frame-info.h
+file path=usr/include/cogl/cogl/cogl-framebuffer-deprecated.h
+file path=usr/include/cogl/cogl/cogl-framebuffer.h
+file path=usr/include/cogl/cogl/cogl-gles2-types.h
+file path=usr/include/cogl/cogl/cogl-gles2.h
+file path=usr/include/cogl/cogl/cogl-glib-source.h
+file path=usr/include/cogl/cogl/cogl-glx.h
+file path=usr/include/cogl/cogl/cogl-index-buffer.h
+file path=usr/include/cogl/cogl/cogl-indices.h
+file path=usr/include/cogl/cogl/cogl-macros.h
+file path=usr/include/cogl/cogl/cogl-material-compat.h
+file path=usr/include/cogl/cogl/cogl-matrix-stack.h
+file path=usr/include/cogl/cogl/cogl-matrix.h
+file path=usr/include/cogl/cogl/cogl-meta-texture.h
+file path=usr/include/cogl/cogl/cogl-object.h
+file path=usr/include/cogl/cogl/cogl-offscreen.h
+file path=usr/include/cogl/cogl/cogl-onscreen-template.h
+file path=usr/include/cogl/cogl/cogl-onscreen.h
+file path=usr/include/cogl/cogl/cogl-output.h
+file path=usr/include/cogl/cogl/cogl-pango.h
+file path=usr/include/cogl/cogl/cogl-pipeline-layer-state.h
+file path=usr/include/cogl/cogl/cogl-pipeline-state.h
+file path=usr/include/cogl/cogl/cogl-pipeline.h
+file path=usr/include/cogl/cogl/cogl-pixel-buffer.h
+file path=usr/include/cogl/cogl/cogl-poll.h
+file path=usr/include/cogl/cogl/cogl-primitive-texture.h
+file path=usr/include/cogl/cogl/cogl-primitive.h
+file path=usr/include/cogl/cogl/cogl-primitives.h
+file path=usr/include/cogl/cogl/cogl-quaternion.h
+file path=usr/include/cogl/cogl/cogl-renderer.h
+file path=usr/include/cogl/cogl/cogl-shader.h
+file path=usr/include/cogl/cogl/cogl-snippet.h
+file path=usr/include/cogl/cogl/cogl-sub-texture.h
+file path=usr/include/cogl/cogl/cogl-swap-chain.h
+file path=usr/include/cogl/cogl/cogl-texture-2d-gl.h
+file path=usr/include/cogl/cogl/cogl-texture-2d-sliced.h
+file path=usr/include/cogl/cogl/cogl-texture-2d.h
+file path=usr/include/cogl/cogl/cogl-texture-3d.h
+file path=usr/include/cogl/cogl/cogl-texture-deprecated.h
+file path=usr/include/cogl/cogl/cogl-texture-pixmap-x11.h
+file path=usr/include/cogl/cogl/cogl-texture-rectangle.h
+file path=usr/include/cogl/cogl/cogl-texture.h
+file path=usr/include/cogl/cogl/cogl-type-casts.h
+file path=usr/include/cogl/cogl/cogl-types.h
+file path=usr/include/cogl/cogl/cogl-vector.h
+file path=usr/include/cogl/cogl/cogl-version.h
+file path=usr/include/cogl/cogl/cogl-vertex-buffer.h
+file path=usr/include/cogl/cogl/cogl-xlib-renderer.h
+file path=usr/include/cogl/cogl/cogl-xlib.h
+file path=usr/include/cogl/cogl/cogl.h
+file path=usr/include/cogl/cogl/cogl1-context.h
+file path=usr/include/cogl/cogl/cogl2-experimental.h
+file path=usr/include/cogl/cogl/deprecated/cogl-auto-texture.h
+file path=usr/include/cogl/cogl/deprecated/cogl-clip-state.h
+file path=usr/include/cogl/cogl/deprecated/cogl-clutter-xlib.h
+file path=usr/include/cogl/cogl/deprecated/cogl-clutter.h
+file path=usr/include/cogl/cogl/deprecated/cogl-fixed.h
+file path=usr/include/cogl/cogl/deprecated/cogl-framebuffer-deprecated.h
+file path=usr/include/cogl/cogl/deprecated/cogl-material-compat.h
+file path=usr/include/cogl/cogl/deprecated/cogl-shader.h
+file path=usr/include/cogl/cogl/deprecated/cogl-texture-deprecated.h
+file path=usr/include/cogl/cogl/deprecated/cogl-type-casts.h
+file path=usr/include/cogl/cogl/deprecated/cogl-vertex-buffer.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-core-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-gles2-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-glsl-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-in-gles-core-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-in-gles2-core-functions.h
+file path=usr/lib/$(MACH64)/girepository-1.0/Cogl-1.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/Cogl-2.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/CoglGst-2.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/CoglPango-1.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/CoglPango-2.0.typelib
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstcogl.so
+link path=usr/lib/$(MACH64)/libcogl-gst.so target=libcogl-gst.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-gst.so.20 target=libcogl-gst.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl-gst.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-pango.so target=libcogl-pango.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-pango.so.20 target=libcogl-pango.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl-pango.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-path.so target=libcogl-path.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-path.so.20 target=libcogl-path.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl-path.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl.so target=libcogl.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl.so.20 target=libcogl.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl.so.20.4.2
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-2.0-experimental.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-gl-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-gst-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-gst-2.0-experimental.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-pango-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-pango-2.0-experimental.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-path-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-path-2.0-experimental.pc
+file path=usr/lib/girepository-1.0/Cogl-1.0.typelib
+file path=usr/lib/girepository-1.0/Cogl-2.0.typelib
+file path=usr/lib/girepository-1.0/CoglGst-2.0.typelib
+file path=usr/lib/girepository-1.0/CoglPango-1.0.typelib
+file path=usr/lib/girepository-1.0/CoglPango-2.0.typelib
+file path=usr/lib/gstreamer-1.0/libgstcogl.so
+link path=usr/lib/libcogl-gst.so target=libcogl-gst.so.20.4.2
+link path=usr/lib/libcogl-gst.so.20 target=libcogl-gst.so.20.4.2
+file path=usr/lib/libcogl-gst.so.20.4.2
+link path=usr/lib/libcogl-pango.so target=libcogl-pango.so.20.4.2
+link path=usr/lib/libcogl-pango.so.20 target=libcogl-pango.so.20.4.2
+file path=usr/lib/libcogl-pango.so.20.4.2
+link path=usr/lib/libcogl-path.so target=libcogl-path.so.20.4.2
+link path=usr/lib/libcogl-path.so.20 target=libcogl-path.so.20.4.2
+file path=usr/lib/libcogl-path.so.20.4.2
+link path=usr/lib/libcogl.so target=libcogl.so.20.4.2
+link path=usr/lib/libcogl.so.20 target=libcogl.so.20.4.2
+file path=usr/lib/libcogl.so.20.4.2
+file path=usr/lib/pkgconfig/cogl-1.0.pc
+file path=usr/lib/pkgconfig/cogl-2.0-experimental.pc
+file path=usr/lib/pkgconfig/cogl-gl-1.0.pc
+file path=usr/lib/pkgconfig/cogl-gst-1.0.pc
+file path=usr/lib/pkgconfig/cogl-gst-2.0-experimental.pc
+file path=usr/lib/pkgconfig/cogl-pango-1.0.pc
+file path=usr/lib/pkgconfig/cogl-pango-2.0-experimental.pc
+file path=usr/lib/pkgconfig/cogl-path-1.0.pc
+file path=usr/lib/pkgconfig/cogl-path-2.0-experimental.pc
+file path=usr/share/cogl/examples-data/crate.jpg
+file path=usr/share/gir-1.0/Cogl-1.0.gir
+file path=usr/share/gir-1.0/Cogl-2.0.gir
+file path=usr/share/gir-1.0/CoglGst-2.0.gir
+file path=usr/share/gir-1.0/CoglPango-1.0.gir
+file path=usr/share/gir-1.0/CoglPango-2.0.gir
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ch01.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-2D-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-3-Component-Vectors.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-3D-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Bitmap.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglAttributeBuffer---Buffers-of-vertex-attributes.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglBuffer---The-Buffer-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglDisplay---Setup-a-display-pipeline.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglFramebuffer---The-Framebuffer-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglIndexBuffer---Buffers-of-vertex-indices.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglOnscreen---The-Onscreen-Framebuffer-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglOnscreenTemplate---Describe-a-template-for-onscreen-framebuffers.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglRenderer---Connect-to-a-backend-renderer.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Color-Type.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Common-Types.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Depth-State.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Eulers-(Rotations).html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Exception-handling.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-GLES-2.0-context.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-GPU-synchronisation-fences.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-GType-Integration-API.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-High-Level-Meta-Textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Indices.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Low-level-primitive-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Main-loop-integration.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Matrices.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Matrix-Stacks.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Offscreen-Framebuffers.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Path-Primitives.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Pipeline.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Primitives.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Quaternions-(Rotations).html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Rectangle-textures-(non-normalized-coordinates).html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Rectangles.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-SDL-Integration.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Shader-snippets.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Sliced-Textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Sub-Textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-The-Object-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-The-Texture-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-The-Top-Level-Context.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Versioning-utility-macros.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Vertex-Attributes.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-X11-Texture-From-Pixmap.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental.devhelp2
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-Blend-Strings.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-buffer-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-buffer-layout-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-context-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-framebuffer-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-general-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-integration.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-meta-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-pipeline-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-primitive-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-primitive-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-utilities.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl_ortho.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/coglglossary.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/fill-rule-even-odd.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/fill-rule-non-zero.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/home.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/index.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix01.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix02.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix03.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix04.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix05.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix06.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/left-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/left.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/license.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/quad-indices-order.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/quad-indices-triangles.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/right-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/right.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/style.css
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/up-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/up.png
+file path=usr/share/gtk-doc/html/cogl-gst/CoglGstVideoSink.html
+file path=usr/share/gtk-doc/html/cogl-gst/ch01.html
+file path=usr/share/gtk-doc/html/cogl-gst/cogl-gst-general-apis.html
+file path=usr/share/gtk-doc/html/cogl-gst/cogl-gst.devhelp2
+file path=usr/share/gtk-doc/html/cogl-gst/coglglossary.html
+file path=usr/share/gtk-doc/html/cogl-gst/home.png
+file path=usr/share/gtk-doc/html/cogl-gst/index.html
+file path=usr/share/gtk-doc/html/cogl-gst/ix01.html
+file path=usr/share/gtk-doc/html/cogl-gst/left-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-gst/left.png
+file path=usr/share/gtk-doc/html/cogl-gst/license.html
+file path=usr/share/gtk-doc/html/cogl-gst/right-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-gst/right.png
+file path=usr/share/gtk-doc/html/cogl-gst/style.css
+file path=usr/share/gtk-doc/html/cogl-gst/up-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-gst/up.png
+file path=usr/share/gtk-doc/html/cogl/ch01.html
+file path=usr/share/gtk-doc/html/cogl/ch02.html
+file path=usr/share/gtk-doc/html/cogl/ch03.html
+file path=usr/share/gtk-doc/html/cogl/cogl-3D-textures.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Bitmaps.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Blend-Strings.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Buffers.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Clipping-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Clipping.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Color-Type.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Fixed-Point-API.html
+file path=usr/share/gtk-doc/html/cogl/cogl-GType-Integration-API.html
+file path=usr/share/gtk-doc/html/cogl/cogl-General-API-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-General-API.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Materials-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Materials.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Matrices.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Offscreen-Buffers-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Offscreen-Buffers.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Path-Primitives.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Primitives.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Quaternions-(Rotations).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Shaders-and-Programmable-Pipeline-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Shaders-and-Programmable-Pipeline.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Textures-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Textures.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Vectors.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Vertex-Buffers-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Vertex-Buffers.html
+file path=usr/share/gtk-doc/html/cogl/cogl.devhelp2
+file path=usr/share/gtk-doc/html/cogl/cogl_ortho.png
+file path=usr/share/gtk-doc/html/cogl/coglglossary.html
+file path=usr/share/gtk-doc/html/cogl/fill-rule-even-odd.png
+file path=usr/share/gtk-doc/html/cogl/fill-rule-non-zero.png
+file path=usr/share/gtk-doc/html/cogl/home.png
+file path=usr/share/gtk-doc/html/cogl/index.html
+file path=usr/share/gtk-doc/html/cogl/ix01.html
+file path=usr/share/gtk-doc/html/cogl/ix02.html
+file path=usr/share/gtk-doc/html/cogl/ix03.html
+file path=usr/share/gtk-doc/html/cogl/ix04.html
+file path=usr/share/gtk-doc/html/cogl/ix05.html
+file path=usr/share/gtk-doc/html/cogl/ix06.html
+file path=usr/share/gtk-doc/html/cogl/ix07.html
+file path=usr/share/gtk-doc/html/cogl/ix08.html
+file path=usr/share/gtk-doc/html/cogl/left-insensitive.png
+file path=usr/share/gtk-doc/html/cogl/left.png
+file path=usr/share/gtk-doc/html/cogl/license.html
+file path=usr/share/gtk-doc/html/cogl/quad-indices-order.png
+file path=usr/share/gtk-doc/html/cogl/quad-indices-triangles.png
+file path=usr/share/gtk-doc/html/cogl/right-insensitive.png
+file path=usr/share/gtk-doc/html/cogl/right.png
+file path=usr/share/gtk-doc/html/cogl/style.css
+file path=usr/share/gtk-doc/html/cogl/up-insensitive.png
+file path=usr/share/gtk-doc/html/cogl/up.png
+file path=usr/share/locale/an/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ar/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/as/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ast/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/be/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/bg/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/bs/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ca/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/cs/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/da/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/de/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/el/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/en_CA/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/eo/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/es/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/eu/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/fa/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/fr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/fur/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/gl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/he/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/hi/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/hr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/hu/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/id/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/it/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ja/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/km/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/kn/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ko/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/lt/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/lv/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ml/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/nb/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ne/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/nl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/oc/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/or/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pa/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pt/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ro/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ru/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sk/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sv/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ta/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/te/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/th/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/tr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ug/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/uk/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/vi/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/cogl.mo

--- a/components/library/cogl/manifests/sample-manifest.p5m
+++ b/components/library/cogl/manifests/sample-manifest.p5m
@@ -1,0 +1,393 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/cogl/cogl-gst/cogl-gst-video-sink.h
+file path=usr/include/cogl/cogl-gst/cogl-gst.h
+file path=usr/include/cogl/cogl-pango/cogl-pango.h
+file path=usr/include/cogl/cogl-path/cogl-path-enum-types.h
+file path=usr/include/cogl/cogl-path/cogl-path-types.h
+file path=usr/include/cogl/cogl-path/cogl-path.h
+file path=usr/include/cogl/cogl-path/cogl1-path-functions.h
+file path=usr/include/cogl/cogl-path/cogl2-path-functions.h
+file path=usr/include/cogl/cogl/cogl-atlas-texture.h
+file path=usr/include/cogl/cogl/cogl-attribute-buffer.h
+file path=usr/include/cogl/cogl/cogl-attribute.h
+file path=usr/include/cogl/cogl/cogl-auto-texture.h
+file path=usr/include/cogl/cogl/cogl-bitmap.h
+file path=usr/include/cogl/cogl/cogl-buffer.h
+file path=usr/include/cogl/cogl/cogl-clip-state.h
+file path=usr/include/cogl/cogl/cogl-clutter-xlib.h
+file path=usr/include/cogl/cogl/cogl-clutter.h
+file path=usr/include/cogl/cogl/cogl-color.h
+file path=usr/include/cogl/cogl/cogl-context.h
+file path=usr/include/cogl/cogl/cogl-defines.h
+file path=usr/include/cogl/cogl/cogl-deprecated.h
+file path=usr/include/cogl/cogl/cogl-depth-state.h
+file path=usr/include/cogl/cogl/cogl-display.h
+file path=usr/include/cogl/cogl/cogl-egl-defines.h
+file path=usr/include/cogl/cogl/cogl-egl.h
+file path=usr/include/cogl/cogl/cogl-enum-types.h
+file path=usr/include/cogl/cogl/cogl-error.h
+file path=usr/include/cogl/cogl/cogl-euler.h
+file path=usr/include/cogl/cogl/cogl-fence.h
+file path=usr/include/cogl/cogl/cogl-fixed.h
+file path=usr/include/cogl/cogl/cogl-frame-info.h
+file path=usr/include/cogl/cogl/cogl-framebuffer-deprecated.h
+file path=usr/include/cogl/cogl/cogl-framebuffer.h
+file path=usr/include/cogl/cogl/cogl-gles2-types.h
+file path=usr/include/cogl/cogl/cogl-gles2.h
+file path=usr/include/cogl/cogl/cogl-glib-source.h
+file path=usr/include/cogl/cogl/cogl-glx.h
+file path=usr/include/cogl/cogl/cogl-index-buffer.h
+file path=usr/include/cogl/cogl/cogl-indices.h
+file path=usr/include/cogl/cogl/cogl-macros.h
+file path=usr/include/cogl/cogl/cogl-material-compat.h
+file path=usr/include/cogl/cogl/cogl-matrix-stack.h
+file path=usr/include/cogl/cogl/cogl-matrix.h
+file path=usr/include/cogl/cogl/cogl-meta-texture.h
+file path=usr/include/cogl/cogl/cogl-object.h
+file path=usr/include/cogl/cogl/cogl-offscreen.h
+file path=usr/include/cogl/cogl/cogl-onscreen-template.h
+file path=usr/include/cogl/cogl/cogl-onscreen.h
+file path=usr/include/cogl/cogl/cogl-output.h
+file path=usr/include/cogl/cogl/cogl-pango.h
+file path=usr/include/cogl/cogl/cogl-pipeline-layer-state.h
+file path=usr/include/cogl/cogl/cogl-pipeline-state.h
+file path=usr/include/cogl/cogl/cogl-pipeline.h
+file path=usr/include/cogl/cogl/cogl-pixel-buffer.h
+file path=usr/include/cogl/cogl/cogl-poll.h
+file path=usr/include/cogl/cogl/cogl-primitive-texture.h
+file path=usr/include/cogl/cogl/cogl-primitive.h
+file path=usr/include/cogl/cogl/cogl-primitives.h
+file path=usr/include/cogl/cogl/cogl-quaternion.h
+file path=usr/include/cogl/cogl/cogl-renderer.h
+file path=usr/include/cogl/cogl/cogl-shader.h
+file path=usr/include/cogl/cogl/cogl-snippet.h
+file path=usr/include/cogl/cogl/cogl-sub-texture.h
+file path=usr/include/cogl/cogl/cogl-swap-chain.h
+file path=usr/include/cogl/cogl/cogl-texture-2d-gl.h
+file path=usr/include/cogl/cogl/cogl-texture-2d-sliced.h
+file path=usr/include/cogl/cogl/cogl-texture-2d.h
+file path=usr/include/cogl/cogl/cogl-texture-3d.h
+file path=usr/include/cogl/cogl/cogl-texture-deprecated.h
+file path=usr/include/cogl/cogl/cogl-texture-pixmap-x11.h
+file path=usr/include/cogl/cogl/cogl-texture-rectangle.h
+file path=usr/include/cogl/cogl/cogl-texture.h
+file path=usr/include/cogl/cogl/cogl-type-casts.h
+file path=usr/include/cogl/cogl/cogl-types.h
+file path=usr/include/cogl/cogl/cogl-vector.h
+file path=usr/include/cogl/cogl/cogl-version.h
+file path=usr/include/cogl/cogl/cogl-vertex-buffer.h
+file path=usr/include/cogl/cogl/cogl-xlib-renderer.h
+file path=usr/include/cogl/cogl/cogl-xlib.h
+file path=usr/include/cogl/cogl/cogl.h
+file path=usr/include/cogl/cogl/cogl1-context.h
+file path=usr/include/cogl/cogl/cogl2-experimental.h
+file path=usr/include/cogl/cogl/deprecated/cogl-auto-texture.h
+file path=usr/include/cogl/cogl/deprecated/cogl-clip-state.h
+file path=usr/include/cogl/cogl/deprecated/cogl-clutter-xlib.h
+file path=usr/include/cogl/cogl/deprecated/cogl-clutter.h
+file path=usr/include/cogl/cogl/deprecated/cogl-fixed.h
+file path=usr/include/cogl/cogl/deprecated/cogl-framebuffer-deprecated.h
+file path=usr/include/cogl/cogl/deprecated/cogl-material-compat.h
+file path=usr/include/cogl/cogl/deprecated/cogl-shader.h
+file path=usr/include/cogl/cogl/deprecated/cogl-texture-deprecated.h
+file path=usr/include/cogl/cogl/deprecated/cogl-type-casts.h
+file path=usr/include/cogl/cogl/deprecated/cogl-vertex-buffer.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-core-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-gles2-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-glsl-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-in-gles-core-functions.h
+file path=usr/include/cogl/cogl/gl-prototypes/cogl-in-gles2-core-functions.h
+file path=usr/lib/$(MACH64)/girepository-1.0/Cogl-1.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/Cogl-2.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/CoglGst-2.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/CoglPango-1.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/CoglPango-2.0.typelib
+file path=usr/lib/$(MACH64)/gstreamer-1.0/libgstcogl.so
+link path=usr/lib/$(MACH64)/libcogl-gst.so target=libcogl-gst.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-gst.so.20 target=libcogl-gst.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl-gst.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-pango.so target=libcogl-pango.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-pango.so.20 target=libcogl-pango.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl-pango.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-path.so target=libcogl-path.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl-path.so.20 target=libcogl-path.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl-path.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl.so target=libcogl.so.20.4.2
+link path=usr/lib/$(MACH64)/libcogl.so.20 target=libcogl.so.20.4.2
+file path=usr/lib/$(MACH64)/libcogl.so.20.4.2
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-2.0-experimental.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-gl-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-gst-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-gst-2.0-experimental.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-pango-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-pango-2.0-experimental.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-path-1.0.pc
+file path=usr/lib/$(MACH64)/pkgconfig/cogl-path-2.0-experimental.pc
+file path=usr/lib/girepository-1.0/Cogl-1.0.typelib
+file path=usr/lib/girepository-1.0/Cogl-2.0.typelib
+file path=usr/lib/girepository-1.0/CoglGst-2.0.typelib
+file path=usr/lib/girepository-1.0/CoglPango-1.0.typelib
+file path=usr/lib/girepository-1.0/CoglPango-2.0.typelib
+file path=usr/lib/gstreamer-1.0/libgstcogl.so
+link path=usr/lib/libcogl-gst.so target=libcogl-gst.so.20.4.2
+link path=usr/lib/libcogl-gst.so.20 target=libcogl-gst.so.20.4.2
+file path=usr/lib/libcogl-gst.so.20.4.2
+link path=usr/lib/libcogl-pango.so target=libcogl-pango.so.20.4.2
+link path=usr/lib/libcogl-pango.so.20 target=libcogl-pango.so.20.4.2
+file path=usr/lib/libcogl-pango.so.20.4.2
+link path=usr/lib/libcogl-path.so target=libcogl-path.so.20.4.2
+link path=usr/lib/libcogl-path.so.20 target=libcogl-path.so.20.4.2
+file path=usr/lib/libcogl-path.so.20.4.2
+link path=usr/lib/libcogl.so target=libcogl.so.20.4.2
+link path=usr/lib/libcogl.so.20 target=libcogl.so.20.4.2
+file path=usr/lib/libcogl.so.20.4.2
+file path=usr/lib/pkgconfig/cogl-1.0.pc
+file path=usr/lib/pkgconfig/cogl-2.0-experimental.pc
+file path=usr/lib/pkgconfig/cogl-gl-1.0.pc
+file path=usr/lib/pkgconfig/cogl-gst-1.0.pc
+file path=usr/lib/pkgconfig/cogl-gst-2.0-experimental.pc
+file path=usr/lib/pkgconfig/cogl-pango-1.0.pc
+file path=usr/lib/pkgconfig/cogl-pango-2.0-experimental.pc
+file path=usr/lib/pkgconfig/cogl-path-1.0.pc
+file path=usr/lib/pkgconfig/cogl-path-2.0-experimental.pc
+file path=usr/share/cogl/examples-data/crate.jpg
+file path=usr/share/gir-1.0/Cogl-1.0.gir
+file path=usr/share/gir-1.0/Cogl-2.0.gir
+file path=usr/share/gir-1.0/CoglGst-2.0.gir
+file path=usr/share/gir-1.0/CoglPango-1.0.gir
+file path=usr/share/gir-1.0/CoglPango-2.0.gir
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ch01.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-2D-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-3-Component-Vectors.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-3D-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Bitmap.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglAttributeBuffer---Buffers-of-vertex-attributes.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglBuffer---The-Buffer-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglDisplay---Setup-a-display-pipeline.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglFramebuffer---The-Framebuffer-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglIndexBuffer---Buffers-of-vertex-indices.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglOnscreen---The-Onscreen-Framebuffer-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglOnscreenTemplate---Describe-a-template-for-onscreen-framebuffers.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-CoglRenderer---Connect-to-a-backend-renderer.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Color-Type.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Common-Types.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Depth-State.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Eulers-(Rotations).html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Exception-handling.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-GLES-2.0-context.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-GPU-synchronisation-fences.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-GType-Integration-API.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-High-Level-Meta-Textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Indices.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Low-level-primitive-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Main-loop-integration.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Matrices.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Matrix-Stacks.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Offscreen-Framebuffers.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Path-Primitives.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Pipeline.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Primitives.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Quaternions-(Rotations).html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Rectangle-textures-(non-normalized-coordinates).html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Rectangles.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-SDL-Integration.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Shader-snippets.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Sliced-Textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Sub-Textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-The-Object-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-The-Texture-Interface.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-The-Top-Level-Context.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Versioning-utility-macros.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-Vertex-Attributes.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental-X11-Texture-From-Pixmap.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-2.0-experimental.devhelp2
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-Blend-Strings.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-buffer-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-buffer-layout-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-context-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-framebuffer-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-general-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-integration.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-meta-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-pipeline-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-primitive-apis.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-primitive-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-textures.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl-utilities.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/cogl_ortho.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/coglglossary.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/fill-rule-even-odd.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/fill-rule-non-zero.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/home.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/index.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix01.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix02.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix03.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix04.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix05.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/ix06.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/left-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/left.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/license.html
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/quad-indices-order.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/quad-indices-triangles.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/right-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/right.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/style.css
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/up-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-2.0-experimental/up.png
+file path=usr/share/gtk-doc/html/cogl-gst/CoglGstVideoSink.html
+file path=usr/share/gtk-doc/html/cogl-gst/ch01.html
+file path=usr/share/gtk-doc/html/cogl-gst/cogl-gst-general-apis.html
+file path=usr/share/gtk-doc/html/cogl-gst/cogl-gst.devhelp2
+file path=usr/share/gtk-doc/html/cogl-gst/coglglossary.html
+file path=usr/share/gtk-doc/html/cogl-gst/home.png
+file path=usr/share/gtk-doc/html/cogl-gst/index.html
+file path=usr/share/gtk-doc/html/cogl-gst/ix01.html
+file path=usr/share/gtk-doc/html/cogl-gst/left-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-gst/left.png
+file path=usr/share/gtk-doc/html/cogl-gst/license.html
+file path=usr/share/gtk-doc/html/cogl-gst/right-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-gst/right.png
+file path=usr/share/gtk-doc/html/cogl-gst/style.css
+file path=usr/share/gtk-doc/html/cogl-gst/up-insensitive.png
+file path=usr/share/gtk-doc/html/cogl-gst/up.png
+file path=usr/share/gtk-doc/html/cogl/ch01.html
+file path=usr/share/gtk-doc/html/cogl/ch02.html
+file path=usr/share/gtk-doc/html/cogl/ch03.html
+file path=usr/share/gtk-doc/html/cogl/cogl-3D-textures.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Bitmaps.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Blend-Strings.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Buffers.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Clipping-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Clipping.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Color-Type.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Fixed-Point-API.html
+file path=usr/share/gtk-doc/html/cogl/cogl-GType-Integration-API.html
+file path=usr/share/gtk-doc/html/cogl/cogl-General-API-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-General-API.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Materials-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Materials.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Matrices.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Offscreen-Buffers-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Offscreen-Buffers.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Path-Primitives.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Primitives.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Quaternions-(Rotations).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Shaders-and-Programmable-Pipeline-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Shaders-and-Programmable-Pipeline.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Textures-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Textures.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Vectors.html
+file path=usr/share/gtk-doc/html/cogl/cogl-Vertex-Buffers-(Deprecated).html
+file path=usr/share/gtk-doc/html/cogl/cogl-Vertex-Buffers.html
+file path=usr/share/gtk-doc/html/cogl/cogl.devhelp2
+file path=usr/share/gtk-doc/html/cogl/cogl_ortho.png
+file path=usr/share/gtk-doc/html/cogl/coglglossary.html
+file path=usr/share/gtk-doc/html/cogl/fill-rule-even-odd.png
+file path=usr/share/gtk-doc/html/cogl/fill-rule-non-zero.png
+file path=usr/share/gtk-doc/html/cogl/home.png
+file path=usr/share/gtk-doc/html/cogl/index.html
+file path=usr/share/gtk-doc/html/cogl/ix01.html
+file path=usr/share/gtk-doc/html/cogl/ix02.html
+file path=usr/share/gtk-doc/html/cogl/ix03.html
+file path=usr/share/gtk-doc/html/cogl/ix04.html
+file path=usr/share/gtk-doc/html/cogl/ix05.html
+file path=usr/share/gtk-doc/html/cogl/ix06.html
+file path=usr/share/gtk-doc/html/cogl/ix07.html
+file path=usr/share/gtk-doc/html/cogl/ix08.html
+file path=usr/share/gtk-doc/html/cogl/left-insensitive.png
+file path=usr/share/gtk-doc/html/cogl/left.png
+file path=usr/share/gtk-doc/html/cogl/license.html
+file path=usr/share/gtk-doc/html/cogl/quad-indices-order.png
+file path=usr/share/gtk-doc/html/cogl/quad-indices-triangles.png
+file path=usr/share/gtk-doc/html/cogl/right-insensitive.png
+file path=usr/share/gtk-doc/html/cogl/right.png
+file path=usr/share/gtk-doc/html/cogl/style.css
+file path=usr/share/gtk-doc/html/cogl/up-insensitive.png
+file path=usr/share/gtk-doc/html/cogl/up.png
+file path=usr/share/locale/an/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ar/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/as/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ast/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/be/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/bg/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/bs/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ca/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/cs/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/da/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/de/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/el/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/en_CA/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/eo/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/es/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/eu/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/fa/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/fr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/fur/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/gl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/he/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/hi/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/hr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/hu/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/id/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/it/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ja/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/km/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/kn/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ko/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/lt/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/lv/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ml/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/nb/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ne/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/nl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/oc/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/or/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pa/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pt/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ro/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ru/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sk/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sl/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/sv/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ta/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/te/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/th/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/tr/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/ug/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/uk/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/vi/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/cogl.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/cogl.mo


### PR DESCRIPTION
cogl is one of the new components that are needed for clutter-related interfaces, including the updated totem.

This must be installed before the forecoming updates to clutter and related packages are built.

This has only been lightly tested.  There may be additional configuration options that should be pursued.