### PR TITLE
logrotate: update to 3.17.0

### DIFF
--- a/components/sysutils/logrotate/Makefile
+++ b/components/sysutils/logrotate/Makefile
@@ -11,6 +11,7 @@
 #
 # Copyright 2015 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
+# Copyright 2020 Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -18,7 +19,7 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		logrotate
-COMPONENT_VERSION=	3.16.0
+COMPONENT_VERSION=	3.17.0
 COMPONENT_PROJECT_URL=	https://github.com/logrotate/logrotate
 COMPONENT_SUMMARY=	Logrotate - Rotates and compresses log files
 COMPONENT_FMRI=		system/file/logrotate
@@ -26,12 +27,14 @@ COMPONENT_CLASSIFICATION=	System/Administration and Configuration
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:e1bae2c72115cf16007bb98ea38752d1120010cfb70addd9867d952c7529de3b
+	sha256:5db8cf4786e0abeeec64f852d605ef702bfcf18f4d7938dce7d7a00ad4de787c
 COMPONENT_ARCHIVE_URL=	https://github.com/logrotate/logrotate/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv2
 COMPONENT_LICENSE_FILE=	COPYING
 
 include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -f -i )
 
 PATH=$(PATH.gnu)
 

--- a/components/sysutils/logrotate/logrotate.p5m
+++ b/components/sysutils/logrotate/logrotate.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright 2015 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
+# Copyright 2020 Nona Hansel
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +27,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 dir path=etc/logrotate.d group=sys
 file examples/btmp path=etc/logrotate.d/utmpx preserve=true
 file examples/wtmp path=etc/logrotate.d/wtmpx preserve=true
-file examples/logrotate.conf path=etc/logrotate.conf preserve=true
+file examples/logrotate.conf path=etc/logrotate.conf mode=0644 preserve=true
 file path=usr/sbin/logrotate
 file path=usr/share/man/man5/logrotate.conf.5
 file logrotate.8 path=usr/share/man/man1/logrotate.1

--- a/components/sysutils/logrotate/patches/01.fix-tests.patch
+++ b/components/sysutils/logrotate/patches/01.fix-tests.patch
@@ -13,36 +13,37 @@
  GNUDATE=$?
  
  # --force to trigger rotation
---- logrotate-3.15.0/test/test-0054.sh	2018-01-04 12:58:46.000000000 +0000
-+++ logrotate-3.15.0/test/test-0054.sh.new	2019-03-07 19:28:01.420265819 +0000
+
+--- logrotate-3.17.0/test/test-0054.sh	2020-03-30 15:35:48.000000000 +0000
++++ logrotate-3.17.0/test/test-0054.sh	2020-12-03 16:18:47.502772740 +0000
 @@ -12,7 +12,7 @@ preptest test.log 54 1 0
  DATE=""
  for i in $(seq 1 60)
  do
--    DATE=$(/bin/date "+%Y-%m-%d" --date "$i day ago" 2>/dev/null)   
-+    DATE=$(/usr/gnu/bin/date "+%Y-%m-%d" --date "$i day ago" 2>/dev/null)   
+-    DATE=$(/bin/date "+%Y-%m-%d" --date "$i day ago" 2>/dev/null)
++    DATE=$(/usr/gnu/bin/date "+%Y-%m-%d" --date "$i day ago" 2>/dev/null)
      echo "x" > test.log-$DATE
  done
- 
---- logrotate-3.15.0/test/test-0055.sh	2018-01-04 12:58:46.000000000 +0000
-+++ logrotate-3.15.0/test/test-0055.sh.new	2019-03-07 19:28:18.700107695 +0000
+
+--- logrotate-3.17.0/test/test-0055.sh	2020-03-30 15:35:48.000000000 +0000
++++ logrotate-3.17.0/test/test-0055.sh	2020-12-03 16:19:58.196920474 +0000
 @@ -12,7 +12,7 @@ preptest test.log 55 1 0
  DATE=""
  for i in $(seq 1 60)
  do
--    DATE=$(/bin/date "+%s" --date "$i hour ago" 2>/dev/null)   
-+    DATE=$(/usr/gnu/bin/date "+%s" --date "$i hour ago" 2>/dev/null)   
+-    DATE=$(/bin/date "+%s" --date "$i hour ago" 2>/dev/null)
++    DATE=$(/usr/gnu/bin/date "+%s" --date "$i hour ago" 2>/dev/null)
      echo "x" > test.log-$DATE.gz
  done
- 
---- logrotate-3.15.0/test/test-0056.sh	2018-01-04 12:58:46.000000000 +0000
-+++ logrotate-3.15.0/test/test-0056.sh.new	2019-03-07 19:28:32.859982092 +0000
+
+--- logrotate-3.17.0/test/test-0056.sh	2020-03-30 15:35:48.000000000 +0000
++++ logrotate-3.17.0/test/test-0056.sh	2020-12-03 16:20:56.830560483 +0000
 @@ -12,7 +12,7 @@ preptest test.log 56 1 0
  DATE=""
  for i in $(seq 1 60)
  do
--    DATE=$(/bin/date "+%d-%m-%Y" --date "$i day ago" 2>/dev/null)   
-+    DATE=$(/usr/gnu/bin/date "+%d-%m-%Y" --date "$i day ago" 2>/dev/null)   
+-    DATE=$(/bin/date "+%d-%m-%Y" --date "$i day ago" 2>/dev/null)
++    DATE=$(/usr/gnu/bin/date "+%d-%m-%Y" --date "$i day ago" 2>/dev/null)
      echo "x" > test.log-$DATE
  done
  
@@ -58,4 +59,3 @@
 +DAYAGO=$(/usr/gnu/bin/date "+%Y-%m-%d" --date "1 day ago" 2>/dev/null)
  
  echo removed > "test.log$DAYAGO"
- 

--- a/components/sysutils/logrotate/patches/02.man.patch
+++ b/components/sysutils/logrotate/patches/02.man.patch
@@ -1,12 +1,12 @@
---- logrotate-3.16.0/logrotate.8.orig	2020-05-24 14:52:14.339980132 +0000
-+++ logrotate-3.16.0/logrotate.8	2020-05-24 14:52:21.052102880 +0000
+--- logrotate-3.17.0/logrotate.8	2020-07-10 11:05:38.000000000 +0000
++++ logrotate-3.17.0/logrotate.8.bak	2020-12-03 16:45:12.653322906 +0000
 @@ -1,4 +1,4 @@
--.TH LOGROTATE 8 "3.16.0" "Linux" "System Administrator's Manual"
-+.TH LOGROTATE 8 "3.16.0" "System Administrator's Manual"
- 
- .SH NAME
- 
-@@ -671,6 +671,7 @@
+-.TH LOGROTATE 8 "3.17.0" "Linux" "System Administrator's Manual"
++.TH LOGROTATE 8 "3.17.0" "System Administrator's Manual"
+ .\" Per groff_man(7), the TQ macro should be copied from an-ext.tmac when
+ .\" not running under groff.  That's not quite right; not all groff
+ .\" installations include this macro.  So bring it in with another name
+@@ -727,6 +727,7 @@ l l l.
  .BR chmod (2),
  .BR gunzip (1),
  .BR gzip (1),
@@ -14,6 +14,7 @@
  .BR mail (1),
  .BR shred (1),
  .BR strftime (3),
+
 --- logrotate-3.15.0/logrotate.conf.5	2017-12-06 15:39:03.000000000 +0000
 +++ logrotate-3.15.0/logrotate.conf.5.new	2019-03-07 19:42:50.619161542 +0000
 @@ -1 +1 @@

--- a/components/sysutils/logrotate/patches/04-secure_getenv.patch
+++ b/components/sysutils/logrotate/patches/04-secure_getenv.patch
@@ -1,0 +1,45 @@
+From c73c0d7cbc081e59b88fee4079eb3a3a3ee7639d Mon Sep 17 00:00:00 2001
+From: SeekingMeaning <meaningseeking@protonmail.com>
+Date: Fri, 10 Jul 2020 11:35:58 -0700
+Subject: [PATCH] use getenv() on macOS and BSD
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+... where secure_getenv() is not available
+
+Reviewed-by: Christian Göttsche
+Closes: https://github.com/logrotate/logrotate/pull/344
+---
+ config.c     | 4 ++++
+ configure.ac | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/config.c b/config.c
+index d2488f1..3b90313 100644
+--- a/config.c
++++ b/config.c
+@@ -45,6 +45,10 @@ struct logInfoHead logs;
+ #include "asprintf.c"
+ #endif
+ 
++#if !defined(HAVE_SECURE_GETENV)
++#define secure_getenv getenv
++#endif
++
+ #if !defined(HAVE_ASPRINTF) && !defined(_FORTIFY_SOURCE)
+ #include <stdarg.h>
+ 
+diff --git a/configure.ac b/configure.ac
+index d95c10e..c937b4f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -166,7 +166,7 @@ AC_SUBST(COMPRESS_EXT)
+ AC_DEFINE_UNQUOTED([ROOT_UID], [0], [Root user-id.])
+ AC_SUBST(ROOT_UID)
+ 
+-AC_CHECK_FUNCS([asprintf madvise qsort strndup strptime utimensat vsyslog])
++AC_CHECK_FUNCS([asprintf madvise qsort secure_getenv strndup strptime utimensat vsyslog])
+ AC_CONFIG_HEADERS([config.h])
+ 
+ AM_CFLAGS="\


### PR DESCRIPTION
Sample-manifest didn't change.

Regarding patches:

- patches from `01.fix-tests.patch` for files `test-0054.sh`, `test-0055.sh` and `test-0056.sh` didn't work. I made the exact same changes into the same patch file.
- patch from `02.man.patch` for file `logrotate.8` didn't work. I made the exact same changes into the same patch file.
- the new patch file is taken from logrotate github repository.

When installed, the man page says the right version. I played with it a little - I uncommented the compress option from `/etc/logrotate.conf` and run `sudo logrotate -df /etc/logrotate.conf`. It seems to me it works.
