### PR TITLE
sqlite: update to 3.33.0

### DIFF
--- a/components/database/sqlite/Makefile
+++ b/components/database/sqlite/Makefile
@@ -22,17 +22,17 @@
 # Copyright (c) 2020 Michal Nowak
 #
 
-BUILD_BITS=		32_and_64
+BUILD_BITS=			32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		sqlite
-COMPONENT_VERSION=	3.31.1
-TARBALL_VERSION=	3310100
+COMPONENT_VERSION=	3.33.0
+TARBALL_VERSION=	3330000
 COMPONENT_SRC=		sqlite-src-$(TARBALL_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).zip
 COMPONENT_ARCHIVE_HASH	= \
-	sha256:f2dc2382855d99a960c363c1e5ae72b49da4c55d49154aa6d100e5970a1fee58
+	sha256:90bf7604a5aa26deece551af7a665fd4ce3d854ea809899c0e4bb19a69d609b8
 COMPONENT_PROJECT_URL=	https://www.sqlite.org
 COMPONENT_ARCHIVE_URL=	https://www.sqlite.org/2020/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		database/sqlite-3
@@ -88,10 +88,8 @@ COMPONENT_POST_INSTALL_ACTION += $(MKDIR) $(PROTO_DIR)$(USRSHAREMAN1DIR) ; $(CP)
 
 COMPONENT_TEST_TARGETS = test
 
-# Build dependencies
-REQUIRED_PACKAGES += library/libedit
 # Auto-generated dependencies
-REQUIRED_PACKAGES += library/readline
+REQUIRED_PACKAGES += library/libedit
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/database/sqlite/manifests/sample-manifest.p5m
+++ b/components/database/sqlite/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -36,4 +36,6 @@ link path=usr/lib/libsqlite3.so target=libsqlite3.so.0.8.6
 link path=usr/lib/libsqlite3.so.0 target=libsqlite3.so.0.8.6
 file path=usr/lib/libsqlite3.so.0.8.6
 file path=usr/lib/pkgconfig/sqlite3.pc
+file path=usr/lib/tcl8.6/sqlite3/libtclsqlite3.so
+file path=usr/lib/tcl8.6/sqlite3/pkgIndex.tcl
 file path=usr/share/man/man1/sqlite3.1

--- a/components/database/sqlite/pkg5
+++ b/components/database/sqlite/pkg5
@@ -1,9 +1,8 @@
 {
     "dependencies": [
-        "library/libedit",
-        "library/readline",
-        "library/zlib",
         "SUNWcs",
+        "library/libedit",
+        "library/zlib",
         "system/library",
         "system/library/math"
     ],

--- a/components/database/sqlite/sqlite.p5m
+++ b/components/database/sqlite/sqlite.p5m
@@ -44,4 +44,6 @@ link path=usr/lib/libsqlite3.so target=libsqlite3.so.0.8.6
 link path=usr/lib/libsqlite3.so.0 target=libsqlite3.so.0.8.6
 file path=usr/lib/libsqlite3.so.0.8.6
 file path=usr/lib/pkgconfig/sqlite3.pc
+#file path=usr/lib/tcl8.6/sqlite3/libtclsqlite3.so
+#file path=usr/lib/tcl8.6/sqlite3/pkgIndex.tcl
 file path=usr/share/man/man1/sqlite3.1


### PR DESCRIPTION
- All test run fine.
- Installed on my desktop system; yelp works fine
- According to https://abi-laboratory.pro/index.php?view=timeline&l=sqlite fully backwards compatible upt to 3.32.3 (no later data available)
- Dependency on runtime/tcl-8 added as it is mentioned in sqlite's docutmentation as a build dependency
- We don't ship tcl bindings yet, thus I commented them out.