### PR TITLE
pyro4: fix missing dependencies

### DIFF
--- a/components/python/pyro4/Makefile
+++ b/components/python/pyro4/Makefile
@@ -14,28 +14,34 @@
 # Copyright 2021 Nona Hansel.  All rights reserved.
 #
 
-BUILD_BITS=		NO_ARCH
+BUILD_BITS=			NO_ARCH
 BUILD_STYLE=		setup.py
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= 	Pyro4
 COMPONENT_VERSION= 	4.80
-COMPONENT_IPS_NAME= 	pyro4
+COMPONENT_REVISION=	1
+COMPONENT_IPS_NAME=	pyro4
 COMPONENT_FMRI= 	library/python/$(COMPONENT_IPS_NAME)
 COMPONENT_SUMMARY= 	Distributed object middleware for Python (RPC)
 COMPONENT_SRC= 		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= 	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= \
-  sha256:46847ca703de3f483fbd0b2d22622f36eff03e6ef7ec7704d4ecaa3964cb2220
-COMPONENT_ARCHIVE_URL= \
-  https://pypi.python.org/packages/source/P/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= sha256:46847ca703de3f483fbd0b2d22622f36eff03e6ef7ec7704d4ecaa3964cb2220
+COMPONENT_ARCHIVE_URL=	https://pypi.python.org/packages/source/P/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://github.com/irmen/Pyro4
 COMPONENT_LICENSE_FILE=	$(COMPONENT_IPS_NAME).license
 
 PYTHON_VERSIONS=	$(PYTHON_VERSIONS_ALL)
 
-TEST_TARGET:	$(NO_TESTS)
+# Running tests need tox what we don't have yet:
+TEST_TARGET=	$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
+
+# Manually add dependencies
+#REQUIRED_PACKAGES += library/python/serpent-27	# serpent-27 is not available anymore
+REQUIRED_PACKAGES += library/python/serpent-35
+REQUIRED_PACKAGES += library/python/serpent-37
+REQUIRED_PACKAGES += library/python/serpent-39
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/python-27

--- a/components/python/pyro4/pkg5
+++ b/components/python/pyro4/pkg5
@@ -1,10 +1,14 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/python/serpent-35",
+        "library/python/serpent-37",
+        "library/python/serpent-39",
         "runtime/python-27",
         "runtime/python-35",
         "runtime/python-37",
-        "runtime/python-39"
+        "runtime/python-39",
+        "shell/ksh93"
     ],
     "fmris": [
         "library/python/pyro4-27",


### PR DESCRIPTION
Add dependency on serpent and a minor for the test target.