### PR TITLE
mark encumbered packages in mapping.json

### DIFF
--- a/components/Makefile
+++ b/components/Makefile
@@ -44,7 +44,9 @@ $(WS_TOP)/components/$(ENCUMBERED)components.mk:	# Makefile # $(WS_TOP)/componen
 # between component path and component FMRI.
 $(WS_TOP)/components/mapping.json:
 	@echo "Generating component mapping..."
-	@$(WS_TOOLS)/userland-mapping --workspace=$(WS_TOP)
+	$(WS_TOOLS)/userland-mapping --workspace=$(WS_TOP) \
+	    --repo=$(PUBLISHER) \
+	    --repo-map=encumbered/=$(PUBLISHER)-encumbered
 mapping.json: $(WS_TOP)/components/mapping.json
 
 # dependencies.json is auto-generate by the build tools. It provides information

--- a/tools/userland-mapping
+++ b/tools/userland-mapping
@@ -72,7 +72,7 @@ def generate_component_data(component_path, subdir='components'):
     return component_fmris, component_name, component_relative_path
 
 
-def generate_userland_mapping(workspace_path, subdir='components'):
+def generate_userland_mapping(workspace_path, subdir='components', repo='userland', repo_map=[]):
     mapping = []
 
     paths = find_component_paths(path=workspace_path, subdir=subdir)
@@ -81,9 +81,15 @@ def generate_userland_mapping(workspace_path, subdir='components'):
 
     for component_fmris, component_name, component_relative_path in results:
         for component_fmri in component_fmris:
+            component_repo = repo
+            for rm in repo_map:
+                if component_relative_path.startswith(rm['pfx']):
+                    component_repo = rm['repo']
+
             mapping.append({'name': component_name,
                             'fmri': component_fmri,
-                            'path': component_relative_path})
+                            'path': component_relative_path,
+                            'repo': component_repo})
 
     component_mapping_file = os.path.join(workspace_path, subdir, COMPONENT_MAPPING_FILENAME)
     with open(component_mapping_file, 'w') as f:
@@ -95,13 +101,24 @@ def main():
 
     parser.add_argument('-w', '--workspace', default=os.getenv('WS_TOP'), help='Path to workspace')
     parser.add_argument('--subdir', default='components', help='Directory holding components')
+    parser.add_argument('--repo', default='userland', help='Default target repository')
+    parser.add_argument('--repo-map', help='Target repository for this directory; e.g., encumbered/=userland-encumbered', action='append')
 
     args = parser.parse_args()
 
     workspace = args.workspace
     subdir = args.subdir
 
-    generate_userland_mapping(workspace_path=workspace, subdir=subdir)
+    repo = args.repo
+    repo_map = []
+    if args.repo_map:
+        for rm in args.repo_map:
+            l = rm.split("=")
+            if len(l) != 2:
+                raise ValueError('invalid --repo-map: ' + rm)
+            repo_map.append({'pfx': l[0], 'repo': l[1]})
+
+    generate_userland_mapping(workspace_path=workspace, subdir=subdir, repo=repo, repo_map=repo_map)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
For build tools to be able to use `mapping.json` there really needs to be a unique mapping from delivered package FMRI to component build path within the tree.  This is mostly true today, but one exception is the encumbered packages.

These are, as far as I can tell, actually part of a separate namespace as they are delivered to a totally separate IPS repository with a different publisher (hipster-encumbered?).  As such, it appears to be acceptable for, say, an obsoleted entry to be present in the encumbered repository and (with the same FMRI) a real package in the primary repository.

To distinguish these two entries, I have added a `repo` field to each entry in `mapping.json`, and marked all encumbered entries as being for the `userland-encumbered` repository instead of `userland`; e.g., some sample entries:

```
...
    {
        "fmri": "minimal_install",
        "name": "install-types",
        "path": "meta-packages/install-types",
        "repo": "userland"
    },
    {
        "fmri": "server_install",
        "name": "install-types",
        "path": "meta-packages/install-types",
        "repo": "userland"
    },
    {
        "fmri": "library/audio/gstreamer1/plugin/libav",
        "name": "gst-libav",
        "path": "encumbered/gst-libav1",
        "repo": "userland-encumbered"
    },
...
```