### PR TITLE
gegl: update to 0.4.28

### DIFF
--- a/components/library/gegl/Makefile
+++ b/components/library/gegl/Makefile
@@ -19,15 +19,13 @@ BUILD_STYLE= meson
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gegl
-COMPONENT_VERSION= 0.4.26
+COMPONENT_VERSION= 0.4.28
 COMPONENT_SUMMARY= GEGL (Generic Graphics Library) is a graph based image processing framework
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= \
-	sha256:0f371e2ed2b92162fefd3dde743e648ca08a6a1b2b05004867fbddc7e211e424
-COMPONENT_ARCHIVE_URL= \
-	https://ftp.gimp.org/pub/gegl/0.4/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= sha256:1d110d8577d54cca3b34239315bd37c57ccb27dd4355655074a2d2b3fd897900
+COMPONENT_ARCHIVE_URL= https://ftp.gimp.org/pub/gegl/0.4/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://www.gegl.org/
 COMPONENT_LICENSE= GPLv3, LGPLv3
 
@@ -35,7 +33,6 @@ include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
-CFLAGS += -std=gnu99
 CFLAGS += $(CFLAGS.$(BITS))
 
 # build with the distribution default libjpeg

--- a/components/library/gegl/gegl.p5m
+++ b/components/library/gegl/gegl.p5m
@@ -145,8 +145,8 @@ file path=usr/lib/$(MACH64)/gegl-0.4/webp-load.so
 file path=usr/lib/$(MACH64)/gegl-0.4/webp-save.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Gegl-0.4.typelib
 link path=usr/lib/$(MACH64)/libgegl-0.4.so target=libgegl-0.4.so.0
-link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.425.1
-file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.425.1
+link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.427.1
+file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.427.1
 file path=usr/lib/$(MACH64)/libgegl-npd-0.4.so
 file path=usr/lib/$(MACH64)/libgegl-sc-0.4.so
 file path=usr/lib/$(MACH64)/pkgconfig/gegl-0.4.pc
@@ -167,6 +167,7 @@ file path=usr/share/locale/hr/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/id/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/is/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/it/LC_MESSAGES/gegl-0.4.mo
+file path=usr/share/locale/kab/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/ko/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/lv/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/mr/LC_MESSAGES/gegl-0.4.mo
@@ -177,6 +178,7 @@ file path=usr/share/locale/oc/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/pl/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/pt/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/pt_BR/LC_MESSAGES/gegl-0.4.mo
+file path=usr/share/locale/ro/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/ru/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/sk/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/sl/LC_MESSAGES/gegl-0.4.mo

--- a/components/library/gegl/manifests/sample-manifest.p5m
+++ b/components/library/gegl/manifests/sample-manifest.p5m
@@ -155,8 +155,8 @@ file path=usr/lib/$(MACH64)/gegl-0.4/webp-load.so
 file path=usr/lib/$(MACH64)/gegl-0.4/webp-save.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Gegl-0.4.typelib
 link path=usr/lib/$(MACH64)/libgegl-0.4.so target=libgegl-0.4.so.0
-link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.425.1
-file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.425.1
+link path=usr/lib/$(MACH64)/libgegl-0.4.so.0 target=libgegl-0.4.so.0.427.1
+file path=usr/lib/$(MACH64)/libgegl-0.4.so.0.427.1
 file path=usr/lib/$(MACH64)/libgegl-npd-0.4.so
 file path=usr/lib/$(MACH64)/libgegl-sc-0.4.so
 file path=usr/lib/$(MACH64)/pkgconfig/gegl-0.4.pc
@@ -177,6 +177,7 @@ file path=usr/share/locale/hr/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/id/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/is/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/it/LC_MESSAGES/gegl-0.4.mo
+file path=usr/share/locale/kab/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/ko/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/lv/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/mr/LC_MESSAGES/gegl-0.4.mo
@@ -187,6 +188,7 @@ file path=usr/share/locale/oc/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/pl/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/pt/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/pt_BR/LC_MESSAGES/gegl-0.4.mo
+file path=usr/share/locale/ro/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/ru/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/sk/LC_MESSAGES/gegl-0.4.mo
 file path=usr/share/locale/sl/LC_MESSAGES/gegl-0.4.mo


### PR DESCRIPTION
- gimp still works
- gmake test has still 2 failing tests (no. 32 and no. 33)