### PR TITLE
prep-svn.mk : set owner,group,mtime on tar output

### DIFF
--- a/make-rules/prep-svn.mk
+++ b/make-rules/prep-svn.mk
@@ -59,6 +59,7 @@ $$(USERLAND_ARCHIVES)$$(COMPONENT_ARCHIVE$(1)):	$(MAKEFILE_PREREQ)
 	 $(SVN) export $$(SVN_REPO$(1)) $$(SVN_REV$(1):%=--revision %) \
 			$$$${TMP_REPO} && \
 	 /usr/gnu/bin/tar --create --file - --absolute-names \
+              --sort=name --mtime="2018-10-05 00:00Z" --owner=0 --group=0 --numeric-owner \
 	      --transform="s;$$$${TMP_REPO};$$(COMPONENT_SRC$(1));g" \
 	      --bzip2 $$$${TMP_REPO} >$$@ && \
 	 $(RM) -rf $$$${TMP_REPO} && \


### PR DESCRIPTION
This is a fix for a problem where COMPONENT_REVISION does not work on components that use prep-svn.mk.

The credit goes to Oracle because solaris-userland has this fix, so it is a backport of Oracle's solaris-userland fix.

The problem is that prep-svn.mk is doing a "svn export" but this uses the current user (e.g. stes) as owner and on the biuld server a different user is used so the tar ball uses different owners and thus the files have different SVN_HASH.

Also svn export is setting the current system time on directories.  This means that 2 subsequent svn export's are producing different repositories and tar creates different archives for them, unless the mtime is set.

Note that I ran into this issue with Squeak-4 which uses the svn-prep.mk

Also I would like this issue fixed so that in the future I can simply update OCMPONENT_REVISION without any change on the squeak subversion repo.

That is not possible for the moment.

This issue may be important for example for the openssl upgrade : simply updating COMPONENT_REVISION is not possible for svn components, unless this patch is merged.

Regards,
David Stes