### PR TITLE
squeak-4: update 4.19.5 revision 3

### DIFF
--- a/components/runtime/squeak4/Makefile
+++ b/components/runtime/squeak4/Makefile
@@ -52,15 +52,15 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak-4
 COMPONENT_VERSION=	4.19.5
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	The Squeak V4 Smalltalk Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
 COMPONENT_FMRI=		runtime/squeak-4
 COMPONENT_CLASSIFICATION=	Development/Other Languages
 SVN_REPO=		http://squeakvm.org/svn/squeak/trunk/
-SVN_REV=		3797
-SVN_HASH=		sha256:a8c4e89262a73ec37ddea1307a779525aac8097f0201a585fc3b0217322beb81
+SVN_REV=		3798
+SVN_HASH=  sha256:d7c8aa40e36f5914469056864b85379149e37915547608f9eddc262c73e4dfba
 
 # See http://wiki.squeak.org/squeak/933
 # See http://wiki.squeak.org/squeak/159
@@ -110,6 +110,20 @@ CONFIGURE_OPTIONS.64+=	--vm-only
 # the squeakvm is called either squeakvm or squeakvm64 in different directories
 COMPONENT_POST_INSTALL_ACTION = \
 ( find $(PROTOUSRLIBDIR)/squeak -name 'squeakvm*' -exec strip {} \; )
+
+#
+# target to update the manifests from sample-manifest
+#
+
+rebuild-manifests::
+	cp manifests/squeak-4.p5m squeak-4.p5m
+	cp manifests/squeak-4-display-X11.p5m squeak-4-display-X11.p5m
+	cp manifests/squeak-4-nodisplay.p5m squeak-4-nodisplay.p5m
+	cp manifests/sample-manifest.p5m sample-manifest.p5m
+	tools/subversion.sh $(SVN_REV) <sample-manifest.p5m >sample.p5m
+	tools/classify.pl <sample.p5m
+	tools/amd64-p5m.sh
+	rm -f sample-manifest.p5m sample.p5m
 
 REQUIRED_PACKAGES += x11/library/mesa
 REQUIRED_PACKAGES += system/library/dbus

--- a/components/runtime/squeak4/manifests/squeak-4-display-X11.p5m
+++ b/components/runtime/squeak4/manifests/squeak-4-display-X11.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/squeak-4-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+
+# the minimal installation consists of the squeak-4-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+
+depend type=require fmri=pkg:/runtime/squeak-4-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+

--- a/components/runtime/squeak4/manifests/squeak-4-nodisplay.p5m
+++ b/components/runtime/squeak4/manifests/squeak-4-nodisplay.p5m
@@ -41,13 +41,3 @@ hardlink path=usr/bin/inisqueak target=inisqueak4 mediator=squeak \
 hardlink path=usr/share/man/man1/squeak.1 target=squeak4.1 mediator=squeak \
     mediator-version=4
 
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.AioPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FileCopyPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnixOSProcessPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-null
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-null
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.AioPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.AioPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.FileCopyPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FileCopyPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UnixOSProcessPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnixOSProcessPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-display-null path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-null
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-sound-null path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-null

--- a/components/runtime/squeak4/manifests/squeak-4.p5m
+++ b/components/runtime/squeak4/manifests/squeak-4.p5m
@@ -1,0 +1,31 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021 David Stes
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# the minimal installation consists of the squeak-4-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+
+depend type=require fmri=pkg:/runtime/squeak-4-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+

--- a/components/runtime/squeak4/patches/02-openssl-cmake.patch
+++ b/components/runtime/squeak4/patches/02-openssl-cmake.patch
@@ -1,0 +1,18 @@
+--- squeak-4-3797/platforms/unix/plugins/SqueakSSL/config.cmake	Tue Nov 10 23:25:35 2020
++++ p0/squeak-4-3797/platforms/unix/plugins/SqueakSSL/config.cmake	Sat Feb 20 20:22:44 2021
+@@ -10,13 +10,13 @@
+ 
+ # Traditional dynamic linking.
+ #
+-# PLUGIN_DEFINITIONS("-DSQSSL_OPENSSL_LINKED")
++PLUGIN_DEFINITIONS("-DSQSSL_OPENSSL_LINKED")
+ 
+ # Runtime symbol and function lookup.
+ # Portable across platforms because only required symbols are looked up.
+ # Requires a Gnu extension for implementation of symbol lookup.
+ #
+-PLUGIN_DEFINITIONS("-D_GNU_SOURCE")
++# PLUGIN_DEFINITIONS("-D_GNU_SOURCE")
+ 
+ ################################################################################
+ #            Explanation from commit notice on opensmalltalk-vm:               #

--- a/components/runtime/squeak4/pkg5
+++ b/components/runtime/squeak4/pkg5
@@ -20,6 +20,7 @@
     ],
     "fmris": [
         "runtime/squeak-4",
+        "runtime/squeak-4-display-X11",
         "runtime/squeak-4-nodisplay"
     ],
     "name": "squeak-4"

--- a/components/runtime/squeak4/squeak-4-display-X11.p5m
+++ b/components/runtime/squeak4/squeak-4-display-X11.p5m
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/squeak-4-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+
+# the minimal installation consists of the squeak-4-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+
+depend type=require fmri=pkg:/runtime/squeak-4-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.B3DAcceleratorPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ClipboardExtendedPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.HostWindowPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ImmX11Plugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Squeak3D
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.XDisplayControlPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-X11
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.B3DAcceleratorPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.B3DAcceleratorPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ClipboardExtendedPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ClipboardExtendedPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.HostWindowPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.HostWindowPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ImmX11Plugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ImmX11Plugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.Squeak3D path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Squeak3D
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.XDisplayControlPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.XDisplayControlPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-display-X11 path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-X11

--- a/components/runtime/squeak4/squeak-4.p5m
+++ b/components/runtime/squeak4/squeak-4.p5m
@@ -13,7 +13,6 @@
 # Copyright 2020, 2021 David Stes
 #
 
-
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
@@ -24,59 +23,37 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
-
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.AioPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.AioPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.B3DAcceleratorPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.B3DAcceleratorPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ClipboardExtendedPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ClipboardExtendedPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.DBusPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.DBusPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.FT2Plugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FT2Plugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.FileCopyPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FileCopyPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.HostWindowPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.HostWindowPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ImmX11Plugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ImmX11Plugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.KedamaPlugin2 path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.KedamaPlugin2
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.Mpeg3Plugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Mpeg3Plugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.RomePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.RomePlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ScratchPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ScratchPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.Squeak3D path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Squeak3D
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakFFIPrims path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakSSL path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UUIDPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UUIDPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UnicodePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnicodePlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UnixOSProcessPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnixOSProcessPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.XDisplayControlPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.XDisplayControlPlugin
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-display-X11 path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-X11
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-display-custom path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-custom
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-sound-custom path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-custom
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-sound-pulse path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-pulse
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.AioPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.B3DAcceleratorPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ClipboardExtendedPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.DBusPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FT2Plugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FileCopyPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.GStreamerPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.HostWindowPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ImmX11Plugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.KedamaPlugin2
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Mpeg3Plugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.RomePlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ScratchPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Squeak3D
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UUIDPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnicodePlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnixOSProcessPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.XDisplayControlPlugin
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-X11
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-custom
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-custom
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-pulse
-
 # the minimal installation consists of the squeak-4-nodisplay package
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
-depend type=require fmri=pkg:/runtime/squeak-4-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/squeak-4-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.DBusPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FT2Plugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.GStreamerPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.KedamaPlugin2
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Mpeg3Plugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.RomePlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ScratchPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UUIDPlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnicodePlugin
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-custom
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-custom
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-pulse
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.DBusPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.DBusPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.FT2Plugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.FT2Plugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.GStreamerPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.GStreamerPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.KedamaPlugin2 path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.KedamaPlugin2
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.Mpeg3Plugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Mpeg3Plugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.RomePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.RomePlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ScratchPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ScratchPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakFFIPrims path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakSSL path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UUIDPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UUIDPlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UnicodePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnicodePlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-display-custom path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-custom
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-sound-custom path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-custom
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-sound-pulse path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-sound-pulse

--- a/components/runtime/squeak4/tools/amd64-p5m.sh
+++ b/components/runtime/squeak4/tools/amd64-p5m.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+for f in squeak-4.p5m squeak-4-display-X11.p5m squeak-4-nodisplay.p5m
+do
+  tools/amd64.pl < $f > $f.out
+  mv $f.out $f
+done
+

--- a/components/runtime/squeak4/tools/amd64.pl
+++ b/components/runtime/squeak4/tools/amd64.pl
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+#
+# currently (and perhaps forever) the Makefile of squeak places binaries
+# in subversion-revision_suffix where suffix can be 64bit
+#
+# the pkglint check for 64binaries in 32bit path will complain on this;
+# the usage enforced by pkglint is 
+# /usr/lib/amd64/squeak/xyz/plugin  instead of /usr/lib/squeak/xyz_64bit/plugin
+# ./amd64.pl < in > out
+# example:  ./amd64.pl < ../manifests/sample-manifest.p5m > sample-manifest.p5m
+#
+
+while (<>) {
+	if (/ckformat/) {
+	   # don't process cause _64bit is already processed
+	   print $_;
+	} elsif (/squeakvm/) {
+	   # don't process cause _64bit is already processed
+	   print $_;
+	} elsif (/_64bit/) {
+		s/file path=//;
+		chomp;
+		$file = $_;
+		$path = $_;
+		$path =~ s/usr\/lib/usr\/lib\/amd64/;
+		$path =~ s/_64bit//;
+		print "file ",$file," path=",$path,"\n";
+	} else {
+		print $_;
+	}
+}
+

--- a/components/runtime/squeak4/tools/classify.pl
+++ b/components/runtime/squeak4/tools/classify.pl
@@ -1,0 +1,94 @@
+#!/usr/bin/perl
+
+#
+# because Squeak has many plugins,
+# there are also many dependencies 
+# in order to have a small "kernel" package
+# this script is used
+#
+# the script "classifies" plugins into currently 3 categories:
+#  - squeak-4-nodisplay (only libc,libm math,libpthread, ksh)
+#  - squeak-4-display-X11 (only x11,xext,xrender)
+#  - squeak-4 (ssl,ffi,pulseaudio freetype2,gnome, everything else)
+#
+# Usage: check the samplemanifest,
+# ./subversion.pl < ../manifests/sample-manifest.p5m > sample2.p5m
+# then classify the files as follows:
+# ./classify.pl < sample2.p5m
+# then alias the amd64 files (install in component directory)
+# ./amd64.pl < squeak-4.p5m > ../squeak-4.p5m
+# or run ./amd64-p5m.sh
+#
+
+open(NODISPLAY,">>","squeak-4-nodisplay.p5m") || die "Can't open squeak-4-nodisplay.p5m";
+
+open(X11,">>","squeak-4-display-X11.p5m") || die "Can't open squeak-4-display-X11.p5m";
+
+open(REST,">>","squeak-4.p5m") || die "Can't open squeak-4.p5m";
+
+while (<>) {
+	if (/^#/) {
+		# ignore lines that start with comment
+	} elsif (/^$/) {
+		# ignore empty lines
+	} elsif (/license /) {
+		# ignore license lines
+	} elsif (/set name=/) {
+		# ignore those lines
+	} elsif (/dir  path=/) {
+		# ignore those lines
+	} elsif (/file path=/) {
+		if (/Sun/) {
+			# ignore the Sun sound plugin - we use pulseaudio
+		} elsif (/usr\/bin/) {
+			# don't deal with driver scripts here
+		} elsif (/man1/) {
+			# don't deal with the manpages here
+		} elsif (/squeakvm/) {
+			# don't deal with the actual binary here
+		} elsif (/ckformat/) {
+			# don't deal with the ckformat binary here
+		} elsif (/AioPlugin/) {
+			print NODISPLAY $_;
+		} elsif (/ClipboardExtendedPlugin/) {
+			print X11 $_;
+		} elsif (/FileCopyPlugin/) {
+			print NODISPLAY $_;
+		} elsif (/HostWindowPlugin/) {
+			print X11 $_;
+		} elsif (/ImmX11Plugin/) {
+			print X11 $_;
+		} elsif (/Squeak3D/) {
+			print X11 $_;
+		} elsif (/B3DAcceleratorPlugin/) {
+			print X11 $_;
+		} elsif (/UnixOSProcessPlugin/) {
+			print NODISPLAY $_;
+		} elsif (/XDisplayControlPlugin/) {
+			print X11 $_;
+		} elsif (/vm-sound-null/) {
+			print NODISPLAY $_;
+		} elsif (/vm-display-null/) {
+			print NODISPLAY $_;
+		} elsif (/vm-display-X11/) {
+			print X11 $_;
+		} elsif (/vm-display-X11/) {
+			print X11 $_;
+		} elsif (/usr\/lib\/squeak/) {
+			print REST $_;
+		} else {
+			# unclassified files
+			print $_;
+		}
+	} elsif (/hardlink path=/) {
+		# unclassified files
+		print $_;
+	} elsif (/link path=/) {
+		# unclassified files
+		print $_;
+	} else {
+		# unclassified files
+		print $_;
+	}
+}
+

--- a/components/runtime/squeak4/tools/subversion.sh
+++ b/components/runtime/squeak4/tools/subversion.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+#
+# script to replace the subversion version by the string $(SVN_REV)
+#
+
+svn_rev=$1
+perl -p -e "s/$svn_rev/\\$\(SVN_REV\)/;"
+


### PR DESCRIPTION
Update to COMPONENT_REVISION 3 with many changes.

It is important that this package is now built with the svn-prep.mk fix that was submitted in the past.

The archive should now look like this:

$ tar tvfJ squeak-4-3798.tar.bz2 | more
tar: blocksize = 10
Decompressing 'squeak-4-3798.tar.bz2' with '/usr/bin/bzcat'...
-rwxr-xr-x   0/0        0 Oct  5 02:00 2018 squeak-4-3798/
-rwxr-xr-x   0/0        0 Oct  5 02:00 2018 squeak-4-3798/platforms/
-rwxr-xr-x   0/0        0 Oct  5 02:00 2018 squeak-4-3798/platforms/Cross/
-rwxr-xr-x   0/0        0 Oct  5 02:00 2018 squeak-4-3798/platforms/Cross/plugins/

Note user ID 0 group ID 0 and date is set to oct/5 2018 for all directories and all files.

This is a known issue apparently with subversion which is said not respect the subversion feature "use-commit-times" on directories.  That is why setting the date on all files to 2018 can help because otherwise every time a new svn export is done, it will use system time (so all times of all archives will be different).

This is important so that the OpenIndiana maintainers can update themselves COMPONENT_REVISION without any input from me myself ...

