### PR TITLE
Changing the default postgres version to 11

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -18,7 +18,7 @@
 #
 # CDDL HEADER END
 #
-# Copyright 2017 Gary Mills
+# Copyright 2017,2021 Gary Mills
 # Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
 #
 
@@ -814,8 +814,8 @@ PKG_MACROS +=   PERL_ARCH=$(PERL_ARCH)
 PKG_MACROS +=   PERL_VERSION=$(PERL_VERSION)
 
 # Config magic for Postgres/EnterpriseDB/...
-# Default DB version is the oldest one, for hopefully best built complatibility
-PG_VERSION ?=   9.5
+# Default DB version.  Can be overridden in component Makefile.
+PG_VERSION ?=   11
 PG_IMPLEM ?=    postgres
 PG_VERNUM =     $(subst .,,$(PG_VERSION))
 # For dependencies, including REQUIRED_PACKAGES if needed
@@ -827,8 +827,14 @@ REQUIRED_PACKAGES_SUBST+= PG_DEVELOPER_PKG
 REQUIRED_PACKAGES_SUBST+= PG_LIBRARY_PKG
 
 PG_HOME =       $(USRDIR)/$(PG_IMPLEM)/$(PG_VERSION)
+# Binary directories match reality now
+ifeq ($(strip $(PG_VERSION)),9.5)
 PG_BINDIR.32 =  $(PG_HOME)/bin
 PG_BINDIR.64 =  $(PG_HOME)/bin/$(MACH64)
+else
+PG_BINDIR.32 =  $(PG_HOME)/bin/$(MACH32)
+PG_BINDIR.64 =  $(PG_HOME)/bin
+endif
 PG_BINDIR =     $(PG_BINDIR.$(BITS))
 PG_INCDIR =     $(PG_HOME)/include
 PG_MANDIR =     $(PG_HOME)/man


### PR DESCRIPTION
This PR is the first step in breaking the logjam of postgres versions.  By a modification of shared-macros.mk, it changes the default version from 9.5 to 11.  As well, it changes the location of the binary directories to match reality.  In this step, the version 9.5 package  still exists, leaving no need to rebuild packages that depend on it.

If the package must be rebuilt for other reasons, developers can use the new default if it works.  Otherwise, they can use the original default version by adding:

    PG_VERSION = 9.5

to the component Makefile.  This is a temporary solution.

The next step is to obsolete 9.5, perhaps simplifying shared-macros.mk at the same time.  As well, the version-independant and pan-version postgres files can be moved to their own component directory.  Either then or later, 9.6 can be obsoleted and 13 packaged.
