### PR TITLE
Add i3

### DIFF
--- a/components/desktop/i3/Makefile
+++ b/components/desktop/i3/Makefile
@@ -28,6 +28,7 @@ COMPONENT_CLASSIFICATION=System/X11
 COMPONENT_ARCHIVE_URL=https://i3wm.org/downloads/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_HASH=sha256:aca48b03c0c70607826a1a91333065ff44d61774c152ddc9210fbc1627355872
 COMPONENT_LICENSE=BSD-3
+PATCH_LEVEL=0
 
 TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
 include $(WS_MAKE_RULES)/common.mk
@@ -37,6 +38,7 @@ LDFLAGS+= -lsocket -lnsl
 CONFIGURE_OPTIONS+= -Dmans=true
 
 REQUIRED_PACKAGES += desktop/dmenu
+REQUIRED_PACKAGES += desktop/window-manager/i3/i3status
 REQUIRED_PACKAGES += text/asciidoc
 REQUIRED_PACKAGES += text/xmlto
 # Auto-generated dependencies

--- a/components/desktop/i3/Makefile
+++ b/components/desktop/i3/Makefile
@@ -1,0 +1,57 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Rick V
+#
+
+BUILD_BITS=32
+include ../../../make-rules/shared-macros.mk
+BUILD_STYLE=meson
+
+COMPILER=gcc
+COMPONENT_NAME=i3
+COMPONENT_VERSION=4.19
+COMPONENT_SUMMARY=improved tiling wm
+COMPONENT_PROJECT_URL=https://i3wm.org
+COMPONENT_FMRI=desktop/window-manager/i3
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
+COMPONENT_CLASSIFICATION=System/X11
+COMPONENT_ARCHIVE_URL=https://i3wm.org/downloads/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=sha256:aca48b03c0c70607826a1a91333065ff44d61774c152ddc9210fbc1627355872
+COMPONENT_LICENSE=BSD-3
+
+TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
+include $(WS_MAKE_RULES)/common.mk
+CPPFLAGS+= -D_XOPEN_SOURCE=700
+CPPFLAGS+= -D__EXTENSIONS__
+LDFLAGS+= -lsocket -lnsl
+CONFIGURE_OPTIONS+= -Dmans=true
+
+REQUIRED_PACKAGES += desktop/dmenu
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += library/desktop/pango
+REQUIRED_PACKAGES += library/desktop/startup-notification
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/libev
+REQUIRED_PACKAGES += library/libyajl2
+REQUIRED_PACKAGES += library/pcre
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libxcb
+REQUIRED_PACKAGES += x11/library/libxkbcommon
+REQUIRED_PACKAGES += x11/library/xcb-util
+REQUIRED_PACKAGES += x11/library/xcb-util-cursor
+REQUIRED_PACKAGES += x11/library/xcb-util-keysyms
+REQUIRED_PACKAGES += x11/library/xcb-util-wm
+REQUIRED_PACKAGES += x11/library/xcb-util-xrm

--- a/components/desktop/i3/Makefile
+++ b/components/desktop/i3/Makefile
@@ -37,6 +37,8 @@ LDFLAGS+= -lsocket -lnsl
 CONFIGURE_OPTIONS+= -Dmans=true
 
 REQUIRED_PACKAGES += desktop/dmenu
+REQUIRED_PACKAGES += text/asciidoc
+REQUIRED_PACKAGES += text/xmlto
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += library/desktop/pango

--- a/components/desktop/i3/i3.license
+++ b/components/desktop/i3/i3.license
@@ -1,0 +1,26 @@
+Copyright © 2009, Michael Stapelberg and contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/desktop/i3/i3.p5m
+++ b/components/desktop/i3/i3.p5m
@@ -1,0 +1,87 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Rick V
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/i3/config
+file path=etc/i3/config.keycodes
+file path=usr/bin/i3
+file path=usr/bin/i3-config-wizard
+file path=usr/bin/i3-dmenu-desktop
+file path=usr/bin/i3-dump-log
+file path=usr/bin/i3-input
+file path=usr/bin/i3-migrate-config-to-v4
+file path=usr/bin/i3-msg
+file path=usr/bin/i3-nagbar
+file path=usr/bin/i3-save-tree
+file path=usr/bin/i3-sensible-editor
+file path=usr/bin/i3-sensible-pager
+file path=usr/bin/i3-sensible-terminal
+link path=usr/bin/i3-with-shmlog target=i3
+file path=usr/bin/i3bar
+file path=usr/include/i3/ipc.h
+file path=usr/share/applications/i3.desktop
+file path=usr/share/doc/i3/bigpicture.png
+file path=usr/share/doc/i3/debugging.html
+file path=usr/share/doc/i3/hacking-howto.html
+file path=usr/share/doc/i3/i3-sync-working.png
+file path=usr/share/doc/i3/i3-sync.png
+file path=usr/share/doc/i3/i3bar-protocol.html
+file path=usr/share/doc/i3/ipc.html
+file path=usr/share/doc/i3/keyboard-layer1.png
+file path=usr/share/doc/i3/keyboard-layer2.png
+file path=usr/share/doc/i3/layout-saving-1.png
+file path=usr/share/doc/i3/layout-saving.html
+file path=usr/share/doc/i3/logo-30.png
+file path=usr/share/doc/i3/modes.png
+file path=usr/share/doc/i3/multi-monitor.html
+file path=usr/share/doc/i3/refcard.html
+file path=usr/share/doc/i3/refcard_style.css
+file path=usr/share/doc/i3/single_terminal.png
+file path=usr/share/doc/i3/snapping.png
+file path=usr/share/doc/i3/testsuite.html
+file path=usr/share/doc/i3/tree-layout1.png
+file path=usr/share/doc/i3/tree-layout2.png
+file path=usr/share/doc/i3/tree-shot1.png
+file path=usr/share/doc/i3/tree-shot2.png
+file path=usr/share/doc/i3/tree-shot3.png
+file path=usr/share/doc/i3/tree-shot4.png
+file path=usr/share/doc/i3/two_columns.png
+file path=usr/share/doc/i3/two_terminals.png
+file path=usr/share/doc/i3/userguide.html
+file path=usr/share/doc/i3/wsbar.html
+file path=usr/share/doc/i3/wsbar.png
+file path=usr/share/man/man1/i3-config-wizard.1
+file path=usr/share/man/man1/i3-dmenu-desktop.1
+file path=usr/share/man/man1/i3-dump-log.1
+file path=usr/share/man/man1/i3-input.1
+file path=usr/share/man/man1/i3-migrate-config-to-v4.1
+file path=usr/share/man/man1/i3-msg.1
+file path=usr/share/man/man1/i3-nagbar.1
+file path=usr/share/man/man1/i3-save-tree.1
+file path=usr/share/man/man1/i3-sensible-editor.1
+file path=usr/share/man/man1/i3-sensible-pager.1
+file path=usr/share/man/man1/i3-sensible-terminal.1
+file path=usr/share/man/man1/i3.1
+file path=usr/share/man/man1/i3bar.1
+file path=usr/share/xsessions/i3-with-shmlog.desktop
+file path=usr/share/xsessions/i3.desktop

--- a/components/desktop/i3/manifests/sample-manifest.p5m
+++ b/components/desktop/i3/manifests/sample-manifest.p5m
@@ -1,0 +1,87 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/i3/config
+file path=etc/i3/config.keycodes
+file path=usr/bin/i3
+file path=usr/bin/i3-config-wizard
+file path=usr/bin/i3-dmenu-desktop
+file path=usr/bin/i3-dump-log
+file path=usr/bin/i3-input
+file path=usr/bin/i3-migrate-config-to-v4
+file path=usr/bin/i3-msg
+file path=usr/bin/i3-nagbar
+file path=usr/bin/i3-save-tree
+file path=usr/bin/i3-sensible-editor
+file path=usr/bin/i3-sensible-pager
+file path=usr/bin/i3-sensible-terminal
+link path=usr/bin/i3-with-shmlog target=i3
+file path=usr/bin/i3bar
+file path=usr/include/i3/ipc.h
+file path=usr/share/applications/i3.desktop
+file path=usr/share/doc/i3/bigpicture.png
+file path=usr/share/doc/i3/debugging.html
+file path=usr/share/doc/i3/hacking-howto.html
+file path=usr/share/doc/i3/i3-sync-working.png
+file path=usr/share/doc/i3/i3-sync.png
+file path=usr/share/doc/i3/i3bar-protocol.html
+file path=usr/share/doc/i3/ipc.html
+file path=usr/share/doc/i3/keyboard-layer1.png
+file path=usr/share/doc/i3/keyboard-layer2.png
+file path=usr/share/doc/i3/layout-saving-1.png
+file path=usr/share/doc/i3/layout-saving.html
+file path=usr/share/doc/i3/logo-30.png
+file path=usr/share/doc/i3/modes.png
+file path=usr/share/doc/i3/multi-monitor.html
+file path=usr/share/doc/i3/refcard.html
+file path=usr/share/doc/i3/refcard_style.css
+file path=usr/share/doc/i3/single_terminal.png
+file path=usr/share/doc/i3/snapping.png
+file path=usr/share/doc/i3/testsuite.html
+file path=usr/share/doc/i3/tree-layout1.png
+file path=usr/share/doc/i3/tree-layout2.png
+file path=usr/share/doc/i3/tree-shot1.png
+file path=usr/share/doc/i3/tree-shot2.png
+file path=usr/share/doc/i3/tree-shot3.png
+file path=usr/share/doc/i3/tree-shot4.png
+file path=usr/share/doc/i3/two_columns.png
+file path=usr/share/doc/i3/two_terminals.png
+file path=usr/share/doc/i3/userguide.html
+file path=usr/share/doc/i3/wsbar.html
+file path=usr/share/doc/i3/wsbar.png
+file path=usr/share/man/man1/i3-config-wizard.1
+file path=usr/share/man/man1/i3-dmenu-desktop.1
+file path=usr/share/man/man1/i3-dump-log.1
+file path=usr/share/man/man1/i3-input.1
+file path=usr/share/man/man1/i3-migrate-config-to-v4.1
+file path=usr/share/man/man1/i3-msg.1
+file path=usr/share/man/man1/i3-nagbar.1
+file path=usr/share/man/man1/i3-save-tree.1
+file path=usr/share/man/man1/i3-sensible-editor.1
+file path=usr/share/man/man1/i3-sensible-pager.1
+file path=usr/share/man/man1/i3-sensible-terminal.1
+file path=usr/share/man/man1/i3.1
+file path=usr/share/man/man1/i3bar.1
+file path=usr/share/xsessions/i3-with-shmlog.desktop
+file path=usr/share/xsessions/i3.desktop

--- a/components/desktop/i3/patches/fix-wizard.patch
+++ b/components/desktop/i3/patches/fix-wizard.patch
@@ -1,0 +1,89 @@
+--- etc/config.keycodes.~1~	Sun Nov 15 11:23:01 2020
++++ etc/config.keycodes	Sat Jan  2 15:28:02 2021
+@@ -23,24 +23,24 @@
+ 
+ # xss-lock grabs a logind suspend inhibit lock and will use i3lock to lock the
+ # screen before suspend. Use loginctl lock-session to lock your screen.
+-exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
++#exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
+ 
+ # NetworkManager is the most popular way to manage wireless networks on Linux,
+ # and nm-applet is a desktop environment-independent system tray GUI for it.
+-exec --no-startup-id nm-applet
++#exec --no-startup-id nm-applet
+ 
+ # Use pactl to adjust volume in PulseAudio.
+-set $refresh_i3status killall -SIGUSR1 i3status
+-bindsym XF86AudioRaiseVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ +10% && $refresh_i3status
+-bindsym XF86AudioLowerVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ -10% && $refresh_i3status
+-bindsym XF86AudioMute exec --no-startup-id pactl set-sink-mute @DEFAULT_SINK@ toggle && $refresh_i3status
+-bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOURCE@ toggle && $refresh_i3status
++#set $refresh_i3status killall -SIGUSR1 i3status
++#bindsym XF86AudioRaiseVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ +10% && $refresh_i3status
++#bindsym XF86AudioLowerVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ -10% && $refresh_i3status
++#bindsym XF86AudioMute exec --no-startup-id pactl set-sink-mute @DEFAULT_SINK@ toggle && $refresh_i3status
++#bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOURCE@ toggle && $refresh_i3status
+ 
+ # Use Mouse+$mod to drag floating windows to their wanted position
+ floating_modifier $mod
+ 
+ # start a terminal
+-bindcode $mod+36 exec i3-sensible-terminal
++bindcode $mod+36 exec xterm
+ 
+ # kill focused window
+ bindcode $mod+Shift+24 kill
+@@ -51,7 +51,7 @@
+ # bindcode $mod+40 exec rofi -modi drun,run -show drun
+ # There also is i3-dmenu-desktop which only displays applications shipping a
+ # .desktop file. It is a wrapper around dmenu, so you need that installed.
+-bindcode $mod+40 exec --no-startup-id i3-dmenu-desktop
++#bindcode $mod+40 exec --no-startup-id i3-dmenu-desktop
+ 
+ # change focus
+ bindcode $mod+44 focus left
+@@ -60,10 +60,10 @@
+ bindcode $mod+47 focus right
+ 
+ # alternatively, you can use the cursor keys:
+-bindcode $mod+113 focus left
+-bindcode $mod+116 focus down
+-bindcode $mod+111 focus up
+-bindcode $mod+114 focus right
++bindcode $mod+100 focus left
++bindcode $mod+104 focus down
++bindcode $mod+98 focus up
++bindcode $mod+102 focus right
+ 
+ # move focused window
+ bindcode $mod+Shift+44 move left
+@@ -72,10 +72,10 @@
+ bindcode $mod+Shift+47 move right
+ 
+ # alternatively, you can use the cursor keys:
+-bindcode $mod+Shift+113 move left
+-bindcode $mod+Shift+116 move down
+-bindcode $mod+Shift+111 move up
+-bindcode $mod+Shift+114 move right
++bindcode $mod+Shift+100 move left
++bindcode $mod+Shift+104 move down
++bindcode $mod+Shift+98 move up
++bindcode $mod+Shift+102 move right
+ 
+ # split in horizontal orientation
+ bindcode $mod+43 split h
+@@ -161,10 +161,10 @@
+         bindcode 47 resize grow width 10 px or 10 ppt
+ 
+         # same bindings, but for the arrow keys
+-        bindcode 113 resize shrink width 10 px or 10 ppt
+-        bindcode 116 resize grow height 10 px or 10 ppt
+-        bindcode 111 resize shrink height 10 px or 10 ppt
+-        bindcode 114 resize grow width 10 px or 10 ppt
++        bindcode 100 resize shrink width 10 px or 10 ppt
++        bindcode 104 resize grow height 10 px or 10 ppt
++        bindcode 98 resize shrink height 10 px or 10 ppt
++        bindcode 102 resize grow width 10 px or 10 ppt
+ 
+         # back to normal: Enter or Escape or $mod+r
+         bindcode 36 mode "default"

--- a/components/desktop/i3/pkg5
+++ b/components/desktop/i3/pkg5
@@ -13,6 +13,8 @@
         "library/pcre",
         "system/library",
         "system/library/math",
+        "text/asciidoc",
+        "text/xmlto",
         "x11/library/libxcb",
         "x11/library/libxkbcommon",
         "x11/library/xcb-util",

--- a/components/desktop/i3/pkg5
+++ b/components/desktop/i3/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "desktop/dmenu",
+        "desktop/window-manager/i3/i3status",
         "developer/build/meson",
         "developer/build/ninja",
         "library/desktop/cairo",

--- a/components/desktop/i3/pkg5
+++ b/components/desktop/i3/pkg5
@@ -1,0 +1,28 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "desktop/dmenu",
+        "developer/build/meson",
+        "developer/build/ninja",
+        "library/desktop/cairo",
+        "library/desktop/pango",
+        "library/desktop/startup-notification",
+        "library/glib2",
+        "library/libev",
+        "library/libyajl2",
+        "library/pcre",
+        "system/library",
+        "system/library/math",
+        "x11/library/libxcb",
+        "x11/library/libxkbcommon",
+        "x11/library/xcb-util",
+        "x11/library/xcb-util-cursor",
+        "x11/library/xcb-util-keysyms",
+        "x11/library/xcb-util-wm",
+        "x11/library/xcb-util-xrm"
+    ],
+    "fmris": [
+        "desktop/window-manager/i3"
+    ],
+    "name": "i3"
+}

--- a/components/desktop/i3status/Makefile
+++ b/components/desktop/i3status/Makefile
@@ -26,6 +26,7 @@ COMPONENT_CLASSIFICATION=System/X11
 COMPONENT_ARCHIVE_URL=https://github.com/i3/i3status/archive/$(COMPONENT_ARCHIVE)
 COMPONENT_ARCHIVE_HASH=sha256:9d545df5c0053be5e05b7d196ec3c4a20deee102c39ef8b7f0eb816e85bae0ce
 COMPONENT_LICENSE=BSD-3
+PATCH_LEVEL=0
 
 TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
 include $(WS_MAKE_RULES)/common.mk
@@ -38,7 +39,6 @@ CFLAGS.studio+=-xspace
 COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -f -i )
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += desktop/window-manager/i3
 REQUIRED_PACKAGES += library/audio/pulseaudio
 REQUIRED_PACKAGES += library/libconfuse
 REQUIRED_PACKAGES += library/libyajl2

--- a/components/desktop/i3status/Makefile
+++ b/components/desktop/i3status/Makefile
@@ -1,0 +1,46 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020-1 Rick V
+#
+
+BUILD_BITS=32
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=i3status
+COMPONENT_VERSION=2.13
+COMPONENT_SUMMARY=status indicator for i3
+COMPONENT_PROJECT_URL=https://i3wm.org
+COMPONENT_FMRI=desktop/window-manager/i3/i3status
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_VERSION).tar.gz
+COMPONENT_CLASSIFICATION=System/X11
+COMPONENT_ARCHIVE_URL=https://github.com/i3/i3status/archive/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=sha256:9d545df5c0053be5e05b7d196ec3c4a20deee102c39ef8b7f0eb816e85bae0ce
+COMPONENT_LICENSE=BSD-3
+
+TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
+include $(WS_MAKE_RULES)/common.mk
+CPPFLAGS+= -D_XOPEN_SOURCE=700
+CPPFLAGS+= -D__EXTENSIONS__
+LDFLAGS+= -lpulse -lsocket -lnsl
+CONFIGURE_OPTIONS+= --enable-debug=no
+CFLAGS.studio+=-xspace 
+
+COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -f -i )
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += desktop/window-manager/i3
+REQUIRED_PACKAGES += library/audio/pulseaudio
+REQUIRED_PACKAGES += library/libconfuse
+REQUIRED_PACKAGES += library/libyajl2
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/desktop/i3status/i3status.license
+++ b/components/desktop/i3status/i3status.license
@@ -1,0 +1,26 @@
+Copyright © 2009, Michael Stapelberg and contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/desktop/i3status/i3status.p5m
+++ b/components/desktop/i3status/i3status.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 Rick V
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/i3status
+file path=usr/etc/i3status.conf
+file path=usr/share/man/man1/i3status.1

--- a/components/desktop/i3status/manifests/sample-manifest.p5m
+++ b/components/desktop/i3status/manifests/sample-manifest.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/i3status
+file path=usr/etc/i3status.conf
+file path=usr/share/man/man1/i3status.1

--- a/components/desktop/i3status/patches/sun.patch
+++ b/components/desktop/i3status/patches/sun.patch
@@ -1,7 +1,7 @@
 diff --git a/configure.ac b/configure.ac
 index aadde5b..0a05966 100644
---- a/configure.ac
-+++ b/configure.ac
+--- configure.ac
++++ configure.ac
 @@ -131,7 +131,7 @@ AM_CONDITIONAL([BUILD_MANS], [test x$ax_mans = xyes && test x$PATH_ASCIIDOC != x
  
  AM_PROG_AR
@@ -13,8 +13,8 @@ index aadde5b..0a05966 100644
  
 diff --git a/src/print_disk_info.c b/src/print_disk_info.c
 index d8cce1c..d5812cf 100644
---- a/src/print_disk_info.c
-+++ b/src/print_disk_info.c
+--- src/print_disk_info.c
++++ src/print_disk_info.c
 @@ -12,6 +12,8 @@
  #include <sys/param.h>
  #include <sys/mount.h>

--- a/components/desktop/i3status/patches/sun.patch
+++ b/components/desktop/i3status/patches/sun.patch
@@ -1,0 +1,35 @@
+diff --git a/configure.ac b/configure.ac
+index aadde5b..0a05966 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -131,7 +131,7 @@ AM_CONDITIONAL([BUILD_MANS], [test x$ax_mans = xyes && test x$PATH_ASCIIDOC != x
+ 
+ AM_PROG_AR
+ 
+-AX_FLAGS_WARN_ALL
++#AX_FLAGS_WARN_ALL
+ AX_CHECK_COMPILE_FLAG([-Wunused-value], [AX_APPEND_FLAG([-Wunused-value], [AM_CFLAGS])])
+ AC_SUBST(AM_CFLAGS)
+ 
+diff --git a/src/print_disk_info.c b/src/print_disk_info.c
+index d8cce1c..d5812cf 100644
+--- a/src/print_disk_info.c
++++ b/src/print_disk_info.c
+@@ -12,6 +12,8 @@
+ #include <sys/param.h>
+ #include <sys/mount.h>
+ #elif defined(__NetBSD__)
++#elif defined(__sun)
++#include <sys/statvfs.h>
+ #else
+ #include <mntent.h>
+ #endif
+@@ -131,7 +133,7 @@ void print_disk_info(yajl_gen json_gen, char *buffer, const char *path, const ch
+         return;
+ 
+     mounted = true;
+-#elif defined(__NetBSD__)
++#elif defined(__NetBSD__) || defined(__sun)
+     struct statvfs buf;
+ 
+     if (statvfs(path, &buf) == -1)

--- a/components/desktop/i3status/pkg5
+++ b/components/desktop/i3status/pkg5
@@ -1,0 +1,15 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "desktop/window-manager/i3",
+        "library/audio/pulseaudio",
+        "library/libconfuse",
+        "library/libyajl2",
+        "system/library",
+        "system/library/math"
+    ],
+    "fmris": [
+        "desktop/window-manager/i3/i3status"
+    ],
+    "name": "i3status"
+}

--- a/components/desktop/i3status/pkg5
+++ b/components/desktop/i3status/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
         "SUNWcs",
-        "desktop/window-manager/i3",
         "library/audio/pulseaudio",
         "library/libconfuse",
         "library/libyajl2",


### PR DESCRIPTION
finally figured out the patch required to get the status indicator app working (something something `statfs` vs `statvfs`....)
the window mgr itself has not required any patches since 4.17 (i was on 4.16 locally)

....except for the thing where keyboard scan codes on Xsun (and some BSD X servers) are different than what linux decides on