### PR TITLE
unrar: update to 5.91

### DIFF
--- a/components/archiver/unrar/Makefile
+++ b/components/archiver/unrar/Makefile
@@ -23,27 +23,29 @@
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2018, Michal Nowak
 #
-
+BUILD_BITS=				64
+BUILD_STYLE=			justmake
 include ../../../make-rules/shared-macros.mk
 
-PATH=$(SPRO_VROOT)/bin:/usr/bin:/usr/gnu/bin:/usr/sbin
+#PATH=$(SPRO_VROOT)/bin:/usr/bin:/usr/gnu/bin:/usr/sbin
+PATH=$(PATH.gnu)
 
-COMPONENT_NAME=		unrar
-COMPONENT_VERSION=	5.6.8
+COMPONENT_NAME=			unrar
+COMPONENT_VERSION=		5.9.4
+IPS_COMPONENT_VERSION=	5.91
 COMPONENT_SRC=		$(COMPONENT_NAME)
-COMPONENT_SUMMARY=	Rar archives extractor utility
-COMPONENT_PROJECT_URL=	http://www.rarlabs.com/rar_add.htm
+COMPONENT_SUMMARY=		Rar archives extractor utility
+COMPONENT_PROJECT_URL=	https://www.rarlabs.com/rar_add.htm
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)src-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:a4cc0ac14a354827751912d2af4a0a09e2c2129df5766576fa7e151791dd3dff
-COMPONENT_ARCHIVE_URL=	http://www.rarlab.com/rar/$(COMPONENT_ARCHIVE)
+	sha256:3d010d14223e0c7a385ed740e8f046edcbe885e5c22c5ad5733d009596865300
+COMPONENT_ARCHIVE_URL=	https://www.rarlab.com/rar/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	archiver/unrar
 COMPONENT_CLASSIFICATION= Applications/System Utilities
-COMPONENT_LICENSE= UnRAR
+COMPONENT_LICENSE= 		UnRAR
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/justmake.mk
-include $(WS_TOP)/make-rules/ips.mk
+TEST_TARGET:		$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PKG_PROTO_DIRS = $(MANGLED_DIR)
 PKG_PROTO_DIRS += $(BUILD_DIR_64)
@@ -60,14 +62,8 @@ COMPONENT_BUILD_ENV += DEFINES="$(CPP_LARGEFILES)"
 
 COMPONENT_BUILD_ARGS += STRIP="/bin/true"
 
-# common targets
-build:		$(BUILD_64)
-
-install:	$(BUILD_64)
-
-test:		$(NO_TESTS)
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += system/library

--- a/components/archiver/unrar/manifests/sample-manifest.p5m
+++ b/components/archiver/unrar/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,3 +22,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=bin/unrar

--- a/components/archiver/unrar/unrar.1
+++ b/components/archiver/unrar/unrar.1
@@ -29,8 +29,8 @@ unrar \- list, test and extract compressed files from RAR archive
 .B e
 Extract files to current directory
 .TP
-.B l[t|b]
-List archive [technical format, bare format]
+.B l[t[a]|b]
+List archive [technical [all] format, bare format]
 .TP
 .B p
 Print file to stdout
@@ -38,8 +38,8 @@ Print file to stdout
 .B t
 Test archive files
 .TP
-.B v[t|b]
-Verbosely list archive [technical format, bare format]
+.B v[t[a]|b]
+Verbosely list archive [technical [all] format, bare format]
 .TP
 .B x
 Extract files with full path
@@ -49,12 +49,18 @@ Extract files with full path
 .TP
 .B \-
 Stop switches scanning
-.\".TP
-.\".B \-ac
-.\"Clear Archive attribute after compression or extraction
+.TP
+.B \-@[+]
+Disable [enable] file lists
 .TP
 .B \-ad
 Append archive name to destination path
+.TP
+.B \-ag[format]
+Generate archive name using the current date
+.TP
+.B \-ai
+Ignore file attributes
 .TP
 .B \-ap<path>
 Set path inside archive
@@ -91,33 +97,26 @@ Send all messages to stderr
 .TP
 .B \-inul
 Disable all messages
-'\".TP
-'\".B \-isnd
-'\"Enable terminal bell
-.\" .TP
-.\" .B \-ioff
-.\" Turn PC off after completing an operation
-.TP
 .B \-kb
 Keep broken extracted files
 .TP
 .B \-n<file>
-Include only specified file
+Additionally filter included files
 .TP
 .B \-n@
-Read file names to include from stdin
+Read additional filter masks from stdin
 .TP
 .B \-n@<list>
-Include files in specified list file
+Read additional filter masks from list file
 .TP
 .B \-o+
 Overwrite existing files
 .TP
 .B \-o\-
 Do not overwrite existing files
-.\".TP
-.\".B \-oc
-.\"Set NTFS Compressed attribute
+.TP
+.B \-ol[a]
+Process symbolic links as the link [absolute paths]
 .TP
 .B \-or
 Rename files automatically
@@ -134,8 +133,8 @@ Do not query password
 .B \-r
 Recurse subdirectories
 .\".TP
-.\".B \-ri<P>[:<S>]
-.\"Set priority (0\-default,1\-min..15\-max) and sleep time in ms
+.\".B \-sc<chr>[obj]
+.\"Specify the character set
 .TP
 .B \-sl<size>
 Process files with size less than specified

--- a/components/archiver/unrar/unrar.license
+++ b/components/archiver/unrar/unrar.license
@@ -10,13 +10,15 @@
    1. All copyrights to RAR and the utility UnRAR are exclusively
       owned by the author - Alexander Roshal.
 
-   2. The UnRAR sources may be used in any software to handle RAR
-      archives without limitations free of charge, but cannot be used
-      to re-create the RAR compression algorithm, which is proprietary.
-      Distribution of modified UnRAR sources in separate form or as a
-      part of other software is permitted, provided that it is clearly
-      stated in the documentation and source comments that the code may
-      not be used to develop a RAR (WinRAR) compatible archiver.
+   2. UnRAR source code may be used in any software to handle
+      RAR archives without limitations free of charge, but cannot be
+      used to develop RAR (WinRAR) compatible archiver and to
+      re-create RAR compression algorithm, which is proprietary.
+      Distribution of modified UnRAR source code in separate form
+      or as a part of other software is permitted, provided that
+      full text of this paragraph, starting from "UnRAR source code"
+      words, is included in license, or in documentation if license
+      is not available, and in source code comments of resulting package.
 
    3. The UnRAR utility may be freely distributed. It is allowed
       to distribute UnRAR inside of other software packages.
@@ -39,9 +41,18 @@
 
                                             Alexander L. Roshal
 
+
 -----------------------------------------------------------------------------
 
+
                            ACKNOWLEDGMENTS
+
+* We used "Screaming Fast Galois Field Arithmetic Using Intel
+  SIMD Instructions" paper by James S. Plank, Kevin M. Greenan
+  and Ethan L. Miller to improve Reed-Solomon coding performance.
+  Also we are grateful to Artem Drobanov and Bulat Ziganshin
+  for samples and ideas allowed to make Reed-Solomon coding
+  more efficient.
 
 * RAR text compression algorithm is based on Dmitry Shkarin PPMII
   and Dmitry Subbotin carryless rangecoder public domain source code.
@@ -119,6 +130,10 @@
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
     OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
     SUCH DAMAGE.
+
+* RAR archives may optionally include BLAKE2sp hash ( https://blake2.net ),
+  designed by Jean-Philippe Aumasson, Samuel Neves, Zooko Wilcox-O'Hearn
+  and Christian Winnerlein.
 
 * Useful hints provided by Alexander Khoroshev and Bulat Ziganshin allowed
   to significantly improve RAR compression and speed.


### PR DESCRIPTION
- Checked with an example RAR file: unrar t  and unrar e still work with that file.
- The source code version (5.9.4) is different from what the app itself says (5.91). So I set the IPS_COMPONENT_VERSION to what the app itself states.