### PR TITLE
Bug #11889: Build of developer/libtool fails with autoconf error

### DIFF
--- a/components/developer/libtool/Makefile
+++ b/components/developer/libtool/Makefile
@@ -29,7 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libtool
 COMPONENT_VERSION=	2.4.6
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_FMRI=	developer/build/libtool
 COMPONENT_SUMMARY=	GNU libtool
 COMPONENT_CLASSIFICATION=	Development/GNU

--- a/components/developer/libtool/patches/002-configure.ac.patch
+++ b/components/developer/libtool/patches/002-configure.ac.patch
@@ -1,0 +1,11 @@
+--- libtool-2.4.6/configure.ac-orig	   :: 
++++ libtool-2.4.6/configure.ac	   :: 
+@@ -24,7 +24,7 @@
+ ####
+ 
+ 
+-AC_PREREQ(2.62)
++AC_PREREQ([2.63])
+ dnl Oldest automake required for bootstrap is below in AM_INIT_AUTOMAKE.
+ 
+ 


### PR DESCRIPTION
This PR makes a minor change to the precursor of the configure script.  The pair of square brackets protect (in the gm4 sense) the version number from premature interpretation.  This the recommended way to use the AC_PREREQ macro.  Otherwise, it misbehaves in certain circumstances.

I tested it both with and without the patch.  The build was successful in both cases.  I've only seen an error when building libtool with an older version of autoconf, probably 2.63 .  Since OI has version 2.69 of autoconf, the patch is behaving as expected.   I only want to make libtool a bit more tolerant.
