### PR TITLE
Bug #13298: NTP fails on boot

### DIFF
--- a/components/network/ntp/Makefile
+++ b/components/network/ntp/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ntp
 COMPONENT_VERSION=	4.2.8p13
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 IPS_COMPONENT_VERSION=	$(subst p,.,$(COMPONENT_VERSION))
 COMPONENT_SUMMARY=	Network Time Protocol Daemon v4
 COMPONENT_DESCRIPTION=	Network Time Protocol v4, NTP Daemon and Utilities

--- a/components/network/ntp/Solaris/ntp.xml
+++ b/components/network/ntp/Solaris/ntp.xml
@@ -20,6 +20,7 @@
 
  CDDL HEADER END
 
+ Copyright 2020 Gary Mills
  Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
 
  NOTE:  This service manifest is not editable; its contents will
@@ -51,13 +52,14 @@
 		    <service_fmri value='svc:/system/filesystem/minimal' />
 	</dependency>
 
-<!--	<dependent
-	    name='ntp_multi-user'
-	    grouping='optional_all'
-	    restart_on='none'>
-		<service_fmri value='svc:/milestone/multi-user' />
-	</dependent>
--->
+ 	<dependency
+		name='milestone'
+		grouping='require_all'
+		restart_on='refresh'
+		type='service'>
+		    <service_fmri value='svc:/milestone/name-services' />
+	</dependency>
+
 
 	<exec_method
 	    type='method'


### PR DESCRIPTION
This PR fixes both of the NTP problems that I mentioned in the bug report.  All it does is to add a third dependancy to the SMF manifest for NTP.  My testing is described in detail in the bug report.

