### PR TITLE
raptor2: patch for new qsort_r(3C)

### DIFF
--- a/components/library/raptor2/Makefile
+++ b/components/library/raptor2/Makefile
@@ -21,10 +21,12 @@
 # Copyright (c) 2013 David Hoeppner. All rights reserved.
 # Copyright (c) 2019 Nona Hansel
 #
+BUILD_BITS=			32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		raptor2
 COMPONENT_VERSION=	2.0.15
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	http://librdf.org/raptor/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -32,22 +34,13 @@ COMPONENT_ARCHIVE_HASH=	\
     sha256:ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed
 COMPONENT_ARCHIVE_URL=	http://download.librdf.org/source/$(COMPONENT_ARCHIVE)
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
-CONFIGURE_OPTIONS  +=		--disable-static
-CONFIGURE_OPTIONS  +=		--enable-shared
+CONFIGURE_OPTIONS	+=		--disable-static
+CONFIGURE_OPTIONS	+=		--enable-shared
 
 $(INSTALL_64):	COMPONENT_POST_INSTALL_ACTION = \
 	/usr/bin/elfedit -e "dyn:runpath ''" $(PROTOUSRLIBDIR64)/libraptor2.so.0.0.0
-
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/libxml2

--- a/components/library/raptor2/patches/02-sort_r.h.patch
+++ b/components/library/raptor2/patches/02-sort_r.h.patch
@@ -1,0 +1,37 @@
+--- raptor2-2.0.15/src/sort_r.h.orig	2014-10-10 01:00:44.000000000 +0000
++++ raptor2-2.0.15/src/sort_r.h	2020-10-11 15:42:02.343998167 +0000
+@@ -31,6 +31,8 @@
+ #  define _SORT_R_LINUX
+ #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
+ #  define _SORT_R_WINDOWS
++#elif (defined __sun__)
++#  define _SORT_R_ILLUMOS
+ #else
+ #  error Cannot detect operating system
+ #endif
+@@ -85,6 +87,7 @@
+     extern void qsort_r(void *base, size_t nel, size_t width,
+                         __compar_d_fn_t __compar, void *arg)
+       __attribute__((nonnull (1, 4)));
++  #elif defined _SORT_R_ILLUMOS
+ 
+   #endif
+ 
+@@ -105,6 +108,10 @@
+       tmp.compar = compar;
+       qsort_r(base, nel, width, &tmp, sort_r_arg_swap);
+ 
++    #elif defined _SORT_R_ILLUMOS
++
++      qsort_r(base, nel, width, compar, arg);
++
+     #else /* defined _SORT_R_WINDOWS */
+ 
+       struct sort_r_data tmp;
+@@ -120,5 +127,6 @@
+ #undef _SORT_R_WINDOWS
+ #undef _SORT_R_LINUX
+ #undef _SORT_R_BSD
++#undef _SORT_R_ILLUMOS
+ 
+ #endif /* SORT_R_H_ */


### PR DESCRIPTION
This is necessary after qsort_r(3C) has landed in illumos-gate.
A similar fix is needed for libreoffice which uses its own raptor2 version.