### PR TITLE
net-snmp: 64-bit fixes, build depends on picl headers

### DIFF
--- a/components/sysutils/net-snmp/Makefile
+++ b/components/sysutils/net-snmp/Makefile
@@ -37,7 +37,7 @@ PATH=$(VPATH):$(PATH.gnu)
 
 COMPONENT_NAME=		net-snmp
 COMPONENT_VERSION=	5.8
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	http://www.net-snmp.org/
 COMPONENT_FMRI= system/management/snmp/net-snmp
 COMPONENT_SRC=    $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -168,3 +168,5 @@ REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += system/management/snmp/net-snmp
 # Bogus dependency due to libssp
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+# Without the picl headers, the build fails on a missing SPARC-specific file.
+REQUIRED_PACKAGES += system/header/header-picl

--- a/components/sysutils/net-snmp/manifests/sample-manifest.p5m
+++ b/components/sysutils/net-snmp/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -202,42 +202,42 @@ file path=etc/net-snmp/snmp/snmpconf-data/snmptrapd-data/logging
 file path=etc/net-snmp/snmp/snmpconf-data/snmptrapd-data/runtime
 file path=etc/net-snmp/snmp/snmpconf-data/snmptrapd-data/snmpconf-config
 file path=etc/net-snmp/snmp/snmpconf-data/snmptrapd-data/traphandle
-file path=usr/bin/agentxtrap
-file path=usr/bin/checkbandwidth
-file path=usr/bin/encode_keychange
-file path=usr/bin/fixproc
-file path=usr/bin/ipf-mod.pl
-file path=usr/bin/mib2c
-file path=usr/bin/mib2c-update
-file path=usr/bin/net-snmp-cert
-file path=usr/bin/net-snmp-config
-file path=usr/bin/net-snmp-create-v3-user
-file path=usr/bin/snmp-bridge-mib
-file path=usr/bin/snmpbulkget
-file path=usr/bin/snmpbulkwalk
-file path=usr/bin/snmpcheck
-file path=usr/bin/snmpconf
-file path=usr/bin/snmpdelta
-file path=usr/bin/snmpdf
-file path=usr/bin/snmpget
-file path=usr/bin/snmpgetnext
-link path=usr/bin/snmpinform target=snmptrap
-file path=usr/bin/snmpnetstat
-file path=usr/bin/snmppcap
-file path=usr/bin/snmpping
-file path=usr/bin/snmpps
-file path=usr/bin/snmpset
-file path=usr/bin/snmpstatus
-file path=usr/bin/snmptable
-file path=usr/bin/snmptest
-link path=usr/bin/snmptop target=snmpps
-file path=usr/bin/snmptranslate
-file path=usr/bin/snmptrap
-file path=usr/bin/snmpusm
-file path=usr/bin/snmpvacm
-file path=usr/bin/snmpwalk
-file path=usr/bin/tkmib
-file path=usr/bin/traptoemail
+file path=usr/bin/$(MACH32)/agentxtrap
+file path=usr/bin/$(MACH32)/checkbandwidth
+file path=usr/bin/$(MACH32)/encode_keychange
+file path=usr/bin/$(MACH32)/fixproc
+file path=usr/bin/$(MACH32)/ipf-mod.pl
+file path=usr/bin/$(MACH32)/mib2c
+file path=usr/bin/$(MACH32)/mib2c-update
+file path=usr/bin/$(MACH32)/net-snmp-cert
+file path=usr/bin/$(MACH32)/net-snmp-config
+file path=usr/bin/$(MACH32)/net-snmp-create-v3-user
+file path=usr/bin/$(MACH32)/snmp-bridge-mib
+file path=usr/bin/$(MACH32)/snmpbulkget
+file path=usr/bin/$(MACH32)/snmpbulkwalk
+file path=usr/bin/$(MACH32)/snmpcheck
+file path=usr/bin/$(MACH32)/snmpconf
+file path=usr/bin/$(MACH32)/snmpdelta
+file path=usr/bin/$(MACH32)/snmpdf
+file path=usr/bin/$(MACH32)/snmpget
+file path=usr/bin/$(MACH32)/snmpgetnext
+link path=usr/bin/$(MACH32)/snmpinform target=snmptrap
+file path=usr/bin/$(MACH32)/snmpnetstat
+file path=usr/bin/$(MACH32)/snmppcap
+file path=usr/bin/$(MACH32)/snmpping
+file path=usr/bin/$(MACH32)/snmpps
+file path=usr/bin/$(MACH32)/snmpset
+file path=usr/bin/$(MACH32)/snmpstatus
+file path=usr/bin/$(MACH32)/snmptable
+file path=usr/bin/$(MACH32)/snmptest
+link path=usr/bin/$(MACH32)/snmptop target=snmpps
+file path=usr/bin/$(MACH32)/snmptranslate
+file path=usr/bin/$(MACH32)/snmptrap
+file path=usr/bin/$(MACH32)/snmpusm
+file path=usr/bin/$(MACH32)/snmpvacm
+file path=usr/bin/$(MACH32)/snmpwalk
+file path=usr/bin/$(MACH32)/tkmib
+file path=usr/bin/$(MACH32)/traptoemail
 file path=usr/include/net-snmp/agent/agent_callbacks.h
 file path=usr/include/net-snmp/agent/agent_handler.h
 file path=usr/include/net-snmp/agent/agent_index.h
@@ -507,8 +507,8 @@ file path=usr/lib/python2.7/vendor-packages/netsnmp_python-1.0a1-py2.7.egg-info/
 file path=usr/lib/python2.7/vendor-packages/netsnmp_python-1.0a1-py2.7.egg-info/SOURCES.txt
 file path=usr/lib/python2.7/vendor-packages/netsnmp_python-1.0a1-py2.7.egg-info/dependency_links.txt
 file path=usr/lib/python2.7/vendor-packages/netsnmp_python-1.0a1-py2.7.egg-info/top_level.txt
-file path=usr/sbin/snmpd
-file path=usr/sbin/snmptrapd
+file path=usr/sbin/$(MACH32)/snmpd
+file path=usr/sbin/$(MACH32)/snmptrapd
 file path=usr/share/man/man1/agentxtrap.1
 file path=usr/share/man/man1/encode_keychange.1
 file path=usr/share/man/man1/fixproc.1

--- a/components/sysutils/net-snmp/net-snmp-base.p5m
+++ b/components/sysutils/net-snmp/net-snmp-base.p5m
@@ -363,64 +363,65 @@ file local/snmpconf.dir/snmptrapd-data/snmpconf-config \
 file local/snmpconf.dir/snmptrapd-data/traphandle \
     path=etc/net-snmp/snmp/snmpconf-data/snmptrapd-data/traphandle
 
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/agentxtrap \
+file build/prototype/$(MACH64)/usr/bin/agentxtrap \
     path=usr/bin/agentxtrap
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/checkbandwidth \
+file build/prototype/$(MACH64)/usr/bin/checkbandwidth \
     path=usr/bin/checkbandwidth
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/encode_keychange \
+file build/prototype/$(MACH64)/usr/bin/encode_keychange \
     path=usr/bin/encode_keychange
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/fixproc path=usr/bin/fixproc
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/ipf-mod.pl \
+file build/prototype/$(MACH64)/usr/bin/fixproc path=usr/bin/fixproc
+file build/prototype/$(MACH64)/usr/bin/ipf-mod.pl \
     path=usr/bin/ipf-mod.pl
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/mib2c path=usr/bin/mib2c
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/mib2c-update \
+file build/prototype/$(MACH64)/usr/bin/mib2c path=usr/bin/mib2c
+file build/prototype/$(MACH64)/usr/bin/mib2c-update \
     path=usr/bin/mib2c-update
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/net-snmp-cert \
+file build/prototype/$(MACH64)/usr/bin/net-snmp-cert \
 		path=usr/bin/net-snmp-cert mode=0555
 
 file path=usr/bin/net-snmp-config
-file path=usr/bin/$(MACH64)/net-snmp-config
+file build/prototype/$(MACH64)/usr/bin/net-snmp-config \
+		path=usr/bin/$(MACH64)/net-snmp-config
 link path=usr/bin/net-snmp-config-32 target=net-snmp-config pkg.linted=true
 link path=usr/bin/net-snmp-config-64 target=$(MACH64)/net-snmp-config pkg.linted=true
 
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/net-snmp-create-v3-user \
+file build/prototype/$(MACH64)/usr/bin/net-snmp-create-v3-user \
     path=usr/bin/net-snmp-create-v3-user
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmp-bridge-mib \
+file build/prototype/$(MACH64)/usr/bin/snmp-bridge-mib \
     path=usr/bin/snmp-bridge-mib mode=0555
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpbulkget \
+file build/prototype/$(MACH64)/usr/bin/snmpbulkget \
     path=usr/bin/snmpbulkget
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpbulkwalk \
+file build/prototype/$(MACH64)/usr/bin/snmpbulkwalk \
     path=usr/bin/snmpbulkwalk
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpcheck \
+file build/prototype/$(MACH64)/usr/bin/snmpcheck \
     path=usr/bin/snmpcheck
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpconf path=usr/bin/snmpconf
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpdelta \
+file build/prototype/$(MACH64)/usr/bin/snmpconf path=usr/bin/snmpconf
+file build/prototype/$(MACH64)/usr/bin/snmpdelta \
     path=usr/bin/snmpdelta
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpdf path=usr/bin/snmpdf
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpget path=usr/bin/snmpget
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpgetnext \
+file build/prototype/$(MACH64)/usr/bin/snmpdf path=usr/bin/snmpdf
+file build/prototype/$(MACH64)/usr/bin/snmpget path=usr/bin/snmpget
+file build/prototype/$(MACH64)/usr/bin/snmpgetnext \
     path=usr/bin/snmpgetnext
 link path=usr/bin/snmpinform target=snmptrap
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpnetstat \
+file build/prototype/$(MACH64)/usr/bin/snmpnetstat \
     path=usr/bin/snmpnetstat
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmppcap path=usr/bin/snmppcap
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpping path=usr/bin/snmpping
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpps path=usr/bin/snmpps
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpset path=usr/bin/snmpset
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpstatus \
+file build/prototype/$(MACH64)/usr/bin/snmppcap path=usr/bin/snmppcap
+file build/prototype/$(MACH64)/usr/bin/snmpping path=usr/bin/snmpping
+file build/prototype/$(MACH64)/usr/bin/snmpps path=usr/bin/snmpps
+file build/prototype/$(MACH64)/usr/bin/snmpset path=usr/bin/snmpset
+file build/prototype/$(MACH64)/usr/bin/snmpstatus \
     path=usr/bin/snmpstatus
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmptable \
+file build/prototype/$(MACH64)/usr/bin/snmptable \
     path=usr/bin/snmptable
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmptest path=usr/bin/snmptest
+file build/prototype/$(MACH64)/usr/bin/snmptest path=usr/bin/snmptest
 link path=usr/bin/snmptop target=snmpps
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmptranslate \
+file build/prototype/$(MACH64)/usr/bin/snmptranslate \
     path=usr/bin/snmptranslate
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmptrap path=usr/bin/snmptrap
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpusm path=usr/bin/snmpusm
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpvacm path=usr/bin/snmpvacm
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/snmpwalk path=usr/bin/snmpwalk
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/tkmib path=usr/bin/tkmib
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/traptoemail \
+file build/prototype/$(MACH64)/usr/bin/snmptrap path=usr/bin/snmptrap
+file build/prototype/$(MACH64)/usr/bin/snmpusm path=usr/bin/snmpusm
+file build/prototype/$(MACH64)/usr/bin/snmpvacm path=usr/bin/snmpvacm
+file build/prototype/$(MACH64)/usr/bin/snmpwalk path=usr/bin/snmpwalk
+file build/prototype/$(MACH64)/usr/bin/tkmib path=usr/bin/tkmib
+file build/prototype/$(MACH64)/usr/bin/traptoemail \
     path=usr/bin/traptoemail
 
 file path=usr/include/net-snmp/agent/agent_callbacks.h
@@ -656,7 +657,7 @@ file path=usr/include/ucd-snmp/util_funcs.h
 file path=usr/include/ucd-snmp/var_struct.h
 file path=usr/include/ucd-snmp/version.h
 
-file build/prototype/$(MACH64)/usr/bin/$(MACH64)/agentxtrap \
+file build/prototype/$(MACH64)/usr/bin/agentxtrap \
     path=usr/lib/$(MACH64)/agentxtrap
 file $(MACH64)/sun/agent/modules/entityMib/libentity.so \
     path=usr/lib/$(MACH64)/libentity.so
@@ -741,8 +742,8 @@ file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/NetSNMP/defaul
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/SNMP/SNMP.so
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/SNMP/autosplit.ix
 
-file build/prototype/$(MACH64)/usr/sbin/$(MACH64)/snmpd path=usr/sbin/snmpd
-file build/prototype/$(MACH64)/usr/sbin/$(MACH64)/snmptrapd \
+file build/prototype/$(MACH64)/usr/sbin/snmpd path=usr/sbin/snmpd
+file build/prototype/$(MACH64)/usr/sbin/snmptrapd \
     path=usr/sbin/snmptrapd
 
 file build/$(MACH32)/docs/html/agent__callbacks_8h_source.html \

--- a/components/sysutils/net-snmp/pkg5
+++ b/components/sysutils/net-snmp/pkg5
@@ -6,6 +6,7 @@
         "runtime/python-27",
         "service/picl",
         "SUNWcs",
+        "system/header/header-picl",
         "system/library",
         "system/library/g++-7-runtime",
         "system/library/gcc-7-runtime",


### PR DESCRIPTION
I was trying to build the `net-snmp` package by doing, effectively:

```
$ cd /ws/oi-userland/components/sysutils/net-snmp
$ gmake publish
```

First, the build failed because I had not installed the PICL headers; the actual failure mentions a SPARC platform-specific header that of course isn't on my x86 host -- but the cause ends up being that it did not detect the right PICL header during the configure process.

Second, the packaging step appeared to fail because (and I am still new to this bit) it seems like the default posture for binary directories has flipped in the last few months.  We are now defaulting 64-bit binaries (where 32- and 64-bit binaries are both built) into `/usr/bin` instead of `/usr/bin/$MACH`, so the manifest doesn't know where to find them.

I also ran `gmake update-metadata` in this directory to fix the `pkg5` file.  Let me know if I missed anything!

Cheers.