### PR TITLE
gexiv2: update to 0.12.2

### DIFF
--- a/components/library/gexiv2/Makefile
+++ b/components/library/gexiv2/Makefile
@@ -18,16 +18,13 @@ BUILD_STYLE= meson
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gexiv2
-COMPONENT_VERSION= 0.12.1
-COMPONENT_REVISION= 1
+COMPONENT_VERSION= 0.12.2
 COMPONENT_SUMMARY= GObject wrapper around the Exiv2 photo metadata library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= \
-  sha256:8aeafd59653ea88f6b78cb03780ee9fd61a2f993070c5f0d0976bed93ac2bd77
-COMPONENT_ARCHIVE_URL= \
-  https://download.gnome.org/sources/gexiv2/0.12/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = https://wiki.gnome.org/Projects/gexiv2
+COMPONENT_ARCHIVE_HASH=	sha256:2322b552aca330eef79724a699c51a302345d5e074738578b398b7f2ff97944c
+COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/gexiv2/0.12/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://wiki.gnome.org/Projects/gexiv2
 COMPONENT_FMRI = image/library/gexiv2
 COMPONENT_LICENSE = GPLv2
 COMPONENT_LICENSE_FILE = COPYING


### PR DESCRIPTION
- sample-manifest didn't change
- gimp still works