### PR TITLE
pulseaudio: switch to openssl-1.1

### DIFF
--- a/components/desktop/pulseaudio/Makefile
+++ b/components/desktop/pulseaudio/Makefile
@@ -15,23 +15,21 @@
 #
 
 PREFERRED_BITS=		64
-BUILD_BITS=		32_and_64
-
+BUILD_BITS=			32_and_64
+USE_OPENSSL11=		yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pulseaudio
 COMPONENT_VERSION=	13.0
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_FMRI=		library/audio/pulseaudio
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 COMPONENT_SUMMARY=	Sample Rate Converter for audio
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= \
-	sha256:961b23ca1acfd28f2bc87414c27bb40e12436efcf2158d29721b1e89f3f28057
-COMPONENT_ARCHIVE_URL= \
-	http://freedesktop.org/software/pulseaudio/releases/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	http://www.freedesktop.org/wiki/Software/PulseAudio/
+COMPONENT_ARCHIVE_HASH= sha256:961b23ca1acfd28f2bc87414c27bb40e12436efcf2158d29721b1e89f3f28057
+COMPONENT_ARCHIVE_URL= https://freedesktop.org/software/pulseaudio/releases/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://www.freedesktop.org/wiki/Software/PulseAudio/
 COMPONENT_LICENSE=	LGPLv2.1,GPLv2,MIT,adrian-license,Sun Public Domain license
 
 include $(WS_MAKE_RULES)/common.mk
@@ -88,17 +86,18 @@ COMPONENT_TEST_TRANSFORMS = "'/TOTAL|PASS|FAIL|XFAIL|SKIP|XPASS|ERROR/'"
 
 # For tests
 REQUIRED_PACKAGES += developer/check
+
 # Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/audio/soxr
 REQUIRED_PACKAGES += library/database/gdbm
 REQUIRED_PACKAGES += library/fftw-3
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/libsndfile
 REQUIRED_PACKAGES += library/libtool/libltdl
-REQUIRED_PACKAGES += library/security/openssl
+REQUIRED_PACKAGES += library/security/openssl-11
 REQUIRED_PACKAGES += library/speexdsp
 REQUIRED_PACKAGES += shell/bash
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/libdbus
 REQUIRED_PACKAGES += system/library/math

--- a/components/desktop/pulseaudio/pkg5
+++ b/components/desktop/pulseaudio/pkg5
@@ -8,7 +8,7 @@
         "library/glib2",
         "library/libsndfile",
         "library/libtool/libltdl",
-        "library/security/openssl",
+        "library/security/openssl-11",
         "library/speexdsp",
         "shell/bash",
         "system/library",


### PR DESCRIPTION
openssl is only used for Airtunes/RAOP