### PR TITLE
squeak-4: fix bug in primitiveLocalMicroseconds

### DIFF
--- a/components/runtime/squeak4/Makefile
+++ b/components/runtime/squeak4/Makefile
@@ -49,15 +49,15 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak-4
 COMPONENT_VERSION=	4.19.6
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	The Squeak V4 Smalltalk Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
 COMPONENT_FMRI=		runtime/squeak-4
 COMPONENT_CLASSIFICATION=	Development/Other Languages
 SVN_REPO=		http://squeakvm.org/svn/squeak/trunk/
-SVN_REV=		3799
-SVN_HASH=  sha256:1ea914c51c82311a6cc2ca7070a55f6cdb5314600fdee80152db89ea35e809d0
+SVN_REV=                3800
+SVN_HASH=  sha256:9a0c9fceb0dec73218e0900d9864caf9eadbcbf060a14ba09bbe20d68283a003
 
 # See http://wiki.squeak.org/squeak/933
 # See http://wiki.squeak.org/squeak/159

--- a/components/runtime/squeak4/pkg5
+++ b/components/runtime/squeak4/pkg5
@@ -8,8 +8,6 @@
         "library/glib2",
         "library/libffi",
         "library/security/openssl",
-        "runtime/squeak-4-display-X11",
-        "runtime/squeak-4-nodisplay",
         "shell/ksh93",
         "system/library",
         "system/library/dbus",


### PR DESCRIPTION
This bug affects Cuis but not Squeak itself.

For Cuis it is an important fix.