### PR TITLE
developer-opensolaris-x: fix dependency on java/jdk

### DIFF
--- a/components/meta-packages/developer-opensolaris-X/Makefile
+++ b/components/meta-packages/developer-opensolaris-X/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		developer-opensolaris-X
 COMPONENT_VERSION=	0.5.11
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_SUMMARY=	Dependencies required to build the X Consolidation.
 
 include ../../../make-rules/ips.mk

--- a/components/meta-packages/developer-opensolaris-X/developer-opensolaris-X.p5m
+++ b/components/meta-packages/developer-opensolaris-X/developer-opensolaris-X.p5m
@@ -36,7 +36,7 @@ depend fmri=pkg:/developer/documentation-tool/opensp type=require
 depend fmri=pkg:/developer/dtrace type=require
 depend fmri=pkg:/developer/gcc-49 type=require
 depend fmri=pkg:/gnome/gnome-common type=require
-depend fmri=pkg:/developer/java/jdk type=require
+depend fmri=pkg:/developer/java/openjdk8 type=require
 depend fmri=pkg:/developer/lexer/flex type=require
 depend fmri=pkg:/developer/linker type=require
 depend fmri=pkg:/developer/object-file type=require


### PR DESCRIPTION
developer/java/jdk ist still installed but removed.