### PR TITLE
keepassx: make it 64-bit

### DIFF
--- a/components/desktop/keepassx/Makefile
+++ b/components/desktop/keepassx/Makefile
@@ -13,13 +13,13 @@
 # Copyright 2019 Andreas Wacknitz <a.wacknitz@gmx.de>
 #
 
-BUILD_BITS=			32
+BUILD_BITS=			64
 BUILD_STYLE=		cmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		keepassx
 COMPONENT_VERSION=	2.0.3
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	https://www.keepassx.org/
 COMPONENT_FMRI=		desktop/keepassx
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/desktop/keepassx/keepassx.p5m
+++ b/components/desktop/keepassx/keepassx.p5m
@@ -23,7 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/keepassx
-file path=usr/lib/keepassx/libkeepassx-autotype-x11.so
+file path=usr/lib/$(MACH64)/keepassx/libkeepassx-autotype-x11.so
 file path=usr/share/applications/keepassx.desktop
 file path=usr/share/icons/hicolor/128x128/apps/keepassx.png
 file path=usr/share/icons/hicolor/128x128/mimetypes/application-x-keepassx.png

--- a/components/desktop/keepassx/manifests/sample-manifest.p5m
+++ b/components/desktop/keepassx/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,7 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/keepassx
-file path=usr/lib/keepassx/libkeepassx-autotype-x11.so
+file path=usr/lib/$(MACH64)/keepassx/libkeepassx-autotype-x11.so
 file path=usr/share/applications/keepassx.desktop
 file path=usr/share/icons/hicolor/128x128/apps/keepassx.png
 file path=usr/share/icons/hicolor/128x128/mimetypes/application-x-keepassx.png

--- a/components/desktop/keepassx/pkg5
+++ b/components/desktop/keepassx/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
+        "SUNWcs",
         "library/qt4",
         "library/zlib",
-        "SUNWcs",
         "system/library",
         "system/library/g++-7-runtime",
         "system/library/gcc-7-runtime",


### PR DESCRIPTION
Changing to 64-bit fixes a warning:
The plugin '/usr/lib/keepassx/libkeepassx-autotype-x11.so' uses incompatible Qt library. Expected build key "i386 solaris g++-4 full-config", got "x86_64 solaris g++-4 full-config"