### PR TITLE
binutils: infer GNU_TRIPLET from gcc

### DIFF
--- a/components/developer/binutils/Makefile
+++ b/components/developer/binutils/Makefile
@@ -32,6 +32,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		binutils
 COMPONENT_VERSION=	2.34
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	GNU collection of binary tools like ld, as
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/binutils/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -47,6 +48,9 @@ include $(WS_MAKE_RULES)/common.mk
 PATH=$(PATH.gnu)
 
 CONFIGURE_PREFIX =	/usr/gnu
+
+# Since gcc-9 the GNU triple is x86_64-pc-solaris2.11 instead of i386-pc-solaris2.11
+GNU_TRIPLET=$(shell $(CC) -dumpmachine)
 
 CONFIGURE_OPTIONS +=	--mandir=$(CONFIGURE_MANDIR)
 CONFIGURE_OPTIONS +=	--infodir=$(CONFIGURE_INFODIR)


### PR DESCRIPTION
Since gcc-9 and gcc-10 are 64-bit, the GNU triplet has changed from i386-pc-solaris2.11 to x86_64-pc-solaris2.11.
The compiler triplet should be consistent with the toolchain target triplet passed to binutils and therefore should be inferred from the compiler.
If not, the build system considers that a cross-compilation toolchain is built and generates prefixed executable names, e.g x86_64-pc-solaris2.11-ar.