### PR TITLE
gawk: update to 5.1.0

### DIFF
--- a/components/text/gawk/Makefile
+++ b/components/text/gawk/Makefile
@@ -21,15 +21,15 @@
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2017, Aurelien Larcher
 # Copyright (c) 2019, Michal Nowak
+# Copyright (c) 2020, Nona Hansel
 #
 
-PREFERRED_BITS=		64
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=          gawk
-COMPONENT_VERSION=       5.0.1
-COMPONENT_REVISION=      1
+COMPONENT_VERSION=       5.1.0
 COMPONENT_SUMMARY=       GNU awk
 COMPONENT_PROJECT_URL=   https://www.gnu.org/software/gawk/
 COMPONENT_FMRI=          text/gawk
@@ -37,13 +37,11 @@ COMPONENT_CLASSIFICATION=Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:8e4e86f04ed789648b66f757329743a0d6dfb5294c3b91b756a474f1ce05a794
+	sha256:cf5fea4ac5665fd5171af4716baab2effc76306a9572988d5ba1078f196382bd
 COMPONENT_ARCHIVE_URL=   http://ftp.gnu.org/gnu/gawk/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=       GPLv3, FDLv1.3
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CFLAGS+= $(gcc_C99_ENABLE) $(CPP_XPG6MODE)
 CFLAGS+= -I$(USRINCDIR)/mpfr -I$(USRINCDIR)/gmp
@@ -60,12 +58,6 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "/^Making/d" ' \
 	'-e "/^--- _/d" ' \
 	'-e "s|\(\*\*\* \\$$(SOURCE_DIR)/test/[^[:space:]]*\).*|\1|g" '
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/gmp

--- a/components/text/gawk/test/results-64.master
+++ b/components/text/gawk/test/results-64.master
@@ -67,6 +67,7 @@ delfunc
 dfamb1
 dfastress
 dynlj
+escapebrace
 eofsplit
 eofsrc1
 exit2
@@ -213,6 +214,7 @@ rscompat
 rsnul1nl
 rsnulbig
 rsnulbig2
+rsnulw
 rstest1
 rstest2
 rstest3
@@ -329,6 +331,8 @@ fpat3
 fpat4
 fpat5
 fpat6
+fpat7
+fpat8
 fpatnull
 fsfwfs
 funlen
@@ -399,6 +403,11 @@ nondec2
 nonfatal1
 nonfatal2
 nonfatal3
+nsawk1a
+nsawk1b
+nsawk1c
+nsawk2a
+nsawk2b
 nsbad
 nsbad_cmd
 nsforloop
@@ -428,6 +437,7 @@ profile9
 profile10
 profile11
 profile12
+profile13
 pty1
 pty2
 rebuf
@@ -456,6 +466,10 @@ strftfld
 strftime
 strtonum
 strtonum1
+stupid1
+stupid2
+stupid3
+stupid4
 switch2
 symtab1
 symtab2
@@ -467,11 +481,14 @@ symtab7
 symtab8
 symtab9
 symtab10
+symtab11
 timeout
 typedregex1
 typedregex2
 typedregex3
 typedregex4
+typedregex5
+typedregex6
 typeof1
 typeof2
 typeof3
@@ -497,7 +514,6 @@ asort
 asorti
 backbigs1
 backsmalls1
-$(SOURCE_DIR)/test/backsmalls1.ok _backsmalls1 differ: char 3, line 2
 backsmalls2
 fmttest
 fnarydel
@@ -528,7 +544,9 @@ functab4
 getfile
 inplace1
 inplace2
+inplace2bcomp
 inplace3
+inplace3bcomp
 ordchr
 ordchr2
 readdir
@@ -559,35 +577,6 @@ mpfrsqrt
 mpfrstrtonum
 mpgforcenum
 mpfruplus
+mpfranswer42
 ======== Done with MPFR tests ========
-1 TESTS FAILED
-for i in _* ; \
-do  \
-	if [ "$i" != "_*" ]; then \
-	echo ============== $i ============= ; \
-	base=`echo $i | sed 's/^_//'` ; \
-	if [ -r ${base}.ok ]; then \
-	diff -c ${base}.ok $i ; \
-	else \
-	diff -c "$(SOURCE_DIR)/test"/${base}.ok  $i ; \
-	fi ; \
-	fi ; \
-done | more
-============== _backsmalls1 =============
-*** $(SOURCE_DIR)/test/backsmalls1.ok
-***************
-*** 1,5 ****
-   
--  
-   
-   
-   
---- 1,4 ----
-***************
-*** 10,14 ****
-   
-   
-   
--  
-  　
---- 9,12 ----
+ALL TESTS PASSED


### PR DESCRIPTION
I adapted tests to this new version, ran `gmake test`, and if I interpret it correctly, all tests passed.
When installed locally, I've tested it with `gawk -F: '$3 > 500 { print $1 }' /etc/passwd` which worked and the man page says the right version.