### PR TITLE
illumos-gate: add overlay file for tagged pointers

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -574,6 +574,9 @@ $(BUILD_DIR)/$(MACH)/publish.transforms: $(BUILD_DIR)/$(MACH)/.overlay
 	echo "<transform set name=pkg.fmri value=pkg://[^/]*/system/boot/loader@.* -> emit file path=boot/forth/brand-hipster.4th group=sys mode=0444 owner=root >" >> $(BUILD_DIR)/$(MACH)/publish.transforms
 	echo "<transform set name=pkg.fmri value=pkg://[^/]*/system/boot/loader@.* -> emit file path=boot/forth/logo-openindiana.4th group=sys mode=0444 owner=root >" >> $(BUILD_DIR)/$(MACH)/publish.transforms
 
+	# Settings for tagged pointers
+	echo "<transform set name=pkg.fmri value=pkg://[^/]*/system/kernel@.* -> emit file path=etc/system.d/reserve_bits_for_tagged_pointers group=sys mode=0644 owner=root preserve=true>" >> $(BUILD_DIR)/$(MACH)/publish.transforms
+
 	for i in $$(cd $(BUILD_DIR)/$(MACH)/overlay; find . -type f | \
 	  cut -c 3- | sort); do \
 	  echo "<transform file path=$$i -> set action.hash $$i >" >> \

--- a/components/openindiana/illumos-gate/overlay/etc/system.d/reserve_bits_for_tagged_pointers
+++ b/components/openindiana/illumos-gate/overlay/etc/system.d/reserve_bits_for_tagged_pointers
@@ -1,0 +1,3 @@
+# This sets the maximum virtual memory address for user processes. It makes the system behave a bit more like Linux.
+# The address space for each 64-bit process is still roughly 128TB.
+set _userlimit=0x7fffc0000000


### PR DESCRIPTION
This is a preparation for newer firefox and thunderbird version which need some reserved bits in pointers. This makes OI generally a little bit more compatible with Linux.