### PR TITLE
nspr: update to 4.30

### DIFF
--- a/components/library/mozilla-nspr/Makefile
+++ b/components/library/mozilla-nspr/Makefile
@@ -18,12 +18,11 @@ BUILD_BITS=			32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         nspr
-COMPONENT_VERSION=      4.29
-COMPONENT_REVISION=     1
+COMPONENT_VERSION=      4.30
 COMPONENT_PROJECT_URL=  https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:22286bdb8059d74632cc7c2865c139e63953ecfb33bf4362ab58827e86e92582
+COMPONENT_ARCHIVE_HASH= sha256:8d4cd8f8409484dc4c3d31e180354bfc506573eccf86cd691106a1ef7edc913b
 COMPONENT_ARCHIVE_URL=  https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$(COMPONENT_VERSION)/src/$(COMPONENT_ARCHIVE)
 
 include $(WS_MAKE_RULES)/common.mk


### PR DESCRIPTION
- sample-manifest didn't change
- gmake test run fine