### PR TITLE
Fix gobject introspection

### DIFF
--- a/components/library/gtk3-nocsd/Makefile
+++ b/components/library/gtk3-nocsd/Makefile
@@ -13,11 +13,13 @@
 # Copyright 2017 Alexander Pyhalov
 #
 
+BUILD_BITS=			64
+BUILD_STYLE=		justmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gtk3-nocsd
 COMPONENT_VERSION=	3
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_FMRI=		library/desktop/gtk3/gtk3-nocsd
 COMPONENT_SUMMARY=	A small module used to disable the client side decoration of Gtk+ 3
 COMPONENT_CLASSIFICATION=Applications/Plug-ins and Run-times
@@ -29,9 +31,8 @@ COMPONENT_ARCHIVE_URL=	https://github.com/PCMan/gtk3-nocsd/archive/v$(COMPONENT_
 COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/justmake.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
@@ -48,11 +49,10 @@ COMPONENT_INSTALL_ENV += bindir=$(BINDIR.$(BITS))
 COMPONENT_INSTALL_ENV += libdir=$(LIBDIR.$(BITS))
 COMPONENT_INSTALL_ENV += bashcompletiondir=/usr/share/bash-completion/completions
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
-test: $(NO_TESTS)
-
+# Manually added build dependencies
 REQUIRED_PACKAGES += library/desktop/gtk3
 REQUIRED_PACKAGES += library/desktop/gobject/gobject-introspection
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library

--- a/components/library/gtk3-nocsd/manifests/sample-manifest.p5m
+++ b/components/library/gtk3-nocsd/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,7 +22,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=etc/X11/xinit/xinitrc.d/0$(COMPONENT_VERSION)10.gtk$(COMPONENT_VERSION)-nocsd
 file path=usr/bin/$(MACH64)/gtk$(COMPONENT_VERSION)-nocsd
 file path=usr/bin/gtk$(COMPONENT_VERSION)-nocsd
 file path=usr/lib/$(MACH64)/libgtk$(COMPONENT_VERSION)-nocsd.so.0

--- a/components/library/gtk3-nocsd/pkg5
+++ b/components/library/gtk3-nocsd/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
+        "SUNWcs",
         "library/desktop/gobject/gobject-introspection",
         "library/desktop/gtk3",
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [

--- a/components/library/lgi-53/Makefile
+++ b/components/library/lgi-53/Makefile
@@ -23,11 +23,14 @@
 # Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
 #
 
+BUILD_BITS=				64
+BUILD_STYLE=			justmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         lgi
 COMPONENT_VERSION=      0.9.1
-COMPONENT_SUMMARY=	Dynamic Lua binding to GObject libraries using GObject-Introspection
+COMPONENT_REVISION=		1
+COMPONENT_SUMMARY=		Dynamic Lua binding to GObject libraries using GObject-Introspection
 COMPONENT_PROJECT_URL=  https://github.com/pavouk/lgi
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
@@ -35,12 +38,11 @@ COMPONENT_ARCHIVE_HASH= sha256:0c70fb2b1ca17d333b7e2c18d5fc943944b5872e063de60df
 COMPONENT_ARCHIVE_URL=  https://github.com/pavouk/lgi/archive/$(COMPONENT_VERSION).tar.gz
 COMPONENT_FMRI=         library/lua/lgi-53
 COMPONENT_CLASSIFICATION=Development/Other Languages
-COMPONENT_LICENSE=	MIT
+COMPONENT_LICENSE=		MIT
 COMPONENT_LICENSE_FILE=	LICENSE
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/justmake.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=			$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PATH.32=/usr/gnu/bin:/usr/bin
 PATH.64=/usr/gnu/bin/$(MACH64):/usr/bin/$(MACH64):/usr/gnu/bin:/usr/bin
@@ -56,15 +58,11 @@ COMPONENT_BUILD_ENV += PATH=$(PATH.$(BITS))
 COMPONENT_INSTALL_ARGS += LUA_VERSION=5.3 PREFIX=$(USRDIR)
 COMPONENT_INSTALL_ARGS.64 += LUA_LIBDIR=$(USRDIR)/lib/lua/5.3/64
 
-build: $(BUILD_32_and_64)
+# Manually added build dependencies
+REQUIRED_PACKAGES += runtime/lua-53
 
-install: $(INSTALL_32_and_64)
-
-test: $(NO_TESTS)
-
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/gobject/gobject-introspection
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += runtime/lua-53

--- a/components/library/lgi-53/lgi.p5m
+++ b/components/library/lgi-53/lgi.p5m
@@ -23,7 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/lua/5.3/64/lgi/corelgilua53.so
-file path=usr/lib/lua/5.3/lgi/corelgilua53.so
 file path=usr/share/lua/5.3/lgi.lua
 file path=usr/share/lua/5.3/lgi/class.lua
 file path=usr/share/lua/5.3/lgi/component.lua

--- a/components/library/lgi-53/manifests/sample-manifest.p5m
+++ b/components/library/lgi-53/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,7 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/lua/5.3/64/lgi/corelgilua53.so
-file path=usr/lib/lua/5.3/lgi/corelgilua53.so
 file path=usr/share/lua/5.3/lgi.lua
 file path=usr/share/lua/5.3/lgi/class.lua
 file path=usr/share/lua/5.3/lgi/component.lua

--- a/components/library/lgi-53/pkg5
+++ b/components/library/lgi-53/pkg5
@@ -1,10 +1,10 @@
 {
     "dependencies": [
+        "SUNWcs",
         "library/desktop/gobject/gobject-introspection",
         "library/glib2",
         "library/libffi",
         "runtime/lua-53",
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [

--- a/components/library/lgi/Makefile
+++ b/components/library/lgi/Makefile
@@ -23,6 +23,8 @@
 # Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
 #
 
+BUILD_BITS=				64
+BUILD_STYLE=			justmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         lgi
@@ -39,9 +41,8 @@ COMPONENT_CLASSIFICATION=	Development/Other Languages
 COMPONENT_LICENSE=	MIT
 COMPONENT_LICENSE_FILE=	LICENSE
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/justmake.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=			$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PATH.32=/usr/gnu/bin:/usr/bin
 PATH.64=/usr/gnu/bin/$(MACH64):/usr/bin/$(MACH64):/usr/gnu/bin:/usr/bin
@@ -56,14 +57,11 @@ COMPONENT_BUILD_ENV += PATH=$(PATH.$(BITS))
 COMPONENT_INSTALL_ARGS += LUA_VERSION=5.2 PREFIX=$(USRDIR)
 COMPONENT_INSTALL_ARGS.64 += LUA_LIBDIR=$(USRDIR)/lib/lua/5.2/64
 
-build: $(BUILD_32_and_64)
+# Manually added build dependencies
+REQUIRED_PACKAGES += runtime/lua
 
-install: $(INSTALL_32_and_64)
-
-test: $(NO_TESTS)
-
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/gobject/gobject-introspection
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/libffi
-REQUIRED_PACKAGES += runtime/lua
+REQUIRED_PACKAGES += system/library

--- a/components/library/lgi/lgi.p5m
+++ b/components/library/lgi/lgi.p5m
@@ -25,7 +25,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 depend type=require fmri=runtime/lua
 
 file path=usr/lib/lua/5.2/64/lgi/corelgilua52.so
-file path=usr/lib/lua/5.2/lgi/corelgilua52.so
 file path=usr/share/lua/5.2/lgi.lua
 file path=usr/share/lua/5.2/lgi/class.lua
 file path=usr/share/lua/5.2/lgi/component.lua

--- a/components/library/lgi/manifests/sample-manifest.p5m
+++ b/components/library/lgi/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,7 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/lua/5.2/64/lgi/corelgilua52.so
-file path=usr/lib/lua/5.2/lgi/corelgilua52.so
 file path=usr/share/lua/5.2/lgi.lua
 file path=usr/share/lua/5.2/lgi/class.lua
 file path=usr/share/lua/5.2/lgi/component.lua

--- a/components/library/lgi/pkg5
+++ b/components/library/lgi/pkg5
@@ -1,10 +1,10 @@
 {
     "dependencies": [
+        "SUNWcs",
         "library/desktop/gobject/gobject-introspection",
         "library/glib2",
         "library/libffi",
         "runtime/lua",
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
I am running a complete (clean) build on my build system.
lgi and lgi-53 don't build 32-bit anymore (I don't know why they build 2 days ago)
gtk3-nocsd hasn't been touched yet but its 32-bit build failed.
