### PR TITLE
Add bhyve firmware package

### DIFF
--- a/components/openindiana/bhyve-fw/Makefile
+++ b/components/openindiana/bhyve-fw/Makefile
@@ -1,0 +1,104 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		uefi-edk2
+COMPONENT_VERSION=	20180309
+COMPONENT_FMRI=		system/bhyve/firmware
+COMPONENT_CLASSIFICATION=System/Core
+COMPONENT_SUMMARY=	UEFI-EDK2(+CSM) firmware for bhyve
+COMPONENT_SRC=		uefi-edk2-il-udk2014.sp1-1
+COMPONENT_ARCHIVE=	il-udk2014.sp1-1.tar.gz
+COMPONENT_ARCHIVE_HASH= \
+	sha256:d894d1ca61beeb0a1b76c2d6bbd137b02feb4783e4307f36e76efa29d415f6a8
+COMPONENT_ARCHIVE_URL= \
+	https://github.com/illumos/uefi-edk2/archive/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://github.com/illumos/uefi-edk2
+COMPONENT_LICENSE=	simplified-BSD
+
+include $(WS_MAKE_RULES)/prep.mk
+include $(WS_MAKE_RULES)/justmake.mk
+include $(WS_MAKE_RULES)/ips.mk
+
+COMPONENT_BUILD_ENV =
+COMPONENT_BUILD_ENV += GCCVER=4.4.4
+COMPONENT_BUILD_ENV += GCCPATH=/opt/gcc/4.4.4
+COMPONENT_BUILD_ENV += GMAKE=/usr/bin/gmake
+COMPONENT_BUILD_ENV += GAS=/usr/bin/gas
+COMPONENT_BUILD_ENV += GAR=/usr/bin/gar
+COMPONENT_BUILD_ENV += GLD=/usr/bin/gld
+COMPONENT_BUILD_ENV += GOBJCOPY=/usr/bin/gobjcopy
+
+# Four variants of the bhyve firmware are built;
+# DEBUG and RELEASE, and with and without CSM.
+VARIANTS =	DEBUG DEBUG.csm RELEASE RELEASE.csm
+
+BUILD_64 =	$(VARIANTS:%=$(BUILD_DIR)/%/.built)
+INSTALL_64 =	$(VARIANTS:%=$(BUILD_DIR)/%/.installed)
+
+COMPONENT_BUILD_ACTION = \
+	cd $(@D); $(ENV) $(COMPONENT_BUILD_ENV) \
+	./build $(COMPONENT_BUILD_ARGS) $(COMPONENT_BUILD_TARGETS)
+
+$(BUILD_DIR)/DEBUG/.built: COMPONENT_BUILD_ARGS =
+$(BUILD_DIR)/DEBUG/.built: COMPONENT_BUILD_TARGETS = DEBUG
+
+$(BUILD_DIR)/DEBUG.csm/.built: COMPONENT_BUILD_ARGS = -csm
+$(BUILD_DIR)/DEBUG.csm/.built: COMPONENT_BUILD_TARGETS = DEBUG
+
+$(BUILD_DIR)/RELEASE/.built: COMPONENT_BUILD_ARGS =
+$(BUILD_DIR)/RELEASE/.built: COMPONENT_BUILD_TARGETS = RELEASE
+
+$(BUILD_DIR)/RELEASE.csm/.built: COMPONENT_BUILD_ARGS = -csm
+$(BUILD_DIR)/RELEASE.csm/.built: COMPONENT_BUILD_TARGETS = RELEASE
+
+COMPONENT_PRE_INSTALL_ACTION = \
+	$(MKDIR) -p $(PROTO_DIR)/usr/share/bhyve/firmware
+
+COMPONENT_INSTALL_ACTION = \
+	cd $(@D); \
+	$(CP) ./Build/BhyveX64/$(COMPONENT_INSTALL_TARGETS)_ILLGCC/FV/BHYVE.fd \
+	    $(PROTO_DIR)/usr/share/bhyve/firmware/$(COMPONENT_INSTALL_FILE)
+
+$(BUILD_DIR)/DEBUG/.installed: COMPONENT_INSTALL_TARGETS = DEBUG
+$(BUILD_DIR)/DEBUG/.installed: COMPONENT_INSTALL_FILE = BHYVE_DEBUG.fd
+
+$(BUILD_DIR)/DEBUG.csm/.installed: COMPONENT_INSTALL_TARGETS = DEBUG
+$(BUILD_DIR)/DEBUG.csm/.installed: COMPONENT_INSTALL_FILE = BHYVE_DEBUG_CSM.fd
+
+$(BUILD_DIR)/RELEASE/.installed: COMPONENT_INSTALL_TARGETS = RELEASE
+$(BUILD_DIR)/RELEASE/.installed: COMPONENT_INSTALL_FILE = BHYVE_RELEASE.fd
+$(BUILD_DIR)/RELEASE/.installed: \
+	COMPONENT_POST_INSTALL_ACTION = $(LN) -s $(COMPONENT_INSTALL_FILE) \
+	$(PROTO_DIR)/usr/share/bhyve/firmware/BHYVE.fd
+
+$(BUILD_DIR)/RELEASE.csm/.installed: COMPONENT_INSTALL_TARGETS = RELEASE
+$(BUILD_DIR)/RELEASE.csm/.installed: COMPONENT_INSTALL_FILE = BHYVE_RELEASE_CSM.fd
+$(BUILD_DIR)/RELEASE.csm/.installed: \
+	COMPONENT_POST_INSTALL_ACTION = $(LN) -s $(COMPONENT_INSTALL_FILE) \
+	$(PROTO_DIR)/usr/share/bhyve/firmware/BHYVE_CSM.fd
+
+build:		$(BUILD_64)
+
+install:	$(INSTALL_64)
+
+test:		$(NO_TESTS)
+
+# Build dependencies
+REQUIRED_PACKAGES += developer/acpi
+REQUIRED_PACKAGES += developer/illumos-gcc
+
+# Auto-generated dependencies

--- a/components/openindiana/bhyve-fw/bhyve-fw.p5m
+++ b/components/openindiana/bhyve-fw/bhyve-fw.p5m
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> set mode 0555>
+
+dir group=bin mode=0755 owner=root path=usr/share/bhyve
+dir group=bin mode=0755 owner=root path=usr/share/bhyve/firmware
+
+link path=usr/share/bhyve/firmware/BHYVE.fd target=BHYVE_RELEASE.fd
+link path=usr/share/bhyve/firmware/BHYVE_CSM.fd target=BHYVE_RELEASE_CSM.fd
+file path=usr/share/bhyve/firmware/BHYVE_DEBUG.fd
+file path=usr/share/bhyve/firmware/BHYVE_DEBUG_CSM.fd
+file path=usr/share/bhyve/firmware/BHYVE_RELEASE.fd
+file path=usr/share/bhyve/firmware/BHYVE_RELEASE_CSM.fd
+

--- a/components/openindiana/bhyve-fw/manifests/sample-manifest.p5m
+++ b/components/openindiana/bhyve-fw/manifests/sample-manifest.p5m
@@ -1,0 +1,30 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/share/bhyve/firmware/BHYVE.fd target=BHYVE_RELEASE.fd
+link path=usr/share/bhyve/firmware/BHYVE_CSM.fd target=BHYVE_RELEASE_CSM.fd
+file path=usr/share/bhyve/firmware/BHYVE_DEBUG.fd
+file path=usr/share/bhyve/firmware/BHYVE_DEBUG_CSM.fd
+file path=usr/share/bhyve/firmware/BHYVE_RELEASE.fd
+file path=usr/share/bhyve/firmware/BHYVE_RELEASE_CSM.fd

--- a/components/openindiana/bhyve-fw/uefi-edk2.license
+++ b/components/openindiana/bhyve-fw/uefi-edk2.license
@@ -1,0 +1,8 @@
+Copyright (c) 2004 - 2010, Intel Corporation. All rights reserved.
+This program and the accompanying materials
+are licensed and made available under the terms and conditions of the BSD License
+which accompanies this distribution.  The full text of the license may be found at
+http://opensource.org/licenses/bsd-license.php
+
+THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.


### PR DESCRIPTION
This is the firmware that will be needed to boot VMs under bhyve, when bhyve is merged to illumos-gate. Work is currently ongoing against https://github.com/illumos/ipd/blob/master/ipd/0015/README.md

Adding it to OpenIndiana will make bhyve usable when it lands and will facilitate testing in advance.
I've tested each firmware file by booting a VM on OmniOS, which already has bhyve. 

This is a pretty old firmware version but it's the one currently shipped with SmartOS and OmniOS.
There is work being done to update the bhyve firmware in FreeBSD to a much newer version and that will be brought over to https://github.com/illumos/uefi-edk2 when it's ready.
