### PR TITLE
cabextract: update to 1.9.1

### DIFF
--- a/components/archiver/cabextract/Makefile
+++ b/components/archiver/cabextract/Makefile
@@ -13,31 +13,24 @@
 # Copyright 2013, Adam Stevko. All rights reserved.
 #
 
+BUILD_BITS=			64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cabextract
-COMPONENT_VERSION=	1.6
+COMPONENT_VERSION=	1.9.1
 COMPONENT_SUMMARY=	cabextract - extract Microsoft cabinet files
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:cee661b56555350d26943c5e127fc75dd290b7f75689d5ebc1f04957c4af55fb
-COMPONENT_PROJECT_URL=	http://www.cabextract.org.uk/
-COMPONENT_ARCHIVE_URL=	http://www.cabextract.org.uk/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:afc253673c8ef316b4d5c29cc4aa8445844bee14afffbe092ee9469405851ca7
+COMPONENT_PROJECT_URL=	https://www.cabextract.org.uk/
+COMPONENT_ARCHIVE_URL=	https://www.cabextract.org.uk/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	archiver/cabextract
 COMPONENT_CLASSIFICATION=	Applications/Accessories
 COMPONENT_LICENSE=	GPLv3
 COMPONENT_LICENSE_FILE=	COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TAGET=			$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
-CONFIGURE_BINDIR.64=/usr/bin
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(NO_TESTSI)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += system/library


### PR DESCRIPTION
sample-manifest didn't change.
This fixes CVE-2018-18584