### PR TITLE
tor: Update to version 0.4.5.7

### DIFF
--- a/components/network/tor/Makefile
+++ b/components/network/tor/Makefile
@@ -15,10 +15,12 @@
 
 BUILD_BITS=		64
 
+USE_OPENSSL11=		yes
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		tor
-COMPONENT_VERSION=	0.4.4.7
+COMPONENT_VERSION=	0.4.5.7
 COMPONENT_PROJECT_URL=	https://www.torproject.org
 COMPONENT_SUMMARY=	Anonymizing overlay network for TCP
 COMPONENT_FMRI=		network/tor
@@ -26,7 +28,7 @@ COMPONENT_CLASSIFICATION=	Applications/Internet
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:326d2926177f0c7838cac213456d0056817d57f3f2e46714a2911c7d7a9b05ee
+	sha256:447fcaaa133e2ef22427e98098a60a9c495edf9ff3e0dd13f484b9ad0185f074
 COMPONENT_ARCHIVE_URL=	https://www.torproject.org/dist/$(COMPONENT_ARCHIVE)
 COMPONENT_SIG_URL=	$(COMPONENT_ARCHIVE_URL).asc	
 COMPONENT_LICENSE_FILE=	LICENSE
@@ -56,14 +58,16 @@ COMPONENT_TEST_TRANSFORMS += \
 # Tests require GNU diff
 REQUIRED_PACKAGES += text/gnu-diffutils
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+
+# Bogus dependency due to libssp
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+
 # Auto-generated dependencies
 REQUIRED_PACKAGES += compress/xz
 REQUIRED_PACKAGES += compress/zstd
 REQUIRED_PACKAGES += library/libevent2
-REQUIRED_PACKAGES += library/security/openssl
+REQUIRED_PACKAGES += library/security/openssl-11
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/network/tor/patches/01-libevent2.patch
+++ b/components/network/tor/patches/01-libevent2.patch
@@ -1,15 +1,16 @@
---- tor-0.4.1.7/configure.ac	2019-12-05 19:33:05.000000000 +0000
-+++ tor-0.4.1.7/configure.ac	2019-12-29 14:35:53.151012745 +0000
-@@ -756,7 +756,7 @@ if test "$enable_static_libevent" = "yes
+--- tor-0.4.5.7/configure.ac  2021-03-15 12:42:55.000000000 +0100
++++ tor-0.4.5.7/configure.ac  2021-03-17 12:42:55.000000000 +0100
+
+@@ -922,7 +922,7 @@ if test "$enable_static_libevent" = "yes
      fi
  fi
  
--TOR_SEARCH_LIBRARY(libevent, $trylibeventdir, [-levent $STATIC_LIBEVENT_FLAGS $TOR_LIB_WS32], [
-+TOR_SEARCH_LIBRARY(libevent, $trylibeventdir, [-levent-2.0 $STATIC_LIBEVENT_FLAGS $TOR_LIB_WS32], [
+-TOR_SEARCH_LIBRARY(libevent, $trylibeventdir, [-levent $STATIC_LIBEVENT_FLAGS $TOR_LIB_IPHLPAPI $TOR_LIB_BCRYPT $TOR_LIB_WS32], [
++TOR_SEARCH_LIBRARY(libevent, $trylibeventdir, [-levent-2.0 $STATIC_LIBEVENT_FLAGS $TOR_LIB_IPHLPAPI $TOR_LIB_BCRYPT $TOR_LIB_WS32], [
  #ifdef _WIN32
  #include <winsock2.h>
  #endif
-@@ -795,8 +795,8 @@ if test "$enable_static_libevent" = "yes
+@@ -959,8 +959,8 @@ if test "$enable_static_libevent" = "yes
     fi
  else
       if test "x$ac_cv_header_event2_event_h" = "xyes"; then

--- a/components/network/tor/test/results-64.master
+++ b/components/network/tor/test/results-64.master
@@ -22,18 +22,19 @@ PASS: src/test/unittest_part4.sh
 PASS: src/test/unittest_part5.sh
 PASS: src/test/unittest_part6.sh
 PASS: src/test/unittest_part7.sh
-PASS: src/test/unittest_part8.sh
+FAIL: src/test/unittest_part8.sh
 PASS: src/test/test_ntor.sh
-SKIP: src/test/test_hs_ntor.sh
+PASS: src/test/test_hs_ntor.sh
 PASS: src/test/test_bt.sh
 PASS: scripts/maint/practracker/test_practracker.sh
 PASS: scripts/maint/run_check_subsystem_order.sh
 PASS: src/test/test_rebind.sh
+PASS: src/test/test_include.sh
 PASS: scripts/maint/checkSpaceTest.sh
-# TOTAL: 32
-# PASS:  29
-# SKIP:  3
+# TOTAL: 33
+# PASS:  30
+# SKIP:  2
 # XFAIL: 0
-# FAIL:  0
+# FAIL:  1
 # XPASS: 0
 # ERROR: 0


### PR DESCRIPTION
A new tor version with LTS was released.
https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/CoreTorReleases

stable version 0.4.5.6 had a bug, so i waited for version 0.4.5.7.

This PR is build for openssl 1.1. It works for openssl 1.0.x also.
(Depending on "pkg mediator openssl")

When starting tor a new information about the used libc is posted.
For OI (and other) it is "... and Unknown N/A as libc ..."

This is OK because the function is rudimentary:

```
tor_libc_get_version_str(void)
{
#ifdef CHECK_LIBC_VERSION
  const char *version = gnu_get_libc_version();
  if (version == NULL)
    return "N/A";
  return version;
#else /* !defined(CHECK_LIBC_VERSION) */
  return "N/A";
#endif /* defined(CHECK_LIBC_VERSION) */
```


"gmake test" has one error:

```
PASS: src/test/unittest_part7.sh
FAIL: src/test/unittest_part8.sh
PASS: src/test/test_ntor.sh
PASS: src/test/test_hs_ntor.sh
PASS: src/test/test_bt.sh
PASS: scripts/maint/practracker/test_practracker.sh
PASS: scripts/maint/run_check_subsystem_order.sh
PASS: src/test/test_rebind.sh
PASS: src/test/test_include.sh
PASS: scripts/maint/checkSpaceTest.sh
# TOTAL: 33
# PASS:  30
# SKIP:  2
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
```

The error in "src/test/unittest_part8.sh" is part of issue:
https://gitlab.torproject.org/tpo/core/tor/-/issues/40335

All work fine.
https://metrics.torproject.org/rs.html#details/AD0FCFD83EA4899DB34735E599701592DEA13690
