### PR TITLE
mate-session-manager: update to 1.24.3

### DIFF
--- a/components/desktop/mate/mate-session-manager/Makefile
+++ b/components/desktop/mate/mate-session-manager/Makefile
@@ -21,13 +21,13 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-session-manager
 COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	2
+COMPONENT_MNR_VERSION=	3
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	The Session manager and session startup stuff
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:6b0b9c0c4fe831e4f000e55a2ebb953cf2a83eed613faaf3e23c8beec42c8bc9
+COMPONENT_ARCHIVE_HASH= sha256:90a0aec5b59b6287b4d2c4d452b0b6410f9d12490ca1f890e81ba2801bdab0a2
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
@@ -54,12 +54,11 @@ COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 REQUIRED_PACKAGES += x11/library/xtrans
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
 REQUIRED_PACKAGES += library/desktop/gtk3
 REQUIRED_PACKAGES += library/glib2
-#REQUIRED_PACKAGES += shell/ksh93
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/dbus/dbus-x11
 REQUIRED_PACKAGES += system/library/libdbus

--- a/components/desktop/mate/mate-session-manager/pkg5
+++ b/components/desktop/mate/mate-session-manager/pkg5
@@ -5,6 +5,7 @@
         "library/desktop/gdk-pixbuf",
         "library/desktop/gtk3",
         "library/glib2",
+        "shell/ksh93",
         "system/library",
         "system/library/dbus/dbus-x11",
         "system/library/libdbus",


### PR DESCRIPTION
sample-manifest didn't change
still works