### PR TITLE
Obsolete remaining python-34 modules

### DIFF
--- a/components/python/geoip/Makefile
+++ b/components/python/geoip/Makefile
@@ -11,11 +11,13 @@
 # Copyright 2016 Adam Stevko
 #
 
+BUILD_BITS=			32_and_64
+BUILD_STYLE=		setup.py
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		GeoIP
 COMPONENT_VERSION=	1.3.2
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_PROJECT_URL=	http://www.maxmind.com/
 COMPONENT_FMRI=		library/python/geoip
 COMPONENT_CLASSIFICATION=Development/Python
@@ -28,16 +30,10 @@ COMPONENT_LICENSE_FILE= LICENSE
 
 PYTHON_VERSIONS=2.7 3.5
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=	$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
-build:          $(BUILD_32_and_64)
-
-install:        $(INSTALL_32_and_64)
-
-test:           $(NO_TESTS)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += database/geoip
 REQUIRED_PACKAGES += runtime/python-27
 REQUIRED_PACKAGES += runtime/python-35

--- a/components/python/geoip/history
+++ b/components/python/geoip/history
@@ -1,2 +1,2 @@
-library/python/geoip-34@1.3.2,2020.0.1.4
+library/python/geoip-34@1.3.2,5.11-2020.0.1.4
 library/python/geoip-26@1.3.2,5.11-2016.0.1.0

--- a/components/python/geoip/pkg5
+++ b/components/python/geoip/pkg5
@@ -1,9 +1,9 @@
 {
     "dependencies": [
+        "SUNWcs",
         "database/geoip",
         "runtime/python-27",
         "runtime/python-35",
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [

--- a/components/python/import-profiler/Makefile
+++ b/components/python/import-profiler/Makefile
@@ -12,11 +12,13 @@
 # Copyright (c) 2017 Predrag Zečević.  All rights reserved.
 #
 
+BUILD_BITS=			NO_ARCH
+BUILD_STYLE=		setup.py
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		import_profiler
 COMPONENT_VERSION=	0.0.3
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_PROJECT_URL=	https://pypi.python.org/pypi/import-profiler
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -30,22 +32,15 @@ COMPONENT_LICENSE=       MIT
 
 PYTHON_VERSIONS=	2.7 3.5
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_FETCH_USER_AGENT=wget
 
 # setup.py needs README.md, but file is missing in archive?
 COMPONENT_PRE_BUILD_ACTION=cd $(SOURCE_DIR) && touch README.md
 
-# common targets
-build:		$(BUILD_NO_ARCH)
-
-install:	$(INSTALL_NO_ARCH)
-
-test:           $(NO_TEST)
-
+# Manually added build dependencies
 REQUIRED_PACKAGES += runtime/python-27
 REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += system/library

--- a/components/python/import-profiler/history
+++ b/components/python/import-profiler/history
@@ -1,1 +1,1 @@
-library/python/import-profiler-34@0.0.3,2020.0.1.2
+library/python/import-profiler-34@0.0.3,5.11-2020.0.1.2

--- a/components/python/import-profiler/pkg5
+++ b/components/python/import-profiler/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
+        "SUNWcs",
         "runtime/python-27",
         "runtime/python-35",
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [

--- a/components/python/msgpack-python/Makefile
+++ b/components/python/msgpack-python/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		msgpack-python
 COMPONENT_VERSION=	0.4.7
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_PROJECT_URL=	https://pypi.python.org/pypi/msgpack-python
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -43,6 +43,7 @@ install:	$(INSTALL_32_and_64)
 
 test:           $(TEST_32_and_64)
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/python-27
 REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += system/library

--- a/components/python/msgpack-python/history
+++ b/components/python/msgpack-python/history
@@ -1,2 +1,2 @@
-library/python/msgpack-python-34@0.4.7,2020.0.1.3
+library/python/msgpack-python-34@0.4.7,5.11-2020.0.1.3
 library/python/msgpack-python-26@0.4.7,5.11-2016.0.1.0

--- a/components/python/msgpack-python/pkg5
+++ b/components/python/msgpack-python/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
+        "SUNWcs",
         "runtime/python-27",
         "runtime/python-35",
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [

--- a/components/python/pymongo/Makefile
+++ b/components/python/pymongo/Makefile
@@ -13,11 +13,13 @@
 # Copyright 2017 Alexander Pyhalov
 #
 
+BUILD_BITS=			32_and_64
+BUILD_STYLE=		setup.py
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= 	pymongo
 COMPONENT_VERSION= 	3.4.0
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_FMRI= 	library/python/$(COMPONENT_NAME)
 COMPONENT_SRC= 		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= 	$(COMPONENT_SRC).tar.gz
@@ -32,16 +34,11 @@ COMPONENT_CLASSIFICATION= Development/Python
 
 PYTHON_VERSIONS=	2.7 3.5
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
-build:		$(BUILD_32_and_64)
 
-install:	$(INSTALL_32_and_64)
-
-test:           $(NO_TESTS)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/python-27
 REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += system/library

--- a/components/python/pymongo/history
+++ b/components/python/pymongo/history
@@ -1,1 +1,1 @@
-library/python/pymongo-34@3.4.0,2020.0.1.2
+library/python/pymongo-34@3.4.0,5.11-2020.0.1.2

--- a/components/python/pymongo/pkg5
+++ b/components/python/pymongo/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
+        "SUNWcs",
         "runtime/python-27",
         "runtime/python-35",
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
pkg list -a | grep -- "-34" | ggrep -v -- "--o"
revealed some omitted python-34 modules (only 2 false positives regarding mongodb :))
