### PR TITLE
findutils: update to 4.8.0

### DIFF
--- a/components/sysutils/findutils/Makefile
+++ b/components/sysutils/findutils/Makefile
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2019, Michal Nowak
+# Copyright (c) 2021, Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -29,7 +30,7 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         findutils
-COMPONENT_VERSION=      4.7.0
+COMPONENT_VERSION=      4.8.0
 COMPONENT_SUMMARY=      GNU findutils
 COMPONENT_PROJECT_URL=	http://www.gnu.org/software/findutils/
 COMPONENT_FMRI=         file/gnu-findutils
@@ -37,7 +38,7 @@ COMPONENT_CLASSIFICATION=Applications/System Utilities
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:c5fefbdf9858f7e4feb86f036e1247a54c79fc2d8e4b7064d5aaa1f47dfa789a
+	sha256:57127b7e97d91282c6ace556378d5455a9509898297e46e10443016ea1387164
 COMPONENT_ARCHIVE_URL= \
 	http://ftp.gnu.org/pub/gnu/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=      GPLv2
@@ -68,6 +69,7 @@ unexport SHELLOPTS
 # Test dependencies:
 REQUIRED_PACKAGES += developer/versioning/cvs
 REQUIRED_PACKAGES += developer/versioning/git
+REQUIRED_PACKAGES += locale/zh_cn-extra
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/sysutils/findutils/test/results-64.master
+++ b/components/sysutils/findutils/test/results-64.master
@@ -7,13 +7,9 @@ PASS: test_splitstring
 # FAIL:  0
 # XPASS: 0
 # ERROR: 0
-# of expected passes		951
-# of expected passes		96
-# of expected passes		28
 PASS: test-accept
 PASS: test-alloca-opt
 PASS: test-areadlink
-PASS: test-areadlink-with-size
 PASS: test-areadlinkat
 PASS: test-argmatch
 PASS: test-arpa_inet
@@ -54,6 +50,7 @@ PASS: test-fgetc
 PASS: test-float
 PASS: test-fnmatch-h
 PASS: test-fnmatch
+PASS: test-fopen-gnu
 PASS: test-fopen-safer
 PASS: test-fopen
 PASS: test-fpending.sh
@@ -62,6 +59,7 @@ PASS: test-fputc
 PASS: test-fread
 PASS: test-freadahead.sh
 PASS: test-freading
+PASS: test-free
 PASS: test-fseek.sh
 PASS: test-fseek2.sh
 PASS: test-fseeko.sh
@@ -90,6 +88,7 @@ PASS: test-getopt-gnu
 PASS: test-getopt-posix
 PASS: test-getprogname
 PASS: test-gettimeofday
+PASS: test-hard-locale
 PASS: test-hash
 PASS: test-i-ring
 PASS: test-ignore-value
@@ -105,6 +104,8 @@ PASS: test-isnand-nolibm
 PASS: test-isnanf-nolibm
 PASS: test-isnanl-nolibm
 PASS: test-iswblank
+PASS: test-iswdigit.sh
+PASS: test-iswxdigit.sh
 PASS: test-langinfo
 PASS: test-limits-h
 PASS: test-listen
@@ -130,6 +131,8 @@ SKIP: test-mbrtowc-w32-2.sh
 SKIP: test-mbrtowc-w32-3.sh
 SKIP: test-mbrtowc-w32-4.sh
 SKIP: test-mbrtowc-w32-5.sh
+SKIP: test-mbrtowc-w32-6.sh
+SKIP: test-mbrtowc-w32-7.sh
 PASS: test-mbscasestr1
 PASS: test-mbscasestr2.sh
 PASS: test-mbscasestr3.sh
@@ -148,6 +151,7 @@ PASS: test-modf
 PASS: test-nanosleep
 PASS: test-netinet_in
 PASS: test-nl_langinfo.sh
+PASS: test-nl_langinfo-mt
 PASS: test-nstrftime
 PASS: test-open
 PASS: test-openat-safer
@@ -158,20 +162,28 @@ PASS: test-perror.sh
 PASS: test-perror2
 PASS: test-pipe
 PASS: test-priv-set
+PASS: test-pthread
+PASS: test-pthread-thread
 PASS: test-pthread_sigmask1
 PASS: test-pthread_sigmask2
 PASS: test-quotearg-simple
 PASS: test-raise
+PASS: test-rawmemchr
 PASS: test-read
 PASS: test-readlink
 PASS: test-readlinkat
 PASS: test-realloc-gnu
 PASS: test-regex
 PASS: test-rmdir
+PASS: test-sched
+PASS: test-scratch-buffer
 PASS: test-select
 PASS: test-select-in.sh
 PASS: test-select-out.sh
 PASS: test-setenv
+PASS: test-setlocale_null
+PASS: test-setlocale_null-mt-one
+PASS: test-setlocale_null-mt-all
 PASS: test-setlocale1.sh
 PASS: test-setlocale2.sh
 PASS: test-setsockopt
@@ -197,6 +209,7 @@ PASS: test-string
 PASS: test-strings
 PASS: test-strnlen
 PASS: test-strstr
+PASS: test-strtoll
 PASS: test-strtoull
 PASS: test-strtoumax
 PASS: test-symlink
@@ -240,20 +253,23 @@ SKIP: test-wcrtomb-w32-2.sh
 SKIP: test-wcrtomb-w32-3.sh
 SKIP: test-wcrtomb-w32-4.sh
 SKIP: test-wcrtomb-w32-5.sh
+SKIP: test-wcrtomb-w32-6.sh
+SKIP: test-wcrtomb-w32-7.sh
 PASS: test-wctype-h
 PASS: test-wcwidth
 PASS: test-xalloc-die.sh
 PASS: test-xstrtol.sh
 PASS: test-xstrtoumax.sh
 PASS: test-yesno.sh
-# TOTAL: 236
-# PASS:  223
-# SKIP:  13
+# TOTAL: 254
+# PASS:  237
+# SKIP:  17
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0
 # ERROR: 0
 FAIL: tests/misc/help-version.sh
+PASS: tests/find/depth-unreadable-dir.sh
 SKIP: tests/find/many-dir-entries-vs-OOM.sh
 PASS: tests/find/name-lbracket-literal.sh
 PASS: tests/find/printf_escapechars.sh
@@ -263,11 +279,13 @@ PASS: tests/find/execdir-fd-leak.sh
 PASS: tests/find/exec-plus-last-file.sh
 PASS: tests/find/refuse-noop.sh
 PASS: tests/find/debug-missing-arg.sh
+SKIP: tests/find/used.sh
+PASS: tests/xargs/conflicting_opts.sh
 PASS: tests/xargs/verbose-quote.sh
 PASS: tests/find/type_list.sh
-# TOTAL: 12
-# PASS:  10
-# SKIP:  1
+# TOTAL: 15
+# PASS:  12
+# SKIP:  2
 # XFAIL: 0
 # FAIL:  1
 # XPASS: 0


### PR DESCRIPTION
It builds, installs and publishes fine, sample-manifest didn't change.
When installed locally, I tested it with:
`pfexec updatedb`
`locate file_name`
`find -type f -name "*string*" | xargs ls -l`
and it worked.
