### PR TITLE
rsync: update to 3.2.2

### DIFF
--- a/components/network/rsync/Makefile
+++ b/components/network/rsync/Makefile
@@ -22,43 +22,44 @@
 #
 # Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2020, Andreas Wacknitz
 #
 
+BUILD_BITS=			64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		rsync
-COMPONENT_VERSION=	3.1.3
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	3.2.2
 COMPONENT_SUMMARY=	Utility that provides fast incremental file transfer and copy
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://rsync.samba.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0
+	sha256:644bd3841779507665211fd7db8359c8a10670c57e305b4aab61b4e40037afa8
 COMPONENT_ARCHIVE_URL=	https://rsync.samba.org/ftp/rsync/src/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	network/rsync
 COMPONENT_CLASSIFICATION= Applications/System Utilities
 COMPONENT_LICENSE=	GPLv3
 COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_BINDIR.64 = $(CONFIGURE_PREFIX)/bin
 
-CONFIGURE_OPTIONS  +=		--with-included-popt
-CONFIGURE_OPTIONS  +=		--enable-xattr-support
+CONFIGURE_OPTIONS  +=	--with-included-popt
+CONFIGURE_OPTIONS  +=	--enable-xattr-support
+# disable xxHash until we provide a package for it (https://github.com/Cyan4973/xxHash)
+CONFIGURE_OPTIONS  +=	--disable-xxhash
 
 COMPONENT_TEST_TRANSFORMER = $(NAWK)
 COMPONENT_TEST_TRANSFORMS = "'/^PASS|^SKIP|^FAIL|^XFAIL/'"
 
-# common targets
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
+# Manually added; needed during tests
+REQUIRED_PACKAGES += developer/fakeroot
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += compress/zstd
+REQUIRED_PACKAGES += library/lz4
+REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += system/library

--- a/components/network/rsync/manifests/sample-manifest.p5m
+++ b/components/network/rsync/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,5 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/rsync
+file path=usr/bin/rsync-ssl
+file path=usr/share/man/man1/rsync-ssl.1
 file path=usr/share/man/man1/rsync.1
 file path=usr/share/man/man5/rsyncd.conf.5

--- a/components/network/rsync/patches/01-15730984.patch
+++ b/components/network/rsync/patches/01-15730984.patch
@@ -1,25 +1,8 @@
 Reduce references to source pathnames down to the respective basenames so
 that builds are reproducible between workspaces.
+The patch is needed to avoid embedding path information from the build area
+in the compiled binares (in particular in error messages).
 
---- rsync-3.1.0/main.c.orig	Sat Jan 19 11:05:53 2013
-+++ rsync-3.1.0/main.c	Mon Mar 17 14:57:32 2014
-@@ -26,6 +26,7 @@
- #if defined CONFIG_LOCALE && defined HAVE_LOCALE_H
- #include <locale.h>
- #endif
-+#include <libgen.h>
- 
- extern int dry_run;
- extern int list_only;
-@@ -1215,7 +1216,7 @@
- 	for (i = 0; argv[i]; i++) {
- 		if (!(argv[i] = strdup(argv[i]))) {
- 			rprintf (FERROR, "out of memory at %s(%d)\n",
--				 __FILE__, __LINE__);
-+				 basename(__FILE__), __LINE__);
- 			return RERR_MALLOC;
- 		}
- 	}
 --- rsync-3.1.0/t_stub.c.orig	Tue Jun 11 18:06:53 2013
 +++ rsync-3.1.0/t_stub.c	Mon Mar 17 14:58:24 2014
 @@ -20,6 +20,7 @@
@@ -62,35 +45,35 @@ that builds are reproducible between workspaces.
  		}
  	}
  }
---- rsync-3.1.2/cleanup.c.~1~	2015-08-08 22:47:03.000000000 +0300
-+++ rsync-3.1.2/cleanup.c	2015-12-22 21:42:58.948691208 +0300
+--- rsync-3.2.2/cleanup.c.orig	2020-06-28 08:14:35.000000000 +0000
++++ rsync-3.2.2/cleanup.c	2020-07-23 18:13:38.184898463 +0000
 @@ -21,6 +21,7 @@
   */
- 
+
  #include "rsync.h"
 +#include <libgen.h>
- 
+
  extern int dry_run;
  extern int am_server;
-@@ -135,7 +136,7 @@
+@@ -137,7 +138,7 @@
  		if (DEBUG_GTE(EXIT, 2)) {
  			rprintf(FINFO,
  				"[%s] _exit_cleanup(code=%d, file=%s, line=%d): entered\n",
 -				who_am_i(), code, file, line);
 +				who_am_i(), code, basename((char *)file), line);
  		}
- 
- 		/* FALLTHROUGH */
-@@ -224,7 +225,7 @@
- 		 * we don't want to output a duplicate error. */
- 		if ((exit_code && line > 0)
- 		 || am_daemon || (logfile_name && (am_server || !INFO_GTE(STATS, 1))))
+
+ #include "case_N.h"
+@@ -226,7 +227,7 @@
+ 			if (am_server && exit_code)
+ 				usleep(50);
+ #endif
 -			log_exit(exit_code, exit_file, exit_line);
 +			log_exit(exit_code, basename((char *)exit_file), exit_line);
- 
- 		/* FALLTHROUGH */
+ 		}
+
  #include "case_N.h"
-@@ -234,7 +235,7 @@
+@@ -236,7 +237,7 @@
  			rprintf(FINFO,
  				"[%s] _exit_cleanup(code=%d, file=%s, line=%d): "
  				"about to call exit(%d)%s\n",

--- a/components/network/rsync/patches/08-getpassphrase.patch
+++ b/components/network/rsync/patches/08-getpassphrase.patch
@@ -1,13 +1,14 @@
---- rsync-3.1.2/authenticate.c.1	2018-03-03 19:09:36.100926361 +0000
-+++ rsync-3.1.2/authenticate.c	2018-03-03 19:10:38.525088488 +0000
-@@ -363,7 +363,11 @@
-                  *
-                  * OpenBSD has a readpassphrase() that might be more suitable.
-                  */
+--- rsync-3.2.2/authenticate.c.orig	2020-06-26 05:54:21.000000000 +0000
++++ rsync-3.2.2/authenticate.c	2020-07-23 16:48:29.526004411 +0000
+@@ -362,7 +362,11 @@
+ 		 *
+ 		 * OpenBSD has a readpassphrase() that might be more suitable.
+ 		 */
+-		pass = getpass("Password: ");
 +#ifdef __sun
-+		pass = getpassphrase("Password: ");
++        pass = getpassphrase("Password: ");
 +#else
- 		pass = getpass("Password: ");
++        pass = getpass("Password: ");
 +#endif
  	}
  

--- a/components/network/rsync/pkg5
+++ b/components/network/rsync/pkg5
@@ -1,6 +1,9 @@
 {
     "dependencies": [
         "SUNWcs",
+        "compress/zstd",
+        "library/lz4",
+        "library/security/openssl",
         "system/library"
     ],
     "fmris": [

--- a/components/network/rsync/test/results-64.master
+++ b/components/network/rsync/test/results-64.master
@@ -1,5 +1,6 @@
 PASS    00-hello
 SKIP    acls (I don't know how to use setfacl or chmod for ACLs)
+PASS    atimes
 PASS    backup
 PASS    batch-mode
 PASS    chgrp
@@ -7,7 +8,7 @@ PASS    chmod-option
 PASS    chmod-temp-dir
 PASS    chmod
 PASS    chown-fake
-SKIP    chown (Can't chown (probably need root))
+PASS    chown
 PASS    compare-dest
 PASS    daemon-gzip-download
 PASS    daemon-gzip-upload
@@ -15,7 +16,7 @@ PASS    daemon
 SKIP    default-acls (I don't know how to use your setfacl command)
 PASS    delete
 PASS    devices-fake
-SKIP    devices (Rsync needs root/fakeroot for device tests)
+PASS    devices
 PASS    dir-sgid
 PASS    duplicates
 PASS    exclude


### PR DESCRIPTION
I reworked the file patch but I don't know whether it's really needed (I don't understand its description).
Furthermore there's a warning (already in our actual version):

configure.sh: WARNING: netinet/ip.h: present but cannot be compiled
configure.sh: WARNING: netinet/ip.h:     check for missing prerequisite headers?
configure.sh: WARNING: netinet/ip.h: see the Autoconf documentation
configure.sh: WARNING: netinet/ip.h:     section "Present But Cannot Be Compiled"
configure.sh: WARNING: netinet/ip.h: proceeding with the compiler's result
configure.sh: WARNING:     ## --------------------------------------------------- ##
configure.sh: WARNING:     ## Report this to http://rsync.samba.org/bugzilla.html ##
configure.sh: WARNING:     ## --------------------------------------------------- ##