### PR TITLE
meta-packages/history: duplicate historic package entries

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -223,7 +223,6 @@ SUNWircii@0.2006.7.25,5.11-0.133 network/chat/ircii@0.2006.7.25-0.133
 SUNWjre-config-plugin@0.5.11,5.11-0.133 web/browser/firefox/plugin/plugin-java@0.5.11,5.11-0.134
 SUNWjunit@4.5,5.11-0.133 developer/java/junit@4.5-0.133
 SUNWlablgtk@2.10.1,5.11-0.170
-SUNWlablgtk@2.10.1,5.11-0.170
 SUNWlang-ar-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-common-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-common@0.5.11,5.11-2015.0.2.0
@@ -304,12 +303,10 @@ SUNWncft@3.2.2,5.11-0.133 network/ftp/ncftp@3.2.3-0.133
 SUNWncurses@0.5.11,5.11-0.175.0.0.0.0.0 library/ncurses@0.5.11-0.133
 SUNWneon@0.29.0,5.11-0.133 library/neon@0.29.0-0.133
 SUNWnet-snmp-addons@5.4.1,5.11-0.133 system/management/snmp/net-snmp/addons@5.4.1-0.133
-SUNWnet-snmp-core@5.4.1,5.11-0.133
 SUNWnet-snmp-core@5.4.1,5.11-0.133 system/management/snmp/net-snmp@5.4.1-0.133
 SUNWnet-snmp-doc@5.4.1,5.11-0.133 system/management/snmp/net-snmp/documentation@5.4.1-0.133
 SUNWnet-snmp-utils@5.4.1,5.11-0.132 SUNWnet-snmp-core@5.4.1,5.11-0.133
 SUNWnethack@3.4.3,5.11-0.133 games/nethack@3.4.3-0.133
-SUNWnimbus-hires@0.5.11,5.11-0.133
 SUNWnimbus-hires@0.5.11,5.11-0.133 gnome/theme/nimbus-hires@0.1.5-0.151.1.8
 SUNWnmap@4.75,5.11-0.133 diagnostic/nmap@4.75-0.133
 SUNWntp@4.2.5.172,5.11-0.133 service/network/ntp@4.2.5.172-0.133
@@ -436,7 +433,6 @@ SUNWthunderbirdl10n-sv-SE@0.5.11,5.11-2015.0.2.0
 SUNWtidy@1.0.0,5.11-0.133 text/tidy@1.0.0-0.133
 SUNWtop@3.8,5.11-0.133 diagnostic/top@3.8-0.133
 SUNWtss@0.3.2,5.11-0.133 library/security/trousers@0.3.2-0.133
-SUNWunison@2.27.57,5.11-0.170
 SUNWunison@2.27.57,5.11-0.170
 SUNWunixodbc@2.2.14,5.11-0.133 library/unixodbc@2.2.14-0.133
 SUNWunrar@3.8.5,5.11-0.133 archiver/unrar@3.8.5-0.133


### PR DESCRIPTION
I noticed some more duplicate entries in `components/mapping.json` that result from duplicates within the historic meta-package build machinery.  Where a duplicate existed with and without rename linkage, I kept the entry that had the rename listed.