### PR TITLE
gnupg: update to 2.2.22

### DIFF
--- a/components/sysutils/gnupg/Makefile
+++ b/components/sysutils/gnupg/Makefile
@@ -28,13 +28,12 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnupg
-COMPONENT_VERSION=	2.2.19
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	2.2.22
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_PROJECT_URL=	http://www.gnupg.org/
+COMPONENT_PROJECT_URL=	https://www.gnupg.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:242554c0e06f3a83c420b052f750b65ead711cc3fddddb5e7274fcdbb4e9dec0
+	sha256:7c1370565e1910b9d8c4e0fb57b9de34aa062ec7bb91abad5803d791f38d855b
 COMPONENT_ARCHIVE_URL=	ftp://ftp.gnupg.org/gcrypt/gnupg/$(COMPONENT_ARCHIVE)
 
 include $(WS_MAKE_RULES)/common.mk
@@ -95,6 +94,7 @@ REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/libsecret
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += compress/bzip2
 REQUIRED_PACKAGES += database/sqlite-3
 REQUIRED_PACKAGES += library/gnutls-3
@@ -107,6 +107,5 @@ REQUIRED_PACKAGES += library/security/libgpg-error
 REQUIRED_PACKAGES += library/security/libksba
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += security/pinentry
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/security/libgcrypt

--- a/components/sysutils/gnupg/gnupg.p5m
+++ b/components/sysutils/gnupg/gnupg.p5m
@@ -53,6 +53,7 @@ file path=usr/bin/gpgconf
 file path=usr/bin/gpgparsemail
 file path=usr/bin/gpgscm
 file path=usr/bin/gpgsm
+file path=usr/bin/gpgsplit
 file path=usr/bin/gpgtar
 file path=usr/bin/gpgv2
 file path=usr/bin/kbxutil

--- a/components/sysutils/gnupg/manifests/sample-manifest.p5m
+++ b/components/sysutils/gnupg/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -37,6 +37,7 @@ file path=usr/bin/gpgconf
 file path=usr/bin/gpgparsemail
 file path=usr/bin/gpgscm
 file path=usr/bin/gpgsm
+file path=usr/bin/gpgsplit
 file path=usr/bin/gpgtar
 file path=usr/bin/gpgv2
 file path=usr/bin/kbxutil

--- a/components/sysutils/gnupg/pkg5
+++ b/components/sysutils/gnupg/pkg5
@@ -1,5 +1,6 @@
 {
     "dependencies": [
+        "SUNWcs",
         "compress/bzip2",
         "database/sqlite-3",
         "library/desktop/gtk2",
@@ -15,7 +16,6 @@
         "library/security/libksba",
         "library/zlib",
         "security/pinentry",
-        "SUNWcs",
         "system/library",
         "system/library/security/libgcrypt"
     ],


### PR DESCRIPTION
While testing this update I encountered some problems with our existing version 2.2.19. The problems are probably not in this package but in pinentry and libassuan:
1. Running gpg2 --gen-key in a non-X11 environment brings an unreadable passphrase dialog (black on black) regardless of the screen colors.
2. Running gpg2 --gen-key ends in an endless loop (asking for entropy data):
The stack looks always like this:
╰─➤  pstack `pgrep gpg2`
12900:	gpg2 --gen-key
 fffffc7fef21c60a read     (4, bfd890, 3ea)
 fffffc7feed2ab4f _assuan_read_line () + 6f
 fffffc7feed2a3a0 assuan_client_read_response () + 30
 fffffc7feed2a70d _assuan_read_from_server () + 4d
 fffffc7feed2a818 assuan_transact () + b8
 00000000004b9eb8 agent_genkey () + 188
 000000000049f699 common_gen () + 49
 000000000049fcb8 do_create () + 248
 00000000004a698b proc_parameter_file () + d1b
 00000000004a9c83 generate_keypair () + f53
 000000000043713d main () + 5ebd
 000000000042f973 _start_crt () + 83
 000000000042f8d8 _start () + 18