### PR TITLE
Update smartmontools.xml

### DIFF
--- a/components/sysutils/smartmontools/files/smartmontools.xml
+++ b/components/sysutils/smartmontools/files/smartmontools.xml
@@ -17,7 +17,7 @@
     <exec_method
        type="method"
        name="start"
-       exec="/usr/sbin/smartd "
+       exec="/usr/sbin/smartd -n"
        timeout_seconds="60">
       <method_context>
         <method_credential user="root" group="root"/>


### PR DESCRIPTION

Disable the automatic fork within smartd to prevent service svc:/system/smartd:default from forking a process every second.

Tested on a system by manually modifying the smartmontools.xml:
steven@dell6510:/lib/svc/manifest/system$ sudo vi smartmontools.xml
steven@dell6510:/lib/svc/manifest/system$ sudo svccfg import smartmontools.xml
steven@dell6510:/lib/svc/manifest/system$ sudo svcadm enable smartd
steven@dell6510:/lib/svc/manifest/system$ ps ax |grep smart
3164 ? S 0:00 /usr/sbin/smartd -n
3166 pts/2 S 0:00 grep smart
steven@dell6510:/lib/svc/manifest/system$ ps ax |grep smart
3164 ? S 0:00 /usr/sbin/smartd -n
3168 pts/2 S 0:00 grep smart
steven@dell6510:/lib/svc/manifest/system$ ps ax |grep smart
3164 ? S 0:00 /usr/sbin/smartd -n
3170 pts/2 S 0:00 grep smart
steven@dell6510:/lib/svc/manifest/system$

Easy testing. If not modified, a new smartd process is invoked every second or so.

Please review.