### PR TITLE
python/cherrypy: build depends on setuptools-scm

### DIFF
--- a/components/python/cherrypy/Makefile
+++ b/components/python/cherrypy/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		CherryPy
 # This is the last version with Python 2.7 support
 COMPONENT_VERSION=	17.3.0
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	'Pythonic, object-oriented HTTP framework'
 COMPONENT_PROJECT_URL=	http://www.cherrypy.org/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -59,7 +59,9 @@ REQUIRED_PACKAGES += library/python/nose-35
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/python/setuptools-27
+REQUIRED_PACKAGES += library/python/setuptools_scm-27
 REQUIRED_PACKAGES += library/python/setuptools-35
+REQUIRED_PACKAGES += library/python/setuptools_scm-35
 REQUIRED_PACKAGES += library/python/six-27
 REQUIRED_PACKAGES += library/python/six-35
 REQUIRED_PACKAGES += runtime/python-27

--- a/components/python/cherrypy/pkg5
+++ b/components/python/cherrypy/pkg5
@@ -2,14 +2,15 @@
     "dependencies": [
         "library/python/nose-27",
         "library/python/nose-35",
+        "library/python/setuptools_scm-27",
+        "library/python/setuptools_scm-35",
         "library/python/setuptools-27",
         "library/python/setuptools-35",
         "library/python/six-27",
         "library/python/six-35",
         "runtime/python-27",
         "runtime/python-35",
-        "SUNWcs",
-        "system/library"
+        "SUNWcs"
     ],
     "fmris": [
         "library/python/cherrypy-27",


### PR DESCRIPTION
I was using the (relatively?) new `userland-zone` tool to set up a build zone that was isolated from the network.  I noticed that the build for cherrypy was trying to download additional Python modules from the Internet.

With these added dependencies, the build then proceeds correctly in the isolated zone.