### PR TITLE
Problem: build recipes looking for clang++-(version) find no such name

### DIFF
--- a/components/developer/clang-80/Makefile
+++ b/components/developer/clang-80/Makefile
@@ -24,6 +24,7 @@ LLVM_NAME=		llvm
 CLANG_NAME=		cfe
 
 COMPONENT_VERSION=	8.0.1
+COMPONENT_REVISION=	1
 COMPONENT_MAJOR_VERSION= \
 	$(shell echo $(COMPONENT_VERSION) | $(GSED) -e 's/\([0-9]\+\.[0-9]\+\).*/\1/')
 COMPONENT_PROJECT_URL=	http://llvm.org/

--- a/components/developer/clang-80/clang-80.p5m
+++ b/components/developer/clang-80/clang-80.p5m
@@ -49,6 +49,7 @@ link path=usr/bin/clang-offload-bundler target=../clang/8.0/bin/clang-offload-bu
 link path=usr/bin/clang-refactor target=../clang/8.0/bin/clang-refactor mediator=clang mediator-version=8.0
 link path=usr/bin/clang-rename target=../clang/8.0/bin/clang-rename mediator=clang mediator-version=8.0
 link path=usr/bin/clang++ target=../clang/8.0/bin/clang++ mediator=clang mediator-version=8.0
+link path=usr/bin/clang++-8 target=../clang/8.0/bin/clang++-8 mediator=clang mediator-version=8.0
 link path=usr/bin/diagtool target=../clang/8.0/bin/diagtool mediator=clang mediator-version=8.0
 link path=usr/bin/dsymutil target=../clang/8.0/bin/dsymutil mediator=clang mediator-version=8.0
 link path=usr/bin/git-clang-format target=../clang/8.0/bin/git-clang-format mediator=clang mediator-version=8.0
@@ -116,6 +117,7 @@ file path=usr/clang/8.0/bin/bugpoint
 file path=usr/clang/8.0/bin/c-index-test
 link path=usr/clang/8.0/bin/clang target=clang-8
 link path=usr/clang/8.0/bin/clang++ target=clang
+link path=usr/clang/8.0/bin/clang++-8 target=clang++
 file path=usr/clang/8.0/bin/clang-8
 file path=usr/clang/8.0/bin/clang-check
 link path=usr/clang/8.0/bin/clang-cl target=clang

--- a/components/developer/clang-90/Makefile
+++ b/components/developer/clang-90/Makefile
@@ -26,6 +26,7 @@ LLVM_NAME=		llvm
 CLANG_NAME=		clang
 
 COMPONENT_VERSION=	9.0.1
+COMPONENT_REVISION=	1
 COMPONENT_MAJOR_VERSION= \
 	$(shell echo $(COMPONENT_VERSION) | $(GSED) -e 's/\([0-9]\+\.[0-9]\+\).*/\1/')
 COMPONENT_PROJECT_URL=	http://llvm.org/

--- a/components/developer/clang-90/clang-90.p5m
+++ b/components/developer/clang-90/clang-90.p5m
@@ -50,6 +50,7 @@ link path=usr/bin/clang-offload-bundler target=../clang/9.0/bin/clang-offload-bu
 link path=usr/bin/clang-refactor target=../clang/9.0/bin/clang-refactor mediator=clang mediator-version=9.0
 link path=usr/bin/clang-rename target=../clang/9.0/bin/clang-rename mediator=clang mediator-version=9.0
 link path=usr/bin/clang++ target=../clang/9.0/bin/clang++ mediator=clang mediator-version=9.0
+link path=usr/bin/clang++-9 target=../clang/9.0/bin/clang++-9 mediator=clang mediator-version=9.0
 link path=usr/bin/diagtool target=../clang/9.0/bin/diagtool mediator=clang mediator-version=9.0
 link path=usr/bin/dsymutil target=../clang/9.0/bin/dsymutil mediator=clang mediator-version=9.0
 link path=usr/bin/git-clang-format target=../clang/9.0/bin/git-clang-format mediator=clang mediator-version=9.0
@@ -118,6 +119,7 @@ file path=usr/clang/9.0/bin/bugpoint
 file path=usr/clang/9.0/bin/c-index-test
 link path=usr/clang/9.0/bin/clang target=clang-9
 link path=usr/clang/9.0/bin/clang++ target=clang
+link path=usr/clang/9.0/bin/clang++-9 target=clang++
 file path=usr/clang/9.0/bin/clang-9
 file path=usr/clang/9.0/bin/clang-check
 link path=usr/clang/9.0/bin/clang-cl target=clang


### PR DESCRIPTION
Solution: add the symlinks to installation tree and mediated to /usr/bin
    
Signed-off-by: Jim Klimov <jimklimov@gmail.com>

