### PR TITLE
[totem-update] new component gnome-desktop

### DIFF
--- a/components/library/gnome-desktop/COPYING
+++ b/components/library/gnome-desktop/COPYING
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/components/library/gnome-desktop/Makefile
+++ b/components/library/gnome-desktop/Makefile
@@ -1,0 +1,72 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Tim Mooney.  All rights reserved.
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		gnome-desktop
+COMPONENT_VERSION=	3.30.2
+COMPONENT_FMRI=		library/desktop/$(COMPONENT_NAME)
+COMPONENT_SUMMARY=	libgnome-desktop - a shared API for desktop applications
+COMPONENT_CLASSIFICATION= Desktop (GNOME)/Libraries
+COMPONENT_PROJECT_URL=	https://github.com/GNOME/gnome-desktop
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH=	\
+  sha256:5475e693cb7ada801a36e8d16bc0dbb58930b793f455419b205cd9241d63d14c
+COMPONENT_ARCHIVE_URL= \
+  http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/3.30/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	GPLv2, LGPLv2, GNU FDL 3.0
+COMPONENT_LICENSE_FILE=	COPYING
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_PRE_CONFIGURE_ACTION += ( $(CLONEY) $(SOURCE_DIR) $(@D) )
+
+PATH=$(PATH.gnu)
+
+CONFIGURE_SCRIPT=	$(@D)/configure
+
+CONFIGURE_OPTIONS+=	--sysconfdir=/etc
+CONFIGURE_OPTIONS+=	--localstatedir=/var
+CONFIGURE_OPTIONS+=	--libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
+CONFIGURE_OPTIONS+=	--disable-static
+CONFIGURE_OPTIONS+=	--enable-gtk-doc
+CONFIGURE_OPTIONS+=	--with-gnome-distributor='openindiana.org'
+
+# Tell g-ir-scanner about compiler
+COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
+COMPONENT_BUILD_ENV += CC="$(CC)"
+
+# common targets
+build:		$(BUILD_32_and_64)
+
+install:	$(INSTALL_32_and_64)
+
+test:		$(TEST_32_and_64)
+
+# build-time dependencies:
+REQUIRED_PACKAGES += developer/documentation-tool/gtk-doc
+REQUIRED_PACKAGES += text/itstool
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
+REQUIRED_PACKAGES += library/desktop/gtk3
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/library/gnome-desktop/gnome-desktop.p5m
+++ b/components/library/gnome-desktop/gnome-desktop.p5m
@@ -1,0 +1,263 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2019 Tim Mooney. All rights reserved
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# transforms for gtk-doc stuff
+<transform file path=usr/share/gtk-doc/.* ->  default facet.doc true>
+<transform file path=usr/share/gtk-doc/html/.* ->  default facet.doc.html true>
+# transform for locale files
+<transform file path=usr/share/locale/([^/]+)(\..+){0,1}(/.+){0,1} -> default facet.locale.%<\1> true>
+
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-bg-crossfade.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-bg-slide-show.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-bg.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-desktop-thumbnail.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-idle-monitor.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-languages.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-pnp-ids.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-rr-config.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-rr.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-wall-clock.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-xkb-info.h
+file path=usr/lib/$(MACH64)/girepository-1.0/GnomeDesktop-3.0.typelib
+file path=usr/lib/$(MACH64)/gnome-rr-debug
+link path=usr/lib/$(MACH64)/libgnome-desktop-3.so \
+    target=libgnome-desktop-3.so.17.0.3
+link path=usr/lib/$(MACH64)/libgnome-desktop-3.so.17 \
+    target=libgnome-desktop-3.so.17.0.3
+file path=usr/lib/$(MACH64)/libgnome-desktop-3.so.17.0.3
+file path=usr/lib/$(MACH64)/pkgconfig/gnome-desktop-3.0.pc
+file path=usr/lib/girepository-1.0/GnomeDesktop-3.0.typelib
+file path=usr/lib/gnome-rr-debug
+link path=usr/lib/libgnome-desktop-3.so target=libgnome-desktop-3.so.17.0.3
+link path=usr/lib/libgnome-desktop-3.so.17 target=libgnome-desktop-3.so.17.0.3
+file path=usr/lib/libgnome-desktop-3.so.17.0.3
+file path=usr/lib/pkgconfig/gnome-desktop-3.0.pc
+file path=usr/share/gir-1.0/GnomeDesktop-3.0.gir
+file path=usr/share/gnome/gnome-version.xml
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeDesktopThumbnailFactory.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeIdleMonitor.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeWallClock.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeXkbInfo.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/annotation-glossary.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/background.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-Language-Utilities.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-bg.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-pnp-ids.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-rr-config.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-rr.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3.devhelp2
+file path=usr/share/gtk-doc/html/gnome-desktop3/home.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/idle-monitor.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/index.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/intro.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/languages.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/left-insensitive.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/left.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/randr.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/right-insensitive.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/right.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/style.css
+file path=usr/share/gtk-doc/html/gnome-desktop3/thumbnail.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/up-insensitive.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/up.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/wall-clock.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/xkb-info.html
+file path=usr/share/help/C/fdl/index.docbook
+file path=usr/share/help/C/gpl/index.docbook
+file path=usr/share/help/C/lgpl/index.docbook
+file path=usr/share/help/ar/fdl/index.docbook
+file path=usr/share/help/ar/gpl/index.docbook
+file path=usr/share/help/ar/lgpl/index.docbook
+file path=usr/share/help/ca/fdl/index.docbook
+file path=usr/share/help/ca/gpl/index.docbook
+file path=usr/share/help/ca/lgpl/index.docbook
+file path=usr/share/help/cs/fdl/index.docbook
+file path=usr/share/help/cs/gpl/index.docbook
+file path=usr/share/help/cs/lgpl/index.docbook
+file path=usr/share/help/de/fdl/index.docbook
+file path=usr/share/help/de/gpl/index.docbook
+file path=usr/share/help/de/lgpl/index.docbook
+file path=usr/share/help/el/fdl/index.docbook
+file path=usr/share/help/el/gpl/index.docbook
+file path=usr/share/help/el/lgpl/index.docbook
+file path=usr/share/help/es/fdl/index.docbook
+file path=usr/share/help/es/gpl/index.docbook
+file path=usr/share/help/es/lgpl/index.docbook
+file path=usr/share/help/eu/fdl/index.docbook
+file path=usr/share/help/eu/gpl/index.docbook
+file path=usr/share/help/eu/lgpl/index.docbook
+file path=usr/share/help/fi/gpl/index.docbook
+file path=usr/share/help/fi/lgpl/index.docbook
+file path=usr/share/help/fr/fdl/index.docbook
+file path=usr/share/help/fr/gpl/index.docbook
+file path=usr/share/help/fr/lgpl/index.docbook
+file path=usr/share/help/gl/fdl/index.docbook
+file path=usr/share/help/gl/gpl/index.docbook
+file path=usr/share/help/hu/fdl/index.docbook
+file path=usr/share/help/hu/gpl/index.docbook
+file path=usr/share/help/hu/lgpl/index.docbook
+file path=usr/share/help/ko/fdl/index.docbook
+file path=usr/share/help/ko/gpl/index.docbook
+file path=usr/share/help/ko/lgpl/index.docbook
+file path=usr/share/help/nds/gpl/index.docbook
+file path=usr/share/help/oc/fdl/index.docbook
+file path=usr/share/help/oc/gpl/index.docbook
+file path=usr/share/help/oc/lgpl/index.docbook
+file path=usr/share/help/pa/gpl/index.docbook
+file path=usr/share/help/pa/lgpl/index.docbook
+file path=usr/share/help/pt_BR/fdl/index.docbook
+file path=usr/share/help/pt_BR/gpl/index.docbook
+file path=usr/share/help/pt_BR/lgpl/index.docbook
+file path=usr/share/help/sl/fdl/index.docbook
+file path=usr/share/help/sl/gpl/index.docbook
+file path=usr/share/help/sl/lgpl/index.docbook
+file path=usr/share/help/sr/gpl/index.docbook
+file path=usr/share/help/sr@latin/gpl/index.docbook
+file path=usr/share/help/sv/fdl/index.docbook
+file path=usr/share/help/sv/gpl/index.docbook
+file path=usr/share/help/sv/lgpl/index.docbook
+file path=usr/share/help/uk/fdl/index.docbook
+file path=usr/share/help/uk/gpl/index.docbook
+file path=usr/share/help/uk/lgpl/index.docbook
+file path=usr/share/help/vi/fdl/index.docbook
+file path=usr/share/help/vi/gpl/index.docbook
+file path=usr/share/help/vi/lgpl/index.docbook
+file path=usr/share/help/zh_CN/fdl/index.docbook
+file path=usr/share/help/zh_CN/gpl/index.docbook
+file path=usr/share/help/zh_CN/lgpl/index.docbook
+file path=usr/share/locale/af/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/am/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/an/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ar/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/as/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ast/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/az/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/be/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/be@latin/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bn_IN/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/br/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bs/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ca/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/crh/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/cs/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/csb/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/cy/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/da/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/de/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/dz/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/el/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en@shaw/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en_CA/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/eo/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/es/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/et/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/eu/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fa/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fur/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fy/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ga/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/gd/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/gl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/gu/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ha/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/he/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hu/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hy/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/id/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ig/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/is/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/it/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ja/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ka/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/kg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/kk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/km/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/kn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ko/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ku/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ky/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/li/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/lo/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/lt/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/lv/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mai/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ml/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ms/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nb/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nds/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ne/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nso/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/oc/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/or/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pa/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ps/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pt/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ro/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ru/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/rw/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/si/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sq/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sv/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ta/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/te/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/tg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/th/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/tk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/tr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ug/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/uk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ur/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/uz/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/uz@cyrillic/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/vi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/wa/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/xh/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/yi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/yo/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zu/LC_MESSAGES/gnome-desktop-3.0.mo

--- a/components/library/gnome-desktop/manifests/sample-manifest.p5m
+++ b/components/library/gnome-desktop/manifests/sample-manifest.p5m
@@ -1,0 +1,257 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-bg-crossfade.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-bg-slide-show.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-bg.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-desktop-thumbnail.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-idle-monitor.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-languages.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-pnp-ids.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-rr-config.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-rr.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-wall-clock.h
+file path=usr/include/gnome-desktop-3.0/libgnome-desktop/gnome-xkb-info.h
+file path=usr/lib/$(MACH64)/girepository-1.0/GnomeDesktop-3.0.typelib
+file path=usr/lib/$(MACH64)/gnome-rr-debug
+link path=usr/lib/$(MACH64)/libgnome-desktop-3.so \
+    target=libgnome-desktop-3.so.17.0.3
+link path=usr/lib/$(MACH64)/libgnome-desktop-3.so.17 \
+    target=libgnome-desktop-3.so.17.0.3
+file path=usr/lib/$(MACH64)/libgnome-desktop-3.so.17.0.3
+file path=usr/lib/$(MACH64)/pkgconfig/gnome-desktop-3.0.pc
+file path=usr/lib/girepository-1.0/GnomeDesktop-3.0.typelib
+file path=usr/lib/gnome-rr-debug
+link path=usr/lib/libgnome-desktop-3.so target=libgnome-desktop-3.so.17.0.3
+link path=usr/lib/libgnome-desktop-3.so.17 target=libgnome-desktop-3.so.17.0.3
+file path=usr/lib/libgnome-desktop-3.so.17.0.3
+file path=usr/lib/pkgconfig/gnome-desktop-3.0.pc
+file path=usr/share/gir-1.0/GnomeDesktop-3.0.gir
+file path=usr/share/gnome/gnome-version.xml
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeDesktopThumbnailFactory.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeIdleMonitor.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeWallClock.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/GnomeXkbInfo.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/annotation-glossary.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/background.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-Language-Utilities.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-bg.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-pnp-ids.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-rr-config.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3-gnome-rr.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/gnome-desktop3.devhelp2
+file path=usr/share/gtk-doc/html/gnome-desktop3/home.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/idle-monitor.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/index.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/intro.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/languages.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/left-insensitive.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/left.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/randr.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/right-insensitive.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/right.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/style.css
+file path=usr/share/gtk-doc/html/gnome-desktop3/thumbnail.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/up-insensitive.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/up.png
+file path=usr/share/gtk-doc/html/gnome-desktop3/wall-clock.html
+file path=usr/share/gtk-doc/html/gnome-desktop3/xkb-info.html
+file path=usr/share/help/C/fdl/index.docbook
+file path=usr/share/help/C/gpl/index.docbook
+file path=usr/share/help/C/lgpl/index.docbook
+file path=usr/share/help/ar/fdl/index.docbook
+file path=usr/share/help/ar/gpl/index.docbook
+file path=usr/share/help/ar/lgpl/index.docbook
+file path=usr/share/help/ca/fdl/index.docbook
+file path=usr/share/help/ca/gpl/index.docbook
+file path=usr/share/help/ca/lgpl/index.docbook
+file path=usr/share/help/cs/fdl/index.docbook
+file path=usr/share/help/cs/gpl/index.docbook
+file path=usr/share/help/cs/lgpl/index.docbook
+file path=usr/share/help/de/fdl/index.docbook
+file path=usr/share/help/de/gpl/index.docbook
+file path=usr/share/help/de/lgpl/index.docbook
+file path=usr/share/help/el/fdl/index.docbook
+file path=usr/share/help/el/gpl/index.docbook
+file path=usr/share/help/el/lgpl/index.docbook
+file path=usr/share/help/es/fdl/index.docbook
+file path=usr/share/help/es/gpl/index.docbook
+file path=usr/share/help/es/lgpl/index.docbook
+file path=usr/share/help/eu/fdl/index.docbook
+file path=usr/share/help/eu/gpl/index.docbook
+file path=usr/share/help/eu/lgpl/index.docbook
+file path=usr/share/help/fi/gpl/index.docbook
+file path=usr/share/help/fi/lgpl/index.docbook
+file path=usr/share/help/fr/fdl/index.docbook
+file path=usr/share/help/fr/gpl/index.docbook
+file path=usr/share/help/fr/lgpl/index.docbook
+file path=usr/share/help/gl/fdl/index.docbook
+file path=usr/share/help/gl/gpl/index.docbook
+file path=usr/share/help/hu/fdl/index.docbook
+file path=usr/share/help/hu/gpl/index.docbook
+file path=usr/share/help/hu/lgpl/index.docbook
+file path=usr/share/help/ko/fdl/index.docbook
+file path=usr/share/help/ko/gpl/index.docbook
+file path=usr/share/help/ko/lgpl/index.docbook
+file path=usr/share/help/nds/gpl/index.docbook
+file path=usr/share/help/oc/fdl/index.docbook
+file path=usr/share/help/oc/gpl/index.docbook
+file path=usr/share/help/oc/lgpl/index.docbook
+file path=usr/share/help/pa/gpl/index.docbook
+file path=usr/share/help/pa/lgpl/index.docbook
+file path=usr/share/help/pt_BR/fdl/index.docbook
+file path=usr/share/help/pt_BR/gpl/index.docbook
+file path=usr/share/help/pt_BR/lgpl/index.docbook
+file path=usr/share/help/sl/fdl/index.docbook
+file path=usr/share/help/sl/gpl/index.docbook
+file path=usr/share/help/sl/lgpl/index.docbook
+file path=usr/share/help/sr/gpl/index.docbook
+file path=usr/share/help/sr@latin/gpl/index.docbook
+file path=usr/share/help/sv/fdl/index.docbook
+file path=usr/share/help/sv/gpl/index.docbook
+file path=usr/share/help/sv/lgpl/index.docbook
+file path=usr/share/help/uk/fdl/index.docbook
+file path=usr/share/help/uk/gpl/index.docbook
+file path=usr/share/help/uk/lgpl/index.docbook
+file path=usr/share/help/vi/fdl/index.docbook
+file path=usr/share/help/vi/gpl/index.docbook
+file path=usr/share/help/vi/lgpl/index.docbook
+file path=usr/share/help/zh_CN/fdl/index.docbook
+file path=usr/share/help/zh_CN/gpl/index.docbook
+file path=usr/share/help/zh_CN/lgpl/index.docbook
+file path=usr/share/locale/af/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/am/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/an/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ar/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/as/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ast/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/az/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/be/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/be@latin/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bn_IN/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/br/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/bs/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ca/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/crh/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/cs/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/csb/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/cy/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/da/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/de/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/dz/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/el/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en@shaw/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en_CA/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/eo/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/es/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/et/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/eu/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fa/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fur/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/fy/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ga/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/gd/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/gl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/gu/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ha/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/he/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hu/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/hy/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/id/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ig/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/is/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/it/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ja/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ka/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/kg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/kk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/km/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/kn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ko/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ku/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ky/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/li/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/lo/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/lt/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/lv/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mai/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ml/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/mr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ms/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nb/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nds/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ne/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nn/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/nso/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/oc/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/or/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pa/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ps/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pt/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ro/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ru/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/rw/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/si/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sl/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sq/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/sv/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ta/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/te/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/tg/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/th/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/tk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/tr/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ug/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/uk/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/ur/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/uz/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/uz@cyrillic/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/vi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/wa/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/xh/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/yi/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/yo/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/gnome-desktop-3.0.mo
+file path=usr/share/locale/zu/LC_MESSAGES/gnome-desktop-3.0.mo


### PR DESCRIPTION
totem 3.24.0 requires the 'gnome-desktop-3.0' library to build, specifically for some icon-related code in src/icon-helpers.c

**I understand that you won't want to include gnome-desktop on hipster**, since there's a similar library mate-desktop.

At the time I was building totem, though, I didn't have time to investigate what changes would be needed to port it from gnome-desktop-3.0 to mate-desktop-2.0, so I just packaged gnome-desktop.

The right change is to not package this, and instead patch totem to use mate-desktop's icon-related code (assuming its suitable).