### PR TITLE
userland: prefer 64-bit for BUILD_BITS=64_and_32

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -144,9 +144,9 @@ endif
 ifeq ($(strip $(BUILD_BITS)),64)
 PREFERRED_BITS=64
 endif
-# Unlike Solaris we still prefer 32bit
+# Now we prefer 64-bit
 ifeq ($(strip $(BUILD_BITS)),64_and_32)
-PREFERRED_BITS ?=32
+PREFERRED_BITS=64
 endif
 PREFERRED_BITS ?= 32
 


### PR DESCRIPTION
Only 4 consumers of BUILD_BITS=64_and_32:

- archiver/zstd (moved to 64-bit preferred)
- library/icu (moved to 64-bit preferred)
- network/samba (no effect, manual rules)
- sysutils/net-snmp (should use 32_and_64)