### PR TITLE
libarchive: bump to 3.4.2

### DIFF
--- a/components/library/libarchive/Makefile
+++ b/components/library/libarchive/Makefile
@@ -29,7 +29,7 @@ BUILD_BITS=		32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libarchive
-COMPONENT_VERSION=	3.4.1
+COMPONENT_VERSION=	3.4.2
 COMPONENT_SUMMARY=	multi-format archive and compression library
 COMPONENT_DESCRIPTION=	The libarchive(3LIB) library provides a flexible\
  interface for reading and writing archives in various formats such as\
@@ -42,7 +42,7 @@ COMPONENT_SRC=		libarchive-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	http://www.libarchive.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:fcf87f3ad8db2e4f74f32526dee62dd1fb9894782b0a503a89c9d7a70a235191
+	sha256:b60d58d12632ecf1e8fad7316dc82c6b9738a35625746b47ecdcaf4aed176176
 COMPONENT_ARCHIVE_URL= \
 	https://github.com/libarchive/libarchive/releases/download/v$(COMPONENT_VERSION)//$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=        library/libarchive

--- a/components/library/libarchive/manifests/sample-manifest.p5m
+++ b/components/library/libarchive/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)


### PR DESCRIPTION
ABI compatible, all tests passed.