### PR TITLE
libp11: update to 0.4.11

### DIFF
--- a/components/library/libp11/Makefile
+++ b/components/library/libp11/Makefile
@@ -12,26 +12,24 @@
 #
 # Copyright 2016 Jim Klimov
 #
+BUILD_BITS=			32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libp11
-COMPONENT_VERSION=	0.4.2
+COMPONENT_VERSION=	0.4.11
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_FMRI=		library/security/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	System/Security
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://github.com/OpenSC/$(COMPONENT_NAME)/wiki
 COMPONENT_ARCHIVE_URL=	https://github.com/OpenSC/$(COMPONENT_NAME)/releases/download/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	\
-	sha256:e2c3614a314b452a9b57e2914252df3ffee59e262dfb75b4fc73a2247f8ddebe
+COMPONENT_ARCHIVE_HASH=	sha256:57d47a12a76fd92664ae30032cf969284ebac1dfc25bf824999d74b016d51366
 COMPONENT_LICENSE=		LGPLv2.1+
 COMPONENT_LICENSE_FILE= COPYING
 COMPONENT_DESCRIPTION=	libp11 is a library implementing a thin layer on top of PKCS11 API to make using PKCS11 implementations easier
 COMPONENT_SUMMARY=	libp11 is a library to make using PKCS11 implementations easier
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PREP_ACTION = \
         (cd $(@D) &&\
@@ -41,7 +39,9 @@ COMPONENT_PREP_ACTION = \
 COMPONENT_PRE_CONFIGURE_ACTION = \
         ($(CLONEY) $(SOURCE_DIR) $(@D))
 
-INDIR.32=/usr/bin
+CFLAGS += $(XPG6MODE)
+
+BINDIR.32=/usr/bin
 BINDIR.64=/usr/bin/$(MACH64)
 LIBDIR.32=/usr/lib
 LIBDIR.64=/usr/lib/$(MACH64)
@@ -60,10 +60,6 @@ COMPONENT_PRE_INSTALL_ACTION = (\
 	)
 
 CONFIGURE_OPTIONS +=	--with-enginesdir=$(DEFENGINESDIR_$(BITS))
-
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
 
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/library/libp11/libp11.p5m
+++ b/components/library/libp11/libp11.p5m
@@ -23,15 +23,16 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 # Common library that other programs link to:
-file path=usr/lib/$(MACH64)/libp11.so.2.4.2
-link path=usr/lib/$(MACH64)/libp11.so target=libp11.so.2.4.2
-link path=usr/lib/$(MACH64)/libp11.so.2 target=libp11.so.2.4.2
+file path=usr/lib/$(MACH64)/libp11.so.2.5.3
+link path=usr/lib/$(MACH64)/libp11.so target=libp11.so.2.5.3
+link path=usr/lib/$(MACH64)/libp11.so.2 target=libp11.so.2.5.3
 
-link path=usr/lib/libp11.so target=libp11.so.2.4.2
-link path=usr/lib/libp11.so.2 target=libp11.so.2.4.2
-file path=usr/lib/libp11.so.2.4.2
+link path=usr/lib/libp11.so target=libp11.so.2.5.3
+link path=usr/lib/libp11.so.2 target=libp11.so.2.5.3
+file path=usr/lib/libp11.so.2.5.3
 
 file path=usr/include/libp11.h
+file path=usr/include/p11_err.h
 
 file path=usr/lib/$(MACH64)/pkgconfig/libp11.pc
 file path=usr/lib/pkgconfig/libp11.pc

--- a/components/library/libp11/manifests/sample-manifest.p5m
+++ b/components/library/libp11/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,14 +27,15 @@ file path=lib/openssl/default/engines/$(MACH64)/pkcs11.so
 link path=lib/openssl/default/engines/libpkcs11.so target=pkcs11.so
 file path=lib/openssl/default/engines/pkcs11.so
 file path=usr/include/libp11.h
+file path=usr/include/p11_err.h
 file path=usr/lib/$(MACH64)/libp11.a
-link path=usr/lib/$(MACH64)/libp11.so target=libp11.so.2.4.2
-link path=usr/lib/$(MACH64)/libp11.so.2 target=libp11.so.2.4.2
-file path=usr/lib/$(MACH64)/libp11.so.2.4.2
+link path=usr/lib/$(MACH64)/libp11.so target=libp11.so.2.5.3
+link path=usr/lib/$(MACH64)/libp11.so.2 target=libp11.so.2.5.3
+file path=usr/lib/$(MACH64)/libp11.so.2.5.3
 file path=usr/lib/$(MACH64)/pkgconfig/libp11.pc
 file path=usr/lib/libp11.a
-link path=usr/lib/libp11.so target=libp11.so.2.4.2
-link path=usr/lib/libp11.so.2 target=libp11.so.2.4.2
-file path=usr/lib/libp11.so.2.4.2
+link path=usr/lib/libp11.so target=libp11.so.2.5.3
+link path=usr/lib/libp11.so.2 target=libp11.so.2.5.3
+file path=usr/lib/libp11.so.2.5.3
 file path=usr/lib/pkgconfig/libp11.pc
 file path=usr/share/doc/libp11/NEWS

--- a/components/library/libp11/patches/01-patch-rsa-common.patch
+++ b/components/library/libp11/patches/01-patch-rsa-common.patch
@@ -1,0 +1,14 @@
+Our softhsm lib is in /usr/lib/softhsm.
+TODO: We also need a pkcs11-tool (probably from Mastercard)
+
+--- libp11-0.4.11/tests/rsa-common.sh.orig	2020-02-27 06:50:01.000000000 +0000
++++ libp11-0.4.11/tests/rsa-common.sh	2020-12-31 11:39:15.046963919 +0000
+@@ -25,7 +25,7 @@
+ 
+ # Set the module to be used
+ for i in /usr/lib64/pkcs11 /usr/lib64/softhsm /usr/lib/x86_64-linux-gnu/softhsm \
+-	/usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib ;do
++	/usr/local/lib/softhsm /opt/local/lib/softhsm /usr/lib/softhsm /usr/lib /usr/lib/softhsm ;do
+ 	if test -f "$i/libsofthsm2.so"; then
+ 		MODULE="$i/libsofthsm2.so"
+ 		break


### PR DESCRIPTION
- gmake test skips all tests because we don't have pkcs11-tool 
- openconnect still works