### PR TITLE
lame: fix undefined lame_init_old() symbol

### DIFF
--- a/components/multimedia/lame/Makefile
+++ b/components/multimedia/lame/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= lame
 COMPONENT_VERSION= 3.100
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY= LAME is a high quality MPEG Audio Layer III (MP3) encoder licensed under the LGPL 
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz

--- a/components/multimedia/lame/patches/04-remove-lame_init_old-sym.patch
+++ b/components/multimedia/lame/patches/04-remove-lame_init_old-sym.patch
@@ -1,0 +1,8 @@
+--- lame-3.100/include/libmp3lame.sym.orig	2017-09-06 21:33:35.000000000 +0000
++++ lame-3.100/include/libmp3lame.sym	2021-01-18 22:20:50.813394403 +0000
+@@ -1,5 +1,4 @@
+ lame_init
+-lame_init_old
+ lame_set_num_samples
+ lame_get_num_samples
+ lame_set_in_samplerate


### PR DESCRIPTION
Building of vlc and freerdp failed with "undefined symbol" without this patch.
