### PR TITLE
tmux: update to 3.1b

### DIFF
--- a/components/sysutils/tmux/Makefile
+++ b/components/sysutils/tmux/Makefile
@@ -19,10 +19,10 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		tmux
-COMPONENT_VERSION=	3.0a
+COMPONENT_VERSION=	3.1b
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
-IPS_COMPONENT_VERSION=	3.0.1
+IPS_COMPONENT_VERSION=	3.1.2
 COMPONENT_FMRI=		terminal/tmux
 COMPONENT_PROJECT_URL=	https://$(COMPONENT_NAME).github.io
 COMPONENT_SUMMARY=	tmux terminal multiplexer
@@ -30,7 +30,7 @@ COMPONENT_CLASSIFICATION= Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:4ad1df28b4afa969e59c08061b45082fdc49ff512f30fc8e43217d7b0e5f8db9
+	sha256:d93f351d50af05a75fe6681085670c786d9504a5da2608e481c47cf5e1486db9
 COMPONENT_ARCHIVE_URL= \
 	https://github.com/tmux/tmux/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE_FILE=	COPYING


### PR DESCRIPTION
Sample-manifest didn't change.
I have installed the new version locally and didn't run into any problem.