### PR TITLE
Perl bitness compiler flags are not passed correctly

### DIFF
--- a/make-rules/makemaker.mk
+++ b/make-rules/makemaker.mk
@@ -27,7 +27,7 @@ COMMON_PERL_ENV +=	MAKE=$(GMAKE)
 COMMON_PERL_ENV +=	PATH=$(dir $(CC)):$(SPRO_VROOT)/bin:$(PATH)
 COMMON_PERL_ENV +=	LANG=""
 COMMON_PERL_ENV +=	CC="$(CC)"
-COMMON_PERL_ENV +=	CFLAGS="$(PERL_OPTIMIZE)"
+COMMON_PERL_ENV +=	CFLAGS="$(CC_BITS) $(PERL_OPTIMIZE)"
 
 # Yes.  Perl is just scripts, for now, but we need architecture
 # directories so that it populates all architecture prototype

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1257,7 +1257,7 @@ COMPONENT_INSTALL_ENV= \
 PERL_OPTIMIZE =$(gcc_OPT)
 
 # We need this to overwrite options of perl used to compile illumos-gate
-PERL_STUDIO_OVERWRITE = cc="$(CC)" cccdlflags="$(CC_PIC)" ld="$(CC)" ccname="$(shell basename $(CC))" optimize="$(gcc_OPT)"
+PERL_STUDIO_OVERWRITE = cc="$(CC)" cccdlflags="$(CC_BITS) $(CC_PIC)" ld="$(CC) $(CC_BITS)" ccname="$(shell basename $(CC))" optimize="$(gcc_OPT)"
 
 # Allow user to override default maximum number of archives
 NUM_EXTRA_ARCHIVES= 1 2 3 4 5 6 7 8 9 10


### PR DESCRIPTION
This causes 32-bit perl modules to be compiled as 64-bit with gcc-10.