### PR TITLE
colorama: update to 0.4.4

### DIFF
--- a/components/python/colorama/Makefile
+++ b/components/python/colorama/Makefile
@@ -9,13 +9,16 @@
 #
 
 #
-# Copyright 2019 Nona Hansel
+# Copyright 2019-2020 Nona Hansel
 #
+
+BUILD_BITS=	NO_ARCH
+BUILD_STYLE=	setup.py
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		colorama
-COMPONENT_VERSION=	0.4.1
+COMPONENT_VERSION=	0.4.4
 COMPONENT_SUMMARY=	Simple cross-platform colored terminal text in Python
 COMPONENT_PROJECT_URL=	https://github.com/tartley/colorama
 COMPONENT_FMRI=		library/python/colorama
@@ -24,20 +27,13 @@ COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	$(call pypi_url)	
 COMPONENT_ARCHIVE_HASH= \
-	sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d
+	sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
 COMPONENT_LICENSE=	BSD 3 Clause
 COMPONENT_LICENSE_FILE=	LICENSE.txt
 
 PYTHON_VERSIONS=	3.5
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
-
-build:          $(BUILD_NO_ARCH)
-
-install:        $(INSTALL_NO_ARCH)
-
-test:           $(NO_TESTS)
+TEST_TARGET:	$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 # Auto-generated dependencies

--- a/components/python/colorama/pkg5
+++ b/components/python/colorama/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "SUNWcs",
-        "system/library"
+        "SUNWcs"
     ],
     "fmris": [
         "library/python/colorama-35",


### PR DESCRIPTION
Sample manifest didn't change.
When installed locally, I tested it with this example
```from colorama import Fore, Back, Style
print(Fore.RED + 'some red text')
print(Back.GREEN + 'and with a green background')
print(Style.DIM + 'and in dim text')
print(Style.RESET_ALL)
print('back to normal now')
```
from colorama website https://pypi.org/project/colorama/ and it worked.