### PR TITLE
gmp: update to 6.2.1

### DIFF
--- a/components/library/gmp/Makefile
+++ b/components/library/gmp/Makefile
@@ -21,29 +21,28 @@
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2016, Aurelien Larcher. All rights reserved.
+# Copyright (c) 2020, Andreas Wacknitz
 #
 
+BUILD_BITS=				32_and_64
 include ../../../make-rules/shared-macros.mk
 
 PATH=$(dir $(CC)):/usr/bin:/usr/gnu/bin
 
 COMPONENT_NAME=         gmp
-COMPONENT_VERSION=      6.1.2
-COMPONENT_REVISION=     2
+COMPONENT_VERSION=      6.2.1
 COMPONENT_SUMMARY=      GNU Multiple Precision Bignum Library
-COMPONENT_PROJECT_URL=  http://gmplib.org/
+COMPONENT_PROJECT_URL=  https://gmplib.org/
 COMPONENT_FMRI=         library/gmp    
 COMPONENT_CLASSIFICATION=Development/High Performance Computing
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
-COMPONENT_ARCHIVE_URL=  http://ftp.gnu.org/gnu/gmp/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=  https://ftp.gnu.org/gnu/gmp/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_HASH= \
-  sha256:5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2
+	sha256:eae9326beb4158c386e39a356818031bd28f3124cf915f8c5b1dc4c7a36b4d7c
 COMPONENT_LICENSE=      LGPLv3,GPLv3,FDLv1.3
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 PATCH_LEVEL = 0
 
@@ -142,12 +141,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 
 ENV += -i
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
-test: $(TEST_32_and_64)
-
-REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+# Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += system/library

--- a/components/library/gmp/Solaris/libgmp.3
+++ b/components/library/gmp/Solaris/libgmp.3
@@ -3,7 +3,7 @@
 .\" Modified for Solaris to to add the Solaris stability classification,
 .\" and to add a note about source availability.
 .\" 
-.TH libgmp 3 "18 Jun 2016" "GNU MP 6.1.2" "Libraries"
+.TH libgmp 3 "14 Nov 2020" "GNU MP 6.2.1" "Libraries"
 
 .SH NAME
 \fBlibgmp\fP,

--- a/components/library/gmp/gmp.p5m
+++ b/components/library/gmp/gmp.p5m
@@ -24,22 +24,26 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/gmp/gmp.h
 file path=usr/include/gmp/gmpxx.h
-link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.3.2
-link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.3.2
-file path=usr/lib/$(MACH64)/libgmp.so.10.3.2
-link path=usr/lib/$(MACH64)/libgmpxx.so target=libgmpxx.so.4.5.2
-link path=usr/lib/$(MACH64)/libgmpxx.so.4 target=libgmpxx.so.4.5.2
-file path=usr/lib/$(MACH64)/libgmpxx.so.4.5.2
+link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.4.1
+link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.4.1
+file path=usr/lib/$(MACH64)/libgmp.so.10.4.1
+link path=usr/lib/$(MACH64)/libgmpxx.so target=libgmpxx.so.4.6.1
+link path=usr/lib/$(MACH64)/libgmpxx.so.4 target=libgmpxx.so.4.6.1
+file path=usr/lib/$(MACH64)/libgmpxx.so.4.6.1
 file path=usr/lib/$(MACH64)/pkgconfig/libgmp.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libgmpxx.pc
-link path=usr/lib/libgmp.so target=libgmp.so.10.3.2
-link path=usr/lib/libgmp.so.10 target=libgmp.so.10.3.2
-file path=usr/lib/libgmp.so.10.3.2
-link path=usr/lib/libgmpxx.so target=libgmpxx.so.4.5.2
-link path=usr/lib/libgmpxx.so.4 target=libgmpxx.so.4.5.2
-file path=usr/lib/libgmpxx.so.4.5.2
+file path=usr/lib/$(MACH64)/pkgconfig/gmp.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gmpxx.pc
+link path=usr/lib/libgmp.so target=libgmp.so.10.4.1
+link path=usr/lib/libgmp.so.10 target=libgmp.so.10.4.1
+file path=usr/lib/libgmp.so.10.4.1
+link path=usr/lib/libgmpxx.so target=libgmpxx.so.4.6.1
+link path=usr/lib/libgmpxx.so.4 target=libgmpxx.so.4.6.1
+file path=usr/lib/libgmpxx.so.4.6.1
 file path=usr/lib/pkgconfig/libgmp.pc
 file path=usr/lib/pkgconfig/libgmpxx.pc
+file path=usr/lib/pkgconfig/gmp.pc
+file path=usr/lib/pkgconfig/gmpxx.pc
 file path=usr/share/info/gmp.info
 file path=usr/share/info/gmp.info-1
 file path=usr/share/info/gmp.info-2

--- a/components/library/gmp/manifests/sample-manifest.p5m
+++ b/components/library/gmp/manifests/sample-manifest.p5m
@@ -5,12 +5,12 @@
 # 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,20 +24,24 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/gmp/gmp.h
 file path=usr/include/gmp/gmpxx.h
-link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.3.2
-link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.3.2
-file path=usr/lib/$(MACH64)/libgmp.so.10.3.2
-link path=usr/lib/$(MACH64)/libgmpxx.so target=libgmpxx.so.4.5.2
-link path=usr/lib/$(MACH64)/libgmpxx.so.4 target=libgmpxx.so.4.5.2
-file path=usr/lib/$(MACH64)/libgmpxx.so.4.5.2
+link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.4.1
+link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.4.1
+file path=usr/lib/$(MACH64)/libgmp.so.10.4.1
+link path=usr/lib/$(MACH64)/libgmpxx.so target=libgmpxx.so.4.6.1
+link path=usr/lib/$(MACH64)/libgmpxx.so.4 target=libgmpxx.so.4.6.1
+file path=usr/lib/$(MACH64)/libgmpxx.so.4.6.1
+file path=usr/lib/$(MACH64)/pkgconfig/gmp.pc
+file path=usr/lib/$(MACH64)/pkgconfig/gmpxx.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libgmp.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libgmpxx.pc
-link path=usr/lib/libgmp.so target=libgmp.so.10.3.2
-link path=usr/lib/libgmp.so.10 target=libgmp.so.10.3.2
-file path=usr/lib/libgmp.so.10.3.2
-link path=usr/lib/libgmpxx.so target=libgmpxx.so.4.5.2
-link path=usr/lib/libgmpxx.so.4 target=libgmpxx.so.4.5.2
-file path=usr/lib/libgmpxx.so.4.5.2
+link path=usr/lib/libgmp.so target=libgmp.so.10.4.1
+link path=usr/lib/libgmp.so.10 target=libgmp.so.10.4.1
+file path=usr/lib/libgmp.so.10.4.1
+link path=usr/lib/libgmpxx.so target=libgmpxx.so.4.6.1
+link path=usr/lib/libgmpxx.so.4 target=libgmpxx.so.4.6.1
+file path=usr/lib/libgmpxx.so.4.6.1
+file path=usr/lib/pkgconfig/gmp.pc
+file path=usr/lib/pkgconfig/gmpxx.pc
 file path=usr/lib/pkgconfig/libgmp.pc
 file path=usr/lib/pkgconfig/libgmpxx.pc
 file path=usr/share/info/dir


### PR DESCRIPTION
- According to https://abi-laboratory.pro/index.php?view=timeline&l=gmp fully backwards compatible
- gmake test runs fine
- mpfr and gawk build and test fine