### PR TITLE
zstd: bump to 1.4.5

### DIFF
--- a/components/archiver/zstd/Makefile
+++ b/components/archiver/zstd/Makefile
@@ -14,11 +14,11 @@
 
 BUILD_BITS=		64_and_32
 BUILD_STYLE=		cmake
-
+PREFERRED_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zstd
-COMPONENT_VERSION=	1.4.4
+COMPONENT_VERSION=	1.4.5
 COMPONENT_SUMMARY=	Zstandard, or zstd for short, is a fast lossless compression algorithm, targeting real-time compression scenarios
 COMPONENT_PROJECT_URL=	https://facebook.github.io/zstd/
 COMPONENT_FMRI=		compress/zstd
@@ -26,9 +26,8 @@ COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/facebook/zstd/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	sha256:59ef70ebb757ffe74a7b3fe9c305e2ba3350021a918d168a046c6300aeea9315
+COMPONENT_ARCHIVE_HASH=	sha256:98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
 COMPONENT_LICENSE=	BSD,GPLv2.0
-COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/archiver/zstd/manifests/sample-manifest.p5m
+++ b/components/archiver/zstd/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,12 +22,12 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-link path=usr/bin/$(MACH64)/unzstd target=zstd
-file path=usr/bin/$(MACH64)/zstd
-link path=usr/bin/$(MACH64)/zstdcat target=zstd
-file path=usr/bin/$(MACH64)/zstdgrep
-file path=usr/bin/$(MACH64)/zstdless
-link path=usr/bin/$(MACH64)/zstdmt target=zstd
+link path=usr/bin/$(MACH32)/unzstd target=zstd
+file path=usr/bin/$(MACH32)/zstd
+link path=usr/bin/$(MACH32)/zstdcat target=zstd
+file path=usr/bin/$(MACH32)/zstdgrep
+file path=usr/bin/$(MACH32)/zstdless
+link path=usr/bin/$(MACH32)/zstdmt target=zstd
 link path=usr/bin/unzstd target=zstd
 file path=usr/bin/zstd
 link path=usr/bin/zstdcat target=zstd
@@ -39,11 +39,19 @@ file path=usr/include/zbuff.h
 file path=usr/include/zdict.h
 file path=usr/include/zstd.h
 file path=usr/include/zstd_errors.h
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdConfigVersion.cmake
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdTargets-release.cmake
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdTargets.cmake
 file path=usr/lib/$(MACH64)/libzstd.a
 link path=usr/lib/$(MACH64)/libzstd.so target=libzstd.so.1
 file path=usr/lib/$(MACH64)/libzstd.so.$(COMPONENT_VERSION)
 link path=usr/lib/$(MACH64)/libzstd.so.1 target=libzstd.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/libzstd.pc
+file path=usr/lib/cmake/zstd/zstdConfig.cmake
+file path=usr/lib/cmake/zstd/zstdConfigVersion.cmake
+file path=usr/lib/cmake/zstd/zstdTargets-release.cmake
+file path=usr/lib/cmake/zstd/zstdTargets.cmake
 file path=usr/lib/libzstd.a
 link path=usr/lib/libzstd.so target=libzstd.so.1
 file path=usr/lib/libzstd.so.$(COMPONENT_VERSION)

--- a/components/archiver/zstd/zstd.p5m
+++ b/components/archiver/zstd/zstd.p5m
@@ -25,12 +25,12 @@ depend fmri=text/gnu-grep type=require
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-link path=usr/bin/$(MACH64)/unzstd target=zstd
-file path=usr/bin/$(MACH64)/zstd
-link path=usr/bin/$(MACH64)/zstdcat target=zstd
-file path=usr/bin/$(MACH64)/zstdgrep
-file path=usr/bin/$(MACH64)/zstdless
-link path=usr/bin/$(MACH64)/zstdmt target=zstd
+link path=usr/bin/$(MACH32)/unzstd target=zstd
+file path=usr/bin/$(MACH32)/zstd
+link path=usr/bin/$(MACH32)/zstdcat target=zstd
+file path=usr/bin/$(MACH32)/zstdgrep
+file path=usr/bin/$(MACH32)/zstdless
+link path=usr/bin/$(MACH32)/zstdmt target=zstd
 link path=usr/bin/unzstd target=zstd
 file path=usr/bin/zstd
 link path=usr/bin/zstdcat target=zstd
@@ -42,12 +42,20 @@ file path=usr/include/zbuff.h
 file path=usr/include/zdict.h
 file path=usr/include/zstd.h
 file path=usr/include/zstd_errors.h
-#file path=usr/lib/$(MACH64)/libzstd.a
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdConfigVersion.cmake
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdTargets-release.cmake
+file path=usr/lib/$(MACH64)/cmake/zstd/zstdTargets.cmake
+file path=usr/lib/$(MACH64)/libzstd.a
 link path=usr/lib/$(MACH64)/libzstd.so target=libzstd.so.1
 file path=usr/lib/$(MACH64)/libzstd.so.$(COMPONENT_VERSION)
 link path=usr/lib/$(MACH64)/libzstd.so.1 target=libzstd.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/libzstd.pc
-#file path=usr/lib/libzstd.a
+file path=usr/lib/cmake/zstd/zstdConfig.cmake
+file path=usr/lib/cmake/zstd/zstdConfigVersion.cmake
+file path=usr/lib/cmake/zstd/zstdTargets-release.cmake
+file path=usr/lib/cmake/zstd/zstdTargets.cmake
+file path=usr/lib/libzstd.a
 link path=usr/lib/libzstd.so target=libzstd.so.1
 file path=usr/lib/libzstd.so.$(COMPONENT_VERSION)
 link path=usr/lib/libzstd.so.1 target=libzstd.so.$(COMPONENT_VERSION)


### PR DESCRIPTION
ABI compatible https://abi-laboratory.pro/index.php?view=timeline&l=zstd.
All tests passed.
Ship static libs for own HPC application.