### PR TITLE
python35: update to 3.5.9, import early pep-538 variant

### DIFF
--- a/components/python/python35/Makefile
+++ b/components/python/python35/Makefile
@@ -29,14 +29,14 @@ BUILD_BITS=	64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Python
-COMPONENT_VERSION=	3.5.8
+COMPONENT_VERSION=	3.5.9
 COMPONENT_PROJECT_URL=	https://www.python.org
 COMPONENT_SUMMARY=	The Python interpreter, libraries and utilities
 COMPONENT_CLASSIFICATION= Development/Python
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:55a345c78ee3afbc2e60678442aad7bcc384ddea5bb95f8d66edc4868d4847d4
+	sha256:c24a37c63a67f53bdd09c5f287b5cff8e8b98f857bf348c577d454d3f74db049
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/ftp/python/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	PSFv2
 
@@ -95,6 +95,8 @@ CONFIGURE_OPTIONS  +=		--with-system-ffi
 CONFIGURE_OPTIONS  +=		--without-gcc
 CONFIGURE_OPTIONS  +=		--without-ensurepip
 CONFIGURE_OPTIONS  +=		--enable-ipv6
+CONFIGURE_OPTIONS  +=		--with-c-locale-coercion
+CONFIGURE_OPTIONS  +=		--without-c-locale-warning
 CONFIGURE_OPTIONS  +=		--bindir=$(USRBINDIR)
 # https://bugs.python.org/issue25003
 # CONFIGURE_OPTIONS  +=		"ac_cv_func_getentropy=no"

--- a/components/python/python35/manifests/sample-manifest.p5m
+++ b/components/python/python35/manifests/sample-manifest.p5m
@@ -1435,6 +1435,7 @@ file path=usr/lib/python3.5/test/test_bufio.py
 file path=usr/lib/python3.5/test/test_builtin.py
 file path=usr/lib/python3.5/test/test_bytes.py
 file path=usr/lib/python3.5/test/test_bz2.py
+file path=usr/lib/python3.5/test/test_c_locale_coercion.py
 file path=usr/lib/python3.5/test/test_calendar.py
 file path=usr/lib/python3.5/test/test_call.py
 file path=usr/lib/python3.5/test/test_capi.py

--- a/components/python/python35/patches/pep538_coerce_legacy_c_locale.patch
+++ b/components/python/python35/patches/pep538_coerce_legacy_c_locale.patch
@@ -1,0 +1,939 @@
+diff -ur Python-3.5.9-orig/configure.ac Python-3.5.9/configure.ac
+--- Python-3.5.9-orig/configure.ac	2020-03-11 20:36:39.886504175 +0000
++++ Python-3.5.9/configure.ac	2020-03-11 20:38:24.810089193 +0000
+@@ -3268,6 +3268,40 @@
+ fi
+ AC_MSG_RESULT($with_pymalloc)
+ 
++# Check for --with-c-locale-coercion
++AC_MSG_CHECKING(for --with-c-locale-coercion)
++AC_ARG_WITH(c-locale-coercion,
++            AS_HELP_STRING([--with(out)-c-locale-coercion],
++              [disable/enable C locale coercion to a UTF-8 based locale]))
++
++if test -z "$with_c_locale_coercion"
++then
++    with_c_locale_coercion="yes"
++fi
++if test "$with_c_locale_coercion" != "no"
++then
++    AC_DEFINE(PY_COERCE_C_LOCALE, 1,
++      [Define if you want to coerce the C locale to a UTF-8 based locale])
++fi
++AC_MSG_RESULT($with_c_locale_coercion)
++
++# Check for --with-c-locale-warning
++AC_MSG_CHECKING(for --with-c-locale-warning)
++AC_ARG_WITH(c-locale-warning,
++            AS_HELP_STRING([--with(out)-c-locale-warning],
++              [disable/enable locale compatibility warning in the C locale]))
++
++if test -z "$with_c_locale_warning"
++then
++    with_c_locale_warning="yes"
++fi
++if test "$with_c_locale_warning" != "no"
++then
++    AC_DEFINE(PY_WARN_ON_C_LOCALE, 1,
++      [Define to emit a locale compatibility warning in the C locale])
++fi
++AC_MSG_RESULT($with_c_locale_warning)
++
+ # Check for Valgrind support
+ AC_MSG_CHECKING([for --with-valgrind])
+ AC_ARG_WITH([valgrind],
+diff -ur Python-3.5.9-orig/Doc/using/cmdline.rst Python-3.5.9/Doc/using/cmdline.rst
+--- Python-3.5.9-orig/Doc/using/cmdline.rst	2020-03-11 20:36:40.709861753 +0000
++++ Python-3.5.9/Doc/using/cmdline.rst	2020-03-11 20:38:24.803197443 +0000
+@@ -620,6 +620,45 @@
+    .. versionadded:: 3.4
+ 
+ 
++
++.. envvar:: PYTHONCOERCECLOCALE
++
++   If set to the value ``0``, causes the main Python command line application
++   to skip coercing the legacy ASCII-based C locale to a more capable UTF-8
++   based alternative. Note that this setting is checked even when the
++   :option:`-E` or :option:`-I` options are used, as it is handled prior to
++   the processing of command line options.
++
++   If this variable is *not* set, or is set to a value other than ``0``, and
++   the current locale reported for the ``LC_CTYPE`` category is the default
++   ``C`` locale, then the Python CLI will attempt to configure one of the
++   following locales for the given locale categories before loading the
++   interpreter runtime:
++
++   * ``C.UTF-8`` (``LC_ALL``)
++   * ``C.utf8`` (``LC_ALL``)
++   * ``UTF-8`` (``LC_CTYPE``)
++
++   If setting one of these locale categories succeeds, then the matching
++   environment variables will be set (both ``LC_ALL`` and ``LANG`` for the
++   ``LC_ALL`` category, and ``LC_CTYPE`` for the ``LC_CTYPE`` category) in
++   the current process environment before the Python runtime is initialized.
++
++   Configuring one of these locales (either explicitly or via the above
++   implicit locale coercion) will automatically set the error handler for
++   :data:`sys.stdin` and :data:`sys.stdout` to ``surrogateescape``. This
++   behavior can be overridden using :envvar:`PYTHONIOENCODING` as usual.
++
++   For debugging purposes, setting ``PYTHONCOERCECLOCALE=warn`` will cause
++   Python to emit warning messages on ``stderr`` if either the locale coercion
++   activates, or else if a locale that *would* have triggered coercion is
++   still active when the Python runtime is initialized.
++
++   Availability: \*nix
++
++   .. versionadded:: 3.7
++      See :pep:`538` for more details.
++
+ Debug-mode variables
+ ~~~~~~~~~~~~~~~~~~~~
+ 
+diff -ur Python-3.5.9-orig/Lib/test/support/script_helper.py Python-3.5.9/Lib/test/support/script_helper.py
+--- Python-3.5.9-orig/Lib/test/support/script_helper.py	2020-03-11 20:36:40.309726025 +0000
++++ Python-3.5.9/Lib/test/support/script_helper.py	2020-03-11 20:38:24.803800486 +0000
+@@ -51,8 +51,35 @@
+     return __cached_interp_requires_environment
+ 
+ 
+-_PythonRunResult = collections.namedtuple("_PythonRunResult",
+-                                          ("rc", "out", "err"))
++class _PythonRunResult(collections.namedtuple("_PythonRunResult",
++                                          ("rc", "out", "err"))):
++    """Helper for reporting Python subprocess run results"""
++    def fail(self, cmd_line):
++        """Provide helpful details about failed subcommand runs"""
++        # Limit to 80 lines to ASCII characters
++        maxlen = 80 * 100
++        out, err = self.out, self.err
++        if len(out) > maxlen:
++            out = b'(... truncated stdout ...)' + out[-maxlen:]
++        if len(err) > maxlen:
++            err = b'(... truncated stderr ...)' + err[-maxlen:]
++        out = out.decode('ascii', 'replace').rstrip()
++        err = err.decode('ascii', 'replace').rstrip()
++        raise AssertionError("Process return code is %d\n"
++                             "command line: %r\n"
++                             "\n"
++                             "stdout:\n"
++                             "---\n"
++                             "%s\n"
++                             "---\n"
++                             "\n"
++                             "stderr:\n"
++                             "---\n"
++                             "%s\n"
++                             "---"
++                             % (self.rc, cmd_line,
++                                out,
++                                err))
+ 
+ 
+ # Executing the interpreter in a subprocess
+@@ -110,30 +137,7 @@
+ def _assert_python(expected_success, *args, **env_vars):
+     res, cmd_line = run_python_until_end(*args, **env_vars)
+     if (res.rc and expected_success) or (not res.rc and not expected_success):
+-        # Limit to 80 lines to ASCII characters
+-        maxlen = 80 * 100
+-        out, err = res.out, res.err
+-        if len(out) > maxlen:
+-            out = b'(... truncated stdout ...)' + out[-maxlen:]
+-        if len(err) > maxlen:
+-            err = b'(... truncated stderr ...)' + err[-maxlen:]
+-        out = out.decode('ascii', 'replace').rstrip()
+-        err = err.decode('ascii', 'replace').rstrip()
+-        raise AssertionError("Process return code is %d\n"
+-                             "command line: %r\n"
+-                             "\n"
+-                             "stdout:\n"
+-                             "---\n"
+-                             "%s\n"
+-                             "---\n"
+-                             "\n"
+-                             "stderr:\n"
+-                             "---\n"
+-                             "%s\n"
+-                             "---"
+-                             % (res.rc, cmd_line,
+-                                out,
+-                                err))
++        res.fail(cmd_line)
+     return res
+ 
+ def assert_python_ok(*args, **env_vars):
+--- /dev/null
++++ b/Lib/test/test_c_locale_coercion.py
+@@ -0,0 +1,353 @@
++# Tests the attempted automatic coercion of the C locale to a UTF-8 locale
++
++import unittest
++import os
++import sys
++import sysconfig
++import shutil
++import subprocess
++from collections import namedtuple
++
++import test.support
++from test.support.script_helper import (
++    run_python_until_end,
++    interpreter_requires_environment,
++)
++
++# Set our expectation for the default encoding used in the C locale
++# for the filesystem encoding and the standard streams
++C_LOCALE_STREAM_ENCODING = "ascii"
++if sys.platform == "darwin":
++    C_LOCALE_FS_ENCODING = "utf-8"
++else:
++    C_LOCALE_FS_ENCODING = C_LOCALE_STREAM_ENCODING
++
++# Note that the above is probably still wrong in some cases, such as:
++# * Windows when PYTHONLEGACYWINDOWSFSENCODING is set
++# * AIX and any other platforms that use latin-1 in the C locale
++#
++# Options for dealing with this:
++# * Don't set PYTHON_COERCE_C_LOCALE on such platforms (e.g. Windows doesn't)
++# * Fix the test expectations to match the actual platform behaviour
++
++# In order to get the warning messages to match up as expected, the candidate
++# order here must much the target locale order in Python/pylifecycle.c
++_C_UTF8_LOCALES = ("C.UTF-8", "C.utf8") #, "UTF-8")
++
++# XXX (ncoghlan): Using UTF-8 as a target locale is currently disabled due to
++#                 problems encountered on *BSD systems with those test cases
++# For additional details see:
++#     nl_langinfo CODESET error: https://bugs.python.org/issue30647
++#     locale handling differences: https://bugs.python.org/issue30672
++
++# There's no reliable cross-platform way of checking locale alias
++# lists, so the only way of knowing which of these locales will work
++# is to try them with locale.setlocale(). We do that in a subprocess
++# to avoid altering the locale of the test runner.
++def _set_locale_in_subprocess(locale_name):
++    cmd_fmt = "import locale; print(locale.setlocale(locale.LC_CTYPE, '{}'))"
++    cmd = cmd_fmt.format(locale_name)
++    result, py_cmd = run_python_until_end("-c", cmd, __isolated=True)
++    return result.rc == 0
++
++_fields = "fsencoding stdin_info stdout_info stderr_info lang lc_ctype lc_all"
++_EncodingDetails = namedtuple("EncodingDetails", _fields)
++
++class EncodingDetails(_EncodingDetails):
++    # XXX (ncoghlan): Using JSON for child state reporting may be less fragile
++    CHILD_PROCESS_SCRIPT = ";".join([
++        "import sys, os",
++        "print(sys.getfilesystemencoding())",
++        "print(sys.stdin.encoding + ':' + sys.stdin.errors)",
++        "print(sys.stdout.encoding + ':' + sys.stdout.errors)",
++        "print(sys.stderr.encoding + ':' + sys.stderr.errors)",
++        "print(os.environ.get('LANG', 'not set'))",
++        "print(os.environ.get('LC_CTYPE', 'not set'))",
++        "print(os.environ.get('LC_ALL', 'not set'))",
++    ])
++
++    @classmethod
++    def get_expected_details(cls, coercion_expected, fs_encoding, stream_encoding, env_vars):
++        """Returns expected child process details for a given encoding"""
++        _stream = stream_encoding + ":{}"
++        # stdin and stdout should use surrogateescape either because the
++        # coercion triggered, or because the C locale was detected
++        stream_info = 2*[_stream.format("surrogateescape")]
++        # stderr should always use backslashreplace
++        stream_info.append(_stream.format("backslashreplace"))
++        expected_lang = env_vars.get("LANG", "not set").lower()
++        if coercion_expected:
++            expected_lc_ctype = CLI_COERCION_TARGET.lower()
++        else:
++            expected_lc_ctype = env_vars.get("LC_CTYPE", "not set").lower()
++        expected_lc_all = env_vars.get("LC_ALL", "not set").lower()
++        env_info = expected_lang, expected_lc_ctype, expected_lc_all
++        return dict(cls(fs_encoding, *stream_info, *env_info)._asdict())
++
++    @staticmethod
++    def _handle_output_variations(data):
++        """Adjust the output to handle platform specific idiosyncrasies
++
++        * Some platforms report ASCII as ANSI_X3.4-1968
++        * Some platforms report ASCII as US-ASCII
++        * Some platforms report UTF-8 instead of utf-8
++        """
++        data = data.replace(b"ANSI_X3.4-1968", b"ascii")
++        data = data.replace(b"US-ASCII", b"ascii")
++        data = data.lower()
++        return data
++
++    @classmethod
++    def get_child_details(cls, env_vars):
++        """Retrieves fsencoding and standard stream details from a child process
++
++        Returns (encoding_details, stderr_lines):
++
++        - encoding_details: EncodingDetails for eager decoding
++        - stderr_lines: result of calling splitlines() on the stderr output
++
++        The child is run in isolated mode if the current interpreter supports
++        that.
++        """
++        result, py_cmd = run_python_until_end(
++            "-c", cls.CHILD_PROCESS_SCRIPT,
++            __isolated=True,
++            **env_vars
++        )
++        if not result.rc == 0:
++            result.fail(py_cmd)
++        # All subprocess outputs in this test case should be pure ASCII
++        adjusted_output = cls._handle_output_variations(result.out)
++        stdout_lines = adjusted_output.decode("ascii").splitlines()
++        child_encoding_details = dict(cls(*stdout_lines)._asdict())
++        stderr_lines = result.err.decode("ascii").rstrip().splitlines()
++        return child_encoding_details, stderr_lines
++
++
++# Details of the shared library warning emitted at runtime
++LEGACY_LOCALE_WARNING = (
++    "Python runtime initialized with LC_CTYPE=C (a locale with default ASCII "
++    "encoding), which may cause Unicode compatibility problems. Using C.UTF-8, "
++    "C.utf8, or UTF-8 (if available) as alternative Unicode-compatible "
++    "locales is recommended."
++)
++
++# Details of the CLI locale coercion warning emitted at runtime
++CLI_COERCION_WARNING_FMT = (
++    "Python detected LC_CTYPE=C: LC_CTYPE coerced to {} (set another locale "
++    "or PYTHONCOERCECLOCALE=0 to disable this locale coercion behavior)."
++)
++
++
++AVAILABLE_TARGETS = None
++CLI_COERCION_TARGET = None
++CLI_COERCION_WARNING = None
++
++def setUpModule():
++    global AVAILABLE_TARGETS
++    global CLI_COERCION_TARGET
++    global CLI_COERCION_WARNING
++
++    if AVAILABLE_TARGETS is not None:
++        # initialization already done
++        return
++    AVAILABLE_TARGETS = []
++
++    # Find the target locales available in the current system
++    for target_locale in _C_UTF8_LOCALES:
++        if _set_locale_in_subprocess(target_locale):
++            AVAILABLE_TARGETS.append(target_locale)
++
++    if AVAILABLE_TARGETS:
++        # Coercion is expected to use the first available target locale
++        CLI_COERCION_TARGET = AVAILABLE_TARGETS[0]
++        CLI_COERCION_WARNING = CLI_COERCION_WARNING_FMT.format(CLI_COERCION_TARGET)
++
++
++class _LocaleHandlingTestCase(unittest.TestCase):
++    # Base class to check expected locale handling behaviour
++
++    def _check_child_encoding_details(self,
++                                      env_vars,
++                                      expected_fs_encoding,
++                                      expected_stream_encoding,
++                                      expected_warnings,
++                                      coercion_expected):
++        """Check the C locale handling for the given process environment
++
++        Parameters:
++            expected_fs_encoding: expected sys.getfilesystemencoding() result
++            expected_stream_encoding: expected encoding for standard streams
++            expected_warning: stderr output to expect (if any)
++        """
++        result = EncodingDetails.get_child_details(env_vars)
++        encoding_details, stderr_lines = result
++        expected_details = EncodingDetails.get_expected_details(
++            coercion_expected,
++            expected_fs_encoding,
++            expected_stream_encoding,
++            env_vars
++        )
++        self.assertEqual(encoding_details, expected_details)
++        if expected_warnings is None:
++            expected_warnings = []
++        self.assertEqual(stderr_lines, expected_warnings)
++
++
++class LocaleConfigurationTests(_LocaleHandlingTestCase):
++    # Test explicit external configuration via the process environment
++
++    def setUpClass():
++        # This relies on setupModule() having been run, so it can't be
++        # handled via the @unittest.skipUnless decorator
++        if not AVAILABLE_TARGETS:
++            raise unittest.SkipTest("No C-with-UTF-8 locale available")
++
++    def test_external_target_locale_configuration(self):
++
++        # Explicitly setting a target locale should give the same behaviour as
++        # is seen when implicitly coercing to that target locale
++        self.maxDiff = None
++
++        expected_fs_encoding = "utf-8"
++        expected_stream_encoding = "utf-8"
++
++        base_var_dict = {
++            "LANG": "",
++            "LC_CTYPE": "",
++            "LC_ALL": "",
++        }
++        for env_var in ("LANG", "LC_CTYPE"):
++            for locale_to_set in AVAILABLE_TARGETS:
++                # XXX (ncoghlan): LANG=UTF-8 doesn't appear to work as
++                #                 expected, so skip that combination for now
++                # See https://bugs.python.org/issue30672 for discussion
++                if env_var == "LANG" and locale_to_set == "UTF-8":
++                    continue
++
++                with self.subTest(env_var=env_var,
++                                  configured_locale=locale_to_set):
++                    var_dict = base_var_dict.copy()
++                    var_dict[env_var] = locale_to_set
++                    self._check_child_encoding_details(var_dict,
++                                                       expected_fs_encoding,
++                                                       expected_stream_encoding,
++                                                       expected_warnings=None,
++                                                       coercion_expected=False)
++
++
++
++@test.support.cpython_only
++@unittest.skipUnless(sysconfig.get_config_var("PY_COERCE_C_LOCALE"),
++                     "C locale coercion disabled at build time")
++class LocaleCoercionTests(_LocaleHandlingTestCase):
++    # Test implicit reconfiguration of the environment during CLI startup
++
++    def _check_c_locale_coercion(self,
++                                 fs_encoding, stream_encoding,
++                                 coerce_c_locale,
++                                 expected_warnings=None,
++                                 coercion_expected=True,
++                                 **extra_vars):
++        """Check the C locale handling for various configurations
++
++        Parameters:
++            fs_encoding: expected sys.getfilesystemencoding() result
++            stream_encoding: expected encoding for standard streams
++            coerce_c_locale: setting to use for PYTHONCOERCECLOCALE
++              None: don't set the variable at all
++              str: the value set in the child's environment
++            expected_warnings: expected warning lines on stderr
++            extra_vars: additional environment variables to set in subprocess
++        """
++        self.maxDiff = None
++
++        if not AVAILABLE_TARGETS:
++            # Locale coercion is disabled when there aren't any target locales
++            fs_encoding = C_LOCALE_FS_ENCODING
++            stream_encoding = C_LOCALE_STREAM_ENCODING
++            coercion_expected = False
++            if expected_warnings:
++                expected_warnings = [LEGACY_LOCALE_WARNING]
++
++        base_var_dict = {
++            "LANG": "",
++            "LC_CTYPE": "",
++            "LC_ALL": "",
++        }
++        base_var_dict.update(extra_vars)
++        for env_var in ("LANG", "LC_CTYPE"):
++            for locale_to_set in ("", "C", "POSIX", "invalid.ascii"):
++                # XXX (ncoghlan): *BSD platforms don't behave as expected in the
++                #                 POSIX locale, so we skip that for now
++                # See https://bugs.python.org/issue30672 for discussion
++                if locale_to_set == "POSIX":
++                    continue
++                with self.subTest(env_var=env_var,
++                                  nominal_locale=locale_to_set,
++                                  PYTHONCOERCECLOCALE=coerce_c_locale):
++                    var_dict = base_var_dict.copy()
++                    var_dict[env_var] = locale_to_set
++                    if coerce_c_locale is not None:
++                        var_dict["PYTHONCOERCECLOCALE"] = coerce_c_locale
++                    # Check behaviour on successful coercion
++                    self._check_child_encoding_details(var_dict,
++                                                       fs_encoding,
++                                                       stream_encoding,
++                                                       expected_warnings,
++                                                       coercion_expected)
++
++    def test_test_PYTHONCOERCECLOCALE_not_set(self):
++        # This should coerce to the first available target locale by default
++        self._check_c_locale_coercion("utf-8", "utf-8", coerce_c_locale=None)
++
++    def test_PYTHONCOERCECLOCALE_not_zero(self):
++        # *Any* string other than "0" is considered "set" for our purposes
++        # and hence should result in the locale coercion being enabled
++        for setting in ("", "1", "true", "false"):
++            self._check_c_locale_coercion("utf-8", "utf-8", coerce_c_locale=setting)
++
++    def test_PYTHONCOERCECLOCALE_set_to_warn(self):
++        # PYTHONCOERCECLOCALE=warn enables runtime warnings for legacy locales
++        self._check_c_locale_coercion("utf-8", "utf-8",
++                                      coerce_c_locale="warn",
++                                      expected_warnings=[CLI_COERCION_WARNING])
++
++
++    def test_PYTHONCOERCECLOCALE_set_to_zero(self):
++        # The setting "0" should result in the locale coercion being disabled
++        self._check_c_locale_coercion(C_LOCALE_FS_ENCODING,
++                                      C_LOCALE_STREAM_ENCODING,
++                                      coerce_c_locale="0",
++                                      coercion_expected=False)
++        # Setting LC_ALL=C shouldn't make any difference to the behaviour
++        self._check_c_locale_coercion(C_LOCALE_FS_ENCODING,
++                                      C_LOCALE_STREAM_ENCODING,
++                                      coerce_c_locale="0",
++                                      LC_ALL="C",
++                                      coercion_expected=False)
++
++    def test_LC_ALL_set_to_C(self):
++        # Setting LC_ALL should render the locale coercion ineffective
++        self._check_c_locale_coercion(C_LOCALE_FS_ENCODING,
++                                      C_LOCALE_STREAM_ENCODING,
++                                      coerce_c_locale=None,
++                                      LC_ALL="C",
++                                      coercion_expected=False)
++        # And result in a warning about a lack of locale compatibility
++        self._check_c_locale_coercion(C_LOCALE_FS_ENCODING,
++                                      C_LOCALE_STREAM_ENCODING,
++                                      coerce_c_locale="warn",
++                                      LC_ALL="C",
++                                      expected_warnings=[LEGACY_LOCALE_WARNING],
++                                      coercion_expected=False)
++
++def test_main():
++    test.support.run_unittest(
++        LocaleConfigurationTests,
++        LocaleCoercionTests
++    )
++    test.support.reap_children()
++
++if __name__ == "__main__":
++    test_main()
+diff -ur Python-3.5.9-orig/Lib/test/test_capi.py Python-3.5.9/Lib/test/test_capi.py
+--- Python-3.5.9-orig/Lib/test/test_capi.py	2020-03-11 20:36:40.318270541 +0000
++++ Python-3.5.9/Lib/test/test_capi.py	2020-03-11 20:38:24.805539263 +0000
+@@ -367,14 +367,21 @@
+     def tearDown(self):
+         os.chdir(self.oldcwd)
+ 
+-    def run_embedded_interpreter(self, *args):
++    def run_embedded_interpreter(self, *args, env=None):
+         """Runs a test in the embedded interpreter"""
+         cmd = [self.test_exe]
+         cmd.extend(args)
++        if env is not None and sys.platform == 'win32':
++            # Windows requires at least the SYSTEMROOT environment variable to
++            # start Python.
++            env = env.copy()
++            env['SYSTEMROOT'] = os.environ['SYSTEMROOT']
++
+         p = subprocess.Popen(cmd,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+-                             universal_newlines=True)
++                             universal_newlines=True,
++                             env=env)
+         (out, err) = p.communicate()
+         self.assertEqual(p.returncode, 0,
+                          "bad returncode %d, stderr is %r" %
+@@ -384,31 +391,21 @@
+     def test_subinterps(self):
+         # This is just a "don't crash" test
+         out, err = self.run_embedded_interpreter()
+-        if support.verbose:
++        if support.verbose > 1:
+             print()
+             print(out)
+             print(err)
+ 
+-    @staticmethod
+-    def _get_default_pipe_encoding():
+-        rp, wp = os.pipe()
+-        try:
+-            with os.fdopen(wp, 'w') as w:
+-                default_pipe_encoding = w.encoding
+-        finally:
+-            os.close(rp)
+-        return default_pipe_encoding
+-
+     def test_forced_io_encoding(self):
+         # Checks forced configuration of embedded interpreter IO streams
+-        out, err = self.run_embedded_interpreter("forced_io_encoding")
+-        if support.verbose:
++        env = dict(os.environ, PYTHONIOENCODING="utf-8:surrogateescape")
++        out, err = self.run_embedded_interpreter("forced_io_encoding", env=env)
++        if support.verbose > 1:
+             print()
+             print(out)
+             print(err)
+-        expected_errors = sys.__stdout__.errors
+-        expected_stdin_encoding = sys.__stdin__.encoding
+-        expected_pipe_encoding = self._get_default_pipe_encoding()
++        expected_stream_encoding = "utf-8"
++        expected_errors = "surrogateescape"
+         expected_output = '\n'.join([
+         "--- Use defaults ---",
+         "Expected encoding: default",
+@@ -435,8 +432,8 @@
+         "stdout: latin-1:replace",
+         "stderr: latin-1:backslashreplace"])
+         expected_output = expected_output.format(
+-                                in_encoding=expected_stdin_encoding,
+-                                out_encoding=expected_pipe_encoding,
++                                in_encoding=expected_stream_encoding,
++                                out_encoding=expected_stream_encoding,
+                                 errors=expected_errors)
+         # This is useful if we ever trip over odd platform behaviour
+         self.maxDiff = None
+diff -ur Python-3.5.9-orig/Lib/test/test_cmd_line.py Python-3.5.9/Lib/test/test_cmd_line.py
+--- Python-3.5.9-orig/Lib/test/test_cmd_line.py	2020-03-11 20:36:40.358269111 +0000
++++ Python-3.5.9/Lib/test/test_cmd_line.py	2020-03-11 20:38:24.805938367 +0000
+@@ -151,6 +151,7 @@
+         env = os.environ.copy()
+         # Use C locale to get ascii for the locale encoding
+         env['LC_ALL'] = 'C'
++        env['PYTHONCOERCECLOCALE'] = '0'
+         code = (
+             b'import locale; '
+             b'print(ascii("' + undecodable + b'"), '
+diff -ur Python-3.5.9-orig/Lib/test/test_sys.py Python-3.5.9/Lib/test/test_sys.py
+--- Python-3.5.9-orig/Lib/test/test_sys.py	2020-03-11 20:36:40.367129863 +0000
++++ Python-3.5.9/Lib/test/test_sys.py	2020-03-11 20:38:24.806607586 +0000
+@@ -679,6 +679,7 @@
+         # Force the POSIX locale
+         env = os.environ.copy()
+         env["LC_ALL"] = "C"
++        env["PYTHONCOERCECLOCALE"] = "0"
+         code = '\n'.join((
+             'import sys',
+             'def dump(name):',
+diff -ur Python-3.5.9-orig/Modules/main.c Python-3.5.9/Modules/main.c
+--- Python-3.5.9-orig/Modules/main.c	2020-03-11 20:36:40.892633645 +0000
++++ Python-3.5.9/Modules/main.c	2020-03-11 20:38:24.807062019 +0000
+@@ -99,8 +99,10 @@
+ PYTHONHASHSEED: if this variable is set to 'random', a random value is used\n\
+    to seed the hashes of str, bytes and datetime objects.  It can also be\n\
+    set to an integer in the range [0,4294967295] to get hash values with a\n\
+-   predictable seed.\n\
+-";
++   predictable seed.\n"
++"PYTHONCOERCECLOCALE: if this variable is set to 0, it disables the locale\n"
++"   coercion behavior. Use PYTHONCOERCECLOCALE=warn to request display of\n"
++"   locale coercion and locale compatibility warnings on stderr.\n";
+ 
+ static int
+ usage(int exitcode, wchar_t* program)
+diff -ur Python-3.5.9-orig/Programs/_testembed.c Python-3.5.9/Programs/_testembed.c
+--- Python-3.5.9-orig/Programs/_testembed.c	2020-03-11 20:36:40.554303118 +0000
++++ Python-3.5.9/Programs/_testembed.c	2020-03-11 20:38:24.807399690 +0000
+@@ -1,4 +1,5 @@
+-#include <Python.h>
++#include "Python.h"
++#include "pyconfig.h"
+ #include <stdio.h>
+ 
+ /*********************************************************
+diff -ur Python-3.5.9-orig/Programs/python.c Python-3.5.9/Programs/python.c
+--- Python-3.5.9-orig/Programs/python.c	2020-03-11 20:36:40.554502561 +0000
++++ Python-3.5.9/Programs/python.c	2020-03-11 20:38:24.807808825 +0000
+@@ -15,6 +15,21 @@
+ }
+ #else
+ 
++/* Access private pylifecycle helper API to better handle the legacy C locale
++ *
++ * The legacy C locale assumes ASCII as the default text encoding, which
++ * causes problems not only for the CPython runtime, but also other
++ * components like GNU readline.
++ *
++ * Accordingly, when the CLI detects it, it attempts to coerce it to a
++ * more capable UTF-8 based alternative.
++ *
++ * See the documentation of the PYTHONCOERCECLOCALE setting for more details.
++ *
++ */
++extern int _Py_LegacyLocaleDetected(void);
++extern void _Py_CoerceLegacyLocale(void);
++
+ int
+ main(int argc, char **argv)
+ {
+@@ -46,7 +61,21 @@
+         return 1;
+     }
+ 
++#ifdef __ANDROID__
++    /* Passing "" to setlocale() on Android requests the C locale rather
++     * than checking environment variables, so request C.UTF-8 explicitly
++     */
++    setlocale(LC_ALL, "C.UTF-8");
++#else
++    /* Reconfigure the locale to the default for this process */
+     setlocale(LC_ALL, "");
++#endif
++
++    if (_Py_LegacyLocaleDetected()) {
++        _Py_CoerceLegacyLocale();
++    }
++
++    /* Convert from char to wchar_t based on the locale settings */
+     for (i = 0; i < argc; i++) {
+         argv_copy[i] = Py_DecodeLocale(argv[i], NULL);
+         if (!argv_copy[i]) {
+diff -ur Python-3.5.9-orig/pyconfig.h.in Python-3.5.9/pyconfig.h.in
+--- Python-3.5.9-orig/pyconfig.h.in	2020-03-11 20:36:40.952207468 +0000
++++ Python-3.5.9/pyconfig.h.in	2020-03-11 20:38:24.810717975 +0000
+@@ -1228,9 +1228,15 @@
+ /* Define to printf format modifier for long long type */
+ #undef PY_FORMAT_LONG_LONG
+ 
++/* Define if you want to coerce the C locale to a UTF-8 based locale */
++#undef PY_COERCE_C_LOCALE
++
+ /* Define to printf format modifier for Py_ssize_t */
+ #undef PY_FORMAT_SIZE_T
+ 
++/* Define to emit a locale compatibility warning in the C locale */
++#undef PY_WARN_ON_C_LOCALE
++
+ /* Define if you want to build an interpreter with many run-time checks. */
+ #undef Py_DEBUG
+ 
+diff -ur Python-3.5.9-orig/Python/pylifecycle.c Python-3.5.9/Python/pylifecycle.c
+--- Python-3.5.9/Python/pylifecycle.c.~1~	2019-11-02 02:02:34.000000000 +0000
++++ Python-3.5.9/Python/pylifecycle.c	2020-03-11 21:13:14.483838369 +0000
+@@ -281,6 +281,183 @@
+ }
+ 
+ 
++/* Helper functions to better handle the legacy C locale
++ *
++ * The legacy C locale assumes ASCII as the default text encoding, which
++ * causes problems not only for the CPython runtime, but also other
++ * components like GNU readline.
++ *
++ * Accordingly, when the CLI detects it, it attempts to coerce it to a
++ * more capable UTF-8 based alternative as follows:
++ *
++ *     if (_Py_LegacyLocaleDetected()) {
++ *         _Py_CoerceLegacyLocale();
++ *     }
++ *
++ * See the documentation of the PYTHONCOERCECLOCALE setting for more details.
++ *
++ * Locale coercion also impacts the default error handler for the standard
++ * streams: while the usual default is "strict", the default for the legacy
++ * C locale and for any of the coercion target locales is "surrogateescape".
++ */
++
++int
++_Py_LegacyLocaleDetected(void)
++{
++#ifndef MS_WINDOWS
++    /* On non-Windows systems, the C locale is considered a legacy locale */
++    /* XXX (ncoghlan): some platforms (notably Mac OS X) don't appear to treat
++     *                 the POSIX locale as a simple alias for the C locale, so
++     *                 we may also want to check for that explicitly.
++     */
++    const char *ctype_loc = setlocale(LC_CTYPE, NULL);
++    return ctype_loc != NULL && strcmp(ctype_loc, "C") == 0;
++#else
++    /* Windows uses code pages instead of locales, so no locale is legacy */
++    return 0;
++#endif
++}
++
++
++static const char *_C_LOCALE_WARNING =
++    "Python runtime initialized with LC_CTYPE=C (a locale with default ASCII "
++    "encoding), which may cause Unicode compatibility problems. Using C.UTF-8, "
++    "C.utf8, or UTF-8 (if available) as alternative Unicode-compatible "
++    "locales is recommended.\n";
++
++static int
++_legacy_locale_warnings_enabled(void)
++{
++    const char *coerce_c_locale = getenv("PYTHONCOERCECLOCALE");
++    return (coerce_c_locale != NULL &&
++            strncmp(coerce_c_locale, "warn", 5) == 0);
++}
++
++static void
++_emit_stderr_warning_for_legacy_locale(void)
++{
++    if (_legacy_locale_warnings_enabled()) {
++        if (_Py_LegacyLocaleDetected()) {
++            fprintf(stderr, "%s", _C_LOCALE_WARNING);
++        }
++    }
++}
++
++typedef struct _CandidateLocale {
++    const char *locale_name; /* The locale to try as a coercion target */
++} _LocaleCoercionTarget;
++
++static _LocaleCoercionTarget _TARGET_LOCALES[] = {
++    {"C.UTF-8"},
++    {"C.utf8"},
++    /* {"UTF-8"}, */
++    {NULL}
++};
++
++/* XXX (ncoghlan): Using UTF-8 as a target locale is currently disabled due to
++ *                 problems encountered on *BSD systems with those test cases
++ * For additional details see:
++ *     nl_langinfo CODESET error: https://bugs.python.org/issue30647
++ *     locale handling differences: https://bugs.python.org/issue30672
++ */
++
++
++static char *
++get_default_standard_stream_error_handler(void)
++{
++    const char *ctype_loc = setlocale(LC_CTYPE, NULL);
++    if (ctype_loc != NULL) {
++#ifdef PY_COERCE_C_LOCALE
++        const _LocaleCoercionTarget *target = NULL;
++#endif
++        /* "surrogateescape" is the default in the legacy C locale */
++        if (strcmp(ctype_loc, "C") == 0) {
++            return "surrogateescape";
++        }
++
++#ifdef PY_COERCE_C_LOCALE
++        /* "surrogateescape" is the default in locale coercion target locales */
++        for (target = _TARGET_LOCALES; target->locale_name; target++) {
++            if (strcmp(ctype_loc, target->locale_name) == 0) {
++                return "surrogateescape";
++            }
++        }
++#endif
++   }
++
++   /* Otherwise return NULL to request the typical default error handler */
++   return NULL;
++}
++
++#ifdef PY_COERCE_C_LOCALE
++static const char *_C_LOCALE_COERCION_WARNING =
++    "Python detected LC_CTYPE=C: LC_CTYPE coerced to %.20s (set another locale "
++    "or PYTHONCOERCECLOCALE=0 to disable this locale coercion behavior).\n";
++
++static void
++_coerce_default_locale_settings(const _LocaleCoercionTarget *target)
++{
++
++    const char *newloc = target->locale_name;
++
++    /* Reset locale back to currently configured defaults */
++    setlocale(LC_ALL, "");
++
++    /* Set the relevant locale environment variable */
++    if (setenv("LC_CTYPE", newloc, 1)) {
++        fprintf(stderr,
++                "Error setting LC_CTYPE, skipping C locale coercion\n");
++        return;
++    }
++    if (_legacy_locale_warnings_enabled()) {
++        fprintf(stderr, _C_LOCALE_COERCION_WARNING, newloc);
++    }
++
++    /* Reconfigure with the overridden environment variables */
++    setlocale(LC_ALL, "");
++}
++#endif
++
++
++void
++_Py_CoerceLegacyLocale(void)
++{
++#ifdef PY_COERCE_C_LOCALE
++    /* We ignore the Python -E and -I flags here, as the CLI needs to sort out
++     * the locale settings *before* we try to do anything with the command
++     * line arguments. For cross-platform debugging purposes, we also need
++     * to give end users a way to force even scripts that are otherwise
++     * isolated from their environment to use the legacy ASCII-centric C
++     * locale.
++     *
++     * Ignoring -E and -I is safe from a security perspective, as we only use
++     * the setting to turn *off* the implicit locale coercion, and anyone with
++     * access to the process environment already has the ability to set
++     * `LC_ALL=C` to override the C level locale settings anyway.
++     */
++    const char *coerce_c_locale = getenv("PYTHONCOERCECLOCALE");
++    if (coerce_c_locale == NULL || strncmp(coerce_c_locale, "0", 2) != 0) {
++        /* PYTHONCOERCECLOCALE is not set, or is set to something other than "0" */
++        const char *locale_override = getenv("LC_ALL");
++        if (locale_override == NULL || *locale_override == '\0') {
++            /* LC_ALL is also not set (or is set to an empty string) */
++            const _LocaleCoercionTarget *target = NULL;
++            for (target = _TARGET_LOCALES; target->locale_name; target++) {
++                const char *new_locale = setlocale(LC_CTYPE,
++                                                   target->locale_name);
++                if (new_locale != NULL) {
++                    /* Successfully configured locale, so make it the default */
++                    _coerce_default_locale_settings(target);
++                    return;
++                }
++            }
++        }
++    }
++    /* No C locale warning here, as Py_Initialize will emit one later */
++#endif
++}
++
++
+ void
+ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
+ {
+@@ -295,11 +472,19 @@
+     initialized = 1;
+     _Py_Finalizing = NULL;
+ 
+-#if defined(HAVE_LANGINFO_H) && defined(HAVE_SETLOCALE)
+-    /* Set up the LC_CTYPE locale, so we can obtain
+-       the locale's charset without having to switch
+-       locales. */
+-    setlocale(LC_CTYPE, "");
++#ifdef __ANDROID__
++    /* Passing "" to setlocale() on Android requests the C locale rather
++     * than checking environment variables, so request C.UTF-8 explicitly
++     */
++    setlocale(LC_CTYPE, "C.UTF-8");
++#else
++#ifndef MS_WINDOWS
++     /* Set up the LC_CTYPE locale, so we can obtain
++        the locale's charset without having to switch
++        locales. */
++     setlocale(LC_CTYPE, "");
++    _emit_stderr_warning_for_legacy_locale();
++#endif
+ #endif
+ 
+     if ((p = Py_GETENV("PYTHONDEBUG")) && *p != '\0')
+@@ -1165,12 +1350,8 @@
+             }
+         }
+         if (!errors && !(pythonioencoding && *pythonioencoding)) {
+-            /* When the LC_CTYPE locale is the POSIX locale ("C locale"),
+-               stdin and stdout use the surrogateescape error handler by
+-               default, instead of the strict error handler. */
+-            char *loc = setlocale(LC_CTYPE, NULL);
+-            if (loc != NULL && strcmp(loc, "C") == 0)
+-                errors = "surrogateescape";
++            /* Choose the default error handler based on the current locale */
++            errors = get_default_standard_stream_error_handler();
+         }
+     }
+ 

--- a/components/python/python35/patches/pep538_coerce_legacy_c_locale.patch
+++ b/components/python/python35/patches/pep538_coerce_legacy_c_locale.patch
@@ -166,7 +166,7 @@ diff -ur Python-3.5.9-orig/Lib/test/support/script_helper.py Python-3.5.9/Lib/te
  def assert_python_ok(*args, **env_vars):
 --- /dev/null
 +++ b/Lib/test/test_c_locale_coercion.py
-@@ -0,0 +1,353 @@
+@@ -0,0 +1,359 @@
 +# Tests the attempted automatic coercion of the C locale to a UTF-8 locale
 +
 +import unittest
@@ -185,9 +185,15 @@ diff -ur Python-3.5.9-orig/Lib/test/support/script_helper.py Python-3.5.9/Lib/te
 +
 +# Set our expectation for the default encoding used in the C locale
 +# for the filesystem encoding and the standard streams
-+C_LOCALE_STREAM_ENCODING = "ascii"
++if sys.platform == "sunos5":
++    C_LOCALE_STREAM_ENCODING = "646"
++else:
++    C_LOCALE_STREAM_ENCODING = "ascii"
++
 +if sys.platform == "darwin":
 +    C_LOCALE_FS_ENCODING = "utf-8"
++elif sys.platform == "sunos5":
++    C_LOCALE_FS_ENCODING = "ascii"
 +else:
 +    C_LOCALE_FS_ENCODING = C_LOCALE_STREAM_ENCODING
 +

--- a/components/python/python35/patches/pep538_coerce_legacy_c_locale.patch
+++ b/components/python/python35/patches/pep538_coerce_legacy_c_locale.patch
@@ -712,8 +712,8 @@ diff -ur Python-3.5.9-orig/pyconfig.h.in Python-3.5.9/pyconfig.h.in
  
 diff -ur Python-3.5.9-orig/Python/pylifecycle.c Python-3.5.9/Python/pylifecycle.c
 --- Python-3.5.9/Python/pylifecycle.c.~1~	2019-11-02 02:02:34.000000000 +0000
-+++ Python-3.5.9/Python/pylifecycle.c	2020-03-11 21:13:14.483838369 +0000
-@@ -281,6 +281,183 @@
++++ Python-3.5.9/Python/pylifecycle.c	2020-03-12 08:39:32.015557356 +0000
+@@ -281,6 +281,197 @@
  }
  
  
@@ -859,6 +859,15 @@ diff -ur Python-3.5.9-orig/Python/pylifecycle.c Python-3.5.9/Python/pylifecycle.
 +_Py_CoerceLegacyLocale(void)
 +{
 +#ifdef PY_COERCE_C_LOCALE
++    char *oldloc = NULL;
++    const char *coerce_c_locale;
++
++    oldloc = _PyMem_RawStrdup(setlocale(LC_CTYPE, NULL));
++    if (oldloc == NULL) {
++        return;
++    }
++
++
 +    /* We ignore the Python -E and -I flags here, as the CLI needs to sort out
 +     * the locale settings *before* we try to do anything with the command
 +     * line arguments. For cross-platform debugging purposes, we also need
@@ -871,7 +880,7 @@ diff -ur Python-3.5.9-orig/Python/pylifecycle.c Python-3.5.9/Python/pylifecycle.
 +     * access to the process environment already has the ability to set
 +     * `LC_ALL=C` to override the C level locale settings anyway.
 +     */
-+    const char *coerce_c_locale = getenv("PYTHONCOERCECLOCALE");
++    coerce_c_locale = getenv("PYTHONCOERCECLOCALE");
 +    if (coerce_c_locale == NULL || strncmp(coerce_c_locale, "0", 2) != 0) {
 +        /* PYTHONCOERCECLOCALE is not set, or is set to something other than "0" */
 +        const char *locale_override = getenv("LC_ALL");
@@ -884,12 +893,17 @@ diff -ur Python-3.5.9-orig/Python/pylifecycle.c Python-3.5.9/Python/pylifecycle.
 +                if (new_locale != NULL) {
 +                    /* Successfully configured locale, so make it the default */
 +                    _coerce_default_locale_settings(target);
-+                    return;
++                    goto done;
 +                }
 +            }
 +        }
 +    }
 +    /* No C locale warning here, as Py_Initialize will emit one later */
++   
++    setlocale(LC_CTYPE, oldloc);
++
++done:
++    PyMem_RawFree(oldloc);
 +#endif
 +}
 +
@@ -897,7 +911,7 @@ diff -ur Python-3.5.9-orig/Python/pylifecycle.c Python-3.5.9/Python/pylifecycle.
  void
  _Py_InitializeEx_Private(int install_sigs, int install_importlib)
  {
-@@ -295,11 +472,19 @@
+@@ -295,11 +486,19 @@
      initialized = 1;
      _Py_Finalizing = NULL;
  
@@ -922,7 +936,7 @@ diff -ur Python-3.5.9-orig/Python/pylifecycle.c Python-3.5.9/Python/pylifecycle.
  #endif
  
      if ((p = Py_GETENV("PYTHONDEBUG")) && *p != '\0')
-@@ -1165,12 +1350,8 @@
+@@ -1165,12 +1364,8 @@
              }
          }
          if (!errors && !(pythonioencoding && *pythonioencoding)) {

--- a/components/python/python35/python-35.p5m
+++ b/components/python/python35/python-35.p5m
@@ -1504,6 +1504,7 @@ file path=usr/lib/python3.5/test/test_bufio.py
 file path=usr/lib/python3.5/test/test_builtin.py
 file path=usr/lib/python3.5/test/test_bytes.py
 file path=usr/lib/python3.5/test/test_bz2.py
+file path=usr/lib/python3.5/test/test_c_locale_coercion.py
 file path=usr/lib/python3.5/test/test_calendar.py
 file path=usr/lib/python3.5/test/test_call.py
 file path=usr/lib/python3.5/test/test_capi.py

--- a/components/python/python35/test/results-64.master
+++ b/components/python/python35/test/results-64.master
@@ -1,8 +1,7 @@
-373 tests OK.
-9 tests failed:
-    test_c_locale_coercion test_cmd_line_script test_import test_mmap
-    test_normalization test_selectors test_socket test_strftime
-    test_zipimport
+374 tests OK.
+8 tests failed:
+    test_cmd_line_script test_import test_mmap test_normalization
+    test_selectors test_socket test_strftime test_zipimport
 18 tests skipped:
     test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
     test_smtpnet test_socketserver test_startfile test_timeout

--- a/components/python/python35/test/results-64.master
+++ b/components/python/python35/test/results-64.master
@@ -1,7 +1,8 @@
 373 tests OK.
-8 tests failed:
-    test_cmd_line_script test_import test_mmap test_re test_selectors
-    test_socket test_strftime test_zipimport
+9 tests failed:
+    test_c_locale_coercion test_cmd_line_script test_import test_mmap
+    test_normalization test_selectors test_socket test_strftime
+    test_zipimport
 18 tests skipped:
     test_dtrace test_gdb test_kqueue test_msilib test_ossaudiodev
     test_smtpnet test_socketserver test_startfile test_timeout


### PR DESCRIPTION
Here we import earlear PEP 538 variant, based on Fedora Python 3.6 backport.
There's significant difference in behavior with later Python versions (tested with Python 3.8, likely the same is seen with Python 3.7): when LC_ALL is set to C, it overrides all other settings. When LC_ALL is not set, LC_CTYPE is set to C.UTF-8.
Likely, we need efficiently set LC_CTYPE to C.UTF-8 when LC_ALL is set to C...