### PR TITLE
jenkins-core-weekly: update to 2.267

### DIFF
--- a/components/developer/jenkins-core-weekly/Makefile
+++ b/components/developer/jenkins-core-weekly/Makefile
@@ -27,9 +27,9 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=				jenkins
 JENKINS_RELEASE=			weekly
 COMPONENT_MAJOR_VERSION=	2
-COMPONENT_MINOR_VERSION=	266
+COMPONENT_MINOR_VERSION=	267
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:378dbc2994e6a4a7b54b1873b914372b1a19c20ce14370520cfc04fe91ad9d71
+	sha256:0fa9251f3a170dc7272c37ad72c6f8bbefb8893be73d883617d21aa565286dfa
 # See $(COMPONENT_ARCHIVE_URL).sha256 e.g. for current weekly release, run
 #   wget -O - http://mirrors.jenkins-ci.org/war/latest/jenkins.war.sha256
 # or for LTS


### PR DESCRIPTION
sample-manifest didn't change