### PR TITLE
python/more-itertools: fix typo in Makefile

### DIFF
--- a/components/python/more-itertools/Makefile
+++ b/components/python/more-itertools/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		more-itertools
 COMPONENT_VERSION=	4.3.0
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	'more-itertools - More routines for operating on iterables'
 COMPONENT_PROJECT_URL=	https://pypi.org/project/more-itertools/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -29,7 +29,7 @@ COMPONENT_CLASSIFICATION=	Development/Python
 COMPONENT_LICENSE=	MIT
 COMPONENT_LICENSE_FILE=	LICENSE
 
-7PYTHON_VERSIONS=	2.7 3.5
+PYTHON_VERSIONS=	2.7 3.5
 
 include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/setup.py.mk


### PR DESCRIPTION
Correct a small typo in the Makefile.  Without this, I was missing a package for whichever of the two versions is not the default.