### PR TITLE
requests: fix build Python 3.7 and 3.9

### DIFF
--- a/components/python/requests/Makefile
+++ b/components/python/requests/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		requests
 COMPONENT_VERSION=	2.22.0
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		library/python/requests
 COMPONENT_CLASSIFICATION=Development/Python
 COMPONENT_SUMMARY=	Python HTTP Requests for Humans

--- a/components/python/requests/patches/dependencies.patch
+++ b/components/python/requests/patches/dependencies.patch
@@ -1,3 +1,6 @@
+We use a newer version of chardet, which is fully compatible but not allowed
+in our version yet.
+
 We are not using certifi package on Solaris as the location of the standard
 certs bundle is patched directly into requests.
 
@@ -8,9 +11,12 @@ of urllib3 (which is why we can allow 1.25.1).
 
 --- requests-2.22.0/setup.py
 +++ requests-2.22.0/setup.py
-@@ -44,8 +44,7 @@ packages = ['requests']
+@@ -42,10 +42,9 @@ if sys.argv[-1] == 'publish':
+ packages = ['requests']
+ 
  requires = [
-     'chardet>=3.0.2,<3.1.0',
+-    'chardet>=3.0.2,<3.1.0',
++    'chardet>=3.0.2,<5',
      'idna>=2.5,<2.9',
 -    'urllib3>=1.21.1,<1.26,!=1.25.0,!=1.25.1',
 -    'certifi>=2017.4.17'
@@ -21,7 +27,8 @@ of urllib3 (which is why we can allow 1.25.1).
 --- requests-2.22.0/requests.egg-info/requires.txt
 +++ requests-2.22.0/requests.egg-info/requires.txt
 @@ -1,7 +1,6 @@
- chardet<3.1.0,>=3.0.2
+-chardet<3.1.0,>=3.0.2
++chardet<5,>=3.0.2
  idna<2.9,>=2.5
 -urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
 -certifi>=2017.4.17
@@ -29,3 +36,18 @@ of urllib3 (which is why we can allow 1.25.1).
  
  [security]
  pyOpenSSL>=0.14
+--- requests-2.22.0/requests/__init__.py
++++ requests-2.22.0/requests/__init__.py
+@@ -65,10 +65,8 @@ def check_compatibility(urllib3_version,
+     # Check chardet for compatibility.
+     major, minor, patch = chardet_version.split('.')[:3]
+     major, minor, patch = int(major), int(minor), int(patch)
+-    # chardet >= 3.0.2, < 3.1.0
+-    assert major == 3
+-    assert minor < 1
+-    assert patch >= 2
++    # chardet >= 3.0.2, < 5.0.0
++    assert (3, 0, 2) <= (major, minor, patch) < (5, 0, 0)
+ 
+ 
+ def _check_cryptography(cryptography_version):

--- a/components/python/requests/pkg5
+++ b/components/python/requests/pkg5
@@ -7,10 +7,10 @@
         "runtime/python-39"
     ],
     "fmris": [
-        "library/python/requests",
-        "library/python/requests",
-        "library/python/requests",
-        "library/python/requests",
+        "library/python/requests-27",
+        "library/python/requests-35",
+        "library/python/requests-37",
+        "library/python/requests-39",
         "library/python/requests"
     ],
     "name": "requests"

--- a/components/python/requests/requests-PYVER.p5m
+++ b/components/python/requests/requests-PYVER.p5m
@@ -13,7 +13,7 @@
 # Copyright 2016 Adam Stevko 
 #
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)


### PR DESCRIPTION
It builds, installs and publishes fine.
When installed locally, it works. I got rid of the warning
```
/usr/lib/python3.7/vendor-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.25.1) or chardet (4.0.0) doesn't match a supported version!
  RequestsDependencyWarning)
```
by applying new patch from solaris:
https://github.com/oracle/solaris-userland/commit/26b94a939229acab40fbf08dd027fe3fb9dcbe82#diff-42f460bac224a20638b8d8157d2751cf6b53e377cca2a36be3d00585986ba572