### PR TITLE
Invalid pkgconfig files in openssl

### DIFF
--- a/components/library/openssl/openssl-1.0.2/Makefile
+++ b/components/library/openssl/openssl-1.0.2/Makefile
@@ -36,7 +36,7 @@ COMPONENT_VERSION =	1.0.2u
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
 IPS_COMPONENT_VERSION = 1.0.2.21
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	https://www.openssl.org
 COMPONENT_SRC =		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE =	$(COMPONENT_SRC).tar.gz
@@ -66,6 +66,7 @@ ENGINESDIR_64 = /lib/openssl/engines/64
 CONFIGURE_OPTIONS =  -DSOLARIS_OPENSSL -DNO_WINDOWS_BRAINDEATH
 CONFIGURE_OPTIONS += --openssldir=/etc/openssl
 CONFIGURE_OPTIONS += --prefix=/usr
+CONFIGURE_OPTIONS += --libdir=lib/$(ARCHLIBSUBDIR)
 # We use OpenSSL install code for installing only manual pages and headers.
 CONFIGURE_OPTIONS += --install_prefix=$(PROTO_DIR)
 CONFIGURE_OPTIONS += no-rc3

--- a/components/library/openssl/openssl-1.0.2/manifests/sample-manifest.p5m
+++ b/components/library/openssl/openssl-1.0.2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -109,6 +109,28 @@ file path=usr/include/openssl/ui_compat.h
 file path=usr/include/openssl/x509.h
 file path=usr/include/openssl/x509_vfy.h
 file path=usr/include/openssl/x509v3.h
+file path=usr/lib/$(MACH64)/engines/lib4758cca.so
+file path=usr/lib/$(MACH64)/engines/libaep.so
+file path=usr/lib/$(MACH64)/engines/libatalla.so
+file path=usr/lib/$(MACH64)/engines/libcapi.so
+file path=usr/lib/$(MACH64)/engines/libchil.so
+file path=usr/lib/$(MACH64)/engines/libcswift.so
+file path=usr/lib/$(MACH64)/engines/libgmp.so
+file path=usr/lib/$(MACH64)/engines/libgost.so
+file path=usr/lib/$(MACH64)/engines/libnuron.so
+file path=usr/lib/$(MACH64)/engines/libpadlock.so
+file path=usr/lib/$(MACH64)/engines/libpk11.so
+file path=usr/lib/$(MACH64)/engines/libsureware.so
+file path=usr/lib/$(MACH64)/engines/libubsec.so
+file path=usr/lib/$(MACH64)/libcrypto.a
+link path=usr/lib/$(MACH64)/libcrypto.so target=libcrypto.so.1.0.0
+file path=usr/lib/$(MACH64)/libcrypto.so.1.0.0
+file path=usr/lib/$(MACH64)/libssl.a
+link path=usr/lib/$(MACH64)/libssl.so target=libssl.so.1.0.0
+file path=usr/lib/$(MACH64)/libssl.so.1.0.0
+file path=usr/lib/$(MACH64)/pkgconfig/libcrypto.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libssl.pc
+file path=usr/lib/$(MACH64)/pkgconfig/openssl.pc
 file path=usr/lib/engines/lib4758cca.so
 file path=usr/lib/engines/libaep.so
 file path=usr/lib/engines/libatalla.so


### PR DESCRIPTION
The recipe does not use files installed in the proto but copies files manually, so the manifest change does not affect the package.

```
> diff -uN /usr/lib/amd64/pkgconfig/openssl.pc build/prototype/i386/usr/lib/amd64/pkgconfig/openssl.pc
--- /usr/lib/amd64/pkgconfig/openssl.pc 2020-06-13 12:16:44.300663172 +0000
+++ build/prototype/i386/usr/lib/amd64/pkgconfig/openssl.pc     2020-06-13 12:27:33.155377507 +0000
@@ -1,6 +1,6 @@
 prefix=/usr
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/lib/amd64
 includedir=${prefix}/include

 Name: OpenSSL
```