### PR TITLE
libfreehand: fix syntax error (missing ';')

### DIFF
--- a/components/library/libfreehand/Makefile
+++ b/components/library/libfreehand/Makefile
@@ -25,7 +25,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libfreehand
 COMPONENT_VERSION=	0.1.2
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_FMRI=     	library/c++/libfreehand
 COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_PROJECT_URL=	https://wiki.documentfoundation.org/DLP/Libraries/libfreehand

--- a/components/library/libfreehand/patches/02-missing-semicolon.patch
+++ b/components/library/libfreehand/patches/02-missing-semicolon.patch
@@ -1,0 +1,11 @@
+--- libfreehand-0.1.2/src/lib/libfreehand_utils.cpp.orig	2020-07-21 17:33:07.920360370 +0000
++++ libfreehand-0.1.2/src/lib/libfreehand_utils.cpp	2020-07-21 17:33:18.998925615 +0000
+@@ -162,7 +162,7 @@
+   while (j < length)
+   {
+     UChar32 c;
+-    U16_NEXT(s, j, length, c)
++    U16_NEXT(s, j, length, c);
+     unsigned char outbuf[U8_MAX_LENGTH+1];
+     int i = 0;
+     U8_APPEND_UNSAFE(&outbuf[0], i, c);

--- a/components/library/libfreehand/pkg5
+++ b/components/library/libfreehand/pkg5
@@ -1,10 +1,10 @@
 {
     "dependencies": [
+        "SUNWcs",
         "developer/cppunit",
         "library/c++/librevenge",
         "library/lcms2",
         "library/zlib",
-        "SUNWcs",
         "system/library",
         "system/library/g++-7-runtime",
         "system/library/gcc-7-runtime",


### PR DESCRIPTION
How did that work before?