### PR TITLE
zstd: update to 1.4.9

### DIFF
--- a/components/archiver/zstd/Makefile
+++ b/components/archiver/zstd/Makefile
@@ -19,7 +19,7 @@ PREFERRED_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zstd
-COMPONENT_VERSION=	1.4.8
+COMPONENT_VERSION=	1.4.9
 COMPONENT_SUMMARY=	Zstandard, or zstd for short, is a fast lossless compression algorithm, targeting real-time compression scenarios
 COMPONENT_PROJECT_URL=	https://facebook.github.io/zstd/
 COMPONENT_FMRI=		compress/zstd
@@ -27,7 +27,7 @@ COMPONENT_CLASSIFICATION=	Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/facebook/zstd/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	sha256:32478297ca1500211008d596276f5367c54198495cf677e9439f4791a4c69f24
+COMPONENT_ARCHIVE_HASH=	sha256:29ac74e19ea28659017361976240c4b5c5c24db3b89338731a6feb97c038d293
 COMPONENT_LICENSE=	BSD,GPLv2.0
 
 include $(WS_MAKE_RULES)/common.mk


### PR DESCRIPTION
Sample manifest didn't change
gmake test run fine