### PR TITLE
p7zip: fix error code mess with gcc-10

### DIFF
--- a/components/archiver/p7zip/Makefile
+++ b/components/archiver/p7zip/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		p7zip
 COMPONENT_VERSION=	16.2
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SRC_VERSION=	16.02
 COMPONENT_FMRI=	compress/p7zip
 COMPONENT_SUMMARY=	The p7zip compression and archiving utility

--- a/components/archiver/p7zip/patches/07-gcc-10.patch
+++ b/components/archiver/p7zip/patches/07-gcc-10.patch
@@ -1,0 +1,38 @@
+--- p7zip_16.02/CPP/Common/MyWindows.h.orig	2020-05-12 13:24:21.437067241 +0000
++++ p7zip_16.02/CPP/Common/MyWindows.h	2020-05-12 13:24:28.787578914 +0000
+@@ -78,15 +78,15 @@
+ typedef ULONG PROPID;
+ typedef LONG SCODE;
+ 
+-#define S_OK    ((HRESULT)0x00000000L)
+-#define S_FALSE ((HRESULT)0x00000001L)
+-#define E_NOTIMPL ((HRESULT)0x80004001L)
+-#define E_NOINTERFACE ((HRESULT)0x80004002L)
+-#define E_ABORT ((HRESULT)0x80004004L)
+-#define E_FAIL ((HRESULT)0x80004005L)
+-#define STG_E_INVALIDFUNCTION ((HRESULT)0x80030001L)
+-#define E_OUTOFMEMORY ((HRESULT)0x8007000EL)
+-#define E_INVALIDARG ((HRESULT)0x80070057L)
++#define S_OK    (0x00000000UL)
++#define S_FALSE (0x00000001UL)
++#define E_NOTIMPL (0x80004001UL)
++#define E_NOINTERFACE (0x80004002UL)
++#define E_ABORT (0x80004004UL)
++#define E_FAIL (0x80004005UL)
++#define STG_E_INVALIDFUNCTION (0x80030001UL)
++#define E_OUTOFMEMORY (0x8007000EUL)
++#define E_INVALIDARG (0x80070057UL)
+ 
+ #ifdef _MSC_VER
+ #define STDMETHODCALLTYPE __stdcall
+--- p7zip_16.02/CPP/7zip/Common/CWrappers.cpp.orig	2020-05-12 13:24:38.196104123 +0000
++++ p7zip_16.02/CPP/7zip/Common/CWrappers.cpp	2020-05-12 13:24:42.645291584 +0000
+@@ -30,7 +30,7 @@
+ 
+ SRes HRESULT_To_SRes(HRESULT res, SRes defaultRes)
+ {
+-  switch (res)
++  switch ((DWORD)res)
+   {
+     case S_OK: return SZ_OK;
+     case E_OUTOFMEMORY: return SZ_ERROR_MEM;


### PR DESCRIPTION
The function MyFormatMessage takes a DWORD as argument (unsigned) while error codes are declared as LONG and possibly negative... the comparison is unlikely to succeed.
Not sure what to do really but since comparison always involve DWORD (unsigned long) or LONG (signed long) I converted error code to the former (wider range).
Tests passed as before.
