### PR TITLE
Bug #12896: QT5 manifest needs mediated symlinks

### DIFF
--- a/components/library/qt5/Makefile
+++ b/components/library/qt5/Makefile
@@ -22,7 +22,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		qt
 COMPONENT_VERSION=	5.8.0
 COMPONENT_VERSION_MJR=	5.8
-COMPONENT_REVISION=	10
+COMPONENT_REVISION=	11
 COMPONENT_FMRI=		library/qt5
 COMPONENT_PROJECT_URL=	https://www.qt.io/
 COMPONENT_SUMMARY=	Qt cross-platform application and UI framework

--- a/components/library/qt5/qt5.p5m
+++ b/components/library/qt5/qt5.p5m
@@ -10,6 +10,7 @@
 #
 
 #
+# Copyright 2020 Gary Mills
 # Copyright 2017 Aurelien Larcher
 #
 
@@ -21,6 +22,49 @@ set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/bin/$(MACH64)/assistant target=../../lib/qt/5.8/bin/$(MACH64)/assistant mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/designer target=../../lib/qt/5.8/bin/$(MACH64)/designer mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/lconvert target=../../lib/qt/5.8/bin/$(MACH64)/lconvert mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/linguist target=../../lib/qt/5.8/bin/$(MACH64)/linguist mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/lrelease target=../../lib/qt/5.8/bin/$(MACH64)/lrelease mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/lupdate target=../../lib/qt/5.8/bin/$(MACH64)/lupdate mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/moc target=../../lib/qt/5.8/bin/$(MACH64)/moc mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/pixeltool target=../../lib/qt/5.8/bin/$(MACH64)/pixeltool mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qcollectiongenerator target=../../lib/qt/5.8/bin/$(MACH64)/qcollectiongenerator mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qdbus target=../../lib/qt/5.8/bin/$(MACH64)/qdbus mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qdbuscpp2xml target=../../lib/qt/5.8/bin/$(MACH64)/qdbuscpp2xml mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qdbusviewer target=../../lib/qt/5.8/bin/$(MACH64)/qdbusviewer mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qdbusxml2cpp target=../../lib/qt/5.8/bin/$(MACH64)/qdbusxml2cpp mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qhelpconverter target=../../lib/qt/5.8/bin/$(MACH64)/qhelpconverter mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qhelpgenerator target=../../lib/qt/5.8/bin/$(MACH64)/qhelpgenerator mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qmake target=../../lib/qt/5.8/bin/$(MACH64)/qmake mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/qmlplugindump target=../../lib/qt/5.8/bin/$(MACH64)/qmlplugindump mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/rcc target=../../lib/qt/5.8/bin/$(MACH64)/rcc mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/uic target=../../lib/qt/5.8/bin/$(MACH64)/uic mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/xmlpatterns target=../../lib/qt/5.8/bin/$(MACH64)/xmlpatterns mediator=qt mediator-version=5.8
+link path=usr/bin/$(MACH64)/xmlpatternsvalidator target=../../lib/qt/5.8/bin/$(MACH64)/xmlpatternsvalidator mediator=qt mediator-version=5.8
+link path=usr/bin/assistant target=../lib/qt/5.8/bin/$(MACH64)/assistant mediator=qt mediator-version=5.8
+link path=usr/bin/designer target=../lib/qt/5.8/bin/$(MACH64)/designer mediator=qt mediator-version=5.8
+link path=usr/bin/lconvert target=../lib/qt/5.8/bin/$(MACH64)/lconvert mediator=qt mediator-version=5.8
+link path=usr/bin/linguist target=../lib/qt/5.8/bin/$(MACH64)/linguist mediator=qt mediator-version=5.8
+link path=usr/bin/lrelease target=../lib/qt/5.8/bin/$(MACH64)/lrelease mediator=qt mediator-version=5.8
+link path=usr/bin/lupdate target=../lib/qt/5.8/bin/$(MACH64)/lupdate mediator=qt mediator-version=5.8
+link path=usr/bin/moc target=../lib/qt/5.8/bin/$(MACH64)/moc mediator=qt mediator-version=5.8
+link path=usr/bin/pixeltool target=../lib/qt/5.8/bin/$(MACH64)/pixeltool mediator=qt mediator-version=5.8
+link path=usr/bin/qcollectiongenerator target=../lib/qt/5.8/bin/$(MACH64)/qcollectiongenerator mediator=qt mediator-version=5.8
+link path=usr/bin/qdbus target=../lib/qt/5.8/bin/$(MACH64)/qdbus mediator=qt mediator-version=5.8
+link path=usr/bin/qdbuscpp2xml target=../lib/qt/5.8/bin/$(MACH64)/qdbuscpp2xml mediator=qt mediator-version=5.8
+link path=usr/bin/qdbusviewer target=../lib/qt/5.8/bin/$(MACH64)/qdbusviewer mediator=qt mediator-version=5.8
+link path=usr/bin/qdbusxml2cpp target=../lib/qt/5.8/bin/$(MACH64)/qdbusxml2cpp mediator=qt mediator-version=5.8
+link path=usr/bin/qhelpconverter target=../lib/qt/5.8/bin/$(MACH64)/qhelpconverter mediator=qt mediator-version=5.8
+link path=usr/bin/qhelpgenerator target=../lib/qt/5.8/bin/$(MACH64)/qhelpgenerator mediator=qt mediator-version=5.8
+link path=usr/bin/qmake target=../lib/qt/5.8/bin/$(MACH64)/qmake mediator=qt mediator-version=5.8
+link path=usr/bin/qmlplugindump target=../lib/qt/5.8/bin/$(MACH64)/qmlplugindump mediator=qt mediator-version=5.8
+link path=usr/bin/rcc target=../lib/qt/5.8/bin/$(MACH64)/rcc mediator=qt mediator-version=5.8
+link path=usr/bin/uic target=../lib/qt/5.8/bin/$(MACH64)/uic mediator=qt mediator-version=5.8
+link path=usr/bin/xmlpatterns target=../lib/qt/5.8/bin/$(MACH64)/xmlpatterns mediator=qt mediator-version=5.8
+link path=usr/bin/xmlpatternsvalidator target=../lib/qt/5.8/bin/$(MACH64)/xmlpatternsvalidator mediator=qt mediator-version=5.8
 
 file path=usr/lib/qt/5.8/bin/$(MACH64)/assistant
 file path=usr/lib/qt/5.8/bin/$(MACH64)/canbusutil


### PR DESCRIPTION
This PR adds mediated links to the qt5 manifest, making it compatible with the qt4 package which already has them.  Both packages can be installed, but the mediated symlinks are taken from the second one installed.  Nothing else has changed.  Nothing has been deleted.
