### PR TITLE
openssl-1.0.2: add fixes for CVE-2021-23840 and CVE-2021-23841

### DIFF
--- a/components/library/openssl/openssl-1.0.2/Makefile
+++ b/components/library/openssl/openssl-1.0.2/Makefile
@@ -36,7 +36,7 @@ COMPONENT_VERSION =	1.0.2u
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
 IPS_COMPONENT_VERSION = 1.0.2.21
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_FMRI =	library/security/openssl
 COMPONENT_SUMMARY =	OpenSSL - a Toolkit for Secure Sockets Layer (SSL v2/v3) and Transport Layer (TLS v1) protocols and general purpose cryptographic library
 COMPONENT_CLASSIFICATION = System/Security

--- a/components/library/openssl/openssl-1.0.2/patches/204-CVE-2021-23840-pre2.patch
+++ b/components/library/openssl/openssl-1.0.2/patches/204-CVE-2021-23840-pre2.patch
@@ -1,0 +1,41 @@
+patch taken from:
+https://git.launchpad.net/ubuntu/+source/openssl1.0/tree/debian/patches?h=applied/ubuntu/bionic-security
+
+Backport of:
+
+From 4bd0db1feaaf97fbc2bd31f54f1fbdeab80b2b1a Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Sun, 9 Dec 2018 14:20:30 +0100
+Subject: [PATCH] make update
+
+Reviewed-by: Kurt Roeckx <kurt@roeckx.be>
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+(Merged from https://github.com/openssl/openssl/pull/7852)
+
+(cherry picked from commit f2f734d4f9e34643a1d3e5b79d2447cd643519f8)
+---
+ crypto/err/openssl.txt   | 1 +
+ crypto/evp/evp_err.c     | 2 ++
+ include/openssl/evperr.h | 1 +
+ 3 files changed, 4 insertions(+)
+
+--- a/crypto/evp/evp_err.c
++++ b/crypto/evp/evp_err.c
+@@ -94,6 +94,7 @@ static ERR_STRING_DATA EVP_str_functs[]
+     {ERR_FUNC(EVP_F_EVP_DECRYPTFINAL_EX), "EVP_DecryptFinal_ex"},
+     {ERR_FUNC(EVP_F_EVP_DECRYPTUPDATE), "EVP_DecryptUpdate"},
+     {ERR_FUNC(EVP_F_EVP_DIGESTINIT_EX), "EVP_DigestInit_ex"},
++    {ERR_FUNC(EVP_F_EVP_ENCRYPTDECRYPTUPDATE), "evp_EncryptDecryptUpdate"},
+     {ERR_FUNC(EVP_F_EVP_ENCRYPTFINAL_EX), "EVP_EncryptFinal_ex"},
+     {ERR_FUNC(EVP_F_EVP_ENCRYPTUPDATE), "EVP_EncryptUpdate"},
+     {ERR_FUNC(EVP_F_EVP_MD_CTX_COPY_EX), "EVP_MD_CTX_copy_ex"},
+--- a/crypto/evp/evp.h
++++ b/crypto/evp/evp.h
+@@ -1491,6 +1491,7 @@ void ERR_load_EVP_strings(void);
+ # define EVP_F_EVP_DECRYPTFINAL_EX                        101
+ # define EVP_F_EVP_DECRYPTUPDATE                          166
+ # define EVP_F_EVP_DIGESTINIT_EX                          128
++# define EVP_F_EVP_ENCRYPTDECRYPTUPDATE                   219
+ # define EVP_F_EVP_ENCRYPTFINAL_EX                        127
+ # define EVP_F_EVP_ENCRYPTUPDATE                          167
+ # define EVP_F_EVP_MD_CTX_COPY_EX                         110

--- a/components/library/openssl/openssl-1.0.2/patches/205-CVE-2021-23840.patch
+++ b/components/library/openssl/openssl-1.0.2/patches/205-CVE-2021-23840.patch
@@ -1,0 +1,82 @@
+patch taken from:
+https://git.launchpad.net/ubuntu/+source/openssl1.0/tree/debian/patches?h=applied/ubuntu/bionic-security
+
+Backport of:
+
+From 6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 2 Feb 2021 17:17:23 +0000
+Subject: [PATCH] Don't overflow the output length in EVP_CipherUpdate calls
+
+CVE-2021-23840
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+---
+ crypto/err/openssl.txt   |  3 ++-
+ crypto/evp/evp_enc.c     | 27 +++++++++++++++++++++++++++
+ crypto/evp/evp_err.c     |  4 +++-
+ include/openssl/evperr.h |  7 +++----
+ 4 files changed, 35 insertions(+), 6 deletions(-)
+
+--- a/crypto/evp/evp_enc.c
++++ b/crypto/evp/evp_enc.c
+@@ -356,6 +356,19 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ct
+             return 1;
+         } else {
+             j = bl - i;
++
++            /*
++             * Once we've processed the first j bytes from in, the amount of
++             * data left that is a multiple of the block length is:
++             * (inl - j) & ~(bl - 1)
++             * We must ensure that this amount of data, plus the one block that
++             * we process from ctx->buf does not exceed INT_MAX
++             */
++            if (((inl - j) & ~(bl - 1)) > INT_MAX - bl) {
++                EVPerr(EVP_F_EVP_ENCRYPTDECRYPTUPDATE,
++                       EVP_R_OUTPUT_WOULD_OVERFLOW);
++                return 0;
++            }
+             memcpy(&(ctx->buf[i]), in, j);
+             if (!M_do_cipher(ctx, out, ctx->buf, bl))
+                 return 0;
+@@ -457,6 +470,19 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ct
+     OPENSSL_assert(b <= sizeof ctx->final);
+ 
+     if (ctx->final_used) {
++        /*
++         * final_used is only ever set if buf_len is 0. Therefore the maximum
++         * length output we will ever see from evp_EncryptDecryptUpdate is
++         * the maximum multiple of the block length that is <= inl, or just:
++         * inl & ~(b - 1)
++         * Since final_used has been set then the final output length is:
++         * (inl & ~(b - 1)) + b
++         * This must never exceed INT_MAX
++         */
++        if ((inl & ~(b - 1)) > INT_MAX - b) {
++            EVPerr(EVP_F_EVP_DECRYPTUPDATE, EVP_R_OUTPUT_WOULD_OVERFLOW);
++            return 0;
++        }
+         memcpy(out, ctx->final, b);
+         out += b;
+         fix_len = 1;
+--- a/crypto/evp/evp_err.c
++++ b/crypto/evp/evp_err.c
+@@ -216,6 +216,7 @@ static ERR_STRING_DATA EVP_str_reasons[]
+     {ERR_REASON(EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE),
+      "operation not supported for this keytype"},
+     {ERR_REASON(EVP_R_OPERATON_NOT_INITIALIZED), "operaton not initialized"},
++    {ERR_REASON(EVP_R_OUTPUT_WOULD_OVERFLOW), "output would overflow"},
+     {ERR_REASON(EVP_R_PKCS8_UNKNOWN_BROKEN_TYPE),
+      "pkcs8 unknown broken type"},
+     {ERR_REASON(EVP_R_PRIVATE_KEY_DECODE_ERROR), "private key decode error"},
+--- a/crypto/evp/evp.h
++++ b/crypto/evp/evp.h
+@@ -1603,6 +1603,7 @@ void ERR_load_EVP_strings(void);
+ # define EVP_R_NO_VERIFY_FUNCTION_CONFIGURED              105
+ # define EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE   150
+ # define EVP_R_OPERATON_NOT_INITIALIZED                   151
++# define EVP_R_OUTPUT_WOULD_OVERFLOW                      184
+ # define EVP_R_PKCS8_UNKNOWN_BROKEN_TYPE                  117
+ # define EVP_R_PRIVATE_KEY_DECODE_ERROR                   145
+ # define EVP_R_PRIVATE_KEY_ENCODE_ERROR                   146

--- a/components/library/openssl/openssl-1.0.2/patches/206-CVE-2021-23841.patch
+++ b/components/library/openssl/openssl-1.0.2/patches/206-CVE-2021-23841.patch
@@ -1,0 +1,43 @@
+patch taken from:
+https://git.launchpad.net/ubuntu/+source/openssl1.0/tree/debian/patches?h=applied/ubuntu/bionic-security
+
+Backport of:
+
+From 122a19ab48091c657f7cb1fb3af9fc07bd557bbf Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Wed, 10 Feb 2021 16:10:36 +0000
+Subject: [PATCH] Fix Null pointer deref in X509_issuer_and_serial_hash()
+
+The OpenSSL public API function X509_issuer_and_serial_hash() attempts
+to create a unique hash value based on the issuer and serial number data
+contained within an X509 certificate. However it fails to correctly
+handle any errors that may occur while parsing the issuer field (which
+might occur if the issuer field is maliciously constructed). This may
+subsequently result in a NULL pointer deref and a crash leading to a
+potential denial of service attack.
+
+The function X509_issuer_and_serial_hash() is never directly called by
+OpenSSL itself so applications are only vulnerable if they use this
+function directly and they use it on certificates that may have been
+obtained from untrusted sources.
+
+CVE-2021-23841
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+Reviewed-by: Paul Dale <pauli@openssl.org>
+(cherry picked from commit 8130d654d1de922ea224fa18ee3bc7262edc39c0)
+---
+ crypto/x509/x509_cmp.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/crypto/x509/x509_cmp.c
++++ b/crypto/x509/x509_cmp.c
+@@ -87,6 +87,8 @@ unsigned long X509_issuer_and_serial_has
+ 
+     EVP_MD_CTX_init(&ctx);
+     f = X509_NAME_oneline(a->cert_info->issuer, NULL, 0);
++    if (f == NULL)
++        goto err;
+     if (!EVP_DigestInit_ex(&ctx, EVP_md5(), NULL))
+         goto err;
+     if (!EVP_DigestUpdate(&ctx, (unsigned char *)f, strlen(f)))


### PR DESCRIPTION
I have integrated 3 patches taken from OmniOSce.
gmake test run fine