### PR TITLE
Add userland as prefered publisher to test installation in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,8 @@ Vagrant.configure("2") do |config|
     pfexec pkg install build-essential
 
     cd /vagrant && gmake setup
-    pfexec pkg set-publisher --sticky --search-before=openindiana.org -g /vagrant/i386/repo userland
+    pfexec pkg set-publisher --non-sticky -g file://$HOME/oi-userland/i386/repo userland
+    pfexec pkg set-publisher --non-sticky openindiana.org
     echo "VM is ready, happy contributing!"
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,6 +83,7 @@ Vagrant.configure("2") do |config|
     pfexec pkg install build-essential
 
     cd /vagrant && gmake setup
+    pfexec pkg set-publisher --sticky --search-before=openindiana.org -g /vagrant/i386/repo userland
     echo "VM is ready, happy contributing!"
   SHELL
 end


### PR DESCRIPTION
A small addition to vagrant that makes installing locally compiled packages a breeze on the vagrant dev VM.