### PR TITLE
parallel: update to 20201122

### DIFF
--- a/components/shell/parallel/Makefile
+++ b/components/shell/parallel/Makefile
@@ -22,22 +22,23 @@
 #
 # Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2019, Michal Nowak
+# Copyright 2020, Nona Hansel
 #
 
-PREFERRED_BITS=		64
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		parallel
-COMPONENT_VERSION=	20190622
+COMPONENT_VERSION=	20201122
 # A leading "0." is included to make it easier to upgrade the package, should
 # the maintainers decide to go to a more standard version numbering system.
-IPS_COMPONENT_VERSION=  0.2019.6.22
+IPS_COMPONENT_VERSION=  0.2020.11.22
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/parallel/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:3f1dfd8c450db7e70e44220e2edd4e214ba1540eebaabeeb5636d0c47b5eaeec
+	sha256:4da0bf42c466493b44dcbd8750e7bf99c31da4c701e8be272276c16ec4caff30
 COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_SUMMARY=	GNU parallel is a shell tool for executing jobs in parallel using one or more computers.
 COMPONENT_FMRI=		shell/parallel
@@ -45,22 +46,14 @@ COMPONENT_LICENSE_FILE=	COPYING
 COMPONENT_LICENSE=	GPLv3
 COMPONENT_CLASSIFICATION=	System/Shells
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET:	$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 # Set PATH to find /usr/perl5/bin/pod2man, so that the man pages can be
 # automatically generated
 COMPONENT_BUILD_ENV +=    PATH="$(PATH):/usr/perl5/bin"
 
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(NO_TESTS)
-
 # Auto-generated dependencies
-REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
 REQUIRED_PACKAGES += shell/which
 REQUIRED_PACKAGES += SUNWcs

--- a/components/shell/parallel/manifests/sample-manifest.p5m
+++ b/components/shell/parallel/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,6 +38,7 @@ file path=usr/bin/niceload
 file path=usr/bin/parallel
 file path=usr/bin/parcat
 file path=usr/bin/parset
+file path=usr/bin/parsort
 link path=usr/bin/sem target=parallel
 file path=usr/bin/sql
 file path=usr/share/doc/parallel/env_parallel.html
@@ -55,7 +56,7 @@ file path=usr/share/doc/parallel/parallel_alternatives.texi
 file path=usr/share/doc/parallel/parallel_book.html
 file path=usr/share/doc/parallel/parallel_book.pdf
 file path=usr/share/doc/parallel/parallel_book.texi
-file path=usr/share/doc/parallel/parallel_cheat.pdf
+file path=usr/share/doc/parallel/parallel_cheat_bw.pdf
 file path=usr/share/doc/parallel/parallel_design.html
 file path=usr/share/doc/parallel/parallel_design.pdf
 file path=usr/share/doc/parallel/parallel_design.texi
@@ -68,6 +69,9 @@ file path=usr/share/doc/parallel/parcat.texi
 file path=usr/share/doc/parallel/parset.html
 file path=usr/share/doc/parallel/parset.pdf
 file path=usr/share/doc/parallel/parset.texi
+file path=usr/share/doc/parallel/parsort.html
+file path=usr/share/doc/parallel/parsort.pdf
+file path=usr/share/doc/parallel/parsort.texi
 file path=usr/share/doc/parallel/sem.html
 file path=usr/share/doc/parallel/sem.pdf
 file path=usr/share/doc/parallel/sem.texi
@@ -79,6 +83,7 @@ file path=usr/share/man/man1/niceload.1
 file path=usr/share/man/man1/parallel.1
 file path=usr/share/man/man1/parcat.1
 file path=usr/share/man/man1/parset.1
+file path=usr/share/man/man1/parsort.1
 file path=usr/share/man/man1/sem.1
 file path=usr/share/man/man1/sql.1
 file path=usr/share/man/man7/parallel_alternatives.7

--- a/components/shell/parallel/parallel.p5m
+++ b/components/shell/parallel/parallel.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright 2015 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
+# Copyright 2020 Nona Hansel
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -29,6 +30,7 @@ file path=usr/bin/niceload
 file path=usr/bin/parallel
 file path=usr/bin/parcat
 file path=usr/bin/parset
+file path=usr/bin/parsort
 link path=usr/bin/sem target=parallel
 file path=usr/bin/sql
 file path=usr/share/doc/parallel/niceload.html
@@ -37,7 +39,7 @@ file path=usr/share/doc/parallel/niceload.texi
 file path=usr/share/doc/parallel/parallel.html
 file path=usr/share/doc/parallel/parallel.pdf
 file path=usr/share/doc/parallel/parallel.texi
-file path=usr/share/doc/parallel/parallel_cheat.pdf
+file path=usr/share/doc/parallel/parallel_cheat_bw.pdf
 file path=usr/share/doc/parallel/parallel_design.html
 file path=usr/share/doc/parallel/parallel_design.pdf
 file path=usr/share/doc/parallel/parallel_design.texi
@@ -50,6 +52,9 @@ file path=usr/share/doc/parallel/parcat.texi
 file path=usr/share/doc/parallel/parset.html
 file path=usr/share/doc/parallel/parset.pdf
 file path=usr/share/doc/parallel/parset.texi
+file path=usr/share/doc/parallel/parsort.html
+file path=usr/share/doc/parallel/parsort.pdf
+file path=usr/share/doc/parallel/parsort.texi
 file path=usr/share/doc/parallel/sem.html
 file path=usr/share/doc/parallel/sem.pdf
 file path=usr/share/doc/parallel/sem.texi
@@ -60,6 +65,7 @@ file path=usr/share/man/man1/niceload.1
 file path=usr/share/man/man1/parallel.1
 file path=usr/share/man/man1/parcat.1
 file path=usr/share/man/man1/parset.1
+file path=usr/share/man/man1/parsort.1
 file path=usr/share/man/man1/sem.1
 file path=usr/share/man/man1/sql.1
 file path=usr/share/man/man7/parallel_design.7

--- a/components/shell/parallel/pkg5
+++ b/components/shell/parallel/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
         "SUNWcs",
-        "runtime/perl-522",
         "runtime/perl-524",
         "shell/which",
         "system/library"


### PR DESCRIPTION
When published, the man page says the right version + tested it with this code
```
echo ada > ada ; echo lovelace > lovelace
echo richard > richard ; echo stallman > stallman
ls -1 | parallel --max-args=2 echo
ls -1 | parallel --max-args=2 cat {1} {2} ">" {1}_{2}.person
```
from this site https://opensource.com/article/18/5/gnu-parallel and it worked.