### PR TITLE
bison: update to 3.5.4

### DIFF
--- a/components/developer/bison/Makefile
+++ b/components/developer/bison/Makefile
@@ -29,13 +29,13 @@ BUILD_BITS=		32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		bison
-COMPONENT_VERSION=	3.5.3
-COMPONENT_PROJECT_URL=	http://www.gnu.org/software/bison/
+COMPONENT_VERSION=	3.5.4
+COMPONENT_PROJECT_URL=	https://www.gnu.org/software/bison/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_SUMMARY=	bison - A YACC Replacement
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:2bf85b5f88a5f2fa8069aed2a2dfc3a9f8d15a97e59c713e3906e5fdd982a7c4
+	sha256:4c17e99881978fa32c05933c5262457fa5b2b611668454f8dc2a695cd6b3720c
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/bison/$(COMPONENT_ARCHIVE)
 COMPONENT_CLASSIFICATION=	Development/Other Languages
 COMPONENT_FMRI=		developer/parser/bison

--- a/components/developer/bison/bison-runtime.p5m
+++ b/components/developer/bison/bison-runtime.p5m
@@ -81,6 +81,7 @@ file path=usr/share/locale/sl/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/sq/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/sr/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/sv/LC_MESSAGES/bison-runtime.mo
+file path=usr/share/locale/ta/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/th/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/tr/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/uk/LC_MESSAGES/bison-runtime.mo

--- a/components/developer/bison/manifests/sample-manifest.p5m
+++ b/components/developer/bison/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -191,6 +191,7 @@ file path=usr/share/locale/sr/LC_MESSAGES/bison.mo
 file path=usr/share/locale/sv/LC_MESSAGES/bison-gnulib.mo
 file path=usr/share/locale/sv/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/sv/LC_MESSAGES/bison.mo
+file path=usr/share/locale/ta/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/th/LC_MESSAGES/bison-runtime.mo
 file path=usr/share/locale/tr/LC_MESSAGES/bison-gnulib.mo
 file path=usr/share/locale/tr/LC_MESSAGES/bison-runtime.mo

--- a/components/developer/bison/pkg5
+++ b/components/developer/bison/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
+        "SUNWcs",
         "developer/documentation-tool/doxygen",
         "developer/macro/gnu-m4",
-        "SUNWcs",
         "system/library",
         "system/library/math",
         "text/gnu-gettext"

--- a/components/developer/bison/test/results-all.master
+++ b/components/developer/bison/test/results-all.master
@@ -23,7 +23,7 @@ PASS: examples/java/Calc.test
 # ERROR: 0
 # ERROR: 0
 ## --------------------------- ##
-## GNU Bison 3.5.3 test suite. ##
+## GNU Bison 3.5.4 test suite. ##
 ## --------------------------- ##
 100: Output files: lalr1.cc                          ok
 101: Output files: lalr1.cc %verbose                 ok
@@ -333,217 +333,219 @@ PASS: examples/java/Calc.test
 405: Token numbers: lalr1.cc api.token.raw           ok
 406: Token numbers: glr.cc                           ok
 407: Token numbers: glr.cc api.token.raw             ok
-408: Token numbers: lalr1.d                          skipped (scanner.at:245)
-409: Token numbers: lalr1.d api.token.raw            skipped (scanner.at:245)
-410: Token numbers: lalr1.cc api.token.raw api.value.type=variant api.token.constructor ok
-411: Calculator                                      ok
-412: Calculator %defines                             ok
-413: Calculator %locations                           ok
-414: Calculator %locations api.location.type={Span}  ok
-415: Calculator %name-prefix "calc"                  ok
-416: Calculator %verbose                             ok
-417: Calculator %yacc                                ok
-418: Calculator parse.error=verbose                  ok
-419: Calculator api.pure=full %locations             ok
-420: Calculator api.push-pull=both api.pure=full %locations  ok
-421: Calculator parse.error=verbose %locations       ok
-422: Calculator parse.error=verbose %locations %defines api.prefix={calc} %verbose %yacc  ok
-423: Calculator parse.error=verbose %locations %defines %name-prefix "calc" api.token.prefix={TOK_} %verbose %yacc  ok
-424: Calculator %debug                               ok
-425: Calculator parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
-426: Calculator parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc  ok
-427: Calculator api.pure=full parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
-428: Calculator api.push-pull=both api.pure=full parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc  ok
-429: Calculator api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-430: Calculator %no-lines api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-431: Calculator %glr-parser                          ok
-432: Calculator %glr-parser %defines                 ok
-433: Calculator %glr-parser %locations               ok
-434: Calculator %glr-parser %locations api.location.type={Span}  ok
-435: Calculator %glr-parser %name-prefix "calc"      ok
-436: Calculator %glr-parser api.prefix={calc}        ok
-437: Calculator %glr-parser %verbose                 ok
-438: Calculator %glr-parser %yacc                    ok
-439: Calculator %glr-parser parse.error=verbose      ok
-440: Calculator %glr-parser api.pure %locations      ok
-441: Calculator %glr-parser parse.error=verbose %locations  ok
-442: Calculator %glr-parser parse.error=verbose %locations %defines %name-prefix "calc" %verbose %yacc  ok
-443: Calculator %glr-parser %debug                   ok
-444: Calculator %glr-parser parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
-445: Calculator %glr-parser parse.error=verbose %debug %locations %defines api.prefix={calc} api.token.prefix={TOK_} %verbose %yacc  ok
-446: Calculator %glr-parser api.pure parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
-447: Calculator %glr-parser api.pure parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-448: Calculator %glr-parser api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-449: Calculator %glr-parser %no-lines api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-450: Calculator lalr1.cc %defines                    ok
-451: Calculator C++                                  ok
-452: Calculator C++ %locations                       ok
-453: Calculator C++ %locations $NO_EXCEPTIONS_CXXFLAGS ok
-454: Calculator C++ %locations api.location.type={Span}  ok
-455: Calculator C++ %defines %locations parse.error=verbose %name-prefix "calc" %verbose %yacc  ok
-456: Calculator C++ %locations parse.error=verbose api.prefix={calc} %verbose %yacc  ok
-457: Calculator C++ %locations parse.error=verbose %debug %name-prefix "calc" %verbose %yacc  ok
-458: Calculator C++ %locations parse.error=verbose %debug api.prefix={calc} %verbose %yacc  ok
-459: Calculator C++ %locations parse.error=verbose %debug api.prefix={calc} api.token.prefix={TOK_} %verbose %yacc  ok
-460: Calculator C++ %defines %locations parse.error=verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-461: Calculator C++ parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-462: Calculator C++ %defines %locations parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-463: Calculator C++ %defines %locations api.location.file=none  ok
-464: Calculator C++ %defines %locations api.location.file="my-location.hh"  ok
-465: Calculator C++ %no-lines %defines %locations api.location.file="my-location.hh"  ok
-466: Calculator glr.cc                               ok
-467: Calculator C++ %glr-parser                      ok
-468: Calculator C++ %glr-parser %locations           ok
-469: Calculator C++ %glr-parser %locations api.location.type={Span}  ok
-470: Calculator C++ %glr-parser %defines parse.error=verbose %name-prefix "calc" %verbose %yacc  ok
-471: Calculator C++ %glr-parser parse.error=verbose api.prefix={calc} %verbose %yacc  ok
-472: Calculator C++ %glr-parser %debug               ok
-473: Calculator C++ %glr-parser parse.error=verbose %debug %name-prefix "calc" %verbose %yacc  ok
-474: Calculator C++ %glr-parser parse.error=verbose %debug %name-prefix "calc" api.token.prefix={TOK_} %verbose %yacc  ok
-475: Calculator C++ %glr-parser %locations %defines parse.error=verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-476: Calculator C++ %glr-parser %locations %defines parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-477: Calculator C++ %glr-parser %no-lines %locations %defines parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
-478: Calculator lalr1.d                              skipped (calc.at:900)
-479: Calculator D                                    skipped (calc.at:909)
-480: Calculator D %locations                         skipped (calc.at:910)
-481: Calculator D parse.error=verbose api.prefix={calc} %verbose  skipped (calc.at:912)
-482: Calculator D %debug                             skipped (calc.at:914)
-483: Calculator D parse.error=verbose %debug %verbose  skipped (calc.at:916)
-484: Big triangle                                    ok
-485: Big horizontal                                  ok
-486: State number type: 128 states                   ok
-487: State number type: 129 states                   ok
-488: State number type: 256 states                   ok
-489: State number type: 257 states                   ok
-490: State number type: 32768 states                 ok
-491: State number type: 65536 states                 ok
-492: State number type: 65537 states                 ok
-493: Many lookahead tokens                           ok
-494: Exploding the Stack Size with Alloca            ok
-495: Exploding the Stack Size with Malloc            ok
-496: GNU AWK 3.1.0 Grammar: LALR(1)                  ok
-497: GNU AWK 3.1.0 Grammar: IELR(1)                  ok
-498: GNU AWK 3.1.0 Grammar: Canonical LR(1)          ok
-499: GNU Cim Grammar: LALR(1)                        ok
-500: GNU Cim Grammar: IELR(1)                        ok
-501: GNU Cim Grammar: Canonical LR(1)                ok
-502: GNU pic (Groff 1.18.1) Grammar: LALR(1)         ok
-503: GNU pic (Groff 1.18.1) Grammar: IELR(1)         ok
-504: GNU pic (Groff 1.18.1) Grammar: Canonical LR(1) ok
-505: Trivial grammars                                ok
-506: YYSTYPE typedef                                 ok
-507: Early token definitions with --yacc             ok
-508: Early token definitions without --yacc          ok
-509: Braces parsing                                  ok
-510: Rule Line Numbers                               ok
-511: Mixing %token styles                            ok
-512: Token definitions                               ok
-513: Characters Escapes                              ok
-514: Web2c Report                                    ok
-515: Web2c Actions                                   ok
-516: Dancer                                          ok
-517: Dancer %glr-parser                              ok
-518: Dancer lalr1.cc                                 ok
-519: Expecting two tokens                            ok
-520: Expecting two tokens %glr-parser                ok
-521: Expecting two tokens lalr1.cc                   ok
-522: Braced code in declaration in rules section     ok
-523: String alias declared after use                 ok
-524: Extra lookahead sets in report                  ok
-525: Token number in precedence declaration          ok
-526: parse-gram.y: LALR = IELR                       ok
-527: parse.error=verbose and YYSTACK_USE_ALLOCA      ok
-528: parse.error=verbose overflow                    ok
-529: LAC: Exploratory stack                          ok
-530: LAC: Memory exhaustion                          ok
-531: Lex and parse params: yacc.c                    ok
-532: Lex and parse params: glr.c                     ok
-533: Lex and parse params: lalr1.cc                  ok
-534: Lex and parse params: glr.cc                    ok
-535: stdio.h is not needed                           ok
-536: Memory Leak for Early Deletion                  ok
-537: Multiple impure instances                       ok
-538: Unsupported Skeletons                           ok
-539: C++ Locations Unit Tests                        ok
-540: C++ Variant-based Symbols Unit Tests            ok
-541: Multiple occurrences of $n and api.value.automove ok
-542: Variants lalr1.cc                               ok
-543: Variants lalr1.cc parse.assert                  ok
-544: Variants lalr1.cc parse.assert api.value.automove ok
-545: Variants lalr1.cc parse.assert %locations       ok
-546: Variants lalr1.cc parse.assert %code {\n#define TWO_STAGE_BUILD\n} ok
-547: Variants lalr1.cc parse.assert api.token.constructor ok
-548: Variants lalr1.cc parse.assert api.token.constructor api.token.prefix={TOK_} ok
-549: Variants lalr1.cc parse.assert api.token.constructor api.token.prefix={TOK_} %locations ok
-550: Variants lalr1.cc parse.assert api.token.constructor api.token.prefix={TOK_} %locations api.value.automove ok
-551: Variants and Typed Midrule Actions              ok
-552: Doxygen Public Documentation                    ok
-553: Doxygen Private Documentation                   ok
-554: Relative namespace references                   ok
-555: Absolute namespace references                   ok
-556: Syntactically invalid namespace references      ok
-557: Syntax error discarding no lookahead            ok
-558: Syntax error as exception: lalr1.cc             ok
-559: Syntax error as exception: glr.cc               ok
-560: Exception safety with error recovery            ok
-561: Exception safety without error recovery         ok
-562: Exception safety with error recovery api.value.type=variant ok
-563: Exception safety without error recovery api.value.type=variant ok
-564: C++ GLR parser identifier shadowing             ok
-565: Shared locations                                ok
-566: Default action                                  ok
-567: Java invalid directives                         ok
-568: Calculator                                      ok
-569: Calculator parse.error=verbose                  ok
-570: Calculator %locations                           ok
-571: Calculator parse.error=verbose %locations       ok
-572: Calculator %lex-param { InputStream is }        ok
-573: Calculator parse.error=verbose %lex-param { InputStream is }  ok
-574: Calculator %locations %lex-param { InputStream is }  ok
-575: Calculator parse.error=verbose %locations %lex-param { InputStream is }  ok
-576: Java parser class and package names             ok
-577: Java parser class modifiers                     ok
-578: Java parser class extends and implements        ok
-579: Java %parse-param and %lex-param                ok
-580: Java throws specifications                      ok
-581: Java constructor init and init_throws           ok
-582: Java value, position, and location types        ok
-583: Java syntax error handling without error token  ok
-584: Trivial Push Parser with api.push-pull verification ok
-585: Trivial Push Parser with %initial-action        ok
-586: Calc parser with api.push-pull both             ok
-587: Calc parser with %locations %code lexer and api.push-pull both ok
-588: GLR: Resolve ambiguity, impure, no locations    ok
-589: GLR: Resolve ambiguity, impure, locations       ok
-590: GLR: Resolve ambiguity, pure, no locations      ok
-591: GLR: Resolve ambiguity, pure, locations         ok
-592: GLR: Merge conflicting parses, impure, no locations ok
-593: GLR: Merge conflicting parses, impure, locations ok
-594: GLR: Merge conflicting parses, pure, no locations ok
-595: GLR: Merge conflicting parses, pure, locations  ok
-596: GLR: Verbose messages, resolve ambiguity, impure, no locations ok
-597: Badly Collapsed GLR States                      ok
-598: Improper handling of embedded actions and dollar(-N) in GLR parsers ok
-599: Improper merging of GLR delayed action sets     ok
-600: Duplicate representation of merged trees        ok
-601: User destructor for unresolved GLR semantic value ok
-602: User destructor after an error during a split parse ok
-603: Duplicated user destructor for lookahead        ok
-604: Incorrectly initialized location for empty right-hand side in GLR ok
-605: No users destructors if stack 0 deleted         ok
-606: Corrupted semantic options if user action cuts parse ok
-607: Undesirable destructors if user action cuts parse ok
-608: Leaked semantic values if user action cuts parse ok
-609: Incorrect lookahead during deterministic GLR    ok
-610: Incorrect lookahead during nondeterministic GLR ok
-611: Leaked semantic values when reporting ambiguity ok
-612: Leaked lookahead after nondeterministic parse syntax error ok
-613: Uninitialized location when reporting ambiguity ok
-614: Missed %merge type warnings when LHS type is declared later ok
-615: Ambiguity reports                               ok
-616: Predicates                                      ok
+408: Token numbers: lalr1.java                       ok
+409: Token numbers: lalr1.java api.token.raw         ok
+410: Token numbers: lalr1.d                          skipped (scanner.at:338)
+411: Token numbers: lalr1.d api.token.raw            skipped (scanner.at:338)
+412: Token numbers: lalr1.cc api.token.raw api.value.type=variant api.token.constructor ok
+413: Calculator                                      ok
+414: Calculator %defines                             ok
+415: Calculator %locations                           ok
+416: Calculator %locations api.location.type={Span}  ok
+417: Calculator %name-prefix "calc"                  ok
+418: Calculator %verbose                             ok
+419: Calculator %yacc                                ok
+420: Calculator parse.error=verbose                  ok
+421: Calculator api.pure=full %locations             ok
+422: Calculator api.push-pull=both api.pure=full %locations  ok
+423: Calculator parse.error=verbose %locations       ok
+424: Calculator parse.error=verbose %locations %defines api.prefix={calc} %verbose %yacc  ok
+425: Calculator parse.error=verbose %locations %defines %name-prefix "calc" api.token.prefix={TOK_} %verbose %yacc  ok
+426: Calculator %debug                               ok
+427: Calculator parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
+428: Calculator parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc  ok
+429: Calculator api.pure=full parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
+430: Calculator api.push-pull=both api.pure=full parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc  ok
+431: Calculator api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+432: Calculator %no-lines api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+433: Calculator %glr-parser                          ok
+434: Calculator %glr-parser %defines                 ok
+435: Calculator %glr-parser %locations               ok
+436: Calculator %glr-parser %locations api.location.type={Span}  ok
+437: Calculator %glr-parser %name-prefix "calc"      ok
+438: Calculator %glr-parser api.prefix={calc}        ok
+439: Calculator %glr-parser %verbose                 ok
+440: Calculator %glr-parser %yacc                    ok
+441: Calculator %glr-parser parse.error=verbose      ok
+442: Calculator %glr-parser api.pure %locations      ok
+443: Calculator %glr-parser parse.error=verbose %locations  ok
+444: Calculator %glr-parser parse.error=verbose %locations %defines %name-prefix "calc" %verbose %yacc  ok
+445: Calculator %glr-parser %debug                   ok
+446: Calculator %glr-parser parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
+447: Calculator %glr-parser parse.error=verbose %debug %locations %defines api.prefix={calc} api.token.prefix={TOK_} %verbose %yacc  ok
+448: Calculator %glr-parser api.pure parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc  ok
+449: Calculator %glr-parser api.pure parse.error=verbose %debug %locations %defines %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+450: Calculator %glr-parser api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+451: Calculator %glr-parser %no-lines api.pure parse.error=verbose %debug %locations %defines api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+452: Calculator lalr1.cc %defines                    ok
+453: Calculator C++                                  ok
+454: Calculator C++ %locations                       ok
+455: Calculator C++ %locations $NO_EXCEPTIONS_CXXFLAGS ok
+456: Calculator C++ %locations api.location.type={Span}  ok
+457: Calculator C++ %defines %locations parse.error=verbose %name-prefix "calc" %verbose %yacc  ok
+458: Calculator C++ %locations parse.error=verbose api.prefix={calc} %verbose %yacc  ok
+459: Calculator C++ %locations parse.error=verbose %debug %name-prefix "calc" %verbose %yacc  ok
+460: Calculator C++ %locations parse.error=verbose %debug api.prefix={calc} %verbose %yacc  ok
+461: Calculator C++ %locations parse.error=verbose %debug api.prefix={calc} api.token.prefix={TOK_} %verbose %yacc  ok
+462: Calculator C++ %defines %locations parse.error=verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+463: Calculator C++ parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+464: Calculator C++ %defines %locations parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+465: Calculator C++ %defines %locations api.location.file=none  ok
+466: Calculator C++ %defines %locations api.location.file="my-location.hh"  ok
+467: Calculator C++ %no-lines %defines %locations api.location.file="my-location.hh"  ok
+468: Calculator glr.cc                               ok
+469: Calculator C++ %glr-parser                      ok
+470: Calculator C++ %glr-parser %locations           ok
+471: Calculator C++ %glr-parser %locations api.location.type={Span}  ok
+472: Calculator C++ %glr-parser %defines parse.error=verbose %name-prefix "calc" %verbose %yacc  ok
+473: Calculator C++ %glr-parser parse.error=verbose api.prefix={calc} %verbose %yacc  ok
+474: Calculator C++ %glr-parser %debug               ok
+475: Calculator C++ %glr-parser parse.error=verbose %debug %name-prefix "calc" %verbose %yacc  ok
+476: Calculator C++ %glr-parser parse.error=verbose %debug %name-prefix "calc" api.token.prefix={TOK_} %verbose %yacc  ok
+477: Calculator C++ %glr-parser %locations %defines parse.error=verbose %debug %name-prefix "calc" %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+478: Calculator C++ %glr-parser %locations %defines parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+479: Calculator C++ %glr-parser %no-lines %locations %defines parse.error=verbose %debug api.prefix={calc} %verbose %yacc %parse-param {semantic_value *result} %parse-param {int *count}  ok
+480: Calculator lalr1.d                              skipped (calc.at:900)
+481: Calculator D                                    skipped (calc.at:909)
+482: Calculator D %locations                         skipped (calc.at:910)
+483: Calculator D parse.error=verbose api.prefix={calc} %verbose  skipped (calc.at:912)
+484: Calculator D %debug                             skipped (calc.at:914)
+485: Calculator D parse.error=verbose %debug %verbose  skipped (calc.at:916)
+486: Big triangle                                    ok
+487: Big horizontal                                  ok
+488: State number type: 128 states                   ok
+489: State number type: 129 states                   ok
+490: State number type: 256 states                   ok
+491: State number type: 257 states                   ok
+492: State number type: 32768 states                 ok
+493: State number type: 65536 states                 ok
+494: State number type: 65537 states                 ok
+495: Many lookahead tokens                           ok
+496: Exploding the Stack Size with Alloca            ok
+497: Exploding the Stack Size with Malloc            ok
+498: GNU AWK 3.1.0 Grammar: LALR(1)                  ok
+499: GNU AWK 3.1.0 Grammar: IELR(1)                  ok
+500: GNU AWK 3.1.0 Grammar: Canonical LR(1)          ok
+501: GNU Cim Grammar: LALR(1)                        ok
+502: GNU Cim Grammar: IELR(1)                        ok
+503: GNU Cim Grammar: Canonical LR(1)                ok
+504: GNU pic (Groff 1.18.1) Grammar: LALR(1)         ok
+505: GNU pic (Groff 1.18.1) Grammar: IELR(1)         ok
+506: GNU pic (Groff 1.18.1) Grammar: Canonical LR(1) ok
+507: Trivial grammars                                ok
+508: YYSTYPE typedef                                 ok
+509: Early token definitions with --yacc             ok
+510: Early token definitions without --yacc          ok
+511: Braces parsing                                  ok
+512: Rule Line Numbers                               ok
+513: Mixing %token styles                            ok
+514: Token definitions                               ok
+515: Characters Escapes                              ok
+516: Web2c Report                                    ok
+517: Web2c Actions                                   ok
+518: Dancer                                          ok
+519: Dancer %glr-parser                              ok
+520: Dancer lalr1.cc                                 ok
+521: Expecting two tokens                            ok
+522: Expecting two tokens %glr-parser                ok
+523: Expecting two tokens lalr1.cc                   ok
+524: Braced code in declaration in rules section     ok
+525: String alias declared after use                 ok
+526: Extra lookahead sets in report                  ok
+527: Token number in precedence declaration          ok
+528: parse-gram.y: LALR = IELR                       ok
+529: parse.error=verbose and YYSTACK_USE_ALLOCA      ok
+530: parse.error=verbose overflow                    ok
+531: LAC: Exploratory stack                          ok
+532: LAC: Memory exhaustion                          ok
+533: Lex and parse params: yacc.c                    ok
+534: Lex and parse params: glr.c                     ok
+535: Lex and parse params: lalr1.cc                  ok
+536: Lex and parse params: glr.cc                    ok
+537: stdio.h is not needed                           ok
+538: Memory Leak for Early Deletion                  ok
+539: Multiple impure instances                       ok
+540: Unsupported Skeletons                           ok
+541: C++ Locations Unit Tests                        ok
+542: C++ Variant-based Symbols Unit Tests            ok
+543: Multiple occurrences of $n and api.value.automove ok
+544: Variants lalr1.cc                               ok
+545: Variants lalr1.cc parse.assert                  ok
+546: Variants lalr1.cc parse.assert api.value.automove ok
+547: Variants lalr1.cc parse.assert %locations       ok
+548: Variants lalr1.cc parse.assert %code {\n#define TWO_STAGE_BUILD\n} ok
+549: Variants lalr1.cc parse.assert api.token.constructor ok
+550: Variants lalr1.cc parse.assert api.token.constructor api.token.prefix={TOK_} ok
+551: Variants lalr1.cc parse.assert api.token.constructor api.token.prefix={TOK_} %locations ok
+552: Variants lalr1.cc parse.assert api.token.constructor api.token.prefix={TOK_} %locations api.value.automove ok
+553: Variants and Typed Midrule Actions              ok
+554: Doxygen Public Documentation                    ok
+555: Doxygen Private Documentation                   ok
+556: Relative namespace references                   ok
+557: Absolute namespace references                   ok
+558: Syntactically invalid namespace references      ok
+559: Syntax error discarding no lookahead            ok
+560: Syntax error as exception: lalr1.cc             ok
+561: Syntax error as exception: glr.cc               ok
+562: Exception safety with error recovery            ok
+563: Exception safety without error recovery         ok
+564: Exception safety with error recovery api.value.type=variant ok
+565: Exception safety without error recovery api.value.type=variant ok
+566: C++ GLR parser identifier shadowing             ok
+567: Shared locations                                ok
+568: Default action                                  ok
+569: Java invalid directives                         ok
+570: Calculator                                      ok
+571: Calculator parse.error=verbose                  ok
+572: Calculator %locations                           ok
+573: Calculator parse.error=verbose %locations       ok
+574: Calculator %lex-param { InputStream is }        ok
+575: Calculator parse.error=verbose %lex-param { InputStream is }  ok
+576: Calculator %locations %lex-param { InputStream is }  ok
+577: Calculator parse.error=verbose %locations %lex-param { InputStream is }  ok
+578: Java parser class and package names             ok
+579: Java parser class modifiers                     ok
+580: Java parser class extends and implements        ok
+581: Java %parse-param and %lex-param                ok
+582: Java throws specifications                      ok
+583: Java constructor init and init_throws           ok
+584: Java value, position, and location types        ok
+585: Java syntax error handling without error token  ok
+586: Trivial Push Parser with api.push-pull verification ok
+587: Trivial Push Parser with %initial-action        ok
+588: Calc parser with api.push-pull both             ok
+589: Calc parser with %locations %code lexer and api.push-pull both ok
+590: GLR: Resolve ambiguity, impure, no locations    ok
+591: GLR: Resolve ambiguity, impure, locations       ok
+592: GLR: Resolve ambiguity, pure, no locations      ok
+593: GLR: Resolve ambiguity, pure, locations         ok
+594: GLR: Merge conflicting parses, impure, no locations ok
+595: GLR: Merge conflicting parses, impure, locations ok
+596: GLR: Merge conflicting parses, pure, no locations ok
+597: GLR: Merge conflicting parses, pure, locations  ok
+598: GLR: Verbose messages, resolve ambiguity, impure, no locations ok
+599: Badly Collapsed GLR States                      ok
+600: Improper handling of embedded actions and dollar(-N) in GLR parsers ok
+601: Improper merging of GLR delayed action sets     ok
+602: Duplicate representation of merged trees        ok
+603: User destructor for unresolved GLR semantic value ok
+604: User destructor after an error during a split parse ok
+605: Duplicated user destructor for lookahead        ok
+606: Incorrectly initialized location for empty right-hand side in GLR ok
+607: No users destructors if stack 0 deleted         ok
+608: Corrupted semantic options if user action cuts parse ok
+609: Undesirable destructors if user action cuts parse ok
+610: Leaked semantic values if user action cuts parse ok
+611: Incorrect lookahead during deterministic GLR    ok
+612: Incorrect lookahead during nondeterministic GLR ok
+613: Leaked semantic values when reporting ambiguity ok
+614: Leaked lookahead after nondeterministic parse syntax error ok
+615: Uninitialized location when reporting ambiguity ok
+616: Missed %merge type warnings when LHS type is declared later ok
+617: Ambiguity reports                               ok
+618: Predicates                                      ok
 ## ------------- ##
 ## Test results. ##
 ## ------------- ##
-608 tests were successful.
+610 tests were successful.
 8 tests were skipped.


### PR DESCRIPTION
There are already newer release branches (3.6.x and 3.7) but these need more work than I can dedicate atm.