### PR TITLE
squeak-5c: Add cog implementation of squeak vm

### DIFF
--- a/components/runtime/squeak5c/Makefile
+++ b/components/runtime/squeak5c/Makefile
@@ -1,0 +1,102 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 David Stes
+#
+
+
+#
+# Package Makefile for the "OpenSmalltalk Cog Spur" Squeak Smalltalk V5 system
+# See http://squeak.org and http://opensmalltalk.org
+#
+
+# opensmalltalk-vm can be built both in 32 and 64bit
+# but generally SqueakV5 images are 64bit
+BUILD_BITS=64
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		squeak-5c
+COMPONENT_VERSION=	5.0.7
+GIT_TAG=		sun-v$(COMPONENT_VERSION)
+PLUGIN_REV=		5.0-202005021055-cog
+COMPONENT_SUMMARY=	The Cog Implementation of the Squeak V5 Smalltalk Virtual Machine
+COMPONENT_PROJECT_URL=	http://www.squeak.org
+COMPONENT_FMRI=		runtime/squeak-5c
+COMPONENT_CLASSIFICATION=	Development/Other Languages
+
+# See http://wiki.squeak.org/squeak/933
+# See http://wiki.squeak.org/squeak/159
+# there's 2 license lines in the manifest, the MIT squeak.license and this one
+COMPONENT_LICENSE=	Squeak5
+COMPONENT_LICENSE_FILE=	squeak5.license
+
+COMPONENT_SRC=		opensmalltalk-vm-$(GIT_TAG)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	sha256:50c180b174048acd98a7d9705f0a40a3dc8bdc62b42d88eb7e20e71834184e4c
+COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
+
+TEST_TARGET= $(NO_TESTS)
+
+# some builds seem to be broken with -Bdirect
+LD_B_DIRECT=
+
+include $(WS_MAKE_RULES)/common.mk
+
+PKG_OPTIONS += -D PLUGIN_REV="$(PLUGIN_REV)"
+
+PATH=$(PATH.gnu)
+
+# opensmalltalk configure script checks for plugins files in builddir
+COMPONENT_PRE_CONFIGURE_ACTION = ( cp plugins.ext plugins.int $(BUILD_DIR_64) )
+
+# the default CFLAGS.gcc will be -m64 -O3 but this does not work for us
+# opensmalltalk code is not compatible with the gcc optimizer -O2 or higher
+# also the -g (debug) flag is intentional, perhaps omit-frame-pointer issues
+gcc_OPT=		-g -DNDEBUG -DDEBUGVM=0 -DCOGMTVM=0
+
+CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/config/configure
+CONFIGURE_OPTIONS +=	--without-npsqueak
+CONFIGURE_OPTIONS +=	--with-vmversion=5.0
+CONFIGURE_OPTIONS +=	--disable-dynamicopenssl
+CONFIGURE_OPTIONS +=	--without-libtls
+CONFIGURE_OPTIONS +=	--with-src=spur64src
+
+CONFIGURE_ENV +=	TARGET_ARCH="-m64"
+
+# the opensmalltalk Makefile does not use DESTDIR
+COMPONENT_INSTALL_ARGS=  	ROOT=$(PROTO_DIR)
+COMPONENT_BUILD_TARGETS= 	getversion squeak plugins
+COMPONENT_INSTALL_TARGETS= 	install-squeak install-doc install-plugins
+
+# Makefile has no strip target
+COMPONENT_POST_INSTALL_ACTION = \
+( $(STRIP) $(PROTOUSRLIBDIR64)/squeak/$(PLUGIN_REV)/squeak )
+
+REQUIRED_PACKAGES += x11/library/mesa
+REQUIRED_PACKAGES += system/library/dbus
+REQUIRED_PACKAGES += library/audio/gstreamer
+REQUIRED_PACKAGES += library/libffi
+REQUIRED_PACKAGES += system/library/freetype-2
+REQUIRED_PACKAGES += x11/library/libxext
+REQUIRED_PACKAGES += x11/library/libxevie
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += library/audio/pulseaudio
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += library/desktop/pango
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/security/openssl
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11
+REQUIRED_PACKAGES += x11/library/libxrender

--- a/components/runtime/squeak5c/manifests/sample-manifest.p5m
+++ b/components/runtime/squeak5c/manifests/sample-manifest.p5m
@@ -1,0 +1,50 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/squeak
+file path=usr/doc/squeak/COPYING
+file path=usr/doc/squeak/COPYRIGHT
+file path=usr/doc/squeak/LICENSE
+file path=usr/doc/squeak/README.Contributing
+file path=usr/doc/squeak/README.Keyboard
+file path=usr/doc/squeak/README.Sound
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/squeak
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202005021055-cog/vm-sound-pulse.so
+hardlink path=usr/share/man/man1/inisqueak.1 target=squeak.1
+file path=usr/share/man/man1/squeak.1
+file path=usr/squeak

--- a/components/runtime/squeak5c/patches/01-Makefile-amd64.patch
+++ b/components/runtime/squeak5c/patches/01-Makefile-amd64.patch
@@ -1,0 +1,15 @@
+--- opensmalltalk-vm-sun-v5.0.7/platforms/unix/config/Makefile.in	Sat May  2 12:55:37 2020
++++ p0/opensmalltalk-vm-sun-v5.0.7/platforms/unix/config/Makefile.in	Tue Jun 16 06:53:28 2020
+@@ -77,10 +77,10 @@
+ 
+ # unix launch scripts
+ squeak.sh: ${cfgdir}/squeak.sh.in getversion
+-	sed "s|.expanded_relative_imgdir.|lib/squeak/`./getversion VERSION_TAG`|" <${cfgdir}/squeak.sh.in >squeak.sh
++	sed "s|.expanded_relative_imgdir.|lib/amd64/squeak/`./getversion VERSION_TAG`|" <${cfgdir}/squeak.sh.in >squeak.sh
+ 
+ bin.squeak.sh: ${cfgdir}/bin.squeak.sh.in getversion
+-	sed "s|.expanded_relative_imgdir.|lib/squeak/`./getversion VERSION_TAG`|" <${cfgdir}/bin.squeak.sh.in >bin.squeak.sh
++	sed "s|.expanded_relative_imgdir.|lib/amd64/squeak/`./getversion VERSION_TAG`|" <${cfgdir}/bin.squeak.sh.in >bin.squeak.sh
+ 
+ # npsqueak
+ 

--- a/components/runtime/squeak5c/patches/02-sqSCCSVersion.patch
+++ b/components/runtime/squeak5c/patches/02-sqSCCSVersion.patch
@@ -1,0 +1,40 @@
+--- opensmalltalk-vm-sun-v5.0.7/platforms/Cross/vm/sqSCCSVersion.h	Sat May  2 12:55:37 2020
++++ p0/opensmalltalk-vm-sun-v5.0.7/platforms/Cross/vm/sqSCCSVersion.h	Tue Jun 16 07:01:52 2020
+@@ -28,13 +28,13 @@
+ 
+ #if SUBVERSION
+ # define PREFIX "r"
+-static char SvnRawRevisionString[] = "$Rev$";
++static char SvnRawRevisionString[] = "$Rev: 202005021055-cog $";
+ # define REV_START (SvnRawRevisionString + 6)
+ 
+-static char SvnRawRevisionDate[] = "$Date$";
++static char SvnRawRevisionDate[] = "$Date: Sat May 2 12:55:37 2020 +0200 $";
+ # define DATE_START (SvnRawRevisionDate + 7)
+ 
+-static char SvnRawRepositoryURL[] = "$URL$";
++static char SvnRawRepositoryURL[] = "$URL: stes@deimos:src/opensmalltalk $";
+ # define URL_START (SvnRawRepositoryURL + 6)
+ 
+ static char *
+@@ -71,16 +71,16 @@
+ # undef URL_START
+ #elif GIT
+ # define PREFIX ""
+-static char GitRawRevisionString[] = "$Rev$";
++static char GitRawRevisionString[] = "$Rev: 202005021055-cog $";
+ # define REV_START (GitRawRevisionString + 6)
+ 
+-static char GitRawRevisionDate[] = "$Date$";
++static char GitRawRevisionDate[] = "$Date: Sat May 2 12:55:37 2020 +0200 $";
+ # define DATE_START (GitRawRevisionDate + 7)
+ 
+-static char GitRawRepositoryURL[] = "$URL$";
++static char GitRawRepositoryURL[] = "$URL: stes@deimos:src/opensmalltalk $";
+ # define URL_START (GitRawRepositoryURL + 6)
+ 
+-static char GitRawRevisionShortHash[] = "$CommitHash$";
++static char GitRawRevisionShortHash[] = "$CommitHash: 5cd355762 $";
+ # define SHORTHASH_START (GitRawRevisionShortHash + 13)
+ 
+ static char *

--- a/components/runtime/squeak5c/patches/03-sqPluginsSCCSVersion.patch
+++ b/components/runtime/squeak5c/patches/03-sqPluginsSCCSVersion.patch
@@ -1,0 +1,28 @@
+--- opensmalltalk-vm-sun-v5.0.7/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sat May  2 12:55:37 2020
++++ p0/opensmalltalk-vm-sun-v5.0.7/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Tue Jun 16 07:01:52 2020
+@@ -9,10 +9,10 @@
+  */
+ 
+ #if SUBVERSION
+-static char SvnRawPluginsRevisionString[] = "$Rev$";
++static char SvnRawPluginsRevisionString[] = "$Rev: 202005021055-cog $";
+ # define PLUGINS_REV_START (SvnRawPluginsRevisionString + 6)
+ 
+-static char SvnRawPluginsRepositoryURL[] = "$URL$";
++static char SvnRawPluginsRepositoryURL[] = "$URL: stes@deimos:src/opensmalltalk $";
+ # define URL_START (SvnRawPluginsRepositoryURL + 6)
+ 
+ static char *
+@@ -35,10 +35,10 @@
+ # undef PLUGINS_REV_START
+ # undef URL_START
+ #elif GIT
+-static char GitRawPluginsRevisionString[] = "$Rev$";
++static char GitRawPluginsRevisionString[] = "$Rev: 202005021055-cog $";
+ # define PLUGINS_REV_START (GitRawPluginsRevisionString + 6)
+ 
+-static char GitRawPluginsRepositoryURL[] = "$URL$";
++static char GitRawPluginsRepositoryURL[] = "$URL: stes@deimos:src/opensmalltalk $";
+ # define URL_START (GitRawPluginsRepositoryURL + 6)
+ 
+ static char *

--- a/components/runtime/squeak5c/patches/04-Makefile-gzip.patch
+++ b/components/runtime/squeak5c/patches/04-Makefile-gzip.patch
@@ -1,0 +1,10 @@
+--- opensmalltalk-vm-sun-v5.0.7/platforms/unix/config/Makefile.install	Sat May  2 12:55:37 2020
++++ p0/opensmalltalk-vm-sun-v5.0.7/platforms/unix/config/Makefile.install	Sun Jul 12 17:11:41 2020
+@@ -63,7 +63,6 @@
+ 	  echo $(INSTALL_DATA) $(topdir)/platforms/unix/doc/$$f $(ROOT)$(docdir); \
+ 	  $(INSTALL_DATA) $(topdir)/platforms/unix/doc/$$f $(ROOT)$(docdir); \
+ 	done
+-	gzip -f9 $(ROOT)$(docdir)/*
+ 	$(MKINSTALLDIRS) $(ROOT)$(mandir)/man1
+ 	$(INSTALL_DATA) squeak.1 $(ROOT)$(mandir)/man1
+ 	rm -f $(ROOT)$(mandir)/man1/inisqueak.1 $(ROOT)$(mandir)/man1/inisqueak.1.gz

--- a/components/runtime/squeak5c/plugins.ext
+++ b/components/runtime/squeak5c/plugins.ext
@@ -1,0 +1,17 @@
+# Copied, perhaps edited, from ../../src/examplePlugins.ext
+EXTERNAL_PLUGINS = \
+MIDIPlugin \
+B3DAcceleratorPlugin \
+BochsIA32Plugin \
+BochsX64Plugin \
+GdbARMPlugin \
+FileAttributesPlugin \
+Squeak3D \
+SqueakFFIPrims \
+SqueakSSL \
+LocalePlugin \
+UnicodePlugin \
+UnixOSProcessPlugin \
+UUIDPlugin \
+ImmX11Plugin \
+XDisplayControlPlugin

--- a/components/runtime/squeak5c/plugins.int
+++ b/components/runtime/squeak5c/plugins.int
@@ -1,0 +1,37 @@
+# Copied, perhaps edited, from ../../src/examplePlugins.int
+INTERNAL_PLUGINS = \
+ADPCMCodecPlugin \
+AioPlugin \
+AsynchFilePlugin \
+B2DPlugin \
+BitBltPlugin \
+BMPReadWriterPlugin \
+CroquetPlugin \
+HostWindowPlugin \
+ZipPlugin \
+DropPlugin \
+DSAPrims \
+FFTPlugin \
+FileCopyPlugin \
+FilePlugin \
+FloatArrayPlugin \
+FloatMathPlugin \
+IA32ABI \
+JoystickTabletPlugin \
+JPEGReaderPlugin \
+JPEGReadWriter2Plugin \
+Klatt \
+LargeIntegers \
+Matrix2x3Plugin \
+MiscPrimitivePlugin \
+Mpeg3Plugin \
+RePlugin \
+SecurityPlugin \
+SerialPlugin \
+SocketPlugin \
+SoundCodecPrims \
+SoundGenerationPlugin \
+SoundPlugin \
+StarSqueakPlugin \
+SurfacePlugin \
+VMProfileLinuxSupportPlugin

--- a/components/runtime/squeak5c/squeak-5c.p5m
+++ b/components/runtime/squeak5c/squeak-5c.p5m
@@ -1,0 +1,62 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+<transform file -> add pkg.depend.bypass-generate vm-display-X11\.so>
+
+# for the sound plugins, we only package vm-sound-pulse
+# we do not package vm-sound-OSS and vm-sound-Sun
+# on my machine, vm-sound-Sun compiles, but it does not work
+
+file usr/bin/squeak path=usr/bin/squeak5c
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/squeak mode=0555
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-pulse.so
+file usr/doc/squeak/COPYING path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/COPYING
+file usr/doc/squeak/COPYRIGHT path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/COPYRIGHT
+file usr/doc/squeak/LICENSE path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/LICENSE
+file usr/share/man/man1/squeak.1 path=usr/share/man/man1/squeak5c.1
+
+# use hardlink (squeak wrapper script may have issue with symlink)
+
+hardlink path=usr/bin/squeak target=squeak5c mediator=squeak \
+    mediator-implementation=cog-spur mediator-version=5
+hardlink path=usr/share/man/man1/squeak.1 target=squeak5c.1 mediator=squeak \
+    mediator-implementation=cog-spur mediator-version=5
+

--- a/components/runtime/squeak5c/squeak.license
+++ b/components/runtime/squeak5c/squeak.license
@@ -1,0 +1,24 @@
+
+MIT License
+
+Copyright (c) 1996-2020 The individual, corporate, and institutional contributors who have collectively contributed elements to this software ("The Squeak Community"). All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Portions of Squeak are covered by the Apache License:
+Apache License, Version 2.0
+
+Copyright (c) 1981-1982 Xerox Corp. All rights reserved.
+Copyright (c) 1985-1996 Apple Computer, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+

--- a/components/runtime/squeak5c/squeak5.license
+++ b/components/runtime/squeak5c/squeak5.license
@@ -1,0 +1,31 @@
+License (MIT):
+All contributions from 3D Immersive Collaboration Consulting in this release are
+Copyright (c) 2013 3D Immersive Collaboration Consulting, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+--
+
+See http://wiki.squeak.org/squeak/933
+See http://wiki.squeak.org/squeak/159
+
+FAQ: Licenses
+Last updated at 4:51 am UTC on 18 February 2017
+License since Squeak 4.0 is MIT
+


### PR DESCRIPTION
This package is offering a slightly different implementation of squeak-5.   It is the so-called "cog" implementation, which in my understanding is slightly faster, but perhaps also less portable than the stack implementation.   To my knowledge, there exists no "sparc" version of the cog implementation although that the stack implementation has ran in the past on sparc.    The package can be installed at the same time as the default implementation thanks to OpenIndiana (IPS) pkg mediator.  It uses the 'implementation' feature of mediator to set a different implementation of the same Smalltalk virtual machine.   The version is set to 5.0.7 because it is built from the same opensmalltalk source code as the stack vm version 5.0.7.    By the way, I initially compiled the "cog" implementation on OpenIndiana but so far I have not seen major performance improvement compared to the classical "stack" implementation, but others may disagree.