### PR TITLE
squeak-4: add inisqueak

### DIFF
--- a/components/runtime/squeak4/Makefile
+++ b/components/runtime/squeak4/Makefile
@@ -32,6 +32,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak-4
 COMPONENT_VERSION=	4.19.2
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	The Squeak V4 Smalltalk Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -39,7 +40,7 @@ COMPONENT_FMRI=		runtime/squeak-4
 COMPONENT_CLASSIFICATION=	Development/Other Languages
 SVN_REPO=		http://squeakvm.org/svn/squeak/trunk/
 SVN_REV=		3790
-SVN_HASH=  sha256:60521172ecd055b182813893e18db9adff528ee5d42f4b1ddd0c5df83a33aaa2
+SVN_HASH=  sha256:73a79cc285fe80672442ee8a66caf1b3aa28695de3edcd5c550772d65dc30915
 
 # See http://wiki.squeak.org/squeak/933
 # See http://wiki.squeak.org/squeak/159

--- a/components/runtime/squeak4/inisqueak4
+++ b/components/runtime/squeak4/inisqueak4
@@ -1,0 +1,249 @@
+#!/bin/sh
+# $Id: inisqueak4,v 1.2 2020/12/01 09:44:53 stes Exp $
+# 
+# inisqueak -- setup a directory for use with Squeak
+# 
+#   Copyright (C) 1996-2004 by Ian Piumarta and other authors/contributors
+#                              listed elsewhere in this file.
+#   All rights reserved.
+#
+#   Copyright (C) 2020 by David Stes
+#   All rights reserved.
+#   
+#   This file is part of Unix Squeak.
+# 
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+# 
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+# 
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#   SOFTWARE.
+# 
+# Author: Ian.Piumarta@INRIA.Fr
+# Last edited: 2006-10-18 10:14:20 by piumarta on emilia.local
+#
+# Author: David Stes
+# -r option to use wget and download image from files.squeak.org
+# $Id: inisqueak4,v 1.2 2020/12/01 09:44:53 stes Exp $
+# 
+
+# subtle difference between SqueakV46.sources not SqueakV4.6.sources
+MAJOR=4.6
+MAJORV=46
+VERSION=4.6-15102
+
+REMOTEDIR="http://files.squeak.org/${MAJOR}/"
+REMOTESOURCES=SqueakV${MAJORV}.sources.zip
+REMOTEIMAGEZIP=Squeak${VERSION}.zip
+
+prefix=/usr
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+imgdir=${prefix}/lib/squeak
+
+if test ! -w .; then
+  echo "You don't have write permission in this directory." >&2
+  exit 1
+fi
+
+# Sun's /bin/sh does not understand "test -e", but [/usr]/bin/test does
+test="`which test`"
+
+list=false
+startup=true
+batch=false
+interactive=true
+remote=true
+
+while true; do
+  case "$1" in
+    -l) list=true; shift;;
+    -n) startup=false; shift;;
+    -r) remote=true; shift;;
+    -R) remote=false; shift;;
+    -b) batch=true; interactive=false; shift;;
+    -h|-help|--help)
+        echo "`basename $0` [-option...] [rootdir]"
+        echo '    -b      batch (avoid interaction, exit status reflects success)'
+        echo '    -h      you already know about'
+        echo '    -r      download Squeak from remote server (default)'
+        echo '    -R      do not download Squeak from remote server'
+        echo '    -help   same as -h'
+        echo '    -l      always present a list of alternative images (overrides -b)'
+        echo '    -n      do not run Squeak after installing the files'
+        echo '    --help  same as -help'
+        exit 0;;
+    *)  break;;
+  esac
+done
+
+if test "$1" != ""; then
+  bindir=${1}/${bindir}
+  imgdir=${1}/${imgdir}
+fi
+
+SQUEAK=${bindir}/squeak
+SOURCES=SqueakV${MAJORV}.sources
+IMAGE=squeak.image.gz
+CHANGES=squeak.changes.gz
+
+# local install function
+
+missing()
+{
+  echo "The file ${1} is missing." >&2
+  echo "Please check your Squeak installation." >&2
+  exit 1
+}
+
+if ${remote}; then
+  echo "Downloading $REMOTESOURCES from $REMOTEDIR"
+  wget -O $REMOTESOURCES $REMOTEDIR/$REMOTESOURCES
+  case $? in
+   0) ;;
+   *) echo "Unable to download $REMOTESOURCES from $REMOTEDIR"; exit 1;
+  esac
+  unzip $REMOTESOURCES
+  case $? in
+   0) ;;
+   *) echo "Unable to unzip $REMOTESOURCES"; exit 1;
+  esac
+  echo "Downloading $REMOTEIMAGEZIP from $REMOTEDIR"
+  wget -O $REMOTEIMAGEZIP $REMOTEDIR/$REMOTEIMAGEZIP
+  case $? in
+   0) ;;
+   *) echo "Unable to download $REMOTEIMAGEZIP from $REMOTEDIR"; exit 1;
+  esac
+  unzip $REMOTEIMAGEZIP
+  case $? in
+   0) ;;
+   *) echo "Unable to unzip $REMOTEIMAGEZIP"; exit 1;
+  esac
+  echo "Copying to default image name .."
+  cp Squeak${VERSION}.image squeak.image
+  cp Squeak${VERSION}.changes squeak.changes
+fi
+
+if ${test} \( -f squeak.image \) -a \( -f squeak.changes \) -a \( -e ${SOURCES} \)
+then
+  if ${startup}; then
+    if test ! -x ${SQUEAK}; then
+      missing "${SQUEAK}"
+    fi
+    if ${interactive}; then
+      echo "Running ${SQUEAK}";
+    fi
+    exec ${SQUEAK}
+  else
+    if ${interactive}; then
+      echo "Squeak is already installed in this directory" >&2
+    fi
+    exit 1
+  fi
+fi
+
+install()
+{
+  cpy="${1}"
+  src="${2}"
+  red="${3}"
+  dst="${4}"
+  if ${test} ! -e ${dst}; then
+    if ${test} -e ${src}; then
+      if ${interactive}; then
+	echo "+ ${cpy} ${src} ${red} ${dst}";
+      fi
+      eval      ${cpy} ${src} ${red} ${dst}
+    else
+      missing "${src}"
+    fi
+  else
+    echo "${dst} is already present -- leaving it alone"
+#   startup=false
+  fi
+}
+
+# choose an image to install
+
+if ${list}; then :; else
+  if ${test} \( ! -e ${imgdir}/${IMAGE} \) \
+          -o \( ! -e ${imgdir}/${CHANGES} \) ; then
+    if ${batch}; then
+      echo "Could not find default image to install -- giving up." >&2
+      exit 1;
+    fi
+    list=true
+    echo "No default image, looking for alternatives..."
+    echo
+  fi
+fi
+
+if ${list}; then
+  images=`ls -1 ${imgdir}/*.image.gz 2>/dev/null | \
+          sed "s.${imgdir}/..;s/.image.gz//"`
+  if test "$images" = ""; then
+    echo "I could not find an image to install." >&2
+    echo "Please check your Squeak installation." >&2
+    exit 1
+  fi
+  nimg=`echo ${images} | tr ' ' '\012' | wc -l`
+  nimg=`echo ${nimg}`
+  more=true
+  while ${more}; do
+    echo "I found the following images:"
+    echo ${images} | tr ' ' '\012' | cat -n
+    if echo ${images} | fgrep "Squeak${VERSION}" >/dev/null; then
+      echo "(of which I might recommend Squeak${VERSION}, unless you know better)."
+    fi
+    echo -n "Which one should I install [1-${nimg}]? "
+    read reply
+    case ${reply} in
+      [1-9]) ;;
+      [1-9][0-9]) ;;
+      *) echo
+         echo "Let's try that again, with a NUMBER between 1 and ${nimg}."
+         echo
+         continue;;
+    esac
+    if test \( ${reply} -ge 1 \) -a \( ${reply} -le ${nimg} \); then
+      more=false
+    fi
+    if ${more}; then
+      echo
+      echo "Ha ha, very clever.  Now give me a number between 1 and ${nimg}"
+      echo "(or hit your interrupt key [^C or whatever] if you don't like"
+      echo "the look of any of them)."
+      echo
+    fi
+  done
+  IMAGE=`echo ${images} | tr ' ' '\012' | tail +${reply} | head -1`
+  CHANGES=${IMAGE}.changes.gz
+  IMAGE=${IMAGE}.image.gz
+fi
+
+if ${interactive}; then echo "Installing ${IMAGE} in `pwd`"; fi
+
+install "ln -s"      "${imgdir}/${SOURCES}" " " "${SOURCES}"
+install "gunzip -dc" "${imgdir}/${IMAGE}"   ">" "squeak.image"
+install "gunzip -dc" "${imgdir}/${CHANGES}" ">" "squeak.changes"
+
+if ${startup}; then
+  if test ! -x ${SQUEAK}; then
+    missing "${SQUEAK}"
+  fi
+  if ${interactive}; then
+    echo "Running ${SQUEAK}";
+  fi
+  exec ${SQUEAK}
+fi

--- a/components/runtime/squeak4/pkg5
+++ b/components/runtime/squeak4/pkg5
@@ -19,7 +19,8 @@
         "x11/library/mesa"
     ],
     "fmris": [
-        "runtime/squeak-4"
+        "runtime/squeak-4",
+        "runtime/squeak-4-nodisplay"
     ],
     "name": "squeak-4"
 }

--- a/components/runtime/squeak4/squeak-4-nodisplay.p5m
+++ b/components/runtime/squeak4/squeak-4-nodisplay.p5m
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/squeak-4-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file inisqueak4 path=usr/bin/inisqueak4
+file usr/bin/squeak path=usr/bin/squeak4
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/ckformat mode=0555
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-display-null
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-sound-null
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/squeakvm mode=0555
+file usr/share/man/man1/squeak.1 path=usr/share/man/man1/squeak4.1
+
+# the squeak script uses test -L (test for symbolic link) - use hardlink
+
+hardlink path=usr/bin/squeak target=squeak4 mediator=squeak \
+    mediator-version=4
+hardlink path=usr/bin/inisqueak target=inisqueak4 mediator=squeak \
+    mediator-version=4
+hardlink path=usr/share/man/man1/squeak.1 target=squeak4.1 mediator=squeak \
+    mediator-version=4
+

--- a/components/runtime/squeak4/squeak-4.p5m
+++ b/components/runtime/squeak4/squeak-4.p5m
@@ -26,8 +26,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
 
-file usr/bin/squeak path=usr/bin/squeak4
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/ckformat mode=0555
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.AioPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.B3DAcceleratorPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.ClipboardExtendedPlugin
@@ -50,17 +48,12 @@ file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.UnixOSProcessPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.XDisplayControlPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-display-X11
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-display-custom
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-display-null
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-sound-custom
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-sound-null
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/so.vm-sound-pulse
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-3790/squeakvm mode=0555
-file usr/share/man/man1/squeak.1 path=usr/share/man/man1/squeak4.1
 
-# the squeak script uses test -L (test for symbolic link) - use hardlink
+# the minimal installation consists of the squeak-4-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
 
-hardlink path=usr/bin/squeak target=squeak4 mediator=squeak \
-    mediator-version=4
-hardlink path=usr/share/man/man1/squeak.1 target=squeak4.1 mediator=squeak \
-    mediator-version=4
+depend type=require fmri=pkg:/runtime/squeak-4-nodisplay@$(IPS_COMPONENT_VERSION)
 


### PR DESCRIPTION
The new package is stlil called 4.19.2 because the upstream Squeak package is the same , still version 4.19.2.

I'm not sure whether OpenIndiana policy allows to push packages that do not change/upgrade the IPS_COMPONENT_VERSION.

In principle IPS allows to have multiple packages with the same version, but with different timestamps.

I realise this is not ideal, but I can't update the version as long as the subversion upstream version is still the same.  

Note that the Squeak subversion repository for the stable release squeak-4 is only rarely updated (every 6 months or so).