### PR TITLE
libgit2: update to 0.28.5

### DIFF
--- a/components/library/libgit2/Makefile
+++ b/components/library/libgit2/Makefile
@@ -11,26 +11,27 @@
 
 #
 # Copyright 2016 Denys Rtveliashvili.  All rights reserved.
+# Copyright 2020 Andreas Wacknitz
 #
 
+BUILD_BITS=			32_and_64
+BUILD_STYLE=		cmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libgit2
-COMPONENT_VERSION=	0.23.4
+COMPONENT_VERSION=	0.28.5
 COMPONENT_FMRI=		library/libgit2
 COMPONENT_CLASSIFICATION=Development/Source Code Management
 COMPONENT_PROJECT_URL=	https://libgit2.github.com/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:1b974f525b7dd10028e4473e2efce991d56e200dae5c0c7bdd98ad11e55eb879
+COMPONENT_ARCHIVE_HASH=	sha256:2b7b68aee6f123bc84cc502a9c12738435b8054e7d628962e091cd2a25be4f42
 COMPONENT_ARCHIVE_URL=	https://github.com/$(COMPONENT_NAME)/$(COMPONENT_NAME)/archive/v$(COMPONENT_VERSION).tar.gz
 COMPONENT_LICENSE=	GPLv2 with Linking Exception
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
 COMPONENT_SUMMARY=      Portable implementation of the Git core methods provided as a library
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/cmake.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CMAKE_OPTIONS +=	-DCMAKE_C_COMPILER=$(CC)
 CMAKE_OPTIONS +=	-DBIN_INSTALL_DIR=/usr/$(CMAKE_LIBDIR.$(BITS))
@@ -40,15 +41,9 @@ COMPONENT_TEST_CMD =    ctest
 COMPONENT_TEST_ARGS =   -V
 COMPONENT_TEST_TARGETS = ""
 
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/http-parser
 REQUIRED_PACKAGES += library/libssh2
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += web/curl

--- a/components/library/libgit2/libgit2.p5m
+++ b/components/library/libgit2/libgit2.p5m
@@ -24,6 +24,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/git2.h
 file path=usr/include/git2/annotated_commit.h
+file path=usr/include/git2/apply.h
 file path=usr/include/git2/attr.h
 file path=usr/include/git2/blame.h
 file path=usr/include/git2/blob.h
@@ -36,6 +37,7 @@ file path=usr/include/git2/commit.h
 file path=usr/include/git2/common.h
 file path=usr/include/git2/config.h
 file path=usr/include/git2/cred_helpers.h
+file path=usr/include/git2/deprecated.h
 file path=usr/include/git2/describe.h
 file path=usr/include/git2/diff.h
 file path=usr/include/git2/errors.h
@@ -46,6 +48,7 @@ file path=usr/include/git2/ignore.h
 file path=usr/include/git2/index.h
 file path=usr/include/git2/indexer.h
 file path=usr/include/git2/inttypes.h
+file path=usr/include/git2/mailmap.h
 file path=usr/include/git2/merge.h
 file path=usr/include/git2/message.h
 file path=usr/include/git2/net.h
@@ -58,6 +61,7 @@ file path=usr/include/git2/oidarray.h
 file path=usr/include/git2/pack.h
 file path=usr/include/git2/patch.h
 file path=usr/include/git2/pathspec.h
+file path=usr/include/git2/proxy.h
 file path=usr/include/git2/rebase.h
 file path=usr/include/git2/refdb.h
 file path=usr/include/git2/reflog.h
@@ -75,6 +79,7 @@ file path=usr/include/git2/status.h
 file path=usr/include/git2/stdint.h
 file path=usr/include/git2/strarray.h
 file path=usr/include/git2/submodule.h
+file path=usr/include/git2/sys/alloc.h
 file path=usr/include/git2/sys/commit.h
 file path=usr/include/git2/sys/config.h
 file path=usr/include/git2/sys/diff.h
@@ -82,13 +87,16 @@ file path=usr/include/git2/sys/filter.h
 file path=usr/include/git2/sys/hashsig.h
 file path=usr/include/git2/sys/index.h
 file path=usr/include/git2/sys/mempack.h
+file path=usr/include/git2/sys/merge.h
 file path=usr/include/git2/sys/odb_backend.h
 file path=usr/include/git2/sys/openssl.h
+file path=usr/include/git2/sys/path.h
 file path=usr/include/git2/sys/refdb_backend.h
 file path=usr/include/git2/sys/reflog.h
 file path=usr/include/git2/sys/refs.h
 file path=usr/include/git2/sys/repository.h
 file path=usr/include/git2/sys/stream.h
+file path=usr/include/git2/sys/time.h
 file path=usr/include/git2/sys/transport.h
 file path=usr/include/git2/tag.h
 file path=usr/include/git2/trace.h
@@ -97,11 +105,12 @@ file path=usr/include/git2/transport.h
 file path=usr/include/git2/tree.h
 file path=usr/include/git2/types.h
 file path=usr/include/git2/version.h
-link path=usr/lib/$(MACH64)/libgit2.so target=libgit2.so.23
+file path=usr/include/git2/worktree.h
+link path=usr/lib/$(MACH64)/libgit2.so target=libgit2.so.28
 file path=usr/lib/$(MACH64)/libgit2.so.$(COMPONENT_VERSION)
-link path=usr/lib/$(MACH64)/libgit2.so.23 target=libgit2.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libgit2.so.28 target=libgit2.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/libgit2.pc
-link path=usr/lib/libgit2.so target=libgit2.so.23
+link path=usr/lib/libgit2.so target=libgit2.so.28
 file path=usr/lib/libgit2.so.$(COMPONENT_VERSION)
-link path=usr/lib/libgit2.so.23 target=libgit2.so.$(COMPONENT_VERSION)
+link path=usr/lib/libgit2.so.28 target=libgit2.so.$(COMPONENT_VERSION)
 file path=usr/lib/pkgconfig/libgit2.pc

--- a/components/library/libgit2/manifests/sample-manifest.p5m
+++ b/components/library/libgit2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,6 +24,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/git2.h
 file path=usr/include/git2/annotated_commit.h
+file path=usr/include/git2/apply.h
 file path=usr/include/git2/attr.h
 file path=usr/include/git2/blame.h
 file path=usr/include/git2/blob.h
@@ -36,6 +37,7 @@ file path=usr/include/git2/commit.h
 file path=usr/include/git2/common.h
 file path=usr/include/git2/config.h
 file path=usr/include/git2/cred_helpers.h
+file path=usr/include/git2/deprecated.h
 file path=usr/include/git2/describe.h
 file path=usr/include/git2/diff.h
 file path=usr/include/git2/errors.h
@@ -46,6 +48,7 @@ file path=usr/include/git2/ignore.h
 file path=usr/include/git2/index.h
 file path=usr/include/git2/indexer.h
 file path=usr/include/git2/inttypes.h
+file path=usr/include/git2/mailmap.h
 file path=usr/include/git2/merge.h
 file path=usr/include/git2/message.h
 file path=usr/include/git2/net.h
@@ -58,6 +61,7 @@ file path=usr/include/git2/oidarray.h
 file path=usr/include/git2/pack.h
 file path=usr/include/git2/patch.h
 file path=usr/include/git2/pathspec.h
+file path=usr/include/git2/proxy.h
 file path=usr/include/git2/rebase.h
 file path=usr/include/git2/refdb.h
 file path=usr/include/git2/reflog.h
@@ -75,6 +79,7 @@ file path=usr/include/git2/status.h
 file path=usr/include/git2/stdint.h
 file path=usr/include/git2/strarray.h
 file path=usr/include/git2/submodule.h
+file path=usr/include/git2/sys/alloc.h
 file path=usr/include/git2/sys/commit.h
 file path=usr/include/git2/sys/config.h
 file path=usr/include/git2/sys/diff.h
@@ -82,13 +87,16 @@ file path=usr/include/git2/sys/filter.h
 file path=usr/include/git2/sys/hashsig.h
 file path=usr/include/git2/sys/index.h
 file path=usr/include/git2/sys/mempack.h
+file path=usr/include/git2/sys/merge.h
 file path=usr/include/git2/sys/odb_backend.h
 file path=usr/include/git2/sys/openssl.h
+file path=usr/include/git2/sys/path.h
 file path=usr/include/git2/sys/refdb_backend.h
 file path=usr/include/git2/sys/reflog.h
 file path=usr/include/git2/sys/refs.h
 file path=usr/include/git2/sys/repository.h
 file path=usr/include/git2/sys/stream.h
+file path=usr/include/git2/sys/time.h
 file path=usr/include/git2/sys/transport.h
 file path=usr/include/git2/tag.h
 file path=usr/include/git2/trace.h
@@ -97,11 +105,12 @@ file path=usr/include/git2/transport.h
 file path=usr/include/git2/tree.h
 file path=usr/include/git2/types.h
 file path=usr/include/git2/version.h
-link path=usr/lib/$(MACH64)/libgit2.so target=libgit2.so.23
+file path=usr/include/git2/worktree.h
+link path=usr/lib/$(MACH64)/libgit2.so target=libgit2.so.28
 file path=usr/lib/$(MACH64)/libgit2.so.$(COMPONENT_VERSION)
-link path=usr/lib/$(MACH64)/libgit2.so.23 target=libgit2.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libgit2.so.28 target=libgit2.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/libgit2.pc
-link path=usr/lib/libgit2.so target=libgit2.so.23
+link path=usr/lib/libgit2.so target=libgit2.so.28
 file path=usr/lib/libgit2.so.$(COMPONENT_VERSION)
-link path=usr/lib/libgit2.so.23 target=libgit2.so.$(COMPONENT_VERSION)
+link path=usr/lib/libgit2.so.28 target=libgit2.so.$(COMPONENT_VERSION)
 file path=usr/lib/pkgconfig/libgit2.pc

--- a/components/library/libgit2/pkg5
+++ b/components/library/libgit2/pkg5
@@ -1,12 +1,11 @@
 {
     "dependencies": [
+        "SUNWcs",
         "library/http-parser",
         "library/libssh2",
         "library/security/openssl",
         "library/zlib",
-        "SUNWcs",
-        "system/library",
-        "web/curl"
+        "system/library"
     ],
     "fmris": [
         "library/libgit2"


### PR DESCRIPTION
There is already a 1.0 branch of libgit2 but geany-plugins seem to have problems with it so I only updated to the (also supported) 0.28 branch and wait for the geany-plugins developer to integrate a newer branch.
At the moment geany-plugins is the only consumer of libgit2
