### PR TITLE
Bug #11890: Undefined symbol in build of network/ntp

### DIFF
--- a/components/network/ntp/Makefile
+++ b/components/network/ntp/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ntp
 COMPONENT_VERSION=	4.2.8p13
+COMPONENT_REVISION=	1
 IPS_COMPONENT_VERSION=	$(subst p,.,$(COMPONENT_VERSION))
 COMPONENT_SUMMARY=	Network Time Protocol Daemon v4
 COMPONENT_DESCRIPTION=	Network Time Protocol v4, NTP Daemon and Utilities
@@ -68,6 +69,8 @@ CONFIGURE_OPTIONS +=	--disable-debugging
 CONFIGURE_OPTIONS +=	--disable-optional-args
 CONFIGURE_OPTIONS +=	--enable-parse-clocks
 CONFIGURE_OPTIONS +=	--enable-ignore-dns-errors
+# To avoid arc4random_addrandom error
+CONFIGURE_OPTIONS +=	--without-sntp
 CONFIGURE_OPTIONS +=	--without-ntpsnmpd
 CONFIGURE_OPTIONS +=	--with-crypto=openssl
 CONFIGURE_OPTIONS +=	--with-openssl-incdir=$(USRINCDIR)
@@ -130,9 +133,6 @@ install:	$(INSTALL_64)
 
 test:		$(TEST_64)
 
-# Required for SNTP but not auto-detected
-REQUIRED_PACKAGES += library/libevent2
-REQUIRED_PACKAGES += runtime/perl-522
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/libedit
 REQUIRED_PACKAGES += library/security/openssl

--- a/components/network/ntp/manifests/sample-manifest.p5m
+++ b/components/network/ntp/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -31,7 +31,6 @@ file path=usr/sbin/ntpdc
 file path=usr/sbin/ntpq
 file path=usr/sbin/ntptime
 file path=usr/sbin/ntptrace
-file path=usr/sbin/sntp
 file path=usr/sbin/tickadj
 file path=usr/sbin/update-leap
 file path=usr/share/doc/ntp/html/access.html

--- a/components/network/ntp/pkg5
+++ b/components/network/ntp/pkg5
@@ -2,9 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "library/libedit",
-        "library/libevent2",
         "library/security/openssl",
-        "runtime/perl-522",
         "runtime/perl-524",
         "service/network/dns/mdns",
         "system/library",


### PR DESCRIPTION
This PR changes only the Makefile.  The patches and the manifest is unchanged, meaning that the package is also unchanged.  It works by omitting the sntp component from the build.  sntp is an alternate NTP client.  The letter s in the name stands for simple, not for secure.  The sntp files were not included in the manifest anyway.  Nothing is lost by not building the sntp component.

I tested these changes by building, installing, and publishing the package.  All were successful.
