### PR TITLE
libmicrohttpd: update to 0.9.71

### DIFF
--- a/components/library/libmicrohttpd/Makefile
+++ b/components/library/libmicrohttpd/Makefile
@@ -18,16 +18,15 @@ BUILD_BITS=		32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmicrohttpd
-COMPONENT_VERSION=	0.9.69
-COMPONENT_REVISION=	1
-COMPONENT_PROJECT_URL=	http://www.gnu.org/software/libmicrohttpd/
+COMPONENT_VERSION=	0.9.71
+COMPONENT_PROJECT_URL=	https://www.gnu.org/software/libmicrohttpd/
 COMPONENT_FMRI=		library/libmicrohttpd
 COMPONENT_SUMMARY=	GNU libmicrohttpd is a small HTTP server as a C library
 COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:fb9b6b148b787493e637d3083588711e65cbcb726fa02cee2cd543c5de27e37e
+	sha256:e8f445e85faf727b89e9f9590daea4473ae00ead38b237cf1eda55172b89b182
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_SIG_URL=	http://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE).sig
 COMPONENT_LICENSE=	LGPL2.1+

--- a/components/library/libmicrohttpd/libmicrohttpd.p5m
+++ b/components/library/libmicrohttpd/libmicrohttpd.p5m
@@ -24,13 +24,13 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/microhttpd.h
-link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.55.0
-link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.55.0
-file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.55.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.56.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.56.0
+file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.56.0
 file path=usr/lib/$(MACH64)/pkgconfig/libmicrohttpd.pc
-link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.55.0
-link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.55.0
-file path=usr/lib/libmicrohttpd.so.12.55.0
+link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.56.0
+link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.56.0
+file path=usr/lib/libmicrohttpd.so.12.56.0
 file path=usr/lib/pkgconfig/libmicrohttpd.pc
 #file path=usr/share/info/dir
 file path=usr/share/info/libmicrohttpd-tutorial.info

--- a/components/library/libmicrohttpd/manifests/sample-manifest.p5m
+++ b/components/library/libmicrohttpd/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,13 +23,13 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/microhttpd.h
-link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.55.0
-link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.55.0
-file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.55.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so target=libmicrohttpd.so.12.56.0
+link path=usr/lib/$(MACH64)/libmicrohttpd.so.12 target=libmicrohttpd.so.12.56.0
+file path=usr/lib/$(MACH64)/libmicrohttpd.so.12.56.0
 file path=usr/lib/$(MACH64)/pkgconfig/libmicrohttpd.pc
-link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.55.0
-link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.55.0
-file path=usr/lib/libmicrohttpd.so.12.55.0
+link path=usr/lib/libmicrohttpd.so target=libmicrohttpd.so.12.56.0
+link path=usr/lib/libmicrohttpd.so.12 target=libmicrohttpd.so.12.56.0
+file path=usr/lib/libmicrohttpd.so.12.56.0
 file path=usr/lib/pkgconfig/libmicrohttpd.pc
 file path=usr/share/info/dir
 file path=usr/share/info/libmicrohttpd-tutorial.info

--- a/components/library/libmicrohttpd/pkg5
+++ b/components/library/libmicrohttpd/pkg5
@@ -1,7 +1,7 @@
 {
     "dependencies": [
-        "library/gnutls-3",
         "SUNWcs",
+        "library/gnutls-3",
         "system/library",
         "system/library/security/libgcrypt"
     ],


### PR DESCRIPTION
- According to https://abi-laboratory.pro/index.php?view=timeline&l=libmicrohttpd the new version is fully backwards compatible.
- Alas some tests fail (no change compared to our actual version).
