### PR TITLE
ccache: add ccache-update-symlinks service and script

### DIFF
--- a/components/developer/ccache/Makefile
+++ b/components/developer/ccache/Makefile
@@ -10,13 +10,14 @@
 #
 
 #
-# Copyright (c) 2015-2016 Jim Klimov
+# Copyright (c) 2015-2021 Jim Klimov
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ccache
 COMPONENT_VERSION=	3.3.4
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	http://ccache.samba.org/
 COMPONENT_DOWNLOAD_URL=	http://samba.org/ftp/$(COMPONENT_NAME)/
 COMPONENT_DOCUMENTATION_URL =	http://ccache.samba.org/manual.html

--- a/components/developer/ccache/ccache.p5m
+++ b/components/developer/ccache/ccache.p5m
@@ -25,25 +25,11 @@ hardlink path=usr/bin/ccache target=../lib/isaexec pkg.linted.userland.action002
 file usr/bin/ccache path=usr/bin/$(MACH32)/ccache
 file path=usr/bin/$(MACH64)/ccache
 file usr/share/man/man1/ccache.1 path=usr/share/man/man1/ccache.1
+file files/ccache-update-symlinks.xml path=lib/svc/manifest/application/ccache-update-symlinks.xml restart_fmri=svc:/system/manifest-import:default
+file files/ccache-update-symlinks.sh path=lib/svc/method/ccache-update-symlinks.sh mode=0555
 
 # Files from tarball (HTMLs may be rebuilt)
 file MANUAL.txt path=usr/share/ccache/manual.txt
 file MANUAL.html path=usr/share/ccache/manual.html
 
-# Softlinks to simplify builds - just prepend /usr/lib/ccache to PATH
-# NOTE: Since these are softlinks, a certain relative directory structure
-# is expected (like rooting at /usr) when the package is installed.
-# You can turn off ccache without changing runtime PATHs by exporting
-# CCACHE_DISABLE=1 before a build
-link target=../../bin/ccache path=usr/lib/ccache/gcc
-link target=../../bin/ccache path=usr/lib/ccache/g++
-link target=../../bin/ccache path=usr/lib/ccache/cc
-link target=../../bin/ccache path=usr/lib/ccache/c++
-link target=../../bin/ccache path=usr/lib/ccache/cpp
-
-# A few links specifically to support gcc-4.4.4-il
-link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-c++
-link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-g++
-link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-gcc
-link target=../../bin/ccache path=usr/lib/ccache/i386-pc-solaris2.11-gcc-4.4.4
-
+dir  path=usr/lib/ccache

--- a/components/developer/ccache/files/ccache-update-symlinks.sh
+++ b/components/developer/ccache/files/ccache-update-symlinks.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+# ccache-update-symlinks - keep ccache symlinks in sync with installed
+# versions of compatible compilers
+# Copyright (C) 2021 by Jim Klimov
+
+# This script can be used standalone, or as an SMF method script
+[ -s /lib/svc/share/smf_include.sh ] && . /lib/svc/share/smf_include.sh
+
+SMF_FMRI_BASE=""
+if [ -n "$SMF_FMRI" ]; then
+    SMF_FMRI_BASE="`echo "$SMF_FMRI" | sed 's|:[^:]*$||'`"
+fi
+
+getproparg() {
+    [ -n "$SMF_FMRI" ] || return
+    val="`svcprop -p "$1" "$SMF_FMRI" 2>/dev/null`" || val="`svcprop -p "$1" "$SMF_FMRI_BASE" 2>/dev/null`"
+    [ -n "$val" ] && echo "$val"
+}
+
+# Caller may `export DEBUG=yes` to trace the decisions in the script
+# Caller may `export DRYRUN=echo` to avoid actual link manipulations
+
+# This is where symlinks named identically to compiler binaries are present.
+# These symlinks point to the ccache binary however, and it knows how to
+# wrap the real thing if called (gcc, clang, maybe icc... and compatibles).
+# Users who want build stuff with a speedup add this to front of their PATH,
+# and their PATH must later contain the location of the real tool's binary.
+# While it is not generally a problem for common /usr/bin it may be for e.g.
+# gcc-4.4.4-il or other not-exposed compilers.
+# Also note that even if the caller has this location in their PATH, they
+# can turn off effects of ccache without changing runtime PATHs just by
+# `export CCACHE_DISABLE=1` before a build.
+LINKDIR="/usr/lib/ccache"
+SYMLINK="../../bin/ccache"
+
+# These are the filenames we manage symlinks for, either exact or suffixed
+# by a dash and number, and optionally add values from SMF instance:
+TOOLS="
+    gcc g++ gcpp
+    clang clang++ clang-cpp
+    c++ cc cpp
+    i386-pc-solaris2.11-c++ i386-pc-solaris2.11-cpp i386-pc-solaris2.11-g++ i386-pc-solaris2.11-gcc
+    `getproparg ccache-update-symlinks/TOOLS_ADD`
+"
+# Rearrange for easier parsing below
+TOOLS="`echo $TOOLS | tr ' ' '\n' | sort -n | uniq`"
+
+PATH_ADD="`getproparg ccache-update-symlinks/PATH_ADD`"
+if [ -n "$PATH_ADD" ]; then
+    PATH="$PATH:$PATH_ADD"
+fi
+
+cd "$LINKDIR" || exit
+
+# TODO: Option in the SMF service to enable additions to PATH for gcc-4.4.4-il
+# (/opt/gcc/4.4.4/bin/...) or other special compilers? It would help everyone
+# if that particular system's admin rather symlinked the custom compiler to
+# common /usr/bin/ instead.
+# Set value from SMF instance if present there
+[ -n "${ALLOW_DELETE-}" ] || ALLOW_DELETE="`getproparg ccache-update-symlinks/ALLOW_DELETE`"
+[ "${ALLOW_DELETE-}" = true -o "${ALLOW_DELETE-}" = false ] || { echo "Defaulting ALLOW_DELETE=false" >&2; ALLOW_DELETE=false; }
+
+# Begin work
+echo "Trawling PATH='$PATH' for TOOLS:" $TOOLS >&2
+
+NAMES=""
+for T in $TOOLS ; do
+    for P in `echo "\"$PATH\"" | sed 's,:," ",g'` ; do
+        P="`echo "$P" | sed 's|^"\(.*\)"$|\1|'`"
+        [ "$P" = "$LINKDIR" ] && continue
+        for F in `ls -1d "$P/$T"* 2>/dev/null` ; do
+            [ -f "$F" ] && [ -x "$F" ] || continue
+            # F represents an existing filename in PATH component P
+            # that starts with tool name T
+            B="`basename "$F"`"
+            case "$B" in
+                ccache*) ;; # Quiet skip
+                "$T"|"$T"-[0123456789]*)
+                    # We have either the default tool name, or one suffixed
+                    # by the version number (may be dotted)
+                    # Assumes no whitespace in compiler filenames
+                    if [ -n "$NAMES" ]; then
+                        NAMES="$NAMES $B"
+                    else
+                        NAMES="$B"
+                    fi
+                    [ "$DEBUG" = yes ] && echo "ADDED:   $B ($F) ($T)" >&2
+                    ;;
+                *)  # Skip other tools with the same prefix
+                    # Note that while looking at T=clang we skip hits of clang++*
+                    [ "$DEBUG" = yes ] && echo "SKIPPED: $B ($F) ($T)" >&2
+                    ;;
+            esac
+        done
+    done
+done
+
+# Dedup
+NAMES="`echo "$NAMES" | tr ' ' '\n' | sort -n | uniq`"
+[ "$DEBUG" = yes ] && echo "=== PATH:" && echo "$NAMES"
+
+LINKS="`ls -1 "$LINKDIR" | sort -n | uniq`"
+[ "$DEBUG" = yes ] && echo "=== LINKDIR:" && echo "$LINKS"
+
+if [ "$NAMES" = "$LINKS" ]; then
+    echo "CCACHE symlinks are already up to date for current PATH='$PATH'" >&2
+    exit 0
+fi
+
+# Link missing compilers to get wrapped by ccache for its consumers
+for N in $NAMES ; do
+    echo "$LINKS" | fgrep "$N" >/dev/null || \
+    { echo "ADDING LINK: $N" >&2; $DRYRUN ln -sf "$SYMLINK" "$LINKDIR/$N"; }
+done
+
+# (optionally) Remove links to compilers that are not in PATH
+$ALLOW_DELETE || DRYRUN="echo Would exec:"
+for L in $LINKS ; do
+    echo "$NAMES" | fgrep "$L" >/dev/null || \
+    { echo "REMOVE LINK: $L" >&2; $DRYRUN rm -f "$LINKDIR/$L"; }
+done
+
+echo "CCACHE symlinks checked/rearranged to be up to date for current PATH='$PATH'" >&2
+exit 0

--- a/components/developer/ccache/files/ccache-update-symlinks.xml
+++ b/components/developer/ccache/files/ccache-update-symlinks.xml
@@ -1,0 +1,104 @@
+<?xml version='1.0'?>
+<!--
+//
+//
+// This file and its contents are supplied under the terms of the
+// Common Development and Distribution License ("CDDL"), version 1.0.
+// You may only use this file in accordance with the terms of version
+// 1.0 of the CDDL.
+//
+// A full copy of the text of the CDDL should have accompanied this
+// source.  A copy of the CDDL is also available via the Internet at
+// http://www.illumos.org/license/CDDL.
+//
+//
+// Copyright 2021 by Jim Klimov
+//
+-->
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='ccache-update-symlinks'>
+  <service
+    name='system/ccache-update-symlinks'
+    type='service'
+    version='1'>
+
+    <create_default_instance enabled='true' />
+
+    <single_instance />
+
+    <!--
+      Wait for all local filesystems to be mounted.
+    -->
+    <dependency name='filesystem-local'
+        grouping='require_all'
+        restart_on='none'
+        type='service'>
+        <service_fmri
+        value='svc:/system/filesystem/local:default'/>
+    </dependency>
+
+    <exec_method type='method'
+               name='start'
+               exec='/lib/svc/method/ccache-update-symlinks.sh'
+               timeout_seconds='60'>
+    </exec_method>
+
+    <exec_method type='method'
+               name='stop'
+               exec=':true'
+               timeout_seconds='0'>
+    </exec_method>
+
+    <exec_method type='method'
+               name='refresh'
+               exec='/lib/svc/method/ccache-update-symlinks.sh'
+               timeout_seconds='60'>
+    </exec_method>
+
+    <property_group name='startd' type='framework'>
+        <propval name='duration' type='astring' value='transient' />
+    </property_group>
+
+    <property_group name='ccache-update-symlinks' type='application'>
+        <stability value='Evolving' />
+        <!-- By default the method script only adds symlinks, to avoid
+             surprises for developers on their systems customized manually
+             (and/or before this service was introduced). After they make
+             sure all symlinks are what they intend to have and nothing
+             unexpected is queued to be deleted (as can be seen in log)
+             then can toggle this flag to "true" in their deployment.
+             Probably customizing PATH_ADD and/or TOOLS_ADD will be
+             critical for those developers for whom it really matters.
+        -->
+        <propval type='boolean' name='ALLOW_DELETE' value='false' />
+        <!-- The PATH_ADD contents are added to the PATH set by SMF, which
+             includes /usr/bin (with most of the packaged compilers) already.
+             Default PATH_ADD below can help find compilers in locations
+             typical for local customizations of OpenIndiana deployments.
+             The "/opt/gcc/4.4.4/bin" refers to illumos-gcc (gcc-4.4.4-il)
+             to speed up rebuilds of illumos-gate; a symlink to it was
+             previously hardcoded in ccache package delivery.
+        -->
+        <propval type='astring' name='PATH_ADD' value='/usr/local/bin:/usr/gnu/bin:/opt/gcc/4.4.4/bin' />
+        <!-- If a developer's system has further filenames for compilers
+             that ccache is compatible with, list the (version-less)
+             names here. For example, "icc" listed here would match
+             and symlink to ccache both "icc" and "icc-123" but neither
+             "icc-style" nor "icc-cpp" nor "icc++" if such names are
+             installed and in PATH (list all relevant prefixes for that
+             tool chain's C and C++ compilers, and CPP preprocessor,
+             separated by whitespaces).
+        -->
+        <propval type='astring' name='TOOLS_ADD' value='' />
+    </property_group>
+
+    <stability value='Evolving' />
+
+    <template>
+      <common_name>
+        <loctext xml:lang='C'>ccache-update-symlinks - keep ccache symlinks in sync with installed compatible compilers</loctext>
+      </common_name>
+    </template>
+
+  </service>
+</service_bundle>

--- a/components/developer/ccache/manifests/sample-manifest.p5m
+++ b/components/developer/ccache/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2020 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/developer/ccache/pkg5
+++ b/components/developer/ccache/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "library/zlib",
+        "shell/ksh93",
         "system/library",
         "system/library/math"
     ],


### PR DESCRIPTION
Finally got tired of maintaining the symlinks I need manually, so proposing an SMF service to update those according to current compatible compilers in PATH.

I hope I've got right the triggering of this service when actual compilers are installed or updated, but did not test yet what happens if they are installed but this service is absent (e.g. ccache package not installed or updated). Comments welcome :)
UPDATE: Triggering moved to PR #6671 so not a concern in this one.

Note: while there is a newer ccache version released since our last bump, updating to it is not in scope of this PR.