### PR TITLE
developer/gcc49: need prior GCC 4.9 installed to build

### DIFF
--- a/components/developer/gcc49/Makefile
+++ b/components/developer/gcc49/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gcc
 COMPONENT_VERSION= 4.9.4
-COMPONENT_REVISION=6
+COMPONENT_REVISION= 7
 MPFR_NAME= mpfr
 MPFR_VERSION=3.1.3
 MPC_NAME=mpc
@@ -128,3 +128,5 @@ REQUIRED_PACKAGES += system/library/gcc-4-runtime
 REQUIRED_PACKAGES += system/library/gfortran-4-runtime
 REQUIRED_PACKAGES += system/library/gobjc-4-runtime
 REQUIRED_PACKAGES += system/library/math
+# GCC builds with itself:
+REQUIRED_PACKAGES += developer/gcc-49


### PR DESCRIPTION
Using an isolated (`userland-zone`) build zone, without most packages installed, I noticed that the GCC 4.9 build would fail without having GCC 4.9 installed already.