### PR TITLE
shared-macros.mk: add PERL5BINDIR as a macro

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -728,9 +728,6 @@ JAVA7_HOME =	/usr/jdk/instances/openjdk1.7.0
 JAVA8_HOME =	/usr/jdk/instances/openjdk1.8.0
 JAVA_HOME = $(JAVA8_HOME)
 
-# Location of pod2man, etc
-PERL5BINDIR = 	/usr/perl5/bin
-
 # This is the default BUILD version of perl
 # Not necessarily the system's default version, i.e. /usr/bin/perl
 PERL_VERSION =  5.22
@@ -743,6 +740,11 @@ PERL.5.24 =	/usr/perl5/5.24/bin/perl
 POD2MAN.5.22 =	/usr/perl5/5.22/bin/pod2man
 POD2MAN.5.24 =	/usr/perl5/5.24/bin/pod2man
 
+# Location of pod2man, etc
+PERL5BINDIR.5.22 =	/usr/perl5/5.22/bin
+PERL5BINDIR.5.24 =	/usr/perl5/5.24/bin
+
+PERL5BINDIR = 	$(PERL5BINDIR.$(PERL_VERSION))
 PERL =		$(PERL.$(PERL_VERSION))
 POD2MAN =	$(POD2MAN.$(PERL_VERSION))
 


### PR DESCRIPTION
this should help to use scripts that are located in PERL5BINDIR depending on the perl version. It will be needed e.g. to build samba-4.12.0 which needs yapp localte in /usr/perl5/5.24/bin ... 