### PR TITLE
build-essential: add lzip, gnupg, ruby

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
 COMPONENT_VERSION=	1.0
-COMPONENT_REVISION=	21
+COMPONENT_REVISION=	22
 
 include ../../../make-rules/ips.mk
 

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -91,12 +91,14 @@ depend fmri=compress/unzip type=require
 depend fmri=compress/xz type=require
 depend fmri=compress/zstd type=require
 depend fmri=compress/bzip2 type=require
+depend fmri=compress/lzip type=require
 depend fmri=archiver/cabextract type=require
 depend fmri=developer/gaa type=require
 depend fmri=file/gnu-coreutils type=require
 depend fmri=file/gnu-findutils type=require
 depend fmri=developer/object-file type=require
 depend fmri=developer/pkgtree type=require
+depend fmri=crypto/gnupg type=require
 
 # Java
 depend fmri=developer/java/openjdk8 type=require
@@ -104,6 +106,7 @@ depend fmri=developer/java/junit type=require
 
 # Runtimes
 depend fmri=runtime/perl-522 type=require
+depend fmri=runtime/ruby type=require
 depend fmri=runtime/lua type=require
 depend fmri=library/apr-util type=require
 depend fmri=runtime/python-27 type=require


### PR DESCRIPTION
After setting up my build environment, I got this message after running `gmake env-prep`
```
pkg list: no packages matching the following patterns are installed:
  /compress/lzip
  /crypto/gnupg
  /runtime/ruby
Adding required packages to build environment...
```
I added this packages. When build-essential published and installed, I got the packages. It looks to me it works fine.
