### PR TITLE
Smartmontools service no auto fork multiple processes every second

### DIFF
--- a/components/sysutils/smartmontools/Makefile
+++ b/components/sysutils/smartmontools/Makefile
@@ -30,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME= smartmontools
 COMPONENT_SUMMARY= smartmontools contains utilities that control and monitor storage devices
 COMPONENT_VERSION= 7.1
+COMPONENT_REVISION=  1
 COMPONENT_FMRI= storage/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/sysutils/smartmontools/files/smartmontools.xml
+++ b/components/sysutils/smartmontools/files/smartmontools.xml
@@ -17,7 +17,7 @@
     <exec_method
        type="method"
        name="start"
-       exec="/usr/sbin/smartd "
+       exec="/usr/sbin/smartd -n"
        timeout_seconds="60">
       <method_context>
         <method_credential user="root" group="root"/>


### PR DESCRIPTION
Enabling the smartd service startsa new process 'smartd' about every second.
This patch add the option "-n" to the start command in the service xml.

i tested the proposed byte-size patch manually by:

steven@dell6510:/lib/svc/manifest/system$ sudo vi smartmontools.xml 
steven@dell6510:/lib/svc/manifest/system$ sudo svccfg import smartmontools.xml 
steven@dell6510:/lib/svc/manifest/system$ sudo svcadm enable smartd
steven@dell6510:/lib/svc/manifest/system$ ps ax |grep smart
  3164 ?        S  0:00 /usr/sbin/smartd -n
  3166 pts/2    S  0:00 grep smart
steven@dell6510:/lib/svc/manifest/system$ ps ax |grep smart
  3164 ?        S  0:00 /usr/sbin/smartd -n
  3168 pts/2    S  0:00 grep smart
steven@dell6510:/lib/svc/manifest/system$ ps ax |grep smart
  3164 ?        S  0:00 /usr/sbin/smartd -n
  3170 pts/2    S  0:00 grep smart

Please review.