### PR TITLE
Upgrade of cluster-glue to python-37

### DIFF
--- a/components/cluster/cluster-glue/Makefile
+++ b/components/cluster/cluster-glue/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= cluster-glue
 COMPONENT_VERSION= 1.0.12
-COMPONENT_REVISION= 5
+COMPONENT_REVISION= 6
 COMPONENT_FMRI= application/cluster/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION= System/Services
 COMPONENT_COMMIT= bdd95fd0f89f31b19fa46ffa0ea3f5022ebcd858
@@ -80,7 +80,7 @@ REQUIRED_PACKAGES += library/libxml2
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
-REQUIRED_PACKAGES += runtime/python-27
+REQUIRED_PACKAGES += runtime/python-37
 REQUIRED_PACKAGES += shell/bash
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)

--- a/components/cluster/cluster-glue/patches/python3.patch
+++ b/components/cluster/cluster-glue/patches/python3.patch
@@ -1,0 +1,151 @@
+--- cluster-glue-src/lib/plugins/stonith/external/riloe-orig	Thu Aug  3 03:41:13 2017
++++ cluster-glue-src/lib/plugins/stonith/external/riloe	Fri Feb  5 15:33:00 2021
+@@ -35,7 +35,7 @@
+ import socket
+ import subprocess
+ import xml.dom.minidom
+-import httplib
++import http.client as httplib
+ import time
+ import re
+ 
+@@ -163,12 +163,12 @@
+ }
+ 
+ if cmd in info:
+-    print info[cmd]
++    print(info[cmd])
+     sys.exit(0)
+ 
+ if cmd == 'getconfignames':
+     for arg in [ "hostlist", "ilo_hostname", "ilo_user", "ilo_password", "ilo_can_reset", "ilo_protocol", "ilo_powerdown_method", "ilo_proxyhost", "ilo_proxyport"]:
+-        print arg
++        print(arg)
+     sys.exit(0)
+ 
+ if not rihost:
+@@ -344,13 +344,13 @@
+             return h
+         else:
+             return httplib.HTTPSConnection(host)
+-    except socket.gaierror, msg:
++    except socket.gaierror as msg:
+         fatal("%s: %s" %(msg,host))
+-    except socket.sslerror, msg:
++    except socket.sslerror as msg:
+         fatal("%s for %s" %(msg,host))
+-    except socket.error, msg:
++    except socket.error as msg:
+         fatal("%s while talking to %s" %(msg,host))
+-    except ImportError, msg:
++    except ImportError as msg:
+         fatal("ssl support missing (%s)" %msg)
+ 
+ def send_request(req,proc_f):
+@@ -364,7 +364,7 @@
+     c = open_ilo(rihost)
+     try:
+         c.send(req+'\r\n')
+-    except socket.error, msg:
++    except socket.error as msg:
+         fatal("%s, while talking to %s" %(msg,rihost))
+     t_end = time.time()
+     my_debug("request sent in %0.2f s" % ((t_end-t_begin)))
+@@ -377,7 +377,7 @@
+             if not reply:
+                 break
+             result.append(reply)
+-        except socket.error, msg:
++        except socket.error as msg:
+             if msg[0] == 6: # connection closed
+                 break
+             my_err("%s, while talking to %s" %(msg,rihost))
+@@ -393,7 +393,7 @@
+             reply = re.sub("<(RIBCL.*)/>", r"<\1>", reply)
+         try:
+             doc = xml.dom.minidom.parseString(reply)
+-        except xml.parsers.expat.ExpatError,msg:
++        except xml.parsers.expat.ExpatError as msg:
+             fatal("malformed response: %s\n%s"%(msg,reply))
+         rc = proc_f(doc)
+         doc.unlink()
+--- cluster-glue-src/lib/plugins/stonith/ribcl.py.in-orig	Thu Aug  3 03:41:13 2017
++++ cluster-glue-src/lib/plugins/stonith/ribcl.py.in	Fri Feb  5 15:27:32 2021
+@@ -18,7 +18,7 @@
+ 
+ import sys
+ import socket
+-from httplib import *
++from http.client import *
+ from time import sleep
+ 
+ 
+@@ -29,7 +29,7 @@
+         host = argv[1].split('.')[0]+'-rm'
+         cmd = argv[2]
+ except IndexError:
+-        print "Not enough arguments"
++        print("Not enough arguments")
+         sys.exit(1)
+ 
+ 
+@@ -66,7 +66,7 @@
+         else:   
+                 acmds.append(login + todo[cmd] + logout)
+ except KeyError:
+-        print "Invalid command: "+ cmd
++        print("Invalid command: "+ cmd)
+         sys.exit(1)
+ 
+ 
+@@ -88,13 +88,13 @@
+                 sleep(1)
+ 
+ 
+-except socket.gaierror, msg:
+-        print msg
++except socket.gaierror as msg:
++        print(msg)
+         sys.exit(1)
+-except socket.sslerror, msg:
+-        print msg
++except socket.sslerror as msg:
++        print(msg)
+         sys.exit(1)
+-except socket.error, msg:
+-        print msg
++except socket.error as msg:
++        print(msg)
+         sys.exit(1)
+ 
+--- cluster-glue-src/lib/plugins/stonith/external/ibmrsa-telnet-orig	Wed Feb  3 10:14:20 2021
++++ cluster-glue-src/lib/plugins/stonith/external/ibmrsa-telnet	Thu Feb  4 11:04:05 2021
+@@ -305,7 +305,7 @@
+             func = getattr(self, cmd, self.not_implemented)
+             rc = func()
+             return(rc)
+-        except Exception, args:
++        except Exception as args:
+             self.echo_log("err", 'Exception raised:', str(args))
+             if self._connection:
+                 self.echo_log("err", self._connection.get_history())
+--- cluster-glue-src/lib/plugins/stonith/external/dracmc-telnet-orig	Wed Feb  3 10:14:20 2021
++++ cluster-glue-src/lib/plugins/stonith/external/dracmc-telnet	Thu Feb  4 11:12:57 2021
+@@ -200,7 +200,7 @@
+                            self._parameters['cyclades_port'])
+                     c.login(self._parameters['username'],
+                             self._parameters['password'])
+-                except Exception, args:
++                except Exception as args:
+                     if "Connection reset by peer" in str(args):
+                         self._echo_debug("Someone is already logged in... retry=%s" % tries)
+                         c.close()
+@@ -362,7 +362,7 @@
+             func = getattr(self, cmd, self.not_implemented)
+             rc = func()
+             return(rc)
+-        except Exception, args:
++        except Exception as args:
+             self.echo_log("err", 'Exception raised:', str(args))
+             if self._connection:
+                 self.echo_log("err", self._connection.get_history())

--- a/components/cluster/cluster-glue/patches/usr_bin_python3.patch
+++ b/components/cluster/cluster-glue/patches/usr_bin_python3.patch
@@ -3,7 +3,7 @@ diff -Nura a/usr/lib/stonith/plugins/external/dracmc-telnet b/usr/lib/stonith/pl
 +++ b/lib/plugins/stonith/external/dracmc-telnet	2016-10-28 08:27:07.576243323 +0200
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python
-+#!/usr/bin/python2.7
++#!/usr/bin/python3.7
  # vim: set filetype=python
  #######################################################################
  #
@@ -12,7 +12,7 @@ diff -Nura a/usr/lib/stonith/plugins/external/ibmrsa-telnet b/usr/lib/stonith/pl
 +++ b/lib/plugins/stonith/external/ibmrsa-telnet	2016-10-28 08:27:34.908188863 +0200
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python
-+#!/usr/bin/python2.7
++#!/usr/bin/python3.7
  # vim: set filetype=python
  #######################################################################
  #
@@ -21,7 +21,7 @@ diff -Nura a/usr/lib/stonith/plugins/external/riloe b/usr/lib/stonith/plugins/ex
 +++ b/lib/plugins/stonith/external/riloe	2016-10-28 08:27:50.022642344 +0200
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python
-+#!/usr/bin/python2.7
++#!/usr/bin/python3.7
  #
  # Stonith module for RILOE Stonith device
  #
@@ -30,7 +30,7 @@ diff -Nura a/usr/lib/stonith/plugins/stonith2/ribcl.py b/usr/lib/stonith/plugins
 +++ b/lib/plugins/stonith/ribcl.py.in	2016-10-28 08:28:16.882225009 +0200
 @@ -1,4 +1,4 @@
 -#!@PYTHON@
-+#!/usr/bin/python2.7
++#!/usr/bin/python3.7
 
  
  

--- a/components/cluster/cluster-glue/pkg5
+++ b/components/cluster/cluster-glue/pkg5
@@ -8,7 +8,7 @@
         "library/zlib",
         "runtime/perl-522",
         "runtime/perl-524",
-        "runtime/python-27",
+        "runtime/python-37",
         "shell/bash",
         "system/library",
         "system/library/g++-7-runtime",


### PR DESCRIPTION
There isn't a new version of this package, as far as I can determine.  The cluster-glue package contains four python scripts.  All of them are written for python-27 .  They use different techniques to obtain the name of the python interpreter on a given system.  The patch usr_bin_python27.patch modifies each of the scripts to give them /usr/bin/python2.7 .  I've renamed this patch and altered it to give them /usr/bin/python3.7 instead.  As well, I've added another patch python3.patch that converts the four scripts from python2 to python3.  The publish step is now successful, as are the previous steps.  The python dependancy is now runtime/python-37 .
