### PR TITLE
[totem-update] new component grilo

### DIFF
--- a/components/library/grilo/Makefile
+++ b/components/library/grilo/Makefile
@@ -1,0 +1,64 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Tim Mooney.  All rights reserved.
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		grilo
+COMPONENT_VERSION=	0.3.6
+COMPONENT_FMRI=		library/desktop/$(COMPONENT_NAME)
+COMPONENT_SUMMARY=	grilo - a framework for media discovery and browsing
+COMPONENT_CLASSIFICATION= System/Multimedia Libraries
+COMPONENT_PROJECT_URL=	https://wiki.gnome.org/Projects/Grilo
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH=	\
+  sha256:1e65ca82dd58020451417fde79310d4b940adc3f63ab59997419c52ed3bc9c91
+COMPONENT_ARCHIVE_URL= \
+  http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/0.3/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	LGPL 2.1
+COMPONENT_LICENSE_FILE=	COPYING
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_PRE_CONFIGURE_ACTION += ( $(CLONEY) $(SOURCE_DIR) $(@D) )
+
+PATH=$(PATH.gnu)
+
+CONFIGURE_SCRIPT=	$(@D)/configure
+
+CONFIGURE_OPTIONS+=	--sysconfdir=/etc
+CONFIGURE_OPTIONS+=	--disable-static
+CONFIGURE_OPTIONS+=	--enable-gtk-doc
+
+# Tell g-ir-scanner about compiler
+COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
+COMPONENT_BUILD_ENV += CC="$(CC)"
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/gtk3
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/liboauth
+REQUIRED_PACKAGES += library/libsoup
+REQUIRED_PACKAGES += library/media-player/totem-pl-parser
+REQUIRED_PACKAGES += system/library

--- a/components/library/grilo/grilo.p5m
+++ b/components/library/grilo/grilo.p5m
@@ -1,0 +1,191 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Tim Mooney. All rights reserved.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file path=usr/share/gtk-doc/.* ->  default facet.doc true>
+<transform file path=usr/share/gtk-doc/html/.* ->  default facet.doc.html true>
+<transform file path=usr/share/locale/([^/]+)(\..+){0,1}(/.+){0,1} -> default facet.locale.%<\1> true>
+
+# which man page transform?
+
+file path=usr/bin/$(MACH64)/grilo-test-ui-0.3
+file path=usr/bin/$(MACH64)/grl-inspect-0.3
+file path=usr/bin/$(MACH64)/grl-launch-0.3
+file path=usr/bin/grilo-test-ui-0.3
+file path=usr/bin/grl-inspect-0.3
+file path=usr/bin/grl-launch-0.3
+file path=usr/include/grilo-0.3/grilo.h
+file path=usr/include/grilo-0.3/grl-caps.h
+file path=usr/include/grilo-0.3/grl-config.h
+file path=usr/include/grilo-0.3/grl-data.h
+file path=usr/include/grilo-0.3/grl-definitions.h
+file path=usr/include/grilo-0.3/grl-error.h
+file path=usr/include/grilo-0.3/grl-log.h
+file path=usr/include/grilo-0.3/grl-media.h
+file path=usr/include/grilo-0.3/grl-metadata-key.h
+file path=usr/include/grilo-0.3/grl-multiple.h
+file path=usr/include/grilo-0.3/grl-operation-options.h
+file path=usr/include/grilo-0.3/grl-operation.h
+file path=usr/include/grilo-0.3/grl-plugin.h
+file path=usr/include/grilo-0.3/grl-range-value.h
+file path=usr/include/grilo-0.3/grl-registry.h
+file path=usr/include/grilo-0.3/grl-related-keys.h
+file path=usr/include/grilo-0.3/grl-source.h
+file path=usr/include/grilo-0.3/grl-util.h
+file path=usr/include/grilo-0.3/grl-value-helper.h
+file path=usr/include/grilo-0.3/net/grl-net-wc.h
+file path=usr/include/grilo-0.3/net/grl-net.h
+file path=usr/include/grilo-0.3/pls/grl-pls.h
+file path=usr/lib/$(MACH64)/girepository-1.0/Grl-0.3.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/GrlNet-0.3.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/GrlPls-0.3.typelib
+link path=usr/lib/$(MACH64)/libgrilo-0.3.so target=libgrilo-0.3.so.0.2.0
+link path=usr/lib/$(MACH64)/libgrilo-0.3.so.0 target=libgrilo-0.3.so.0.2.0
+file path=usr/lib/$(MACH64)/libgrilo-0.3.so.0.2.0
+link path=usr/lib/$(MACH64)/libgrlnet-0.3.so target=libgrlnet-0.3.so.0.0.5
+link path=usr/lib/$(MACH64)/libgrlnet-0.3.so.0 target=libgrlnet-0.3.so.0.0.5
+file path=usr/lib/$(MACH64)/libgrlnet-0.3.so.0.0.5
+link path=usr/lib/$(MACH64)/libgrlpls-0.3.so target=libgrlpls-0.3.so.0.0.0
+link path=usr/lib/$(MACH64)/libgrlpls-0.3.so.0 target=libgrlpls-0.3.so.0.0.0
+file path=usr/lib/$(MACH64)/libgrlpls-0.3.so.0.0.0
+file path=usr/lib/$(MACH64)/pkgconfig/grilo-0.3.pc
+file path=usr/lib/$(MACH64)/pkgconfig/grilo-net-0.3.pc
+file path=usr/lib/$(MACH64)/pkgconfig/grilo-pls-0.3.pc
+file path=usr/lib/girepository-1.0/Grl-0.3.typelib
+file path=usr/lib/girepository-1.0/GrlNet-0.3.typelib
+file path=usr/lib/girepository-1.0/GrlPls-0.3.typelib
+link path=usr/lib/libgrilo-0.3.so target=libgrilo-0.3.so.0.2.0
+link path=usr/lib/libgrilo-0.3.so.0 target=libgrilo-0.3.so.0.2.0
+file path=usr/lib/libgrilo-0.3.so.0.2.0
+link path=usr/lib/libgrlnet-0.3.so target=libgrlnet-0.3.so.0.0.5
+link path=usr/lib/libgrlnet-0.3.so.0 target=libgrlnet-0.3.so.0.0.5
+file path=usr/lib/libgrlnet-0.3.so.0.0.5
+link path=usr/lib/libgrlpls-0.3.so target=libgrlpls-0.3.so.0.0.0
+link path=usr/lib/libgrlpls-0.3.so.0 target=libgrlpls-0.3.so.0.0.0
+file path=usr/lib/libgrlpls-0.3.so.0.0.0
+file path=usr/lib/pkgconfig/grilo-0.3.pc
+file path=usr/lib/pkgconfig/grilo-net-0.3.pc
+file path=usr/lib/pkgconfig/grilo-pls-0.3.pc
+file path=usr/share/gir-1.0/Grl-0.3.gir
+file path=usr/share/gir-1.0/GrlNet-0.3.gir
+file path=usr/share/gir-1.0/GrlPls-0.3.gir
+file path=usr/share/gtk-doc/html/grilo/annotation-glossary.html
+file path=usr/share/gtk-doc/html/grilo/api-index-full.html
+file path=usr/share/gtk-doc/html/grilo/caps-options.html
+file path=usr/share/gtk-doc/html/grilo/ch01.html
+file path=usr/share/gtk-doc/html/grilo/ch02.html
+file path=usr/share/gtk-doc/html/grilo/ch03.html
+file path=usr/share/gtk-doc/html/grilo/ch04.html
+file path=usr/share/gtk-doc/html/grilo/configure.html
+file path=usr/share/gtk-doc/html/grilo/data.html
+file path=usr/share/gtk-doc/html/grilo/deprecated-api-index.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlCaps.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlConfig.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlData.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlMedia.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlNetWc.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlOperationOptions.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlPls.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlPlugin.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlRegistry.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlRelatedKeys.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlSource.html
+file path=usr/share/gtk-doc/html/grilo/grilo-Multiple.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grilo.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-definitions.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-error.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-log.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-metadata-key.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-operation.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-util.html
+file path=usr/share/gtk-doc/html/grilo/grilo-net.html
+file path=usr/share/gtk-doc/html/grilo/grilo-pls.html
+file path=usr/share/gtk-doc/html/grilo/grilo.devhelp2
+file path=usr/share/gtk-doc/html/grilo/home.png
+file path=usr/share/gtk-doc/html/grilo/index.html
+file path=usr/share/gtk-doc/html/grilo/left-insensitive.png
+file path=usr/share/gtk-doc/html/grilo/left.png
+file path=usr/share/gtk-doc/html/grilo/misc.html
+file path=usr/share/gtk-doc/html/grilo/multiple.html
+file path=usr/share/gtk-doc/html/grilo/plugin-management.html
+file path=usr/share/gtk-doc/html/grilo/pr01.html
+file path=usr/share/gtk-doc/html/grilo/right-insensitive.png
+file path=usr/share/gtk-doc/html/grilo/right.png
+file path=usr/share/gtk-doc/html/grilo/rn01.html
+file path=usr/share/gtk-doc/html/grilo/rn02.html
+file path=usr/share/gtk-doc/html/grilo/rn03.html
+file path=usr/share/gtk-doc/html/grilo/rn04.html
+file path=usr/share/gtk-doc/html/grilo/sources.html
+file path=usr/share/gtk-doc/html/grilo/style.css
+file path=usr/share/gtk-doc/html/grilo/up-insensitive.png
+file path=usr/share/gtk-doc/html/grilo/up.png
+file path=usr/share/locale/as/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/bg/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/bs/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ca/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/cs/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/da/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/de/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/el/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/eo/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/es/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/eu/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/fr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/fur/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/gl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/he/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/hr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/hu/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/id/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/it/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ja/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ko/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/lt/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/lv/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ml/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/nb/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ne/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/nl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/oc/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pa/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pt/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ro/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ru/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sk/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sv/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/tg/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/tr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/uk/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/grilo.mo
+file path=usr/share/man/man1/grilo-test-ui-0.3.1
+file path=usr/share/man/man1/grl-inspect-0.3.1
+file path=usr/share/man/man1/grl-launch-0.3.1

--- a/components/library/grilo/manifests/sample-manifest.p5m
+++ b/components/library/grilo/manifests/sample-manifest.p5m
@@ -1,0 +1,185 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH64)/grilo-test-ui-0.3
+file path=usr/bin/$(MACH64)/grl-inspect-0.3
+file path=usr/bin/$(MACH64)/grl-launch-0.3
+file path=usr/bin/grilo-test-ui-0.3
+file path=usr/bin/grl-inspect-0.3
+file path=usr/bin/grl-launch-0.3
+file path=usr/include/grilo-0.3/grilo.h
+file path=usr/include/grilo-0.3/grl-caps.h
+file path=usr/include/grilo-0.3/grl-config.h
+file path=usr/include/grilo-0.3/grl-data.h
+file path=usr/include/grilo-0.3/grl-definitions.h
+file path=usr/include/grilo-0.3/grl-error.h
+file path=usr/include/grilo-0.3/grl-log.h
+file path=usr/include/grilo-0.3/grl-media.h
+file path=usr/include/grilo-0.3/grl-metadata-key.h
+file path=usr/include/grilo-0.3/grl-multiple.h
+file path=usr/include/grilo-0.3/grl-operation-options.h
+file path=usr/include/grilo-0.3/grl-operation.h
+file path=usr/include/grilo-0.3/grl-plugin.h
+file path=usr/include/grilo-0.3/grl-range-value.h
+file path=usr/include/grilo-0.3/grl-registry.h
+file path=usr/include/grilo-0.3/grl-related-keys.h
+file path=usr/include/grilo-0.3/grl-source.h
+file path=usr/include/grilo-0.3/grl-util.h
+file path=usr/include/grilo-0.3/grl-value-helper.h
+file path=usr/include/grilo-0.3/net/grl-net-wc.h
+file path=usr/include/grilo-0.3/net/grl-net.h
+file path=usr/include/grilo-0.3/pls/grl-pls.h
+file path=usr/lib/$(MACH64)/girepository-1.0/Grl-0.3.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/GrlNet-0.3.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/GrlPls-0.3.typelib
+link path=usr/lib/$(MACH64)/libgrilo-0.3.so target=libgrilo-0.3.so.0.2.0
+link path=usr/lib/$(MACH64)/libgrilo-0.3.so.0 target=libgrilo-0.3.so.0.2.0
+file path=usr/lib/$(MACH64)/libgrilo-0.3.so.0.2.0
+link path=usr/lib/$(MACH64)/libgrlnet-0.3.so target=libgrlnet-0.3.so.0.0.5
+link path=usr/lib/$(MACH64)/libgrlnet-0.3.so.0 target=libgrlnet-0.3.so.0.0.5
+file path=usr/lib/$(MACH64)/libgrlnet-0.3.so.0.0.5
+link path=usr/lib/$(MACH64)/libgrlpls-0.3.so target=libgrlpls-0.3.so.0.0.0
+link path=usr/lib/$(MACH64)/libgrlpls-0.3.so.0 target=libgrlpls-0.3.so.0.0.0
+file path=usr/lib/$(MACH64)/libgrlpls-0.3.so.0.0.0
+file path=usr/lib/$(MACH64)/pkgconfig/grilo-0.3.pc
+file path=usr/lib/$(MACH64)/pkgconfig/grilo-net-0.3.pc
+file path=usr/lib/$(MACH64)/pkgconfig/grilo-pls-0.3.pc
+file path=usr/lib/girepository-1.0/Grl-0.3.typelib
+file path=usr/lib/girepository-1.0/GrlNet-0.3.typelib
+file path=usr/lib/girepository-1.0/GrlPls-0.3.typelib
+link path=usr/lib/libgrilo-0.3.so target=libgrilo-0.3.so.0.2.0
+link path=usr/lib/libgrilo-0.3.so.0 target=libgrilo-0.3.so.0.2.0
+file path=usr/lib/libgrilo-0.3.so.0.2.0
+link path=usr/lib/libgrlnet-0.3.so target=libgrlnet-0.3.so.0.0.5
+link path=usr/lib/libgrlnet-0.3.so.0 target=libgrlnet-0.3.so.0.0.5
+file path=usr/lib/libgrlnet-0.3.so.0.0.5
+link path=usr/lib/libgrlpls-0.3.so target=libgrlpls-0.3.so.0.0.0
+link path=usr/lib/libgrlpls-0.3.so.0 target=libgrlpls-0.3.so.0.0.0
+file path=usr/lib/libgrlpls-0.3.so.0.0.0
+file path=usr/lib/pkgconfig/grilo-0.3.pc
+file path=usr/lib/pkgconfig/grilo-net-0.3.pc
+file path=usr/lib/pkgconfig/grilo-pls-0.3.pc
+file path=usr/share/gir-1.0/Grl-0.3.gir
+file path=usr/share/gir-1.0/GrlNet-0.3.gir
+file path=usr/share/gir-1.0/GrlPls-0.3.gir
+file path=usr/share/gtk-doc/html/grilo/annotation-glossary.html
+file path=usr/share/gtk-doc/html/grilo/api-index-full.html
+file path=usr/share/gtk-doc/html/grilo/caps-options.html
+file path=usr/share/gtk-doc/html/grilo/ch01.html
+file path=usr/share/gtk-doc/html/grilo/ch02.html
+file path=usr/share/gtk-doc/html/grilo/ch03.html
+file path=usr/share/gtk-doc/html/grilo/ch04.html
+file path=usr/share/gtk-doc/html/grilo/configure.html
+file path=usr/share/gtk-doc/html/grilo/data.html
+file path=usr/share/gtk-doc/html/grilo/deprecated-api-index.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlCaps.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlConfig.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlData.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlMedia.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlNetWc.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlOperationOptions.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlPls.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlPlugin.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlRegistry.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlRelatedKeys.html
+file path=usr/share/gtk-doc/html/grilo/grilo-GrlSource.html
+file path=usr/share/gtk-doc/html/grilo/grilo-Multiple.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grilo.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-definitions.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-error.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-log.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-metadata-key.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-operation.html
+file path=usr/share/gtk-doc/html/grilo/grilo-grl-util.html
+file path=usr/share/gtk-doc/html/grilo/grilo-net.html
+file path=usr/share/gtk-doc/html/grilo/grilo-pls.html
+file path=usr/share/gtk-doc/html/grilo/grilo.devhelp2
+file path=usr/share/gtk-doc/html/grilo/home.png
+file path=usr/share/gtk-doc/html/grilo/index.html
+file path=usr/share/gtk-doc/html/grilo/left-insensitive.png
+file path=usr/share/gtk-doc/html/grilo/left.png
+file path=usr/share/gtk-doc/html/grilo/misc.html
+file path=usr/share/gtk-doc/html/grilo/multiple.html
+file path=usr/share/gtk-doc/html/grilo/plugin-management.html
+file path=usr/share/gtk-doc/html/grilo/pr01.html
+file path=usr/share/gtk-doc/html/grilo/right-insensitive.png
+file path=usr/share/gtk-doc/html/grilo/right.png
+file path=usr/share/gtk-doc/html/grilo/rn01.html
+file path=usr/share/gtk-doc/html/grilo/rn02.html
+file path=usr/share/gtk-doc/html/grilo/rn03.html
+file path=usr/share/gtk-doc/html/grilo/rn04.html
+file path=usr/share/gtk-doc/html/grilo/sources.html
+file path=usr/share/gtk-doc/html/grilo/style.css
+file path=usr/share/gtk-doc/html/grilo/up-insensitive.png
+file path=usr/share/gtk-doc/html/grilo/up.png
+file path=usr/share/locale/as/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/bg/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/bs/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ca/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/cs/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/da/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/de/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/el/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/eo/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/es/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/eu/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/fr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/fur/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/gl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/he/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/hr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/hu/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/id/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/it/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ja/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ko/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/lt/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/lv/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ml/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/nb/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ne/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/nl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/oc/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pa/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pt/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ro/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/ru/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sk/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sl/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/sv/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/tg/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/tr/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/uk/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/grilo.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/grilo.mo
+file path=usr/share/man/man1/grilo-test-ui-0.3.1
+file path=usr/share/man/man1/grl-inspect-0.3.1
+file path=usr/share/man/man1/grl-launch-0.3.1

--- a/components/library/grilo/patches/grilo-0.3.6-printf-getpid.patch
+++ b/components/library/grilo/patches/grilo-0.3.6-printf-getpid.patch
@@ -1,0 +1,17 @@
+diff -ur grilo-0.3.6.orig/libs/net/grl-net-wc.c grilo-0.3.6/libs/net/grl-net-wc.c
+--- grilo-0.3.6.orig/libs/net/grl-net-wc.c	2018-07-25 07:12:13.000000000 +0000
++++ grilo-0.3.6/libs/net/grl-net-wc.c	2019-10-04 17:02:53.134843110 +0000
+@@ -523,7 +523,13 @@
+ 
+   /* Append record about the just written file to "grl-net-mock-data-%PID.ini"
+    * in the capture directory. */
++#if defined(__sun) && defined(_LP64)
++  char *filename = g_strdup_printf ("grl-net-mock-data-%d.ini", getpid());
++#elif defined(__sun)
++  char *filename = g_strdup_printf ("grl-net-mock-data-%ld.ini", getpid());
++#else
+   char *filename = g_strdup_printf ("grl-net-mock-data-%u.ini", getpid());
++#endif
+   path = g_build_filename (capture_dir, filename, NULL);
+   g_free (filename);
+ 


### PR DESCRIPTION
new component grilo is a plugin registry/framework, required by recent totem.

I'll have a separate PR for grilo/plugins , which also have additional package requirements.

This version (0.3.6) is the last version that used configure.  There are newer versions (0.3.12 is recent), but I haven't tried updating them for meson.

Either grilo or something from grilo-plugins has a tendency to leave plugin cache directories in /tmp or /var/tmp.  Perhaps that's fixed in later versions.