### PR TITLE
libarchive: upate to 3.5.1

### DIFF
--- a/components/library/libarchive/Makefile
+++ b/components/library/libarchive/Makefile
@@ -29,7 +29,7 @@ BUILD_BITS=		32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libarchive
-COMPONENT_VERSION=	3.5.0
+COMPONENT_VERSION=	3.5.1
 COMPONENT_SUMMARY=	multi-format archive and compression library
 COMPONENT_DESCRIPTION=	The libarchive(3LIB) library provides a flexible\
  interface for reading and writing archives in various formats such as\
@@ -41,10 +41,8 @@ COMPONENT_DESCRIPTION=	The libarchive(3LIB) library provides a flexible\
 COMPONENT_SRC=		libarchive-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://www.libarchive.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	\
-	sha256:fc4bc301188376adc18780d35602454cc8df6396e1b040fbcbb0d4c0469faf54
-COMPONENT_ARCHIVE_URL= \
-	https://github.com/libarchive/libarchive/releases/download/v$(COMPONENT_VERSION)//$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:9015d109ec00bb9ae1a384b172bf2fc1dff41e2c66e5a9eeddf933af9db37f5a
+COMPONENT_ARCHIVE_URL= https://www.libarchive.org/downloads/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=        library/libarchive
 COMPONENT_CLASSIFICATION=       System/Libraries
 COMPONENT_LICENSE=      BSD-like


### PR DESCRIPTION
- sample-manifest didn't change
- gmake test run fine