### PR TITLE
xorriso: update to 1.5.4

### DIFF
--- a/components/sysutils/xorriso/Makefile
+++ b/components/sysutils/xorriso/Makefile
@@ -20,6 +20,7 @@
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2019, Michal Nowak
+# Copyright (c) 2021, Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -27,13 +28,13 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         xorriso
-COMPONENT_VERSION=      1.5.3
+COMPONENT_VERSION=      1.5.4
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_SUMMARY=	command line ISO-9660 and Rock Ridge manipulation tool
 COMPONENT_PROJECT_URL=  https://www.gnu.org/software/xorriso/
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:bb8db9274caecd44993e8242e6acff4298b3508b83ac3c51c9fd970b9e765adc
+	sha256:3ac155f0ca53e8dbeefacc7f32205a98f4f27d2d348de39ee0183ba8a4c9e392
 COMPONENT_ARCHIVE_URL=  https://www.gnu.org/software/xorriso/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		media/xorriso
 COMPONENT_CLASSIFICATION=	System/Media

--- a/components/sysutils/xorriso/test/results-64.master
+++ b/components/sysutils/xorriso/test/results-64.master
@@ -2,19 +2,19 @@ make[1]: Entering directory '$(@D)'
 /usr/gnu/bin/make  check-local
 make[2]: Entering directory '$(@D)'
 xorriso/xorriso -no_rc -version -list_extras all
-GNU xorriso 1.5.3 : RockRidge filesystem manipulator, libburnia project.
+GNU xorriso 1.5.4 : RockRidge filesystem manipulator, libburnia project.
 
-GNU xorriso 1.5.3
+GNU xorriso 1.5.4
 ISO 9660 Rock Ridge filesystem manipulator and CD/DVD/BD burn program
 Copyright (C) 2019, Thomas Schmitt <scdbackup@gmx.net>, libburnia project.
-xorriso version   :  1.5.3
-Version timestamp :  2019.12.07.203142
+xorriso version   :  1.5.4
+Version timestamp :  2021.01.30.150001
 Build timestamp   :  -none-given-
-libisofs   in use :  1.5.3  (min. 1.5.3)
+libisofs   in use :  1.5.4  (min. 1.5.4)
 libjte     in use :  2.0.0  (min. 2.0.0)
-libburn    in use :  1.5.3  (min. 1.5.3)
+libburn    in use :  1.5.4  (min. 1.5.4)
 libburn OS adapter:  internal Solaris uscsi adapter sg-solaris
-libisoburn in use :  1.5.3  (min. 1.5.3)
+libisoburn in use :  1.5.4  (min. 1.5.4)
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.


### PR DESCRIPTION
It builds, installs and publishes fine, sample-manifest didn't change.
When installed locally, I tested it with `xorriso -devices` and `xorriso -list_arg_sorting` and it looks to me it works.