### PR TITLE
libjpeg-turbo: bump to 2.0.4

### DIFF
--- a/components/library/libjpeg-turbo/Makefile
+++ b/components/library/libjpeg-turbo/Makefile
@@ -12,46 +12,51 @@
 # Copyright 2015 Aurelien Larcher
 #
 
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libjpeg-turbo
-COMPONENT_VERSION= 1.5.2
+COMPONENT_VERSION= 2.0.4
 COMPONENT_FMRI= image/library/libjpeg-turbo
 COMPONENT_PROJECT_URL= http://www.libjpeg-turbo.org/
 COMPONENT_SUMMARY= libjpeg -JPEG Turbo libraries
 COMPONENT_SRC= libjpeg-turbo-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:9098943b270388727ae61de82adec73cf9f0dbb240b3bc8b172595ebf405b528
+  sha256:33dd8547efd5543639e890efbf2ef52d5a21df81faf41bb940657af916a23406
 COMPONENT_ARCHIVE_URL= http://sourceforge.net/projects/libjpeg-turbo/files/$(COMPONENT_VERSION)/$(COMPONENT_SRC).tar.gz/download
 COMPONENT_LICENSE= IJG,BSD,zlib
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 
-
 include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
+include $(WS_MAKE_RULES)/cmake.mk
 include $(WS_MAKE_RULES)/ips.mk
 
-CONFIGURE_DEFAULT_DIRS=no
+CMAKE_DEFAULT_DIRS=no
 
 # Warnings are normal: libtool:   error: ignoring unknown tag NASM
 
-CONFIGURE_OPTIONS.JPEG6= 
-CONFIGURE_OPTIONS.JPEG7= --with-jpeg7
-CONFIGURE_OPTIONS.JPEG8= --with-jpeg8
+CMAKE_OPTIONS.JPEG6= 
+CMAKE_OPTIONS.JPEG7= -DWITH_JPEG7=ON
+CMAKE_OPTIONS.JPEG8= -DWITH_JPEG8=ON
 
-CONFIGURE_OPTIONS+=	--enable-shared
-CONFIGURE_OPTIONS+=	--disable-static
+LIBJPEG_TURBO_X_PREFIX=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo
+
+CMAKE_OPTIONS+=	-DENABLE_STATIC=FALSE
 # Allow for build with different API compliance
-CONFIGURE_OPTIONS+=	$(CONFIGURE_OPTIONS.JPEG$(JPEG_API_VERSION))
-CONFIGURE_OPTIONS+= --mandir=$(CONFIGURE_MANDIR)
-CONFIGURE_OPTIONS+= --includedir=$(CONFIGURE_INCLUDEDIR)/libjpeg$(JPEG_API_VERSION)-turbo
-CONFIGURE_OPTIONS.32+= --bindir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/bin
-CONFIGURE_OPTIONS.32+= --libdir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/lib
-# Autoconf infers the build type incorrectly from the host triplet
-CONFIGURE_OPTIONS.64+= --build=x86_64-solaris2.11
-CONFIGURE_OPTIONS.64+= --bindir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/bin/$(MACH64)
-CONFIGURE_OPTIONS.64+= --libdir=$(USRLIBDIR)/libjpeg$(JPEG_API_VERSION)-turbo/lib/$(MACH64)
+CMAKE_OPTIONS+=	$(CMAKE_OPTIONS.JPEG$(JPEG_API_VERSION))
+CMAKE_OPTIONS+=	-DCMAKE_INSTALL_PREFIX=$(LIBJPEG_TURBO_X_PREFIX)
+CMAKE_OPTIONS+= -DCMAKE_INSTALL_MANDIR=$(USRSHAREMANDIR)
+CMAKE_OPTIONS+= -DCMAKE_INSTALL_DOCDIR=$(USRSHAREDOCDIR)/libjpeg-turbo
+CMAKE_OPTIONS+= -DCMAKE_INSTALL_INCLUDEDIR=$(USRINCDIR)/libjpeg$(JPEG_API_VERSION)-turbo
+CMAKE_OPTIONS.32+= -DCMAKE_INSTALL_BINDIR=$(LIBJPEG_TURBO_X_PREFIX)/bin
+CMAKE_OPTIONS.32+= -DCMAKE_INSTALL_LIBDIR=$(LIBJPEG_TURBO_X_PREFIX)/lib
+CMAKE_OPTIONS.64+= -DCMAKE_INSTALL_BINDIR=$(LIBJPEG_TURBO_X_PREFIX)/bin/$(MACH64)
+CMAKE_OPTIONS.64+= -DCMAKE_INSTALL_LIBDIR=$(LIBJPEG_TURBO_X_PREFIX)/lib/$(MACH64)
+
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
+
+COMPONENT_TEST_TRANSFORMS+= '-e "s/[0-9. ]*sec//g"'
 
 # Define rules for each API build
 BUILD_DIR_32_6 =		$(BUILD_DIR)/$(MACH32)/6
@@ -84,20 +89,32 @@ $(BUILD_DIR)/%/6/.installed: JPEG_API_VERSION=6
 $(BUILD_DIR)/%/7/.installed: JPEG_API_VERSION=7
 $(BUILD_DIR)/%/8/.installed: JPEG_API_VERSION=8
 
-TEST_32 =		$(BUILD_DIR_32_6)/.tested $(BUILD_DIR_32_7)/.tested $(BUILD_DIR_32_8)/.tested
-TEST_64 =		$(BUILD_DIR_64_6)/.tested $(BUILD_DIR_64_7)/.tested $(BUILD_DIR_64_8)/.tested
-TEST_32_and_64 =	$(TEST_32) $(TEST_64)
+ifeq ($(strip $(wildcard $(COMPONENT_TEST_RESULTS_DIR)/results-*.master)),)
+TEST_32 = $(BUILD_DIR_32_6)/.tested $(BUILD_DIR_32_7)/.tested $(BUILD_DIR_32_8)/.tested
+TEST_64 = $(BUILD_DIR_64_6)/.tested $(BUILD_DIR_64_7)/.tested $(BUILD_DIR_64_8)/.tested
 $(BUILD_DIR_32)/%/.tested:		BITS=32
 $(BUILD_DIR_64)/%/.tested:		BITS=64
 $(BUILD_DIR)/%/6/.tested: JPEG_API_VERSION=6
 $(BUILD_DIR)/%/7/.tested: JPEG_API_VERSION=7
 $(BUILD_DIR)/%/8/.tested: JPEG_API_VERSION=8
+else
+TEST_32 = $(BUILD_DIR_32_6)/.tested-and-compared $(BUILD_DIR_32_7)/.tested-and-compared $(BUILD_DIR_32_8)/.tested-and-compared
+TEST_64 = $(BUILD_DIR_64_6)/.tested-and-compared $(BUILD_DIR_64_7)/.tested-and-compared $(BUILD_DIR_64_8)/.tested-and-compared
+$(BUILD_DIR_32)/%/.tested-and-compared:	BITS=32
+$(BUILD_DIR_64)/%/.tested-and-compared:	BITS=64
+$(BUILD_DIR)/%/6/.tested-and-compared: JPEG_API_VERSION=6
+$(BUILD_DIR)/%/7/.tested-and-compared: JPEG_API_VERSION=7
+$(BUILD_DIR)/%/8/.tested-and-compared: JPEG_API_VERSION=8
+endif
 
-build:		$(BUILD_32_and_64)
+TEST_32_and_64 =	$(TEST_32) $(TEST_64)
 
-install:	$(INSTALL_32_and_64)
+build:         $(BUILD_32_and_64)
 
-test:		$(TEST_32_and_64)
+install:       $(INSTALL_32_and_64)
+
+test:          $(TEST_32_and_64)
+
 
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/library/libjpeg-turbo/libjpeg-turbo.license
+++ b/components/library/libjpeg-turbo/libjpeg-turbo.license
@@ -1,25 +1,27 @@
 libjpeg-turbo Licenses
-----------------------
+======================
 
 libjpeg-turbo is covered by three compatible BSD-style open source licenses:
 
--- The IJG (Independent JPEG Group) License, which is listed in README
+- The IJG (Independent JPEG Group) License, which is listed in
+  [README.ijg](README.ijg)
 
-   This license applies to the libjpeg API library and associated programs
-   (any code inherited from libjpeg, and any modifications to that code.)
+  This license applies to the libjpeg API library and associated programs
+  (any code inherited from libjpeg, and any modifications to that code.)
 
--- The Modified (3-clause) BSD License, which is listed in turbojpeg.c
+- The Modified (3-clause) BSD License, which is listed below
 
-   This license covers the TurboJPEG API library and associated programs.
+  This license covers the TurboJPEG API library and associated programs, as
+  well as the build system.
 
--- The zlib License, which is listed in simd/jsimdext.inc
+- The [zlib License](https://opensource.org/licenses/Zlib)
 
-   This license is a subset of the other two, and it covers the libjpeg-turbo
-   SIMD extensions.
+  This license is a subset of the other two, and it covers the libjpeg-turbo
+  SIMD extensions.
 
 
 Complying with the libjpeg-turbo Licenses
------------------------------------------
+=========================================
 
 This section provides a roll-up of the libjpeg-turbo licensing terms, to the
 best of our understanding.
@@ -27,53 +29,104 @@ best of our understanding.
 1.  If you are distributing a modified version of the libjpeg-turbo source,
     then:
 
-    a.  You cannot alter or remove any existing copyright or license notices
+    1.  You cannot alter or remove any existing copyright or license notices
         from the source.
 
-        Origin:  Clause 1 of the IJG License
-                 Clause 1 of the Modified BSD License
-                 Clauses 1 and 3 of the zlib License
+        **Origin**
+        - Clause 1 of the IJG License
+        - Clause 1 of the Modified BSD License
+        - Clauses 1 and 3 of the zlib License
 
-    b.  You must add your own copyright notice to the header of each source
+    2.  You must add your own copyright notice to the header of each source
         file you modified, so others can tell that you modified that file (if
         there is not an existing copyright header in that file, then you can
         simply add a notice stating that you modified the file.)
 
-        Origin:  Clause 1 of the IJG License
-                 Clause 2 of the zlib License
+        **Origin**
+        - Clause 1 of the IJG License
+        - Clause 2 of the zlib License
 
-    c.  You must include the IJG README file, and you must not alter any of the
+    3.  You must include the IJG README file, and you must not alter any of the
         copyright or license text in that file.
 
-        Origin:  Clause 1 of the IJG License
+        **Origin**
+        - Clause 1 of the IJG License
 
 2.  If you are distributing only libjpeg-turbo binaries without the source, or
     if you are distributing an application that statically links with
     libjpeg-turbo, then:
 
-    a.  Your product documentation must include a message stating:
+    1.  Your product documentation must include a message stating:
 
         This software is based in part on the work of the Independent JPEG
         Group.
 
-        Origin:  Clause 2 of the IJG license
+        **Origin**
+        - Clause 2 of the IJG license
 
-    b.  If your binary distribution includes or uses the TurboJPEG API, then
+    2.  If your binary distribution includes or uses the TurboJPEG API, then
         your product documentation must include the text of the Modified BSD
-        License.
+        License (see below.)
 
-        Origin:  Clause 2 of the Modified BSD License
+        **Origin**
+        - Clause 2 of the Modified BSD License
 
 3.  You cannot use the name of the IJG or The libjpeg-turbo Project or the
     contributors thereof in advertising, publicity, etc.
 
-    Origin:  IJG License
-             Clause 3 of the Modified BSD License
+    **Origin**
+    - IJG License
+    - Clause 3 of the Modified BSD License
 
 4.  The IJG and The libjpeg-turbo Project do not warrant libjpeg-turbo to be
     free of defects, nor do we accept any liability for undesirable
     consequences resulting from your use of the software.
 
-    Origin:  IJG License
-             Modified BSD License
-             zlib License
+    **Origin**
+    - IJG License
+    - Modified BSD License
+    - zlib License
+
+
+The Modified (3-clause) BSD License
+===================================
+
+Copyright (C)2009-2019 D. R. Commander.  All Rights Reserved.
+Copyright (C)2015 Viktor Szathmáry.  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of the libjpeg-turbo Project nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS",
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+Why Three Licenses?
+===================
+
+The zlib License could have been used instead of the Modified (3-clause) BSD
+License, and since the IJG License effectively subsumes the distribution
+conditions of the zlib License, this would have effectively placed
+libjpeg-turbo binary distributions under the IJG License.  However, the IJG
+License specifically refers to the Independent JPEG Group and does not extend
+attribution and endorsement protections to other entities.  Thus, it was
+desirable to choose a license that granted us the same protections for new code
+that were granted to the IJG for code derived from their software.

--- a/components/library/libjpeg-turbo/libjpeg-turbo.p5m
+++ b/components/library/libjpeg-turbo/libjpeg-turbo.p5m
@@ -25,22 +25,34 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # Require package with default JPEG API
 depend fmri=image/library/libjpeg8-turbo type=require
 
+# Dependency on libjpeg6 with removed docs and symlinks
+depend fmri=image/library/libjpeg6@6.0.2-2020.0.1.1 type=optional
+
 # Only shipped by libjpeg-turbo
 file path=usr/share/doc/libjpeg-turbo/LICENSE.md
 file path=usr/share/doc/libjpeg-turbo/README.ijg
 file path=usr/share/doc/libjpeg-turbo/README.md
-file path=usr/share/doc/libjpeg-turbo/example.c
+file path=usr/share/doc/libjpeg-turbo/example.txt
 file path=usr/share/doc/libjpeg-turbo/libjpeg.txt
 file path=usr/share/doc/libjpeg-turbo/structure.txt
+file path=usr/share/doc/libjpeg-turbo/tjexample.c
 file path=usr/share/doc/libjpeg-turbo/usage.txt
 file path=usr/share/doc/libjpeg-turbo/wizard.txt
 
-# Already shipped by libjpeg6-ijg
-#file path=usr/share/man/man1/cjpeg.1
-#file path=usr/share/man/man1/djpeg.1
-#file path=usr/share/man/man1/jpegtran.1
-#file path=usr/share/man/man1/rdjpgcom.1
-#file path=usr/share/man/man1/wrjpgcom.1
+# Previously shipped by libjpeg6-ijg
+file path=usr/share/man/man1/cjpeg.1
+file path=usr/share/man/man1/djpeg.1
+file path=usr/share/man/man1/jpegtran.1
+file path=usr/share/man/man1/rdjpgcom.1
+file path=usr/share/man/man1/wrjpgcom.1
+
+# Add symlinks to default binaries
+link path=usr/bin/cjpeg target=../lib/libjpeg8-turbo/bin/$(MACH64)/cjpeg
+link path=usr/bin/djpeg target=../lib/libjpeg8-turbo/bin/$(MACH64)/djpeg
+link path=usr/bin/jpegtran target=../lib/libjpeg8-turbo/bin/$(MACH64)/jpegtran
+link path=usr/bin/rdjpgcom target=../lib/libjpeg8-turbo/bin/$(MACH64)/rdjpgcom
+link path=usr/bin/tjbench target=../lib/libjpeg8-turbo/bin/$(MACH64)/tjbench
+link path=usr/bin/wrjpgcom target=../lib/libjpeg8-turbo/bin/$(MACH64)/wrjpgcom
 
 # Add symlinks to default pkg-config files
 link path=usr/lib/pkgconfig/libjpeg.pc \

--- a/components/library/libjpeg-turbo/libjpeg6-turbo.p5m
+++ b/components/library/libjpeg-turbo/libjpeg6-turbo.p5m
@@ -42,25 +42,23 @@ file path=usr/lib/libjpeg6-turbo/bin/jpegtran
 file path=usr/lib/libjpeg6-turbo/bin/rdjpgcom
 file path=usr/lib/libjpeg6-turbo/bin/tjbench
 file path=usr/lib/libjpeg6-turbo/bin/wrjpgcom
-link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so \
-    target=libjpeg.so.62.2.0
+link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.62
 link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62 \
-    target=libjpeg.so.62.2.0
-file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62.2.0
+    target=libjpeg.so.62.3.0
+file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62.3.0
 link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0
 link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/pkgconfig/libturbojpeg.pc
-link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so target=libjpeg.so.62.2.0
-link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62 target=libjpeg.so.62.2.0
-file path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62.2.0
-link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so target=libjpeg.so.62
+link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62 target=libjpeg.so.62.3.0
+file path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62.3.0
+link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0
 link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg6-turbo/lib/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg6-turbo/lib/pkgconfig/libturbojpeg.pc

--- a/components/library/libjpeg-turbo/libjpeg7-turbo.p5m
+++ b/components/library/libjpeg-turbo/libjpeg7-turbo.p5m
@@ -42,26 +42,23 @@ file path=usr/lib/libjpeg7-turbo/bin/jpegtran
 file path=usr/lib/libjpeg7-turbo/bin/rdjpgcom
 file path=usr/lib/libjpeg7-turbo/bin/tjbench
 file path=usr/lib/libjpeg7-turbo/bin/wrjpgcom
-link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so \
-    target=libjpeg.so.7.2.0
+link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.7
 link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7 \
-    target=libjpeg.so.7.2.0
-file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7.2.0
+    target=libjpeg.so.7.3.0
+file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7.3.0
 link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0
 link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/pkgconfig/libturbojpeg.pc
-link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so target=libjpeg.so.7.2.0
-link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7 target=libjpeg.so.7.2.0
-file path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7.2.0
-link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so target=libjpeg.so.7
+link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7 target=libjpeg.so.7.3.0
+file path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7.3.0
+link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0
 link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0.1.0
-
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg7-turbo/lib/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg7-turbo/lib/pkgconfig/libturbojpeg.pc

--- a/components/library/libjpeg-turbo/libjpeg8-turbo.p5m
+++ b/components/library/libjpeg-turbo/libjpeg8-turbo.p5m
@@ -42,25 +42,23 @@ file path=usr/lib/libjpeg8-turbo/bin/jpegtran
 file path=usr/lib/libjpeg8-turbo/bin/rdjpgcom
 file path=usr/lib/libjpeg8-turbo/bin/tjbench
 file path=usr/lib/libjpeg8-turbo/bin/wrjpgcom
-link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so \
-    target=libjpeg.so.8.1.2
+link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.8
 link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8 \
-    target=libjpeg.so.8.1.2
-file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.1.2
+    target=libjpeg.so.8.2.2
+file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.2.2
 link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0
 link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/pkgconfig/libturbojpeg.pc
-link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so target=libjpeg.so.8.1.2
-link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8 target=libjpeg.so.8.1.2
-file path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8.1.2
-link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so target=libjpeg.so.8
+link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8 target=libjpeg.so.8.2.2
+file path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8.2.2
+link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0
 link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg8-turbo/lib/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg8-turbo/lib/pkgconfig/libturbojpeg.pc

--- a/components/library/libjpeg-turbo/manifests/sample-manifest.p5m
+++ b/components/library/libjpeg-turbo/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -49,26 +49,24 @@ file path=usr/lib/libjpeg6-turbo/bin/jpegtran
 file path=usr/lib/libjpeg6-turbo/bin/rdjpgcom
 file path=usr/lib/libjpeg6-turbo/bin/tjbench
 file path=usr/lib/libjpeg6-turbo/bin/wrjpgcom
-link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so \
-    target=libjpeg.so.62.2.0
+link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.62
 link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62 \
-    target=libjpeg.so.62.2.0
-file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62.2.0
+    target=libjpeg.so.62.3.0
+file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libjpeg.so.62.3.0
 link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0
 link path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg6-turbo/lib/$(MACH64)/pkgconfig/libturbojpeg.pc
-link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so target=libjpeg.so.62.2.0
-link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62 target=libjpeg.so.62.2.0
-file path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62.2.0
-link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so target=libjpeg.so.62
+link path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62 target=libjpeg.so.62.3.0
+file path=usr/lib/libjpeg6-turbo/lib/libjpeg.so.62.3.0
+link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0
 link path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg6-turbo/lib/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg6-turbo/lib/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg6-turbo/lib/pkgconfig/libturbojpeg.pc
 file path=usr/lib/libjpeg7-turbo/bin/$(MACH64)/cjpeg
@@ -83,26 +81,24 @@ file path=usr/lib/libjpeg7-turbo/bin/jpegtran
 file path=usr/lib/libjpeg7-turbo/bin/rdjpgcom
 file path=usr/lib/libjpeg7-turbo/bin/tjbench
 file path=usr/lib/libjpeg7-turbo/bin/wrjpgcom
-link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so \
-    target=libjpeg.so.7.2.0
+link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.7
 link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7 \
-    target=libjpeg.so.7.2.0
-file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7.2.0
+    target=libjpeg.so.7.3.0
+file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libjpeg.so.7.3.0
 link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0
 link path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg7-turbo/lib/$(MACH64)/pkgconfig/libturbojpeg.pc
-link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so target=libjpeg.so.7.2.0
-link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7 target=libjpeg.so.7.2.0
-file path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7.2.0
-link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so target=libjpeg.so.7
+link path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7 target=libjpeg.so.7.3.0
+file path=usr/lib/libjpeg7-turbo/lib/libjpeg.so.7.3.0
+link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0
 link path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg7-turbo/lib/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg7-turbo/lib/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg7-turbo/lib/pkgconfig/libturbojpeg.pc
 file path=usr/lib/libjpeg8-turbo/bin/$(MACH64)/cjpeg
@@ -117,34 +113,33 @@ file path=usr/lib/libjpeg8-turbo/bin/jpegtran
 file path=usr/lib/libjpeg8-turbo/bin/rdjpgcom
 file path=usr/lib/libjpeg8-turbo/bin/tjbench
 file path=usr/lib/libjpeg8-turbo/bin/wrjpgcom
-link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so \
-    target=libjpeg.so.8.1.2
+link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so target=libjpeg.so.8
 link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8 \
-    target=libjpeg.so.8.1.2
-file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.1.2
+    target=libjpeg.so.8.2.2
+file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.2.2
 link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0
 link path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg8-turbo/lib/$(MACH64)/pkgconfig/libturbojpeg.pc
-link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so target=libjpeg.so.8.1.2
-link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8 target=libjpeg.so.8.1.2
-file path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8.1.2
-link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so \
-    target=libturbojpeg.so.0.1.0
+link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so target=libjpeg.so.8
+link path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8 target=libjpeg.so.8.2.2
+file path=usr/lib/libjpeg8-turbo/lib/libjpeg.so.8.2.2
+link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so target=libturbojpeg.so.0
 link path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0 \
-    target=libturbojpeg.so.0.1.0
-file path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0.1.0
+    target=libturbojpeg.so.0.2.0
+file path=usr/lib/libjpeg8-turbo/lib/libturbojpeg.so.0.2.0
 file path=usr/lib/libjpeg8-turbo/lib/pkgconfig/libjpeg.pc
 file path=usr/lib/libjpeg8-turbo/lib/pkgconfig/libturbojpeg.pc
 file path=usr/share/doc/libjpeg-turbo/LICENSE.md
 file path=usr/share/doc/libjpeg-turbo/README.ijg
 file path=usr/share/doc/libjpeg-turbo/README.md
-file path=usr/share/doc/libjpeg-turbo/example.c
+file path=usr/share/doc/libjpeg-turbo/example.txt
 file path=usr/share/doc/libjpeg-turbo/libjpeg.txt
 file path=usr/share/doc/libjpeg-turbo/structure.txt
+file path=usr/share/doc/libjpeg-turbo/tjexample.c
 file path=usr/share/doc/libjpeg-turbo/usage.txt
 file path=usr/share/doc/libjpeg-turbo/wizard.txt
 file path=usr/share/man/man1/cjpeg.1

--- a/components/library/libjpeg-turbo/patches/01-pkgconfig.patch
+++ b/components/library/libjpeg-turbo/patches/01-pkgconfig.patch
@@ -1,18 +1,20 @@
---- libjpeg-turbo-1.5.1/release/libjpeg.pc.in.orig	2017-03-02 23:32:25.537068631 +0100
-+++ libjpeg-turbo-1.5.1/release/libjpeg.pc.in	2017-03-02 23:33:34.182713980 +0100
+Always link to the right JPEG implementation
+
+--- libjpeg-turbo-2.0.4/release/libjpeg.pc.in.orig	2020-06-02 15:34:29.911504279 +0000
++++ libjpeg-turbo-2.0.4/release/libjpeg.pc.in	2020-06-02 15:35:32.056317779 +0000
 @@ -6,5 +6,5 @@
  Name: libjpeg
  Description: A SIMD-accelerated JPEG codec that provides the libjpeg API
- Version: @PACKAGE_VERSION@
+ Version: @VERSION@
 -Libs: -L${libdir} -ljpeg
 +Libs: -L${libdir} -R${libdir} -ljpeg
  Cflags: -I${includedir}
---- libjpeg-turbo-1.5.1/release/libturbojpeg.pc.in.orig	2017-03-02 23:33:09.858744986 +0100
-+++ libjpeg-turbo-1.5.1/release/libturbojpeg.pc.in	2017-03-02 23:33:50.072086016 +0100
+--- libjpeg-turbo-2.0.4/release/libturbojpeg.pc.in.orig	2020-06-02 15:34:25.683280703 +0000
++++ libjpeg-turbo-2.0.4/release/libturbojpeg.pc.in	2020-06-02 15:35:14.503478680 +0000
 @@ -6,5 +6,5 @@
  Name: libturbojpeg
  Description: A SIMD-accelerated JPEG codec that provides the TurboJPEG API
- Version: @PACKAGE_VERSION@
+ Version: @VERSION@
 -Libs: -L${libdir} -lturbojpeg
 +Libs: -L${libdir} -R${libdir} -lturbojpeg
  Cflags: -I${includedir}

--- a/components/library/libjpeg-turbo/test/results-all.master
+++ b/components/library/libjpeg-turbo/test/results-all.master
@@ -1,0 +1,307 @@
+Test project $(@D)
+        Start   1: tjunittest-shared
+  1/151 Test   #1: tjunittest-shared .................................   Passed
+        Start   2: tjunittest-shared-alloc
+  2/151 Test   #2: tjunittest-shared-alloc ...........................   Passed
+        Start   3: tjunittest-shared-yuv
+  3/151 Test   #3: tjunittest-shared-yuv .............................   Passed
+        Start   4: tjunittest-shared-yuv-alloc
+  4/151 Test   #4: tjunittest-shared-yuv-alloc .......................   Passed
+        Start   5: tjunittest-shared-yuv-nopad
+  5/151 Test   #5: tjunittest-shared-yuv-nopad .......................   Passed
+        Start   6: tjunittest-shared-bmp
+  6/151 Test   #6: tjunittest-shared-bmp .............................   Passed
+        Start   7: tjbench-shared-tile-cp
+  7/151 Test   #7: tjbench-shared-tile-cp ............................   Passed
+        Start   8: tjbench-shared-tile
+  8/151 Test   #8: tjbench-shared-tile ...............................   Passed
+        Start   9: tjbench-shared-tile-gray-8x8-cmp
+  9/151 Test   #9: tjbench-shared-tile-gray-8x8-cmp ..................   Passed
+        Start  10: tjbench-shared-tile-420-8x8-cmp
+ 10/151 Test  #10: tjbench-shared-tile-420-8x8-cmp ...................   Passed
+        Start  11: tjbench-shared-tile-422-8x8-cmp
+ 11/151 Test  #11: tjbench-shared-tile-422-8x8-cmp ...................   Passed
+        Start  12: tjbench-shared-tile-444-8x8-cmp
+ 12/151 Test  #12: tjbench-shared-tile-444-8x8-cmp ...................   Passed
+        Start  13: tjbench-shared-tile-gray-16x16-cmp
+ 13/151 Test  #13: tjbench-shared-tile-gray-16x16-cmp ................   Passed
+        Start  14: tjbench-shared-tile-420-16x16-cmp
+ 14/151 Test  #14: tjbench-shared-tile-420-16x16-cmp .................   Passed
+        Start  15: tjbench-shared-tile-422-16x16-cmp
+ 15/151 Test  #15: tjbench-shared-tile-422-16x16-cmp .................   Passed
+        Start  16: tjbench-shared-tile-444-16x16-cmp
+ 16/151 Test  #16: tjbench-shared-tile-444-16x16-cmp .................   Passed
+        Start  17: tjbench-shared-tile-gray-32x32-cmp
+ 17/151 Test  #17: tjbench-shared-tile-gray-32x32-cmp ................   Passed
+        Start  18: tjbench-shared-tile-420-32x32-cmp
+ 18/151 Test  #18: tjbench-shared-tile-420-32x32-cmp .................   Passed
+        Start  19: tjbench-shared-tile-422-32x32-cmp
+ 19/151 Test  #19: tjbench-shared-tile-422-32x32-cmp .................   Passed
+        Start  20: tjbench-shared-tile-444-32x32-cmp
+ 20/151 Test  #20: tjbench-shared-tile-444-32x32-cmp .................   Passed
+        Start  21: tjbench-shared-tile-gray-64x64-cmp
+ 21/151 Test  #21: tjbench-shared-tile-gray-64x64-cmp ................   Passed
+        Start  22: tjbench-shared-tile-420-64x64-cmp
+ 22/151 Test  #22: tjbench-shared-tile-420-64x64-cmp .................   Passed
+        Start  23: tjbench-shared-tile-422-64x64-cmp
+ 23/151 Test  #23: tjbench-shared-tile-422-64x64-cmp .................   Passed
+        Start  24: tjbench-shared-tile-444-64x64-cmp
+ 24/151 Test  #24: tjbench-shared-tile-444-64x64-cmp .................   Passed
+        Start  25: tjbench-shared-tile-gray-128x128-cmp
+ 25/151 Test  #25: tjbench-shared-tile-gray-128x128-cmp ..............   Passed
+        Start  26: tjbench-shared-tile-420-128x128-cmp
+ 26/151 Test  #26: tjbench-shared-tile-420-128x128-cmp ...............   Passed
+        Start  27: tjbench-shared-tile-422-128x128-cmp
+ 27/151 Test  #27: tjbench-shared-tile-422-128x128-cmp ...............   Passed
+        Start  28: tjbench-shared-tile-444-128x128-cmp
+ 28/151 Test  #28: tjbench-shared-tile-444-128x128-cmp ...............   Passed
+        Start  29: tjbench-shared-tilem-cp
+ 29/151 Test  #29: tjbench-shared-tilem-cp ...........................   Passed
+        Start  30: tjbench-shared-tilem
+ 30/151 Test  #30: tjbench-shared-tilem ..............................   Passed
+        Start  31: tjbench-shared-tile-420m-8x8-cmp
+ 31/151 Test  #31: tjbench-shared-tile-420m-8x8-cmp ..................   Passed
+        Start  32: tjbench-shared-tile-422m-8x8-cmp
+ 32/151 Test  #32: tjbench-shared-tile-422m-8x8-cmp ..................   Passed
+        Start  33: tjbench-shared-tile-420m-16x16-cmp
+ 33/151 Test  #33: tjbench-shared-tile-420m-16x16-cmp ................   Passed
+        Start  34: tjbench-shared-tile-422m-16x16-cmp
+ 34/151 Test  #34: tjbench-shared-tile-422m-16x16-cmp ................   Passed
+        Start  35: tjbench-shared-tile-420m-32x32-cmp
+ 35/151 Test  #35: tjbench-shared-tile-420m-32x32-cmp ................   Passed
+        Start  36: tjbench-shared-tile-422m-32x32-cmp
+ 36/151 Test  #36: tjbench-shared-tile-422m-32x32-cmp ................   Passed
+        Start  37: tjbench-shared-tile-420m-64x64-cmp
+ 37/151 Test  #37: tjbench-shared-tile-420m-64x64-cmp ................   Passed
+        Start  38: tjbench-shared-tile-422m-64x64-cmp
+ 38/151 Test  #38: tjbench-shared-tile-422m-64x64-cmp ................   Passed
+        Start  39: tjbench-shared-tile-420m-128x128-cmp
+ 39/151 Test  #39: tjbench-shared-tile-420m-128x128-cmp ..............   Passed
+        Start  40: tjbench-shared-tile-422m-128x128-cmp
+ 40/151 Test  #40: tjbench-shared-tile-422m-128x128-cmp ..............   Passed
+        Start  41: cjpeg-shared-rgb-islow
+ 41/151 Test  #41: cjpeg-shared-rgb-islow ............................   Passed
+        Start  42: cjpeg-shared-rgb-islow-cmp
+ 42/151 Test  #42: cjpeg-shared-rgb-islow-cmp ........................   Passed
+        Start  43: djpeg-shared-rgb-islow
+ 43/151 Test  #43: djpeg-shared-rgb-islow ............................   Passed
+        Start  44: djpeg-shared-rgb-islow-cmp
+ 44/151 Test  #44: djpeg-shared-rgb-islow-cmp ........................   Passed
+        Start  45: djpeg-shared-rgb-islow-icc-cmp
+ 45/151 Test  #45: djpeg-shared-rgb-islow-icc-cmp ....................   Passed
+        Start  46: jpegtran-shared-icc
+ 46/151 Test  #46: jpegtran-shared-icc ...............................   Passed
+        Start  47: jpegtran-shared-icc-cmp
+ 47/151 Test  #47: jpegtran-shared-icc-cmp ...........................   Passed
+        Start  48: djpeg-shared-rgb-islow-565
+ 48/151 Test  #48: djpeg-shared-rgb-islow-565 ........................   Passed
+        Start  49: djpeg-shared-rgb-islow-565-cmp
+ 49/151 Test  #49: djpeg-shared-rgb-islow-565-cmp ....................   Passed
+        Start  50: djpeg-shared-rgb-islow-565D
+ 50/151 Test  #50: djpeg-shared-rgb-islow-565D .......................   Passed
+        Start  51: djpeg-shared-rgb-islow-565D-cmp
+ 51/151 Test  #51: djpeg-shared-rgb-islow-565D-cmp ...................   Passed
+        Start  52: cjpeg-shared-422-ifast-opt
+ 52/151 Test  #52: cjpeg-shared-422-ifast-opt ........................   Passed
+        Start  53: cjpeg-shared-422-ifast-opt-cmp
+ 53/151 Test  #53: cjpeg-shared-422-ifast-opt-cmp ....................   Passed
+        Start  54: djpeg-shared-422-ifast
+ 54/151 Test  #54: djpeg-shared-422-ifast ............................   Passed
+        Start  55: djpeg-shared-422-ifast-cmp
+ 55/151 Test  #55: djpeg-shared-422-ifast-cmp ........................   Passed
+        Start  56: djpeg-shared-422m-ifast
+ 56/151 Test  #56: djpeg-shared-422m-ifast ...........................   Passed
+        Start  57: djpeg-shared-422m-ifast-cmp
+ 57/151 Test  #57: djpeg-shared-422m-ifast-cmp .......................   Passed
+        Start  58: djpeg-shared-422m-ifast-565
+ 58/151 Test  #58: djpeg-shared-422m-ifast-565 .......................   Passed
+        Start  59: djpeg-shared-422m-ifast-565-cmp
+ 59/151 Test  #59: djpeg-shared-422m-ifast-565-cmp ...................   Passed
+        Start  60: djpeg-shared-422m-ifast-565D
+ 60/151 Test  #60: djpeg-shared-422m-ifast-565D ......................   Passed
+        Start  61: djpeg-shared-422m-ifast-565D-cmp
+ 61/151 Test  #61: djpeg-shared-422m-ifast-565D-cmp ..................   Passed
+        Start  62: cjpeg-shared-420-q100-ifast-prog
+ 62/151 Test  #62: cjpeg-shared-420-q100-ifast-prog ..................   Passed
+        Start  63: cjpeg-shared-420-q100-ifast-prog-cmp
+ 63/151 Test  #63: cjpeg-shared-420-q100-ifast-prog-cmp ..............   Passed
+        Start  64: djpeg-shared-420-q100-ifast-prog
+ 64/151 Test  #64: djpeg-shared-420-q100-ifast-prog ..................   Passed
+        Start  65: djpeg-shared-420-q100-ifast-prog-cmp
+ 65/151 Test  #65: djpeg-shared-420-q100-ifast-prog-cmp ..............   Passed
+        Start  66: djpeg-shared-420m-q100-ifast-prog
+ 66/151 Test  #66: djpeg-shared-420m-q100-ifast-prog .................   Passed
+        Start  67: djpeg-shared-420m-q100-ifast-prog-cmp
+ 67/151 Test  #67: djpeg-shared-420m-q100-ifast-prog-cmp .............   Passed
+        Start  68: cjpeg-shared-gray-islow
+ 68/151 Test  #68: cjpeg-shared-gray-islow ...........................   Passed
+        Start  69: cjpeg-shared-gray-islow-cmp
+ 69/151 Test  #69: cjpeg-shared-gray-islow-cmp .......................   Passed
+        Start  70: djpeg-shared-gray-islow
+ 70/151 Test  #70: djpeg-shared-gray-islow ...........................   Passed
+        Start  71: djpeg-shared-gray-islow-cmp
+ 71/151 Test  #71: djpeg-shared-gray-islow-cmp .......................   Passed
+        Start  72: djpeg-shared-gray-islow-rgb
+ 72/151 Test  #72: djpeg-shared-gray-islow-rgb .......................   Passed
+        Start  73: djpeg-shared-gray-islow-rgb-cmp
+ 73/151 Test  #73: djpeg-shared-gray-islow-rgb-cmp ...................   Passed
+        Start  74: djpeg-shared-gray-islow-565
+ 74/151 Test  #74: djpeg-shared-gray-islow-565 .......................   Passed
+        Start  75: djpeg-shared-gray-islow-565-cmp
+ 75/151 Test  #75: djpeg-shared-gray-islow-565-cmp ...................   Passed
+        Start  76: djpeg-shared-gray-islow-565D
+ 76/151 Test  #76: djpeg-shared-gray-islow-565D ......................   Passed
+        Start  77: djpeg-shared-gray-islow-565D-cmp
+ 77/151 Test  #77: djpeg-shared-gray-islow-565D-cmp ..................   Passed
+        Start  78: cjpeg-shared-420s-ifast-opt
+ 78/151 Test  #78: cjpeg-shared-420s-ifast-opt .......................   Passed
+        Start  79: cjpeg-shared-420s-ifast-opt-cmp
+ 79/151 Test  #79: cjpeg-shared-420s-ifast-opt-cmp ...................   Passed
+        Start  80: cjpeg-shared-3x2-float-prog
+ 80/151 Test  #80: cjpeg-shared-3x2-float-prog .......................   Passed
+        Start  81: cjpeg-shared-3x2-float-prog-cmp
+ 81/151 Test  #81: cjpeg-shared-3x2-float-prog-cmp ...................   Passed
+        Start  82: djpeg-shared-3x2-float-prog
+ 82/151 Test  #82: djpeg-shared-3x2-float-prog .......................   Passed
+        Start  83: djpeg-shared-3x2-float-prog-cmp
+ 83/151 Test  #83: djpeg-shared-3x2-float-prog-cmp ...................   Passed
+        Start  84: cjpeg-shared-3x2-ifast-prog
+ 84/151 Test  #84: cjpeg-shared-3x2-ifast-prog .......................   Passed
+        Start  85: cjpeg-shared-3x2-ifast-prog-cmp
+ 85/151 Test  #85: cjpeg-shared-3x2-ifast-prog-cmp ...................   Passed
+        Start  86: djpeg-shared-3x2-ifast-prog
+ 86/151 Test  #86: djpeg-shared-3x2-ifast-prog .......................   Passed
+        Start  87: djpeg-shared-3x2-ifast-prog-cmp
+ 87/151 Test  #87: djpeg-shared-3x2-ifast-prog-cmp ...................   Passed
+        Start  88: cjpeg-shared-420-islow-ari
+ 88/151 Test  #88: cjpeg-shared-420-islow-ari ........................   Passed
+        Start  89: cjpeg-shared-420-islow-ari-cmp
+ 89/151 Test  #89: cjpeg-shared-420-islow-ari-cmp ....................   Passed
+        Start  90: jpegtran-shared-420-islow-ari
+ 90/151 Test  #90: jpegtran-shared-420-islow-ari .....................   Passed
+        Start  91: jpegtran-shared-420-islow-ari-cmp
+ 91/151 Test  #91: jpegtran-shared-420-islow-ari-cmp .................   Passed
+        Start  92: cjpeg-shared-444-islow-progari
+ 92/151 Test  #92: cjpeg-shared-444-islow-progari ....................   Passed
+        Start  93: cjpeg-shared-444-islow-progari-cmp
+ 93/151 Test  #93: cjpeg-shared-444-islow-progari-cmp ................   Passed
+        Start  94: djpeg-shared-420m-ifast-ari
+ 94/151 Test  #94: djpeg-shared-420m-ifast-ari .......................   Passed
+        Start  95: djpeg-shared-420m-ifast-ari-cmp
+ 95/151 Test  #95: djpeg-shared-420m-ifast-ari-cmp ...................   Passed
+        Start  96: jpegtran-shared-420-islow
+ 96/151 Test  #96: jpegtran-shared-420-islow .........................   Passed
+        Start  97: jpegtran-shared-420-islow-cmp
+ 97/151 Test  #97: jpegtran-shared-420-islow-cmp .....................   Passed
+        Start  98: djpeg-shared-420m-islow-2_1
+ 98/151 Test  #98: djpeg-shared-420m-islow-2_1 .......................   Passed
+        Start  99: djpeg-shared-420m-islow-2_1-cmp
+ 99/151 Test  #99: djpeg-shared-420m-islow-2_1-cmp ...................   Passed
+        Start 100: djpeg-shared-420m-islow-15_8
+100/151 Test #100: djpeg-shared-420m-islow-15_8 ......................   Passed
+        Start 101: djpeg-shared-420m-islow-15_8-cmp
+101/151 Test #101: djpeg-shared-420m-islow-15_8-cmp ..................   Passed
+        Start 102: djpeg-shared-420m-islow-13_8
+102/151 Test #102: djpeg-shared-420m-islow-13_8 ......................   Passed
+        Start 103: djpeg-shared-420m-islow-13_8-cmp
+103/151 Test #103: djpeg-shared-420m-islow-13_8-cmp ..................   Passed
+        Start 104: djpeg-shared-420m-islow-11_8
+104/151 Test #104: djpeg-shared-420m-islow-11_8 ......................   Passed
+        Start 105: djpeg-shared-420m-islow-11_8-cmp
+105/151 Test #105: djpeg-shared-420m-islow-11_8-cmp ..................   Passed
+        Start 106: djpeg-shared-420m-islow-9_8
+106/151 Test #106: djpeg-shared-420m-islow-9_8 .......................   Passed
+        Start 107: djpeg-shared-420m-islow-9_8-cmp
+107/151 Test #107: djpeg-shared-420m-islow-9_8-cmp ...................   Passed
+        Start 108: djpeg-shared-420m-islow-7_8
+108/151 Test #108: djpeg-shared-420m-islow-7_8 .......................   Passed
+        Start 109: djpeg-shared-420m-islow-7_8-cmp
+109/151 Test #109: djpeg-shared-420m-islow-7_8-cmp ...................   Passed
+        Start 110: djpeg-shared-420m-islow-3_4
+110/151 Test #110: djpeg-shared-420m-islow-3_4 .......................   Passed
+        Start 111: djpeg-shared-420m-islow-3_4-cmp
+111/151 Test #111: djpeg-shared-420m-islow-3_4-cmp ...................   Passed
+        Start 112: djpeg-shared-420m-islow-5_8
+112/151 Test #112: djpeg-shared-420m-islow-5_8 .......................   Passed
+        Start 113: djpeg-shared-420m-islow-5_8-cmp
+113/151 Test #113: djpeg-shared-420m-islow-5_8-cmp ...................   Passed
+        Start 114: djpeg-shared-420m-islow-1_2
+114/151 Test #114: djpeg-shared-420m-islow-1_2 .......................   Passed
+        Start 115: djpeg-shared-420m-islow-1_2-cmp
+115/151 Test #115: djpeg-shared-420m-islow-1_2-cmp ...................   Passed
+        Start 116: djpeg-shared-420m-islow-3_8
+116/151 Test #116: djpeg-shared-420m-islow-3_8 .......................   Passed
+        Start 117: djpeg-shared-420m-islow-3_8-cmp
+117/151 Test #117: djpeg-shared-420m-islow-3_8-cmp ...................   Passed
+        Start 118: djpeg-shared-420m-islow-1_4
+118/151 Test #118: djpeg-shared-420m-islow-1_4 .......................   Passed
+        Start 119: djpeg-shared-420m-islow-1_4-cmp
+119/151 Test #119: djpeg-shared-420m-islow-1_4-cmp ...................   Passed
+        Start 120: djpeg-shared-420m-islow-1_8
+120/151 Test #120: djpeg-shared-420m-islow-1_8 .......................   Passed
+        Start 121: djpeg-shared-420m-islow-1_8-cmp
+121/151 Test #121: djpeg-shared-420m-islow-1_8-cmp ...................   Passed
+        Start 122: djpeg-shared-420-islow-256
+122/151 Test #122: djpeg-shared-420-islow-256 ........................   Passed
+        Start 123: djpeg-shared-420-islow-256-cmp
+123/151 Test #123: djpeg-shared-420-islow-256-cmp ....................   Passed
+        Start 124: djpeg-shared-420-islow-565
+124/151 Test #124: djpeg-shared-420-islow-565 ........................   Passed
+        Start 125: djpeg-shared-420-islow-565-cmp
+125/151 Test #125: djpeg-shared-420-islow-565-cmp ....................   Passed
+        Start 126: djpeg-shared-420-islow-565D
+126/151 Test #126: djpeg-shared-420-islow-565D .......................   Passed
+        Start 127: djpeg-shared-420-islow-565D-cmp
+127/151 Test #127: djpeg-shared-420-islow-565D-cmp ...................   Passed
+        Start 128: djpeg-shared-420m-islow-565
+128/151 Test #128: djpeg-shared-420m-islow-565 .......................   Passed
+        Start 129: djpeg-shared-420m-islow-565-cmp
+129/151 Test #129: djpeg-shared-420m-islow-565-cmp ...................   Passed
+        Start 130: djpeg-shared-420m-islow-565D
+130/151 Test #130: djpeg-shared-420m-islow-565D ......................   Passed
+        Start 131: djpeg-shared-420m-islow-565D-cmp
+131/151 Test #131: djpeg-shared-420m-islow-565D-cmp ..................   Passed
+        Start 132: djpeg-shared-420-islow-skip15_31
+132/151 Test #132: djpeg-shared-420-islow-skip15_31 ..................   Passed
+        Start 133: djpeg-shared-420-islow-skip15_31-cmp
+133/151 Test #133: djpeg-shared-420-islow-skip15_31-cmp ..............   Passed
+        Start 134: djpeg-shared-420-islow-ari-skip16_139
+134/151 Test #134: djpeg-shared-420-islow-ari-skip16_139 .............   Passed
+        Start 135: djpeg-shared-420-islow-ari-skip16_139-cmp
+135/151 Test #135: djpeg-shared-420-islow-ari-skip16_139-cmp .........   Passed
+        Start 136: cjpeg-shared-420-islow-prog
+136/151 Test #136: cjpeg-shared-420-islow-prog .......................   Passed
+        Start 137: djpeg-shared-420-islow-prog-crop62x62_71_71
+137/151 Test #137: djpeg-shared-420-islow-prog-crop62x62_71_71 .......   Passed
+        Start 138: djpeg-shared-420-islow-prog-crop62x62_71_71-cmp
+138/151 Test #138: djpeg-shared-420-islow-prog-crop62x62_71_71-cmp ...   Passed
+        Start 139: djpeg-shared-420-islow-ari-crop53x53_4_4
+139/151 Test #139: djpeg-shared-420-islow-ari-crop53x53_4_4 ..........   Passed
+        Start 140: djpeg-shared-420-islow-ari-crop53x53_4_4-cmp
+140/151 Test #140: djpeg-shared-420-islow-ari-crop53x53_4_4-cmp ......   Passed
+        Start 141: cjpeg-shared-444-islow
+141/151 Test #141: cjpeg-shared-444-islow ............................   Passed
+        Start 142: djpeg-shared-444-islow-skip1_6
+142/151 Test #142: djpeg-shared-444-islow-skip1_6 ....................   Passed
+        Start 143: djpeg-shared-444-islow-skip1_6-cmp
+143/151 Test #143: djpeg-shared-444-islow-skip1_6-cmp ................   Passed
+        Start 144: cjpeg-shared-444-islow-prog
+144/151 Test #144: cjpeg-shared-444-islow-prog .......................   Passed
+        Start 145: djpeg-shared-444-islow-prog-crop98x98_13_13
+145/151 Test #145: djpeg-shared-444-islow-prog-crop98x98_13_13 .......   Passed
+        Start 146: djpeg-shared-444-islow-prog-crop98x98_13_13-cmp
+146/151 Test #146: djpeg-shared-444-islow-prog-crop98x98_13_13-cmp ...   Passed
+        Start 147: cjpeg-shared-444-islow-ari
+147/151 Test #147: cjpeg-shared-444-islow-ari ........................   Passed
+        Start 148: djpeg-shared-444-islow-ari-crop37x37_0_0
+148/151 Test #148: djpeg-shared-444-islow-ari-crop37x37_0_0 ..........   Passed
+        Start 149: djpeg-shared-444-islow-ari-crop37x37_0_0-cmp
+149/151 Test #149: djpeg-shared-444-islow-ari-crop37x37_0_0-cmp ......   Passed
+        Start 150: jpegtran-shared-crop
+150/151 Test #150: jpegtran-shared-crop ..............................   Passed
+        Start 151: jpegtran-shared-crop-cmp
+151/151 Test #151: jpegtran-shared-crop-cmp ..........................   Passed
+
+100% tests passed, 0 tests failed out of 151
+
+Total Test time (real) =


### PR DESCRIPTION
After #5840 

ABI compatible https://abi-laboratory.pro/index.php?view=timeline&l=libjpeg-turbo