### PR TITLE
tqdm: update to 4.53.0

### DIFF
--- a/components/python/tqdm/Makefile
+++ b/components/python/tqdm/Makefile
@@ -9,14 +9,16 @@
 #
 
 #
-# Copyright 2019 Nona Hansel
+# Copyright 2019-2020 Nona Hansel
 #
+
+BUILD_BITS=	NO_ARCH
+BUILD_STYLE=	setup.py
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		tqdm
-COMPONENT_VERSION=	4.34.0
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	4.53.0
 COMPONENT_SUMMARY=	'Fast, extensible progress bar for Python and CLI'
 COMPONENT_PROJECT_URL=	https://github.com/tqdm/tqdm
 COMPONENT_FMRI=		library/python/tqdm		
@@ -25,21 +27,14 @@ COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	$(call pypi_url)
 COMPONENT_ARCHIVE_HASH= \
-	sha256:ebc205051d79b49989140f5f6c73ec23fce5f590cbc4d9cd6e4c47f168fa0f10
+	sha256:3d3f1470d26642e88bd3f73353cb6ff4c51ef7d5d7efef763238f4bc1f7e4e81
 COMPONENT_LICENSE=	MPLv2.0,MIT
 COMPONENT_LICENSE_FILE=	LICENCE
 
 PYTHON_VERSIONS=	3.5
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
-
-build:          $(BUILD_NO_ARCH)
-
-install:        $(INSTALL_NO_ARCH)
-
-test:           $(NO_TESTS)
+TEST_TARGET:	$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/python/setuptools-35

--- a/components/python/tqdm/manifests/sample-manifest.p5m
+++ b/components/python/tqdm/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -31,6 +31,7 @@ file path=usr/lib/python3.5/vendor-packages/tqdm-$(COMPONENT_VERSION)-py3.5.egg-
 file path=usr/lib/python3.5/vendor-packages/tqdm-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
 file path=usr/lib/python3.5/vendor-packages/tqdm/__init__.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/__main__.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/_dist_ver.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_main.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_monitor.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm.py
@@ -38,7 +39,22 @@ file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm_gui.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm_notebook.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm_pandas.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_utils.py
-file path=usr/lib/python3.5/vendor-packages/tqdm/_version.py
-file path=usr/lib/python3.5/vendor-packages/tqdm/auto/__init__.py
-file path=usr/lib/python3.5/vendor-packages/tqdm/autonotebook/__init__.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/asyncio.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/auto.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/autonotebook.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/cli.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/completion.sh
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/__init__.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/bells.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/concurrent.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/discord.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/itertools.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/telegram.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/utils_worker.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/gui.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/keras.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/notebook.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/std.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/tqdm.1
+file path=usr/lib/python3.5/vendor-packages/tqdm/utils.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/version.py

--- a/components/python/tqdm/pkg5
+++ b/components/python/tqdm/pkg5
@@ -2,8 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "library/python/setuptools-35",
-        "runtime/python-35",
-        "system/library"
+        "runtime/python-35"
     ],
     "fmris": [
         "library/python/tqdm-35",

--- a/components/python/tqdm/tqdm-PYVER.p5m
+++ b/components/python/tqdm/tqdm-PYVER.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2019 Nona Hansel 
+# Copyright 2019-2020 Nona Hansel
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -33,6 +33,7 @@ file path=usr/lib/python3.5/vendor-packages/tqdm-$(COMPONENT_VERSION)-py3.5.egg-
 file path=usr/lib/python3.5/vendor-packages/tqdm-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
 file path=usr/lib/python3.5/vendor-packages/tqdm/__init__.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/__main__.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/_dist_ver.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_main.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_monitor.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm.py
@@ -40,7 +41,22 @@ file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm_gui.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm_notebook.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_tqdm_pandas.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/_utils.py
-file path=usr/lib/python3.5/vendor-packages/tqdm/_version.py
-file path=usr/lib/python3.5/vendor-packages/tqdm/auto/__init__.py
-file path=usr/lib/python3.5/vendor-packages/tqdm/autonotebook/__init__.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/asyncio.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/auto.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/autonotebook.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/cli.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/completion.sh
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/__init__.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/bells.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/concurrent.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/discord.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/itertools.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/telegram.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/contrib/utils_worker.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/gui.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/keras.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/notebook.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/std.py
 file path=usr/lib/python3.5/vendor-packages/tqdm/tqdm.1
+file path=usr/lib/python3.5/vendor-packages/tqdm/utils.py
+file path=usr/lib/python3.5/vendor-packages/tqdm/version.py


### PR DESCRIPTION
When installed locally, pip3.5 shows the right version and I tested it with this example
```
from tqdm import tqdm
for i in tqdm(range(int(9e6))):
    pass
```
and it worked.