### PR TITLE
thunderbird: update v78.9.1 driven by CVE-2021-23987

### DIFF
--- a/components/mail/thunderbird/Makefile
+++ b/components/mail/thunderbird/Makefile
@@ -31,13 +31,13 @@ COMPILER = gcc
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =	thunderbird
-COMPONENT_VERSION =	78.8.1
+COMPONENT_VERSION =	78.9.1
 COMPONENT_SUMMARY = Mozilla Thunderbird Email Application
 COMPONENT_PROJECT_URL =	https://www.thunderbird.net/
 COMPONENT_SRC = $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE = 	$(COMPONENT_SRC).source.tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:1a0b9cc1c314fdfdf7aa10246b8c5062385b62df3c9cef2358d1aa657e8a6f0f
+	sha256:6be0daf439ea5aeef0fd1619511cb1af4f1ba056823910475adc17e60069317d	
 ifndef CANDIDATE_BUILD
 MOZILLA_FTP = 		http://ftp.mozilla.org/pub/$(COMPONENT_NAME)/releases/$(COMPONENT_VERSION)
 else

--- a/components/mail/thunderbird/thunderbird.p5m
+++ b/components/mail/thunderbird/thunderbird.p5m
@@ -36,13 +36,6 @@ link path=usr/bin/thunderbird target=../lib/amd64/thunderbird/thunderbird mediat
 
 # Generated section (include only usr/lib/thunderbird/*, don't include dictionaries/en-US* or usr/bin/thunderbird ):
 
-#file path=usr/lib/thunderbird/dictionaries/en-US.aff
-#file path=usr/lib/thunderbird/dictionaries/en-US.dic
-# file path=usr/lib/thunderbird/libxul.so pkg.depend.runpath=$PKGDEPEND_RUNPATH:usr/lib/thunderbird
-# file path=usr/lib/thunderbird/plugin-container mode=0555 pkg.depend.runpath=$PKGDEPEND_RUNPATH:usr/lib/thunderbird
-#file path=usr/lib/thunderbird/run-mozilla.sh mode=0555
-# file path=usr/lib/thunderbird/thunderbird mode=0555
-# file path=usr/lib/thunderbird/thunderbird-bin mode=0555
 file path=usr/lib/$(MACH64)/thunderbird/application.ini
 file path=usr/lib/$(MACH64)/thunderbird/chrome/icons/default/calendar-alarm-dialog.png
 file path=usr/lib/$(MACH64)/thunderbird/chrome/icons/default/calendar-event-dialog.png
@@ -88,7 +81,7 @@ file path=usr/lib/$(MACH64)/thunderbird/libsoftokn3.so
 file path=usr/lib/$(MACH64)/thunderbird/libssl3.so
 file path=usr/lib/$(MACH64)/thunderbird/libxul.so
 file path=usr/lib/$(MACH64)/thunderbird/omni.ja
-file path=usr/lib/$(MACH64)/thunderbird/pingsender
+file path=usr/lib/$(MACH64)/thunderbird/pingsender mode=0555
 file path=usr/lib/$(MACH64)/thunderbird/platform.ini
 file path=usr/lib/$(MACH64)/thunderbird/plugin-container mode=0555
 file path=usr/lib/$(MACH64)/thunderbird/removed-files


### PR DESCRIPTION
I update thunderbird because there is a  CVE-2021-23987 which recommends to update at least to 78.9.