### PR TITLE
libmusicbrainz-5: fix build with newer cmake

### DIFF
--- a/components/library/libmusicbrainz-5/Makefile
+++ b/components/library/libmusicbrainz-5/Makefile
@@ -14,11 +14,13 @@
 # Copyright 2019 Nona Hansel
 #
 
+BUILD_BITS=			32_and_64
+BUILD_STYLE=		cmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmusicbrainz
 COMPONENT_VERSION=	5.1.0
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	Software library for accessing MusicBrainz servers
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -32,24 +34,16 @@ COMPONENT_FMRI=		library/musicbrainz/libmusicbrainz-5
 COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	COPYING.txt
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/cmake.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CMAKE_OPTIONS += -DCMAKE_BUILD_TYPE=Release
 CMAKE_OPTIONS += -DCMAKE_VERBOSE_MAKEFILE=1
 
 CMAKE_OPTIONS.64 += -DLIB_SUFFIX=/$(MACH64)
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
-test: $(TEST_32_and_64)
-
 # Auto-generated dependencies
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += library/libxml2
 REQUIRED_PACKAGES += library/neon
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)

--- a/components/library/libmusicbrainz-5/patches/01-replace-wildcard-depends.patch
+++ b/components/library/libmusicbrainz-5/patches/01-replace-wildcard-depends.patch
@@ -1,0 +1,17 @@
+Newer cmake version fail with wildcard dependencies here.
+This has been taken from upstream where
+https://github.com/metabrainz/libmusicbrainz/commit/8be45b12a86bc0e46f2f836c8ac88e1e98d82aee
+has been integrated but no new release has been published since its integration.
+ 
+--- libmusicbrainz-5.1.0/src/CMakeLists.txt.orig	2014-11-13 14:12:24.000000000 +0000
++++ libmusicbrainz-5.1.0/src/CMakeLists.txt	2020-08-25 17:50:20.951200565 +0000
+@@ -36,7 +36,8 @@
+ 	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mb5_c.cc ${CMAKE_CURRENT_BINARY_DIR}/mb5_c.h ${CMAKE_CURRENT_BINARY_DIR}/../include/musicbrainz5/mb5_c.h
+ 	COMMAND make-c-interface ${CMAKE_CURRENT_SOURCE_DIR} cinterface.xml ${CMAKE_CURRENT_BINARY_DIR} mb5_c.cc mb5_c.h
+ 	COMMAND ${CMAKE_COMMAND} -E copy_if_different 	${CMAKE_CURRENT_BINARY_DIR}/mb5_c.h ${CMAKE_CURRENT_BINARY_DIR}/../include/musicbrainz5/mb5_c.h
+-	DEPENDS make-c-interface cinterface.xml *.inc
++    DEPENDS make-c-interface cinterface.xml c-int-medium-defines.inc c-int-query-source.inc c-int-source-funcs.inc
++        c-int-medium-source.inc c-int-release-defines.inc c-int-query-defines.inc c-int-release-source.inc
+ )
+ 
+ ADD_CUSTOM_TARGET(src_gen DEPENDS mb5_c.h)

--- a/components/library/libmusicbrainz-5/pkg5
+++ b/components/library/libmusicbrainz-5/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
+        "SUNWcs",
         "library/libxml2",
         "library/neon",
-        "SUNWcs",
         "system/library",
         "system/library/g++-7-runtime",
         "system/library/gcc-7-runtime"


### PR DESCRIPTION
Newer cmake versions need this patch. It is already integrated upstream but there is no new version yet.