### PR TITLE
desktop-file-utils: update to 0.26 and change to 64-bit

### DIFF
--- a/components/desktop/desktop-file-utils/Makefile
+++ b/components/desktop/desktop-file-utils/Makefile
@@ -11,12 +11,15 @@
 #
 # Copyright (c) 2014 Alexander Pyhalov. All rights reserved
 # Copyright (c) 2019 Michal Nowak
+# Copyright (c) 2020 Andreas Wacknitz
 #
 
+BUILD_BITS=			64
+BUILD_STYLE=		meson
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		desktop-file-utils
-COMPONENT_VERSION=	0.24
+COMPONENT_VERSION=	0.26
 COMPONENT_PROJECT_URL=	https://www.freedesktop.org/wiki/Software/desktop-file-utils/
 COMPONENT_SUMMARY=	A few command line utilities for working with desktop entries
 COMPONENT_FMRI=		library/desktop/desktop-file-utils
@@ -24,22 +27,15 @@ COMPONENT_CLASSIFICATION= Desktop (GNOME)/Scripts
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:a1de5da60cbdbe91e5c9c10ac9afee6c3deb019e0cee5fdb9a99dddc245f83d9
-COMPONENT_ARCHIVE_URL=	http://www.freedesktop.org/software/desktop-file-utils/releases/$(COMPONENT_ARCHIVE)
+	sha256:b26dbde79ea72c8c84fb7f9d870ffd857381d049a86d25e0038c4cef4c747309
+COMPONENT_ARCHIVE_URL=	https://www.freedesktop.org/software/desktop-file-utils/releases/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE_FILE= COPYING
 COMPONENT_LICENSE=	GPLv2
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
-
-build:		$(BUILD_32)
-
-install:	$(INSTALL_32)
-
-test:		$(NO_TESTS)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/glib2

--- a/components/desktop/desktop-file-utils/desktop-file-utils.p5m
+++ b/components/desktop/desktop-file-utils/desktop-file-utils.p5m
@@ -1,16 +1,18 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL"). You may
-# only use this file in accordance with the terms of the CDDL.
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 
 #
 # Copyright 2014 Alexander Pyhalov. All rights reserved.
 # Copyright 2019 Michal Nowak
+# Copyright 2020 Andreas Wacknitz
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,8 +28,8 @@ link path=usr/bin/desktop-file-edit target=desktop-file-install
 file path=usr/bin/desktop-file-install
 file path=usr/bin/desktop-file-validate
 file path=usr/bin/update-desktop-database
-#file path=usr/share/emacs/site-lisp/desktop-entry-mode.el
-link path=usr/share/man/man1/desktop-file-edit.1 target=desktop-file-install.1
+file path=usr/share/emacs/site-lisp/desktop-entry-mode.el
+file path=usr/share/man/man1/desktop-file-edit.1
 file path=usr/share/man/man1/desktop-file-install.1
 file path=usr/share/man/man1/desktop-file-validate.1
 file path=usr/share/man/man1/update-desktop-database.1

--- a/components/desktop/desktop-file-utils/manifests/sample-manifest.p5m
+++ b/components/desktop/desktop-file-utils/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,7 +27,7 @@ file path=usr/bin/desktop-file-install
 file path=usr/bin/desktop-file-validate
 file path=usr/bin/update-desktop-database
 file path=usr/share/emacs/site-lisp/desktop-entry-mode.el
-link path=usr/share/man/man1/desktop-file-edit.1 target=desktop-file-install.1
+file path=usr/share/man/man1/desktop-file-edit.1
 file path=usr/share/man/man1/desktop-file-install.1
 file path=usr/share/man/man1/desktop-file-validate.1
 file path=usr/share/man/man1/update-desktop-database.1


### PR DESCRIPTION
I am not sure why Michal didn't want to install the emacs lisp file. As an emacs user I want to have it, though. Of course we don't want to make the package dependant on emacs.