### PR TITLE
libreoffice: fix build after qsort_r(3C) introduction

### DIFF
--- a/components/desktop/libreoffice/Makefile
+++ b/components/desktop/libreoffice/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=	libreoffice
 COMPONENT_VERSION= 6.4.3
 COMPONENT_RC_VERSION= 2
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_FULL_VERSION=$(COMPONENT_VERSION).$(COMPONENT_RC_VERSION)
 COMPONENT_SUMMARY= LibreOffice is a powerful office suite
 COMPONENT_PROJECT_URL= https://www.libreoffice.org/
@@ -61,9 +61,9 @@ COMPONENT_ARCHIVE_7 = a233181e03d3c307668b4c722d881661-mariadb_client-2.0.0-src.
 COMPONENT_ARCHIVE_HASH_7 = sha256:fd2f751dea049c1907735eb236aeace1d811d6a8218118b00bbaa9b84dc5cd60
 COMPONENT_ARCHIVE_URL_7 = https://dev-www.libreoffice.org/src/$(COMPONENT_ARCHIVE_7)
 
-COMPONENT_ARCHIVE_8 = a39f6c07ddb20d7dd2ff1f95fa21e2cd-raptor2-2.0.15.tar.gz
-COMPONENT_ARCHIVE_HASH_8 = sha256:ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed
-COMPONENT_ARCHIVE_URL_8 = https://dev-www.libreoffice.org/src/$(COMPONENT_ARCHIVE_8)
+COMPONENT_ARCHIVE_8 = raptor2-2.0.15-patched.tar.bz2
+COMPONENT_ARCHIVE_HASH_8 = sha256:e0a4bbe6421c115fba4684f6fa009541ed041f64fca609569967805831b0a9db
+COMPONENT_ARCHIVE_URL_8 = http://dlc.openindiana.org/oi-userland/source-archives/$(COMPONENT_ARCHIVE_8)
 
 COMPONENT_ARCHIVE_9 = a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz
 COMPONENT_ARCHIVE_HASH_9 = sha256:1e81f395d8c851c3e4e75b568e20fa2fa549354e75ab397f9de4b0e0790a305f
@@ -233,6 +233,7 @@ REQUIRED_PACKAGES += library/c++/mdds
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += compress/xz
 REQUIRED_PACKAGES += gnome/config/dconf
 REQUIRED_PACKAGES += image/library/libjpeg8-turbo
@@ -279,7 +280,6 @@ REQUIRED_PACKAGES += library/openldap
 REQUIRED_PACKAGES += library/print/cups-libs
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += library/zlib
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/fontconfig
 REQUIRED_PACKAGES += system/library/freetype-2

--- a/components/desktop/libreoffice/patches/12-change-download.patch
+++ b/components/desktop/libreoffice/patches/12-change-download.patch
@@ -1,0 +1,37 @@
+After #3763 Implement qsort_r(3C) had been integrated on Sep 23rd, 2020, raptor2 needs a patch to build.
+We need to provide a patched version of raptor-2.0.15 that is being used by libreoffice.
+Thus, we change the archive name, checksum and download location.
+
+--- libreoffice-6.4.3.2/Makefile.fetch.orig	2020-04-07 17:26:49.000000000 +0000
++++ libreoffice-6.4.3.2/Makefile.fetch	2020-12-25 20:00:50.398885813 +0000
+@@ -206,7 +206,6 @@
+ 		$(call fetch_Optional,POSTGRESQL,POSTGRESQL_TARBALL) \
+ 		$(call fetch_Optional,PYTHON,PYTHON_TARBALL) \
+ 		$(call fetch_Optional,QXP,QXP_TARBALL) \
+-		$(call fetch_Optional,REDLAND,RAPTOR_TARBALL) \
+ 		$(call fetch_Optional,REDLAND,RASQAL_TARBALL) \
+ 		$(call fetch_Optional,REDLAND,REDLAND_TARBALL) \
+ 		$(call fetch_Optional,REVENGE,REVENGE_TARBALL) \
+@@ -225,6 +224,9 @@
+ 		$(call fetch_Optional,ZMF,ZMF_TARBALL) \
+ 	,$(call fetch_Download_item,https://dev-www.libreoffice.org/src,$(item)))
+ 	$(foreach item, \
++		$(call fetch_Optional,REDLAND,RAPTOR_TARBALL) \
++	,$(call fetch_Download_item,http://dlc.openindiana.org/oi-userland/source-archives,$(item)))
++	$(foreach item, \
+ 		$(call fetch_Optional,ODK,UNOWINREG_DLL) \
+ 		$(call fetch_Optional,OPENSYMBOL,OPENSYMBOL_TTF) \
+ 		$(call fetch_Optional,ODFVALIDATOR,ODFVALIDATOR_JAR) \
+--- libreoffice-6.4.3.2/download.lst.orig	2020-04-07 17:26:49.000000000 +0000
++++ libreoffice-6.4.3.2/download.lst	2020-12-25 20:02:09.529275219 +0000
+@@ -218,8 +218,8 @@
+ export QRCODEGEN_TARBALL := QR-Code-generator-1.4.0.tar.gz
+ export QXP_SHA256SUM := e137b6b110120a52c98edd02ebdc4095ee08d0d5295a94316a981750095a945c
+ export QXP_TARBALL := libqxp-0.0.2.tar.xz
+-export RAPTOR_SHA256SUM := ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed
+-export RAPTOR_TARBALL := a39f6c07ddb20d7dd2ff1f95fa21e2cd-raptor2-2.0.15.tar.gz
++export RAPTOR_SHA256SUM := e0a4bbe6421c115fba4684f6fa009541ed041f64fca609569967805831b0a9db
++export RAPTOR_TARBALL := raptor2-2.0.15-patched.tar.bz2
+ export RASQAL_SHA256SUM := 6924c9ac6570bd241a9669f83b467c728a322470bf34f4b2da4f69492ccfd97c
+ export RASQAL_TARBALL := 1f5def51ca0026cd192958ef07228b52-rasqal-0.9.33.tar.gz
+ export REDLAND_SHA256SUM := de1847f7b59021c16bdc72abb4d8e2d9187cd6124d69156f3326dd34ee043681


### PR DESCRIPTION
Building libreoffice fails in raptor2 liberary which is dynamically downloaded by libreofffices build system. We need to provide our own version of it as a fix.
The resulting app works even better than before on my desktop.