### PR TITLE
benchmark/filebench not delivered from illumos-gate

### DIFF
--- a/components/openindiana/illumos-gate/packages.ignore.in
+++ b/components/openindiana/illumos-gate/packages.ignore.in
@@ -359,6 +359,7 @@ SUNWzyd
 avs
 BRCMbnx
 BRCMbnxe
+benchmark/filebench
 consolidation/man/man-incorporation
 CPQary3
 driver/graphics/agpgart

--- a/components/openindiana/illumos-gate/pkg5
+++ b/components/openindiana/illumos-gate/pkg5
@@ -10,7 +10,6 @@
         "SUNWcs",
         "SUNWcsd",
         "audio/audio-utilities",
-        "benchmark/filebench",
         "compatibility/ucb",
         "consolidation/l10n/l10n-incorporation",
         "consolidation/osnet/osnet-incorporation",

--- a/components/openindiana/illumos-gate/pkg5.fmris
+++ b/components/openindiana/illumos-gate/pkg5.fmris
@@ -1,7 +1,6 @@
 SUNWcs
 SUNWcsd
 audio/audio-utilities
-benchmark/filebench
 compatibility/ucb
 consolidation/l10n/l10n-incorporation
 consolidation/osnet/osnet-incorporation


### PR DESCRIPTION
While trying to make use of `components/mapping.json` I noticed that the `benchmark/filebench` package is shipped from another directory, but the obsoleted package from the gate is still exposed in `mapping.json`.