### PR TITLE
tmux: update to 3.1c

### DIFF
--- a/components/sysutils/tmux/Makefile
+++ b/components/sysutils/tmux/Makefile
@@ -12,6 +12,7 @@
 # Copyright 2011, 2013, EveryCity Ltd. All rights reserved.
 # Copyright 2019, Michal Nowak
 # Copyright 2019, Solene Rapenne
+# Copyright 2020, Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -19,11 +20,10 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		tmux
-COMPONENT_VERSION=	3.1b
+COMPONENT_VERSION=	3.1c
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
-IPS_COMPONENT_VERSION=	3.1.2
-COMPONENT_REVISION=	1
+IPS_COMPONENT_VERSION=	3.1.3
 COMPONENT_FMRI=		terminal/tmux
 COMPONENT_PROJECT_URL=	https://$(COMPONENT_NAME).github.io
 COMPONENT_SUMMARY=	tmux terminal multiplexer
@@ -31,7 +31,7 @@ COMPONENT_CLASSIFICATION= Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:d93f351d50af05a75fe6681085670c786d9504a5da2608e481c47cf5e1486db9
+	sha256:918f7220447bef33a1902d4faff05317afd9db4ae1c9971bef5c787ac6c88386
 COMPONENT_ARCHIVE_URL= \
 	https://github.com/tmux/tmux/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE_FILE=	COPYING


### PR DESCRIPTION
Sample manifest didn't change. When published, the man page says the right version. I tested it performing some basic commands (splitting pane, switching between panes) and it worked.