### PR TITLE
Ignoring vagrant temporary directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tools/python/pkglint/__pycache__
 tools/parfait
 tools/pkglint
 tools/time-*o
+
+.vagrant


### PR DESCRIPTION
This adds the temporary directory vagrant creates to the list of ignored directories