### PR TITLE
Bump Jenkins weekly to 2.237 and LTS to 2.222.3

### DIFF
--- a/components/developer/jenkins-core-lts/Makefile
+++ b/components/developer/jenkins-core-lts/Makefile
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016-2019 Jim Klimov
+# Copyright 2016-2020 Jim Klimov
 #
 include ../../../make-rules/shared-macros.mk
 
@@ -27,10 +27,10 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		jenkins
 JENKINS_RELEASE=lts
 COMPONENT_MAJOR_VERSION=	2
-COMPONENT_MINOR_VERSION=	190
-COMPONENT_PATCH_VERSION=	2
+COMPONENT_MINOR_VERSION=	222
+COMPONENT_PATCH_VERSION=	3
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:47620a00004af5634e45904149897fe4a36b0463ec691bfabc2086779f90f127
+	sha256:1529d642e29e74f65369ff5611935e9361065d9e8f65344a64912c5660cc0781
 # See $(COMPONENT_ARCHIVE_URL).sha256 e.g. for current weekly release, run
 #   wget -O - http://mirrors.jenkins-ci.org/war/latest/jenkins.war.sha256
 # or for LTS

--- a/components/developer/jenkins-core-lts/check-version.sh
+++ b/components/developer/jenkins-core-lts/check-version.sh
@@ -2,22 +2,29 @@
 
 # Find the latest (tarball) release under original site
 #
-# Copyright 2016-2018 Jim Klimov
+# Copyright 2016-2020 Jim Klimov
 #
 
 BASE_URL="http://mirrors.jenkins.io/war-stable/"
+DL_PAGE_URL="https://www.jenkins.io/download/"
 
 echo "=== Checking latest numbered release under $BASE_URL..."
-VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'DIR.*[0-9]*\.[0-9]*' | grep -vw latest | tail -1 | sed 's,^.*a href="\([0-9]*\.[0-9]*\.[0-9]*\)/*".*,\1,'`" \
-    && [ -n "$VERSION" ] && echo "Latest VERSION   = $VERSION" \
-    || echo "WARNING: Could not fetch a VERSION" >&2
+UPSTREAM_VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'DIR.*[0-9]*\.[0-9]*' | grep -vw latest | tail -1 | sed 's,^.*a href="\([0-9]*\.[0-9]*\.[0-9]*\)/*".*,\1,'`" \
+    && [ -n "$UPSTREAM_VERSION" ] && echo "Latest UPSTREAM_VERSION   = $UPSTREAM_VERSION" \
+    || echo "WARNING: Could not fetch an UPSTREAM_VERSION, check manually at $DL_PAGE_URL " >&2
 
-CHECKSUM="`wget -O - "$BASE_URL/latest/jenkins.war.sha256" 2>/dev/null`" \
-    && [ -n "$CHECKSUM" ] && echo "Latest SHA256SUM = sha256:$CHECKSUM" \
-    || echo "WARNING: Could not fetch a CHECKSUM" >&2
+UPSTREAM_CHECKSUM="`wget -O - "$BASE_URL/latest/jenkins.war.sha256" 2>/dev/null | awk '{print $1}'`" \
+    && [ -n "$UPSTREAM_CHECKSUM" ] && echo "Latest SHA256SUM = sha256:$UPSTREAM_CHECKSUM" \
+    || echo "WARNING: Could not fetch an UPSTREAM_CHECKSUM" >&2
 
-echo "=== Data in current `dirname $0`/Makefile:"
-egrep '(^[\t\ ]*(COMPONENT_[A-Z]*_VERSION.*=|JENKINS_RELEASE.*=)|sha256:)' "`dirname $0`/Makefile"
+MF="`dirname $0`/Makefile"
+echo "=== Data in current ${MF}:"
+egrep '(^[\t\ ]*(COMPONENT_[A-Z]*_VERSION.*=|JENKINS_RELEASE.*=)|sha256:)' "${MF}"
+MAKEFILE_CHECKSUM="`grep 'sha256:' ${MF} | sed 's,^.*sha256:,,'`"
+
+if [ "$MAKEFILE_CHECKSUM" = "$UPSTREAM_CHECKSUM" ] ; then
+    echo "=== MAKEFILE_CHECKSUM matches the UPSTREAM_CHECKSUM currently"
+fi
 
 echo "=== Please edit the Makefile and commit like this:"
-echo "    git add -p Makefile; git commit -m 'Bump jenkins-core-lts to v${VERSION}'"
+echo "    git add -p Makefile; git commit -m 'Bump jenkins-core-lts to v${UPSTREAM_VERSION}'"

--- a/components/developer/jenkins-core-weekly/Makefile
+++ b/components/developer/jenkins-core-weekly/Makefile
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016-2019 Jim Klimov
+# Copyright 2016-2020 Jim Klimov
 #
 include ../../../make-rules/shared-macros.mk
 
@@ -27,9 +27,9 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		jenkins
 JENKINS_RELEASE=weekly
 COMPONENT_MAJOR_VERSION=	2
-COMPONENT_MINOR_VERSION=	203
+COMPONENT_MINOR_VERSION=	237
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:a3ec1d740063181b1996116a410b1dad0c75a41b208315e3e5255c219155834b
+	sha256:63841651fb65d4abd3b16708a14d281e6eaaf6c5ca8ed36996ace3996e38dd61
 # See $(COMPONENT_ARCHIVE_URL).sha256 e.g. for current weekly release, run
 #   wget -O - http://mirrors.jenkins-ci.org/war/latest/jenkins.war.sha256
 # or for LTS


### PR DESCRIPTION
Just a road bump :)

Also, http://mirrors.jenkins-ci.org/war/ recently changed to be a text page instead of a directory listing (from which we can induce the release number) so the helper re-versioning script dances around the fallout. The LTS directory is still served as it was, but just in case the fix is also applied to its copy of the script.