### PR TITLE
wget: update to 1.21

### DIFF
--- a/components/web/wget/Makefile
+++ b/components/web/wget/Makefile
@@ -20,25 +20,24 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2018, Michal Nowak
+# Copyright (c) 2021, Nona Hansel
 #
+
+BUILD_BITS=64
 
 include ../../../make-rules/shared-macros.mk
 
-PREFERRED_BITS=64
-
 COMPONENT_NAME=		wget
-COMPONENT_VERSION=	1.20.3
+COMPONENT_VERSION=	1.21
 COMPONENT_PROJECT_URL=	https://www.gnu.org/software/wget/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.lz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:69607ce8216c2d1126b7a872db594b3f21e511e660e07ca1f81be96650932abb
-COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/wget/$(COMPONENT_ARCHIVE)
+	sha256:87ae105e76e5b550e03e009ba94341143c66623a5ecbba047f6ef850608b6596
+COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/gnu/wget/$(COMPONENT_ARCHIVE)
 COMPONENT_BUGDB=	utility/wget
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 # wget doesn't detect libidn2 include directory
 CPPFLAGS +=	-I/usr/include/idn2
@@ -60,12 +59,6 @@ COMPONENT_TEST_TRANSFORMS += '-ne "/^===/p" '
 COMPONENT_TEST_TRANSFORMS += '-ne "/^\# /p" '
 COMPONENT_TEST_TRANSFORMS += '-ne "/^See/p" '
 COMPONENT_TEST_TRANSFORMS += '-ne "/^Please/p" '
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
 
 # For the test suite
 REQUIRED_PACKAGES += library/perl-5/http-daemon

--- a/components/web/wget/manifests/sample-manifest.p5m
+++ b/components/web/wget/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,43 +26,81 @@ file path=etc/wgetrc
 file path=usr/bin/wget
 file path=usr/share/info/dir
 file path=usr/share/info/wget.info
+file path=usr/share/locale/af/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/be/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/be/LC_MESSAGES/wget.mo
+file path=usr/share/locale/bg/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/bg/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ca/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ca/LC_MESSAGES/wget.mo
+file path=usr/share/locale/cs/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/cs/LC_MESSAGES/wget.mo
+file path=usr/share/locale/da/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/da/LC_MESSAGES/wget.mo
+file path=usr/share/locale/de/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/de/LC_MESSAGES/wget.mo
+file path=usr/share/locale/el/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/el/LC_MESSAGES/wget.mo
 file path=usr/share/locale/en_GB/LC_MESSAGES/wget.mo
+file path=usr/share/locale/eo/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/eo/LC_MESSAGES/wget.mo
+file path=usr/share/locale/es/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/es/LC_MESSAGES/wget.mo
+file path=usr/share/locale/et/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/et/LC_MESSAGES/wget.mo
+file path=usr/share/locale/eu/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/eu/LC_MESSAGES/wget.mo
+file path=usr/share/locale/fi/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/fi/LC_MESSAGES/wget.mo
+file path=usr/share/locale/fr/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/fr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ga/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ga/LC_MESSAGES/wget.mo
+file path=usr/share/locale/gl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/gl/LC_MESSAGES/wget.mo
 file path=usr/share/locale/he/LC_MESSAGES/wget.mo
 file path=usr/share/locale/hr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/hu/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/hu/LC_MESSAGES/wget.mo
 file path=usr/share/locale/id/LC_MESSAGES/wget.mo
+file path=usr/share/locale/it/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/it/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ja/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ja/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ko/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/lt/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ms/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/nb/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/nb/LC_MESSAGES/wget.mo
+file path=usr/share/locale/nl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/nl/LC_MESSAGES/wget.mo
+file path=usr/share/locale/pl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/pl/LC_MESSAGES/wget.mo
+file path=usr/share/locale/pt/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/pt/LC_MESSAGES/wget.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/pt_BR/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ro/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ro/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ru/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ru/LC_MESSAGES/wget.mo
+file path=usr/share/locale/rw/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/sk/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sk/LC_MESSAGES/wget.mo
+file path=usr/share/locale/sl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sl/LC_MESSAGES/wget.mo
+file path=usr/share/locale/sr/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/sv/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sv/LC_MESSAGES/wget.mo
+file path=usr/share/locale/tr/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/tr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/uk/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/uk/LC_MESSAGES/wget.mo
+file path=usr/share/locale/vi/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/vi/LC_MESSAGES/wget.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/wget.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/zh_TW/LC_MESSAGES/wget.mo
 file path=usr/share/man/man1/wget.1

--- a/components/web/wget/patches/no-fuzz.patch
+++ b/components/web/wget/patches/no-fuzz.patch
@@ -1,13 +1,13 @@
 Disable fuzz tests, as they require fmemopen
 
---- wget-1.19.5/Makefile.in.1	2018-05-14 13:12:56.368147267 +0000
-+++ wget-1.19.5/Makefile.in	2018-05-14 13:13:10.470098770 +0000
-@@ -1443,7 +1443,7 @@
+--- wget-1.21/Makefile.in	2020-12-31 16:54:36.000000000 +0000
++++ wget-1.21/Makefile.in	2021-01-01 20:23:27.118043752 +0000
+@@ -1637,7 +1637,7 @@ distuninstallcheck_listfiles = find . -t
  ACLOCAL_AMFLAGS = -I m4
  
  # subdirectories in the distribution
--SUBDIRS = lib src doc po util fuzz tests testenv
-+SUBDIRS = lib src doc po util tests testenv
+-SUBDIRS = lib src doc po gnulib_po util fuzz tests testenv
++SUBDIRS = lib src doc po gnulib_po util tests testenv
  EXTRA_DIST = MAILING-LIST \
               msdos/config.h msdos/Makefile.DJ \
               msdos/Makefile.WC ABOUT-NLS \

--- a/components/web/wget/test/results-64.master
+++ b/components/web/wget/test/results-64.master
@@ -135,10 +135,11 @@ PASS: Test-redirect-crash.py
 PASS: Test--rejected-log.py
 PASS: Test-reserved-chars.py
 PASS: Test--spider-r.py
+PASS: Test-no_proxy-env.py
 ============================================================================
 ============================================================================
-# TOTAL: 44
-# PASS:  44
+# TOTAL: 45
+# PASS:  45
 # SKIP:  0
 # XFAIL: 0
 # FAIL:  0

--- a/components/web/wget/wget.p5m
+++ b/components/web/wget/wget.p5m
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Nona Hansel
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
@@ -37,46 +38,84 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 file path=etc/wgetrc group=sys mode=0644 preserve=true
 file path=usr/bin/wget
-link path=usr/sfw/bin/wget target=../../bin/wget
+#file path=usr/share/info/dir
 file path=usr/share/info/wget.info
+file path=usr/share/locale/af/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/be/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/be/LC_MESSAGES/wget.mo
+file path=usr/share/locale/bg/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/bg/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ca/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ca/LC_MESSAGES/wget.mo
+file path=usr/share/locale/cs/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/cs/LC_MESSAGES/wget.mo
+file path=usr/share/locale/da/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/da/LC_MESSAGES/wget.mo
+file path=usr/share/locale/de/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/de/LC_MESSAGES/wget.mo
+file path=usr/share/locale/el/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/el/LC_MESSAGES/wget.mo
 file path=usr/share/locale/en_GB/LC_MESSAGES/wget.mo
+file path=usr/share/locale/eo/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/eo/LC_MESSAGES/wget.mo
+file path=usr/share/locale/es/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/es/LC_MESSAGES/wget.mo
+file path=usr/share/locale/et/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/et/LC_MESSAGES/wget.mo
+file path=usr/share/locale/eu/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/eu/LC_MESSAGES/wget.mo
+file path=usr/share/locale/fi/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/fi/LC_MESSAGES/wget.mo
+file path=usr/share/locale/fr/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/fr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ga/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ga/LC_MESSAGES/wget.mo
+file path=usr/share/locale/gl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/gl/LC_MESSAGES/wget.mo
 file path=usr/share/locale/he/LC_MESSAGES/wget.mo
 file path=usr/share/locale/hr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/hu/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/hu/LC_MESSAGES/wget.mo
 file path=usr/share/locale/id/LC_MESSAGES/wget.mo
+file path=usr/share/locale/it/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/it/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ja/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ja/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ko/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/lt/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ms/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/nb/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/nb/LC_MESSAGES/wget.mo
+file path=usr/share/locale/nl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/nl/LC_MESSAGES/wget.mo
+file path=usr/share/locale/pl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/pl/LC_MESSAGES/wget.mo
+file path=usr/share/locale/pt/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/pt/LC_MESSAGES/wget.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/pt_BR/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ro/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ro/LC_MESSAGES/wget.mo
+file path=usr/share/locale/ru/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ru/LC_MESSAGES/wget.mo
+file path=usr/share/locale/rw/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/sk/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sk/LC_MESSAGES/wget.mo
+file path=usr/share/locale/sl/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sl/LC_MESSAGES/wget.mo
+file path=usr/share/locale/sr/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/sv/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/sv/LC_MESSAGES/wget.mo
+file path=usr/share/locale/tr/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/tr/LC_MESSAGES/wget.mo
+file path=usr/share/locale/uk/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/uk/LC_MESSAGES/wget.mo
+file path=usr/share/locale/vi/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/vi/LC_MESSAGES/wget.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/wget.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/zh_TW/LC_MESSAGES/wget.mo
 file path=usr/share/man/man1/wget.1
 license wget.license license="GPLv3, FDLv1.2"


### PR DESCRIPTION
It builds, installs, and publishes fine. All tests passed.
I had to redo one patch, but the change is the same.
Tested it with `wget https://github.com/powerline/powerline/archive/2.8.1.tar.gz` which worked and the man page says the right version.