### PR TITLE
gimp: add dependency on graphviz #13477

### DIFF
--- a/components/image/gimp/Makefile
+++ b/components/image/gimp/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gimp
 COMPONENT_VERSION=	2.10.22
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	https://www.gimp.org/
 COMPONENT_SUMMARY=	Gimp - The Free & Open Source Image Editor
 COMPONENT_FMRI=		image/editor/gimp

--- a/components/image/gimp/gimp.p5m
+++ b/components/image/gimp/gimp.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2020 Alexander Pyhalov
+# Copyright 2021 Andreas Wacknitz
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,6 +28,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=etc/gimp/2.0/.* -> default preserve true>
 
 depend type=require fmri=pkg:/library/mypaint-brushes
+depend type=require fmri=pkg:/image/graphviz
 
 # Python 2.7 searchs for 64-bit binary modules in "64" subdirectory
 file usr/lib/$(MACH64)/gimp/2.0/python/_gimpenums.so \


### PR DESCRIPTION
As reported in https://www.illumos.org/issues/13477 gimp doesn't start without graphviz being installed.