### PR TITLE
grep: update to 3.5

### DIFF
--- a/components/text/ggrep/Makefile
+++ b/components/text/ggrep/Makefile
@@ -21,6 +21,7 @@
 #
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2020, Michal Nowak
+# Copyright (c) 2020, Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -28,7 +29,7 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		grep
-COMPONENT_VERSION=	3.4
+COMPONENT_VERSION=	3.5
 COMPONENT_FMRI=		text/gnu-grep
 COMPONENT_SUMMARY= 	GNU grep utilities
 COMPONENT_CLASSIFICATION= Applications/System Utilities
@@ -36,7 +37,7 @@ COMPONENT_PROJECT_URL=	http://gnu.org/software/grep/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:58e6751c41a7c25bfc6e9363a41786cff3ba5709cf11d5ad903cf7cce31cc3fb
+	sha256:b82ac77707c2ab945520c8404c9fa9f890f7791a62cf2103cf6238acad87a44a
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/grep/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3, FDLv1.3
 

--- a/components/text/ggrep/test/results-64.master
+++ b/components/text/ggrep/test/results-64.master
@@ -2,10 +2,12 @@ PASS: backref
 PASS: backref-alt
 PASS: backref-multibyte-slow
 PASS: backref-word
+PASS: backslash-dot
 PASS: backslash-s-and-repetition-operators
 PASS: backslash-s-vs-invalid-multibyte
 SKIP: big-hole
 SKIP: big-match
+PASS: binary-file-matches
 PASS: bogus-wctob
 PASS: bre
 PASS: c-locale
@@ -54,6 +56,7 @@ PASS: khadafy
 PASS: kwset-abuse
 SKIP: long-line-vs-2GiB-read
 SKIP: long-pattern-perf
+SKIP: many-regex-performance
 PASS: match-lines
 PASS: max-count-overread
 PASS: max-count-vs-context
@@ -111,9 +114,9 @@ PASS: word-multibyte
 PASS: write-error-msg
 PASS: yesno
 PASS: z-anchor-newline
-# TOTAL: 113
-# PASS:  98
-# SKIP:  13
+# TOTAL: 116
+# PASS:  100
+# SKIP:  14
 # XFAIL: 2
 # FAIL:  0
 # XPASS: 0
@@ -137,8 +140,8 @@ PASS: test-cloexec
 PASS: test-close
 PASS: test-connect
 PASS: test-ctype
-PASS: dfa-invalid-char-class.sh
-PASS: dfa-match.sh
+PASS: test-dfa-invalid-char-class.sh
+PASS: test-dfa-match.sh
 PASS: test-dirent
 PASS: test-dup
 PASS: test-dup2
@@ -162,6 +165,8 @@ PASS: test-fgetc
 PASS: test-float
 PASS: test-fnmatch-h
 PASS: test-fnmatch
+PASS: test-fopen-gnu
+PASS: test-fopen
 PASS: test-fpending.sh
 PASS: test-fputc
 PASS: test-fread
@@ -189,6 +194,8 @@ PASS: test-ioctl
 PASS: test-isatty
 PASS: test-isblank
 PASS: test-iswblank
+PASS: test-iswdigit.sh
+PASS: test-iswxdigit.sh
 PASS: test-langinfo
 PASS: test-limits-h
 PASS: test-listen
@@ -204,10 +211,10 @@ PASS: test-mbsinit.sh
 PASS: test-mbsrtowcs1.sh
 PASS: test-mbsrtowcs2.sh
 SKIP: test-mbsrtowcs3.sh
-PASS: test-mbsrtowcs4.sh
+SKIP: test-mbsrtowcs4.sh
 PASS: test-mbsstr1
 PASS: test-mbsstr2.sh
-PASS: test-mbsstr3.sh
+SKIP: test-mbsstr3.sh
 PASS: test-memchr
 PASS: test-memchr2
 PASS: test-memrchr
@@ -228,6 +235,7 @@ PASS: test-pthread_sigmask1
 PASS: test-pthread_sigmask2
 PASS: test-quotearg-simple
 PASS: test-raise
+PASS: test-rawmemchr
 PASS: test-read
 PASS: test-realloc-gnu
 PASS: test-regex
@@ -287,7 +295,7 @@ PASS: uniwidth/test-uc_width2.sh
 PASS: test-unsetenv
 PASS: test-vasnprintf
 PASS: test-vc-list-files-git.sh
-PASS: test-vc-list-files-cvs.sh
+SKIP: test-vc-list-files-cvs.sh
 PASS: test-verify
 PASS: test-verify.sh
 PASS: test-version-etc.sh
@@ -298,14 +306,16 @@ SKIP: test-wcrtomb-w32-2.sh
 SKIP: test-wcrtomb-w32-3.sh
 SKIP: test-wcrtomb-w32-4.sh
 SKIP: test-wcrtomb-w32-5.sh
+SKIP: test-wcrtomb-w32-6.sh
+SKIP: test-wcrtomb-w32-7.sh
 PASS: test-wctype-h
 PASS: test-wcwidth
 PASS: test-xalloc-die.sh
 PASS: test-xstrtoimax.sh
 PASS: test-xstrtol.sh
-# TOTAL: 185
-# PASS:  178
-# SKIP:  7
+# TOTAL: 192
+# PASS:  180
+# SKIP:  12
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0


### PR DESCRIPTION
Tested it running `gmake test`, all tests passed after adapting them to this new version.
When installed locally, the man page says the right version and it worked when I tested it with `ggrep root /etc/passwd`.