### PR TITLE
openindiana-welcome: change to 64-bit

### DIFF
--- a/components/openindiana/openindiana-welcome/Makefile
+++ b/components/openindiana/openindiana-welcome/Makefile
@@ -75,9 +75,9 @@ $(SOURCE_DIR)/.prep: $(SOURCE_DIR)/.downloaded Makefile
 		autoconf -f
 	touch $(SOURCE_DIR)/.prep
 
-build: $(BUILD_32)
+build: $(BUILD_64)
 
-install: $(INSTALL_32)
+install: $(INSTALL_64)
 
 download:: $(SOURCE_DIR)/.downloaded
 

--- a/components/openindiana/openindiana-welcome/manifests/sample-manifest.p5m
+++ b/components/openindiana/openindiana-welcome/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,7 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/openindiana-about
+file path=usr/bin/$(MACH64)/openindiana-about
 file path=usr/share/applications/openindiana-about.desktop
 file path=usr/share/applications/openindiana-welcome.desktop
 file path=usr/share/doc/openindiana-welcome/html/C/index.html

--- a/components/openindiana/openindiana-welcome/os-welcome.p5m
+++ b/components/openindiana/openindiana-welcome/os-welcome.p5m
@@ -23,7 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/openindiana-about
+file path=usr/bin/$(MACH64)/openindiana-about
 file path=usr/share/applications/openindiana-about.desktop
 file path=usr/share/applications/openindiana-welcome.desktop
 file path=usr/share/doc/openindiana-welcome/html/C/index.html


### PR DESCRIPTION
Another victim of the Python 3.4 removal.