### PR TITLE
gegl: update to 0.4.26

### DIFF
--- a/components/library/gegl/Makefile
+++ b/components/library/gegl/Makefile
@@ -19,16 +19,16 @@ BUILD_STYLE= meson
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gegl
-COMPONENT_VERSION= 0.4.24
+COMPONENT_VERSION= 0.4.26
 COMPONENT_SUMMARY= GEGL (Generic Graphics Library) is a graph based image processing framework
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:7765499f27341b0d16032e665319cbc12876483ff6a944fcdf24a9c58e3e254a
+	sha256:0f371e2ed2b92162fefd3dde743e648ca08a6a1b2b05004867fbddc7e211e424
 COMPONENT_ARCHIVE_URL= \
-  http://ftp.gimp.org/pub/gegl/0.4/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://www.gegl.org/
+	https://ftp.gimp.org/pub/gegl/0.4/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL = https://www.gegl.org/
 COMPONENT_LICENSE= GPLv3, LGPLv3
 
 include $(WS_MAKE_RULES)/common.mk
@@ -61,7 +61,8 @@ COMPONENT_TEST_ENV += LD_LIBRARY_PATH=$(BUILD_DIR_64)/gegl
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += image/library/babl
-REQUIRED_PACKAGES += image/library/gexiv2
+#REQUIRED_PACKAGES += image/library/gegl
+REQUIRED_PACKAGES += image/library/lensfun
 REQUIRED_PACKAGES += image/library/libjpeg8-turbo
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += image/library/libraw

--- a/components/library/gegl/gegl.p5m
+++ b/components/library/gegl/gegl.p5m
@@ -145,8 +145,8 @@ file path=usr/lib/$(MACH64)/gegl-0.4/webp-load.so
 file path=usr/lib/$(MACH64)/gegl-0.4/webp-save.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Gegl-0.4.typelib
 link path=usr/lib/$(MACH64)/libgegl-0.4.so target=libgegl-0.4.so.0
-link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.423.1
-file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.423.1
+link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.425.1
+file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.425.1
 file path=usr/lib/$(MACH64)/libgegl-npd-0.4.so
 file path=usr/lib/$(MACH64)/libgegl-sc-0.4.so
 file path=usr/lib/$(MACH64)/pkgconfig/gegl-0.4.pc

--- a/components/library/gegl/gegl_workshop.p5m
+++ b/components/library/gegl/gegl_workshop.p5m
@@ -25,6 +25,7 @@ license $(COMPONENT_LICENSE_FILE) license="$(COMPONENT_LICENSE)"
 file path=usr/lib/$(MACH64)/gegl-0.4/average.so
 file path=usr/lib/$(MACH64)/gegl-0.4/blend-reflect.so
 file path=usr/lib/$(MACH64)/gegl-0.4/gegl-workshop.so
+file path=usr/lib/$(MACH64)/gegl-0.4/lens-correct.so
 file path=usr/lib/$(MACH64)/gegl-0.4/line-profile.so
 file path=usr/lib/$(MACH64)/gegl-0.4/negation.so
 file path=usr/lib/$(MACH64)/gegl-0.4/soft-burn.so

--- a/components/library/gegl/manifests/sample-manifest.p5m
+++ b/components/library/gegl/manifests/sample-manifest.p5m
@@ -122,6 +122,7 @@ file path=usr/lib/$(MACH64)/gegl-0.4/grey2.json
 file path=usr/lib/$(MACH64)/gegl-0.4/jpg-load.so
 file path=usr/lib/$(MACH64)/gegl-0.4/jpg-save.so
 file path=usr/lib/$(MACH64)/gegl-0.4/lcms-from-profile.so
+file path=usr/lib/$(MACH64)/gegl-0.4/lens-correct.so
 file path=usr/lib/$(MACH64)/gegl-0.4/line-profile.so
 file path=usr/lib/$(MACH64)/gegl-0.4/negation.so
 file path=usr/lib/$(MACH64)/gegl-0.4/npd.so
@@ -154,8 +155,8 @@ file path=usr/lib/$(MACH64)/gegl-0.4/webp-load.so
 file path=usr/lib/$(MACH64)/gegl-0.4/webp-save.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Gegl-0.4.typelib
 link path=usr/lib/$(MACH64)/libgegl-0.4.so target=libgegl-0.4.so.0
-link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.423.1
-file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.423.1
+link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.425.1
+file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.425.1
 file path=usr/lib/$(MACH64)/libgegl-npd-0.4.so
 file path=usr/lib/$(MACH64)/libgegl-sc-0.4.so
 file path=usr/lib/$(MACH64)/pkgconfig/gegl-0.4.pc

--- a/components/library/gegl/pkg5
+++ b/components/library/gegl/pkg5
@@ -4,7 +4,7 @@
         "developer/build/meson",
         "developer/build/ninja",
         "image/library/babl",
-        "image/library/gexiv2",
+        "image/library/lensfun",
         "image/library/libjpeg8-turbo",
         "image/library/libpng16",
         "image/library/libraw",


### PR DESCRIPTION
needed for gimp-2.10.22