### PR TITLE
sdl2: update to 2.0.12

### DIFF
--- a/components/library/SDL2/Makefile
+++ b/components/library/SDL2/Makefile
@@ -10,20 +10,21 @@
 
 #
 # Copyright (c) 2016 Jim Klimov
+# Copyright (c) 2020 Andreas Wacknitz
 #
 
+BUILD_BITS=			32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		SDL2
-COMPONENT_VERSION=	2.0.7
-COMPONENT_REVISION=	1
-COMPONENT_PROJECT_URL=	http://www.libsdl.org/
+COMPONENT_VERSION=	2.0.12
+COMPONENT_PROJECT_URL=	https://www.libsdl.org/
 COMPONENT_SUMMARY=	libsdl2 - Simple DirectMedia Layer 2.0
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:490428b41c3231395d2774dd25cdd6e5e2bae308adc77ebb61219ad49d6537cc
-COMPONENT_ARCHIVE_URL=	http://www.libsdl.org/release/$(COMPONENT_ARCHIVE)
+	sha256:349268f695c02efbc9b9148a70b85e58cefbbf704abd3e91be654db7f1e2c863
+COMPONENT_ARCHIVE_URL=	https://www.libsdl.org/release/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI =	library/sdl2
 # Note: license change from LGPL was significant in 2.x vs 1.x series, and now
 # static linking is permitted. See e.g. https://wiki.libsdl.org/Installation
@@ -31,9 +32,8 @@ COMPONENT_LICENSE=	ZLIB
 COMPONENT_LICENSE_FILE=	COPYING.txt
 COMPONENT_CLASSIFICATION =	System/Libraries
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=		$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
@@ -42,13 +42,7 @@ COMPONENT_PREP_ACTION = \
 
 CONFIGURE_OPTIONS += --disable-rpath
 
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(NO_TESTS)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/library/SDL2/manifests/sample-manifest.p5m
+++ b/components/library/SDL2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -49,6 +49,7 @@ file path=usr/include/SDL2/SDL_loadso.h
 file path=usr/include/SDL2/SDL_log.h
 file path=usr/include/SDL2/SDL_main.h
 file path=usr/include/SDL2/SDL_messagebox.h
+file path=usr/include/SDL2/SDL_metal.h
 file path=usr/include/SDL2/SDL_mouse.h
 file path=usr/include/SDL2/SDL_mutex.h
 file path=usr/include/SDL2/SDL_name.h
@@ -69,6 +70,7 @@ file path=usr/include/SDL2/SDL_render.h
 file path=usr/include/SDL2/SDL_revision.h
 file path=usr/include/SDL2/SDL_rwops.h
 file path=usr/include/SDL2/SDL_scancode.h
+file path=usr/include/SDL2/SDL_sensor.h
 file path=usr/include/SDL2/SDL_shape.h
 file path=usr/include/SDL2/SDL_stdinc.h
 file path=usr/include/SDL2/SDL_surface.h
@@ -96,19 +98,21 @@ file path=usr/include/SDL2/SDL_video.h
 file path=usr/include/SDL2/SDL_vulkan.h
 file path=usr/include/SDL2/begin_code.h
 file path=usr/include/SDL2/close_code.h
+file path=usr/lib/$(MACH64)/cmake/SDL2/sdl2-config-version.cmake
 file path=usr/lib/$(MACH64)/cmake/SDL2/sdl2-config.cmake
-link path=usr/lib/$(MACH64)/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.7.0
-file path=usr/lib/$(MACH64)/libSDL2-2.0.so.0.7.0
+link path=usr/lib/$(MACH64)/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.12.0
+file path=usr/lib/$(MACH64)/libSDL2-2.0.so.0.12.0
 file path=usr/lib/$(MACH64)/libSDL2.a
-link path=usr/lib/$(MACH64)/libSDL2.so target=libSDL2-2.0.so.0.7.0
+link path=usr/lib/$(MACH64)/libSDL2.so target=libSDL2-2.0.so.0.12.0
 file path=usr/lib/$(MACH64)/libSDL2_test.a
 file path=usr/lib/$(MACH64)/libSDL2main.a
 file path=usr/lib/$(MACH64)/pkgconfig/sdl2.pc
+file path=usr/lib/cmake/SDL2/sdl2-config-version.cmake
 file path=usr/lib/cmake/SDL2/sdl2-config.cmake
-link path=usr/lib/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.7.0
-file path=usr/lib/libSDL2-2.0.so.0.7.0
+link path=usr/lib/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.12.0
+file path=usr/lib/libSDL2-2.0.so.0.12.0
 file path=usr/lib/libSDL2.a
-link path=usr/lib/libSDL2.so target=libSDL2-2.0.so.0.7.0
+link path=usr/lib/libSDL2.so target=libSDL2-2.0.so.0.12.0
 file path=usr/lib/libSDL2_test.a
 file path=usr/lib/libSDL2main.a
 file path=usr/lib/pkgconfig/sdl2.pc

--- a/components/library/SDL2/sdl2.p5m
+++ b/components/library/SDL2/sdl2.p5m
@@ -26,20 +26,21 @@ file path=usr/bin/$(MACH64)/sdl2-config
 file path=usr/bin/sdl2-config
 file path=usr/lib/$(MACH64)/pkgconfig/sdl2.pc
 file path=usr/lib/pkgconfig/sdl2.pc
-file path=usr/lib/$(MACH64)/libSDL2-2.0.so.0.7.0
-link path=usr/lib/$(MACH64)/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.7.0
+file path=usr/lib/$(MACH64)/libSDL2-2.0.so.0.12.0
+link path=usr/lib/$(MACH64)/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.12.0
 link path=usr/lib/$(MACH64)/libSDL2-2.0.so target=libSDL2-2.0.so.0
 link path=usr/lib/$(MACH64)/libSDL2.so target=libSDL2-2.0.so
 file path=usr/lib/$(MACH64)/libSDL2.a
 file path=usr/lib/$(MACH64)/libSDL2_test.a
 file path=usr/lib/$(MACH64)/libSDL2main.a
-file path=usr/lib/libSDL2-2.0.so.0.7.0
-link path=usr/lib/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.7.0
+file path=usr/lib/libSDL2-2.0.so.0.12.0
+link path=usr/lib/libSDL2-2.0.so.0 target=libSDL2-2.0.so.0.12.0
 link path=usr/lib/libSDL2-2.0.so target=libSDL2-2.0.so.0
 link path=usr/lib/libSDL2.so target=libSDL2-2.0.so
 file path=usr/lib/libSDL2.a
 file path=usr/lib/libSDL2_test.a
 file path=usr/lib/libSDL2main.a
+file path=usr/lib/$(MACH64)/cmake/SDL2/sdl2-config-version.cmake
 file path=usr/lib/$(MACH64)/cmake/SDL2/sdl2-config.cmake
 file path=usr/lib/cmake/SDL2/sdl2-config.cmake
 file path=usr/share/aclocal/sdl2.m4
@@ -69,6 +70,7 @@ file path=usr/include/SDL2/SDL_test_fuzzer.h
 file path=usr/include/SDL2/SDL_render.h
 file include/SDL_config_winrt.h path=usr/include/SDL2/SDL_config_winrt.h
 file path=usr/include/SDL2/SDL_scancode.h
+file path=usr/include/SDL2/SDL_sensor.h
 file include/SDL_config_windows.h path=usr/include/SDL2/SDL_config_windows.h
 file path=usr/include/SDL2/SDL_test.h
 file path=usr/include/SDL2/SDL_version.h
@@ -122,6 +124,7 @@ file path=usr/include/SDL2/SDL_opengl_glext.h
 file path=usr/include/SDL2/SDL_main.h
 file include/SDL_config_wiz.h path=usr/include/SDL2/SDL_config_wiz.h
 file path=usr/include/SDL2/SDL_messagebox.h
+file path=usr/include/SDL2/SDL_metal.h
 file include/SDL_config_android.h path=usr/include/SDL2/SDL_config_android.h
 file path=usr/include/SDL2/SDL_mutex.h
 file path=usr/include/SDL2/SDL_filesystem.h


### PR DESCRIPTION
- qt5 still builds (with one new lib)
- apps using qt5 still work