### PR TITLE
fix bind dependencies

### DIFF
--- a/components/network/bind/Makefile
+++ b/components/network/bind/Makefile
@@ -115,6 +115,6 @@ REQUIRED_PACKAGES += library/zlib
 #REQUIRED_PACKAGES += network/dns/bind
 REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += service/security/kerberos-5
-REQUIRED_PACKAGES += shell/ksh93
+#REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/security/gss

--- a/components/network/bind/pkg5
+++ b/components/network/bind/pkg5
@@ -10,7 +10,6 @@
         "library/zlib",
         "runtime/python-35",
         "service/security/kerberos-5",
-        "shell/ksh93",
         "system/library",
         "system/library/security/gss"
     ],


### PR DESCRIPTION
illumos-gate has separated ksh93 out but our build server hasn't been updated yet.