### PR TITLE
ocamlbuild: fix publish with already installed ocamlbuild

### DIFF
--- a/components/ocaml/ocamlbuild/Makefile
+++ b/components/ocaml/ocamlbuild/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= ocamlbuild
 COMPONENT_VERSION= 0.14.0
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= ocamlbuild - OCaml build tool
 COMPONENT_PROJECT_URL= https://github.com/ocaml/num
 COMPONENT_FMRI= library/ocaml/ocamlbuild
@@ -37,6 +38,7 @@ PATH=$(PATH.gnu)
 COMPONENT_PRE_CONFIGURE_ACTION  +=  $(CLONEY) $(SOURCE_DIR) $(@D) ;
 
 COMPONENT_BUILD_ARGS+= PREFIX=$(USRDIR) MANDIR=$(USRSHAREMANDIR)
+COMPONENT_INSTALL_ARGS+= CHECK_IF_PREINSTALLED=false
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/ocaml


### PR DESCRIPTION
Publishing with an already installed ocamlbuild fails because of a check in the Makefile:

check-if-preinstalled:
ifeq ($(CHECK_IF_PREINSTALLED), true)
    if test -d $(shell ocamlc -where)/ocamlbuild; then\
      >&2 echo "ERROR: Preinstalled ocamlbuild detected at"\
           "$(shell ocamlc -where)/ocamlbuild";\
      >&2 echo "Installation aborted; if you want to bypass this"\
            "safety check, pass CHECK_IF_PREINSTALLED=false to make";\
      exit 2;\
    fi
endif