### PR TITLE
libgcrypt: update to 1.8.6

### DIFF
--- a/components/library/libgcrypt/Makefile
+++ b/components/library/libgcrypt/Makefile
@@ -27,14 +27,14 @@ BUILD_BITS=		32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libgcrypt
-COMPONENT_VERSION=	1.8.5
+COMPONENT_VERSION=	1.8.6
 COMPONENT_FMRI=		system/library/security/libgcrypt
 COMPONENT_SUMMARY=	GnuPG libgcrypt library
-COMPONENT_PROJECT_URL=	http://www.gnu.org/software/libgcrypt/
+COMPONENT_PROJECT_URL=	https://www.gnu.org/software/libgcrypt/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3
+	sha256:0cba2700617b99fc33864a0c16b1fa7fdf9781d9ed3509f5d767178e5fd7b975
 COMPONENT_ARCHIVE_URL=	ftp://ftp.gnupg.org/gcrypt/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_CLASSIFICATION= System/Security
 COMPONENT_LICENSE=	LGPL, BSD, BSD-like

--- a/components/library/libgcrypt/libgcrypt.p5m
+++ b/components/library/libgcrypt/libgcrypt.p5m
@@ -32,13 +32,13 @@ file path=usr/bin/hmac256
 file path=usr/bin/libgcrypt-config
 file path=usr/bin/mpicalc
 file path=usr/include/gcrypt.h
-link path=usr/lib/$(MACH64)/libgcrypt.so target=libgcrypt.so.20.2.5
-link path=usr/lib/$(MACH64)/libgcrypt.so.20 target=libgcrypt.so.20.2.5
-file path=usr/lib/$(MACH64)/libgcrypt.so.20.2.5
+link path=usr/lib/$(MACH64)/libgcrypt.so target=libgcrypt.so.20.2.6
+link path=usr/lib/$(MACH64)/libgcrypt.so.20 target=libgcrypt.so.20.2.6
+file path=usr/lib/$(MACH64)/libgcrypt.so.20.2.6
 file path=usr/lib/$(MACH64)/pkgconfig/libgcrypt.pc
-link path=usr/lib/libgcrypt.so target=libgcrypt.so.20.2.5
-link path=usr/lib/libgcrypt.so.20 target=libgcrypt.so.20.2.5
-file path=usr/lib/libgcrypt.so.20.2.5
+link path=usr/lib/libgcrypt.so target=libgcrypt.so.20.2.6
+link path=usr/lib/libgcrypt.so.20 target=libgcrypt.so.20.2.6
+file path=usr/lib/libgcrypt.so.20.2.6
 file path=usr/lib/pkgconfig/libgcrypt.pc
 file path=usr/share/aclocal/libgcrypt.m4
 #file path=usr/share/info/dir

--- a/components/library/libgcrypt/manifests/sample-manifest.p5m
+++ b/components/library/libgcrypt/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -31,13 +31,13 @@ file path=usr/bin/hmac256
 file path=usr/bin/libgcrypt-config
 file path=usr/bin/mpicalc
 file path=usr/include/gcrypt.h
-link path=usr/lib/$(MACH64)/libgcrypt.so target=libgcrypt.so.20.2.5
-link path=usr/lib/$(MACH64)/libgcrypt.so.20 target=libgcrypt.so.20.2.5
-file path=usr/lib/$(MACH64)/libgcrypt.so.20.2.5
+link path=usr/lib/$(MACH64)/libgcrypt.so target=libgcrypt.so.20.2.6
+link path=usr/lib/$(MACH64)/libgcrypt.so.20 target=libgcrypt.so.20.2.6
+file path=usr/lib/$(MACH64)/libgcrypt.so.20.2.6
 file path=usr/lib/$(MACH64)/pkgconfig/libgcrypt.pc
-link path=usr/lib/libgcrypt.so target=libgcrypt.so.20.2.5
-link path=usr/lib/libgcrypt.so.20 target=libgcrypt.so.20.2.5
-file path=usr/lib/libgcrypt.so.20.2.5
+link path=usr/lib/libgcrypt.so target=libgcrypt.so.20.2.6
+link path=usr/lib/libgcrypt.so.20 target=libgcrypt.so.20.2.6
+file path=usr/lib/libgcrypt.so.20.2.6
 file path=usr/lib/pkgconfig/libgcrypt.pc
 file path=usr/share/aclocal/libgcrypt.m4
 file path=usr/share/info/dir

--- a/components/library/libgcrypt/pkg5
+++ b/components/library/libgcrypt/pkg5
@@ -1,7 +1,7 @@
 {
     "dependencies": [
-        "library/security/libgpg-error",
         "SUNWcs",
+        "library/security/libgpg-error",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
- Tests are still fine
- lightdm, remmina and keepassx still work after the update (haven't done tests, though)