### PR TITLE
libebml: update to 1.4.1

### DIFF
--- a/components/library/libebml/Makefile
+++ b/components/library/libebml/Makefile
@@ -14,23 +14,21 @@
 # Copyright (c) 2020 Andreas Wacknitz
 #
 
-BUILD_BITS=			32_and_64
-BUILD_STYLE=		cmake
+BUILD_BITS=				32_and_64
+BUILD_STYLE=			cmake
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=           libebml
-COMPONENT_VERSION=        1.4.0
-COMPONENT_PROJECT_URL=    https://matroska-org.github.io/libebml/
-COMPONENT_SUMMARY=        Extensible Binary Markup Language
-COMPONENT_SRC=            $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= \
-	sha256:80abc9a82549615018798ee704997270a39b43de9a6e7e0d23b62f8ce682c4b3
-COMPONENT_ARCHIVE_URL= \
-	https://dl.matroska.org/downloads/libebml/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE=	LGPLv2.1
+COMPONENT_NAME=         libebml
+COMPONENT_VERSION=      1.4.1
+COMPONENT_PROJECT_URL=  https://matroska-org.github.io/libebml/
+COMPONENT_SUMMARY=      Extensible Binary Markup Language
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH=	sha256:6e94c669405061aa0d25a523b9f1bea8ac73536e37721a110b3372c7f8717032
+COMPONENT_ARCHIVE_URL=	https://dl.matroska.org/downloads/libebml/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=		LGPLv2.1
 COMPONENT_LICENSE_FILE=	LICENSE.LGPL
-COMPONENT_FMRI=		library/libebml
+COMPONENT_FMRI=			library/libebml
 COMPONENT_CLASSIFICATION=	System/Libraries
 
 TEST_TARGET:		$(NO_TESTS)
@@ -38,7 +36,6 @@ include $(WS_MAKE_RULES)/common.mk
 
 CMAKE_OPTIONS += -DBUILD_SHARED_LIBS:BOOL=ON
 CMAKE_OPTIONS += -DSTATIC_BUILD:BOOL=OFF
-
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)


### PR DESCRIPTION
- sample-manifest didn't change
- vlc still works