### PR TITLE
fix python metadata dependency problem

### DIFF
--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -82,6 +82,7 @@ PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/docs
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/locale
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/python-3-soabi
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/python-3-no-32bit
+PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/python-3-metadata
 PUBLISH_TRANSFORMS +=	$(PKGMOGRIFY_TRANSFORMS)
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/publish-cleanup
 

--- a/transforms/python-3-metadata
+++ b/transforms/python-3-metadata
@@ -1,0 +1,26 @@
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+# Newer setup tools creates entry point scripts which do:
+
+#        try:
+#            from importlib.metadata import distribution
+#        except ImportError:
+#            try:
+#                from importlib_metadata import distribution
+#            except ImportError:
+#                from pkg_resources import load_entry_point
+#
+# The IPS dependency resolver cannot process this and fails to find a
+# dependency for the 'metadata' requirement, which is only available from
+# python 3.8. Bypass this dependency globally.
+
+<transform file path=.*/bin/ -> set pkg.depend.bypass-generate .*metadata.* >


### PR DESCRIPTION
Many python packages fail to publish atm. This fixes the problems (taken from OmniOSce). There they have this transformation local for python 3.7.
I am not sure whether activating it globally does any harm.