### PR TITLE
expat: update to 2.2.10

### DIFF
--- a/components/library/libexpat/Makefile
+++ b/components/library/libexpat/Makefile
@@ -30,7 +30,7 @@ BUILD_BITS=		32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libexpat
-COMPONENT_VERSION=	2.2.9
+COMPONENT_VERSION=	2.2.10
 COMPONENT_VERSION_U=	$(shell echo $(COMPONENT_VERSION) | tr . _)
 COMPONENT_FMRI=		library/expat
 COMPONENT_SUMMARY=	libexpat - XML parser library
@@ -41,7 +41,7 @@ COMPONENT_SRC_NAME=	expat
 COMPONENT_SRC=		$(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.lz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:a1e85abcd97c2aa71005190d24a7c46dcf7bd29c097c31e917cda1b400c38a49
+	sha256:a17adece0afd5c42a1ba9549fad00e5066838c87c4d2ac395ff447558fe045de
 COMPONENT_ARCHIVE_URL= \
 	https://github.com/libexpat/libexpat/releases/download/R_$(COMPONENT_VERSION_U)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	expat license

--- a/components/library/libexpat/expat.p5m
+++ b/components/library/libexpat/expat.p5m
@@ -27,13 +27,13 @@ file path=usr/bin/xmlwf
 file path=usr/include/expat.h
 file path=usr/include/expat_config.h
 file path=usr/include/expat_external.h
-link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.11
-link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.11
-file path=usr/lib/$(MACH64)/libexpat.so.1.6.11
+link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.12
+link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.12
+file path=usr/lib/$(MACH64)/libexpat.so.1.6.12
 file path=usr/lib/$(MACH64)/pkgconfig/expat.pc
-link path=usr/lib/libexpat.so target=libexpat.so.1.6.11
-link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.11
-file path=usr/lib/libexpat.so.1.6.11
+link path=usr/lib/libexpat.so target=libexpat.so.1.6.12
+link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.12
+file path=usr/lib/libexpat.so.1.6.12
 file path=usr/lib/pkgconfig/expat.pc
 #file path=usr/share/doc/expat/AUTHORS
 #file path=usr/share/doc/expat/changelog

--- a/components/library/libexpat/manifests/sample-manifest.p5m
+++ b/components/library/libexpat/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,13 +26,13 @@ file path=usr/bin/xmlwf
 file path=usr/include/expat.h
 file path=usr/include/expat_config.h
 file path=usr/include/expat_external.h
-link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.11
-link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.11
-file path=usr/lib/$(MACH64)/libexpat.so.1.6.11
+link path=usr/lib/$(MACH64)/libexpat.so target=libexpat.so.1.6.12
+link path=usr/lib/$(MACH64)/libexpat.so.1 target=libexpat.so.1.6.12
+file path=usr/lib/$(MACH64)/libexpat.so.1.6.12
 file path=usr/lib/$(MACH64)/pkgconfig/expat.pc
-link path=usr/lib/libexpat.so target=libexpat.so.1.6.11
-link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.11
-file path=usr/lib/libexpat.so.1.6.11
+link path=usr/lib/libexpat.so target=libexpat.so.1.6.12
+link path=usr/lib/libexpat.so.1 target=libexpat.so.1.6.12
+file path=usr/lib/libexpat.so.1.6.12
 file path=usr/lib/pkgconfig/expat.pc
 file path=usr/share/doc/expat/AUTHORS
 file path=usr/share/doc/expat/changelog


### PR DESCRIPTION
- My desktop still works with it, especially LibreOffice can read and write odt and docx files
- cmake still works and I successfully build several packages (eg. percona-server-5.7, mariadb-10.1)