### PR TITLE
Update GTK3 to 3.24.23

### DIFF
--- a/components/library/gtk+3/Makefile
+++ b/components/library/gtk+3/Makefile
@@ -12,6 +12,7 @@
 #
 # Copyright 2017 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
+# Copyright 2020 Marco van Wieringen
 #
 
 BUILD_BITS=		32_and_64
@@ -19,15 +20,14 @@ BUILD_BITS=		32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gtk+
-COMPONENT_VERSION=	3.24.12
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	3.24.23
 COMPONENT_SUMMARY=	GTK+ - GIMP Toolkit Library for creation of graphical user interfaces
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:1384eba5614fed160044ae0d32369e3df7b4f517b03f4b1f24d383e528f4be83
+	sha256:5d864d248357a2251545b3387b35942de5f66e4c66013f0962eb5cb6f8dae2b1
 COMPONENT_ARCHIVE_URL= \
-	http://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/3.24/$(COMPONENT_ARCHIVE)
+	https://ftp.gnome.org/pub/GNOME/sources/$(COMPONENT_NAME)/3.24/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://www.gtk.org/
 COMPONENT_LICENSE=	LGPLv2
 COMPONENT_LICENSE_FILE=	COPYING

--- a/components/library/gtk+3/gtk3.p5m
+++ b/components/library/gtk+3/gtk3.p5m
@@ -468,12 +468,12 @@ file path=usr/lib/$(MACH64)/gtk-3.0/3.0.0/printbackends/libprintbackend-file.so
 link path=usr/lib/$(MACH64)/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/$(MACH64)/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/$(MACH64)/libgailutil-3.so.0.0.0
-link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.8
-link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.8
-file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.8
-link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.8
-link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.8
-file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.8
+link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.19
+link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.19
+file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.19
+link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.19
+link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.19
+file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.19
 file path=usr/lib/$(MACH64)/pkgconfig/gail-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-x11-3.0.pc
@@ -498,12 +498,12 @@ file path=usr/lib/gtk-3.0/3.0.0/printbackends/libprintbackend-file.so
 link path=usr/lib/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/libgailutil-3.so.0.0.0
-link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.8
-link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.8
-file path=usr/lib/libgdk-3.so.0.2404.8
-link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.8
-link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.8
-file path=usr/lib/libgtk-3.so.0.2404.8
+link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.19
+link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.19
+file path=usr/lib/libgdk-3.so.0.2404.19
+link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.19
+link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.19
+file path=usr/lib/libgtk-3.so.0.2404.19
 file path=usr/lib/pkgconfig/gail-3.0.pc
 file path=usr/lib/pkgconfig/gdk-3.0.pc
 file path=usr/lib/pkgconfig/gdk-x11-3.0.pc
@@ -526,6 +526,7 @@ file path=usr/share/glib-2.0/schemas/org.gtk.Settings.EmojiChooser.gschema.xml
 file path=usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml
 file path=usr/share/glib-2.0/schemas/org.gtk.exampleapp.gschema.xml
 file path=usr/share/gtk-3.0/gtkbuilder.rng
+file path=usr/share/gtk-3.0/valgrind/gtk.supp
 file path=usr/share/gtk-doc/html/gail-libgail-util3/gail-libgail-util3-GailMisc.html
 file path=usr/share/gtk-doc/html/gail-libgail-util3/gail-libgail-util3-GailTextUtil.html
 file path=usr/share/gtk-doc/html/gail-libgail-util3/gail-libgail-util3.devhelp2
@@ -1151,6 +1152,7 @@ file path=usr/share/gtk-doc/html/gtk3/panes.png
 file path=usr/share/gtk-doc/html/gtk3/placessidebar.png
 file path=usr/share/gtk-doc/html/gtk3/platform-support.html
 file path=usr/share/gtk-doc/html/gtk3/popup-anchors.png
+file path=usr/share/gtk-doc/html/gtk3/popup-at.svg
 file path=usr/share/gtk-doc/html/gtk3/popup-flip.png
 file path=usr/share/gtk-doc/html/gtk3/popup-slide.png
 file path=usr/share/gtk-doc/html/gtk3/printdialog.png
@@ -1253,6 +1255,8 @@ file path=usr/share/locale/ca/LC_MESSAGES/gtk30-properties.mo
 file path=usr/share/locale/ca/LC_MESSAGES/gtk30.mo
 file path=usr/share/locale/ca@valencia/LC_MESSAGES/gtk30-properties.mo
 file path=usr/share/locale/ca@valencia/LC_MESSAGES/gtk30.mo
+file path=usr/share/locale/ckb/LC_MESSAGES/gtk30-properties.mo
+file path=usr/share/locale/ckb/LC_MESSAGES/gtk30.mo
 file path=usr/share/locale/crh/LC_MESSAGES/gtk30-properties.mo
 file path=usr/share/locale/crh/LC_MESSAGES/gtk30.mo
 file path=usr/share/locale/cs/LC_MESSAGES/gtk30-properties.mo

--- a/components/library/gtk+3/manifests/sample-manifest.p5m
+++ b/components/library/gtk+3/manifests/sample-manifest.p5m
@@ -457,12 +457,12 @@ file path=usr/lib/$(MACH64)/gtk-3.0/3.0.0/printbackends/libprintbackend-lpr.so
 link path=usr/lib/$(MACH64)/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/$(MACH64)/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/$(MACH64)/libgailutil-3.so.0.0.0
-link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.8
-link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.8
-file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.8
-link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.8
-link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.8
-file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.8
+link path=usr/lib/$(MACH64)/libgdk-3.so target=libgdk-3.so.0.2404.19
+link path=usr/lib/$(MACH64)/libgdk-3.so.0 target=libgdk-3.so.0.2404.19
+file path=usr/lib/$(MACH64)/libgdk-3.so.0.2404.19
+link path=usr/lib/$(MACH64)/libgtk-3.so target=libgtk-3.so.0.2404.19
+link path=usr/lib/$(MACH64)/libgtk-3.so.0 target=libgtk-3.so.0.2404.19
+file path=usr/lib/$(MACH64)/libgtk-3.so.0.2404.19
 file path=usr/lib/$(MACH64)/pkgconfig/gail-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-3.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-x11-3.0.pc
@@ -487,12 +487,12 @@ file path=usr/lib/gtk-3.0/3.0.0/printbackends/libprintbackend-lpr.so
 link path=usr/lib/libgailutil-3.so target=libgailutil-3.so.0.0.0
 link path=usr/lib/libgailutil-3.so.0 target=libgailutil-3.so.0.0.0
 file path=usr/lib/libgailutil-3.so.0.0.0
-link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.8
-link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.8
-file path=usr/lib/libgdk-3.so.0.2404.8
-link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.8
-link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.8
-file path=usr/lib/libgtk-3.so.0.2404.8
+link path=usr/lib/libgdk-3.so target=libgdk-3.so.0.2404.19
+link path=usr/lib/libgdk-3.so.0 target=libgdk-3.so.0.2404.19
+file path=usr/lib/libgdk-3.so.0.2404.19
+link path=usr/lib/libgtk-3.so target=libgtk-3.so.0.2404.19
+link path=usr/lib/libgtk-3.so.0 target=libgtk-3.so.0.2404.19
+file path=usr/lib/libgtk-3.so.0.2404.19
 file path=usr/lib/pkgconfig/gail-3.0.pc
 file path=usr/lib/pkgconfig/gdk-3.0.pc
 file path=usr/lib/pkgconfig/gdk-x11-3.0.pc
@@ -515,6 +515,7 @@ file path=usr/share/glib-2.0/schemas/org.gtk.Settings.EmojiChooser.gschema.xml
 file path=usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml
 file path=usr/share/glib-2.0/schemas/org.gtk.exampleapp.gschema.xml
 file path=usr/share/gtk-3.0/gtkbuilder.rng
+file path=usr/share/gtk-3.0/valgrind/gtk.supp
 file path=usr/share/gtk-doc/html/gail-libgail-util3/gail-libgail-util3-GailMisc.html
 file path=usr/share/gtk-doc/html/gail-libgail-util3/gail-libgail-util3-GailTextUtil.html
 file path=usr/share/gtk-doc/html/gail-libgail-util3/gail-libgail-util3.devhelp2
@@ -1140,6 +1141,7 @@ file path=usr/share/gtk-doc/html/gtk3/panes.png
 file path=usr/share/gtk-doc/html/gtk3/placessidebar.png
 file path=usr/share/gtk-doc/html/gtk3/platform-support.html
 file path=usr/share/gtk-doc/html/gtk3/popup-anchors.png
+file path=usr/share/gtk-doc/html/gtk3/popup-at.svg
 file path=usr/share/gtk-doc/html/gtk3/popup-flip.png
 file path=usr/share/gtk-doc/html/gtk3/popup-slide.png
 file path=usr/share/gtk-doc/html/gtk3/printdialog.png
@@ -1242,6 +1244,8 @@ file path=usr/share/locale/ca/LC_MESSAGES/gtk30-properties.mo
 file path=usr/share/locale/ca/LC_MESSAGES/gtk30.mo
 file path=usr/share/locale/ca@valencia/LC_MESSAGES/gtk30-properties.mo
 file path=usr/share/locale/ca@valencia/LC_MESSAGES/gtk30.mo
+file path=usr/share/locale/ckb/LC_MESSAGES/gtk30-properties.mo
+file path=usr/share/locale/ckb/LC_MESSAGES/gtk30.mo
 file path=usr/share/locale/crh/LC_MESSAGES/gtk30-properties.mo
 file path=usr/share/locale/crh/LC_MESSAGES/gtk30.mo
 file path=usr/share/locale/cs/LC_MESSAGES/gtk30-properties.mo


### PR DESCRIPTION
Think its time after almost 1 year to sync gtk3 to the latest stable. 
From 3.24.12 to 3.24.23 so no major minor change. Also don't think there is any ABI/API breakage.
First tests with mate stuff looks ok.