### PR TITLE
zstd: update to 1.4.7

### DIFF
--- a/components/archiver/zstd/Makefile
+++ b/components/archiver/zstd/Makefile
@@ -10,6 +10,7 @@
 
 #
 # Copyright 2019 Michal Nowak
+# Copyright 2020 Nona Hansel
 #
 
 BUILD_BITS=		64_and_32
@@ -18,7 +19,7 @@ PREFERRED_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zstd
-COMPONENT_VERSION=	1.4.5
+COMPONENT_VERSION=	1.4.7
 COMPONENT_SUMMARY=	Zstandard, or zstd for short, is a fast lossless compression algorithm, targeting real-time compression scenarios
 COMPONENT_PROJECT_URL=	https://facebook.github.io/zstd/
 COMPONENT_FMRI=		compress/zstd
@@ -26,7 +27,7 @@ COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/facebook/zstd/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	sha256:98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
+COMPONENT_ARCHIVE_HASH=	sha256:192cbb1274a9672cbcceaf47b5c4e9e59691ca60a357f1d4a8b2dfa2c365d757
 COMPONENT_LICENSE=	BSD,GPLv2.0
 
 include $(WS_MAKE_RULES)/common.mk

--- a/components/archiver/zstd/manifests/sample-manifest.p5m
+++ b/components/archiver/zstd/manifests/sample-manifest.p5m
@@ -34,8 +34,6 @@ link path=usr/bin/zstdcat target=zstd
 file path=usr/bin/zstdgrep
 file path=usr/bin/zstdless
 link path=usr/bin/zstdmt target=zstd
-file path=usr/include/cover.h
-file path=usr/include/zbuff.h
 file path=usr/include/zdict.h
 file path=usr/include/zstd.h
 file path=usr/include/zstd_errors.h

--- a/components/archiver/zstd/zstd.p5m
+++ b/components/archiver/zstd/zstd.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2019 Michal Nowak
+# Copyright 2020 Nona Hansel
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -37,8 +38,6 @@ link path=usr/bin/zstdcat target=zstd
 file path=usr/bin/zstdgrep
 file path=usr/bin/zstdless
 link path=usr/bin/zstdmt target=zstd
-file path=usr/include/cover.h
-file path=usr/include/zbuff.h
 file path=usr/include/zdict.h
 file path=usr/include/zstd.h
 file path=usr/include/zstd_errors.h


### PR DESCRIPTION
It builds, installs and publishes fine, although runnig `gmake sample-manifest`, it gave me this message
```
if [ "X" != "X" ]; \
then sed  /export/home/nona/oi-userland/components/archiver/zstd/manifests/sample-manifest.p5m \
	| gawk '!seen[$0]++' > /export/home/nona/oi-userland/components/archiver/zstd/manifests/generic-manifest.p5m; fi;
```
which I'm not familiar with. The subsequent `echo $?` gives me 0.

I tested it with `zstd file` and `zstd -d file.zst` and it worked and the man page says the right version.