### PR TITLE
add perl module Parse::Yapp in version 1.21

### DIFF
--- a/components/perl/Parse-Yapp/Makefile
+++ b/components/perl/Parse-Yapp/Makefile
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Rouven Weiler
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=         Parse-Yapp
+COMPONENT_VERSION=      1.21
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+  sha256:3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5
+COMPONENT_ARCHIVE_URL= \
+  https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=  https://metacpan.org/release/Parse-Yapp/source/lib/Parse/Yapp.pm
+
+include $(WS_TOP)/make-rules/prep.mk
+include $(WS_TOP)/make-rules/makemaker.mk
+include $(WS_TOP)/make-rules/ips.mk
+
+COMPONENT_TEST_TARGETS = test
+
+build:          $(BUILD_32_and_64)
+
+install:        $(INSTALL_32_and_64)
+
+test:           $(TEST_32_and_64)
+
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524

--- a/components/perl/Parse-Yapp/Parse-Yapp-PERLVER.p5m
+++ b/components/perl/Parse-Yapp/Parse-Yapp-PERLVER.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Rouven Weiler
+#
+
+set name=pkg.fmri value=pkg:/library/perl-5/parse-yapp-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="Perl extension for generating and using LALR parsers"
+set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license Parse-Yapp.license license="Artistic"
+
+link path=usr/bin/yapp target=../perl5/$(PERLVER)/bin/yapp \
+    mediator=perl mediator-version=$(PERLVER)
+
+file path=usr/perl5/$(PERLVER)/bin/yapp
+file path=usr/perl5/$(PERLVER)/man/man1/yapp.1
+file path=usr/perl5/$(PERLVER)/man/man3/Parse::Yapp.3
+file path=usr/perl5/vendor_perl/$(PERLVER)/Parse/Yapp.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Parse/Yapp/Driver.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Parse/Yapp/Grammar.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Parse/Yapp/Lalr.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Parse/Yapp/Options.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Parse/Yapp/Output.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Parse/Yapp/Parse.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/auto/Parse/Yapp/.packlist

--- a/components/perl/Parse-Yapp/Parse-Yapp.license
+++ b/components/perl/Parse-Yapp/Parse-Yapp.license
@@ -1,0 +1,127 @@
+			 The "Artistic License"
+
+				Preamble
+
+The intent of this document is to state the conditions under which a
+Package may be copied, such that the Copyright Holder maintains some
+semblance of artistic control over the development of the package,
+while giving the users of the package the right to use and distribute
+the Package in a more-or-less customary fashion, plus the right to make
+reasonable modifications.
+
+Definitions:
+
+	"Package" refers to the collection of files distributed by the
+	Copyright Holder, and derivatives of that collection of files
+	created through textual modification.
+
+	"Standard Version" refers to such a Package if it has not been
+	modified, or has been modified in accordance with the wishes
+	of the Copyright Holder as specified below.
+
+	"Copyright Holder" is whoever is named in the copyright or
+	copyrights for the package.
+
+	"You" is you, if you're thinking about copying or distributing
+	this Package.
+
+	"Reasonable copying fee" is whatever you can justify on the
+	basis of media cost, duplication charges, time of people involved,
+	and so on.  (You will not be required to justify it to the
+	Copyright Holder, but only to the computing community at large
+	as a market that must bear the fee.)
+
+	"Freely Available" means that no fee is charged for the item
+	itself, though there may be fees involved in handling the item.
+	It also means that recipients of the item may redistribute it
+	under the same conditions they received it.
+
+1. You may make and give away verbatim copies of the source form of the
+Standard Version of this Package without restriction, provided that you
+duplicate all of the original copyright notices and associated disclaimers.
+
+2. You may apply bug fixes, portability fixes and other modifications
+derived from the Public Domain or from the Copyright Holder.  A Package
+modified in such a way shall still be considered the Standard Version.
+
+3. You may otherwise modify your copy of this Package in any way, provided
+that you insert a prominent notice in each changed file stating how and
+when you changed that file, and provided that you do at least ONE of the
+following:
+
+    a) place your modifications in the Public Domain or otherwise make them
+    Freely Available, such as by posting said modifications to Usenet or
+    an equivalent medium, or placing the modifications on a major archive
+    site such as uunet.uu.net, or by allowing the Copyright Holder to include
+    your modifications in the Standard Version of the Package.
+
+    b) use the modified Package only within your corporation or organization.
+
+    c) rename any non-standard executables so the names do not conflict
+    with standard executables, which must also be provided, and provide
+    a separate manual page for each non-standard executable that clearly
+    documents how it differs from the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+4. You may distribute the programs of this Package in object code or
+executable form, provided that you do at least ONE of the following:
+
+    a) distribute a Standard Version of the executables and library files,
+    together with instructions (in the manual page or equivalent) on where
+    to get the Standard Version.
+
+    b) accompany the distribution with the machine-readable source of
+    the Package with your modifications.
+
+    c) give non-standard executables non-standard names, and clearly
+    document the differences in manual pages (or equivalent), together
+    with instructions on where to get the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+5. You may charge a reasonable copying fee for any distribution of this
+Package.  You may charge any fee you choose for support of this
+Package.  You may not charge a fee for this Package itself.  However,
+you may distribute this Package in aggregate with other (possibly
+commercial) programs as part of a larger (possibly commercial) software
+distribution provided that you do not advertise this Package as a
+product of your own.  You may embed this Package's interpreter within
+an executable of yours (by linking); this shall be construed as a mere
+form of aggregation, provided that the complete Standard Version of the
+interpreter is so embedded.
+
+6. The scripts and library files supplied as input to or produced as
+output from the programs of this Package do not automatically fall
+under the copyright of this Package, but belong to whoever generated
+them, and may be sold commercially, and may be aggregated with this
+Package.  If such scripts or library files are aggregated with this
+Package via the so-called "undump" or "unexec" methods of producing a
+binary executable image, then distribution of such an image shall
+neither be construed as a distribution of this Package nor shall it
+fall under the restrictions of Paragraphs 3 and 4, provided that you do
+not represent such an executable image as a Standard Version of this
+Package.
+
+7. C subroutines (or comparably compiled subroutines in other
+languages) supplied by you and linked into this Package in order to
+emulate subroutines and variables of the language defined by this
+Package shall not be considered part of this Package, but are the
+equivalent of input as in Paragraph 6, provided these subroutines do
+not change the language in any way that would cause it to fail the
+regression tests for the language.
+
+8. Aggregation of this Package with a commercial distribution is always
+permitted provided that the use of this Package is embedded; that is,
+when no overt attempt is made to make this Package's interfaces visible
+to the end user of the commercial distribution.  Such use shall not be
+construed as a distribution of this Package.
+
+9. The name of the Copyright Holder may not be used to endorse or promote
+products derived from this software without specific prior written permission.
+
+10. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+				The End

--- a/components/perl/Parse-Yapp/manifests/sample-manifest.p5m
+++ b/components/perl/Parse-Yapp/manifests/sample-manifest.p5m
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/5.22/bin/yapp
+file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
+file path=usr/perl5/5.22/man/man1/yapp.1
+file path=usr/perl5/5.22/man/man3/Parse::Yapp.3
+file path=usr/perl5/5.24/bin/yapp
+file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.24/man/man1/yapp.1
+file path=usr/perl5/5.24/man/man3/Parse::Yapp.3
+file path=usr/perl5/vendor_perl/5.22/Parse/Yapp.pm
+file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Driver.pm
+file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Grammar.pm
+file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Lalr.pm
+file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Options.pm
+file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Output.pm
+file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Parse.pm
+file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/Parse/Yapp/.packlist
+file path=usr/perl5/vendor_perl/5.24/Parse/Yapp.pm
+file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Driver.pm
+file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Grammar.pm
+file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Lalr.pm
+file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Options.pm
+file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Output.pm
+file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Parse.pm
+file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Parse/Yapp/.packlist


### PR DESCRIPTION
Could you please check for consistency with other perl modules.
This is my first perl module I add.

I stumbled on the REQUIRED_PACKAGES. They are hardcoded. Maybe there is a mechnism automating the perl versions...