### PR TITLE
Bug #13187: Libreoffice breaks man

### DIFF
--- a/components/sysutils/environment-modules/Makefile
+++ b/components/sysutils/environment-modules/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		environment-modules
 COMPONENT_VERSION=	3.2.10
-COMPONENT_REVISION=     1
+COMPONENT_REVISION=     2
 COMPONENT_FMRI=		package/$(COMPONENT_NAME)
 COMPONENT_PROJECT_URL=	http://modules.sourceforge.net/
 SOURCE_NAME=		modules

--- a/components/sysutils/environment-modules/files/modules.sh
+++ b/components/sysutils/environment-modules/files/modules.sh
@@ -22,10 +22,6 @@ case "$0" in
 	;;
 esac
 
-MANPATH='::'
-
-export MANPATH
-
 # Allow adding modules list in .modules
 if [ -r $HOME/.modules ]; then
 	. $HOME/.modules


### PR DESCRIPTION
This PR corrects the modules.sh script to remove the lines that set and export MANPATH to the shell environment.  I don't know what the intention was, but setting MANPATH in this way interferes with the man  command.  Curiously, it sets it without mediation by the module command.

I have tested removing those lines from modules.sh .  Doing this has no effect on libreoffice and no effect on other commands.  It does restore the man command back to normal operation.
