### PR TITLE
cog-spur, stack-spur : update to 5.0.2957

### DIFF
--- a/components/runtime/squeak5/Makefile
+++ b/components/runtime/squeak5/Makefile
@@ -14,12 +14,11 @@
 
 
 #
-# Package Makefile for the "OpenSmalltalk Cog Spur" Squeak Smalltalk V5 system
+# Package Makefile for the "OpenSmalltalk" Squeak Smalltalk system
 # See http://squeak.org and http://opensmalltalk.org
 #
 
 # opensmalltalk-vm can be built both in 32 and 64bit
-# but unfortunately it does not deliver a driver script (like squeak-4 does)
 #
 # we deliver our own script squeak.ips as driver script
 #
@@ -34,13 +33,13 @@ include ../../../make-rules/shared-macros.mk
 # we use 5.0.<n> for VMMaker.oscog-eem.<n>
 # sometimes the Stack VM is generated from a different VMMaker as the Cog VM
 
-COMPONENT_NAME=		squeak-5
-COMPONENT_VERSION=	5.0.2952
-GIT_TAG=		sun-v5.0.28
-PLUGIN_REV=		5.0-202104231732
-COMPONENT_SUMMARY=	The Squeak V5 Smalltalk Virtual Machine
+COMPONENT_NAME=		stack-spur
+COMPONENT_VERSION=	5.0.2957
+GIT_TAG=		sun-v5.0.29
+PLUGIN_REV=		5.0-202105050900
+COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
-COMPONENT_FMRI=		runtime/squeak-5
+COMPONENT_FMRI=		runtime/smalltalk/stack-spur
 COMPONENT_CLASSIFICATION=	Development/Other Languages
 
 # See http://wiki.squeak.org/squeak/933
@@ -51,7 +50,7 @@ COMPONENT_LICENSE_FILE=	squeak5.license
 
 COMPONENT_SRC=		opensmalltalk-vm-$(GIT_TAG)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:26ec608fdf69879bc8f8aae7c615af2a4888feaf7c26f9262b510ec08d147413
+COMPONENT_ARCHIVE_HASH=	sha256:6975d8be2d8f4cf80c6f5ca60f14550325b6406f3be7b1bcd3e16cead7c86210
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 TEST_TARGET= $(NO_TESTS)
@@ -114,9 +113,9 @@ COMPONENT_POST_INSTALL_ACTION = \
 #
 
 rebuild-manifests::
-	cp manifests/squeak-5.p5m squeak-5.p5m
-	cp manifests/squeak-5-display-X11.p5m squeak-5-display-X11.p5m
-	cp manifests/squeak-5-nodisplay.p5m squeak-5-nodisplay.p5m
+	cp manifests/stack-spur.p5m stack-spur.p5m
+	cp manifests/stack-spur-display-X11.p5m stack-spur-display-X11.p5m
+	cp manifests/stack-spur-nodisplay.p5m stack-spur-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m
 	tools/pluginrev.sh $(PLUGIN_REV) <sample-manifest.p5m >sample.p5m
 	tools/classify.pl <sample.p5m

--- a/components/runtime/squeak5/manifests/sample-manifest.p5m
+++ b/components/runtime/squeak5/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -32,44 +32,44 @@ file path=usr/doc/squeak/LICENSE
 file path=usr/doc/squeak/README.Contributing
 file path=usr/doc/squeak/README.Keyboard
 file path=usr/doc/squeak/README.Sound
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/B3DAcceleratorPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/DESPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/ImmX11Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/MD5Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/SHA2Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/UnixOSProcessPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/XDisplayControlPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/squeak
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/vm-display-X11.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/vm-display-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/vm-sound-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732/vm-sound-pulse.so
-file path=usr/lib/squeak/5.0-202104231732/B3DAcceleratorPlugin.so
-file path=usr/lib/squeak/5.0-202104231732/DESPlugin.so
-file path=usr/lib/squeak/5.0-202104231732/FileAttributesPlugin.so
-file path=usr/lib/squeak/5.0-202104231732/ImmX11Plugin.so
-file path=usr/lib/squeak/5.0-202104231732/LocalePlugin.so
-file path=usr/lib/squeak/5.0-202104231732/MD5Plugin.so
-file path=usr/lib/squeak/5.0-202104231732/SHA2Plugin.so
-file path=usr/lib/squeak/5.0-202104231732/Squeak3D.so
-file path=usr/lib/squeak/5.0-202104231732/SqueakFFIPrims.so
-file path=usr/lib/squeak/5.0-202104231732/SqueakSSL.so
-file path=usr/lib/squeak/5.0-202104231732/UUIDPlugin.so
-file path=usr/lib/squeak/5.0-202104231732/UnicodePlugin.so
-file path=usr/lib/squeak/5.0-202104231732/UnixOSProcessPlugin.so
-file path=usr/lib/squeak/5.0-202104231732/XDisplayControlPlugin.so
-file path=usr/lib/squeak/5.0-202104231732/squeak
-file path=usr/lib/squeak/5.0-202104231732/vm-display-X11.so
-file path=usr/lib/squeak/5.0-202104231732/vm-display-null.so
-file path=usr/lib/squeak/5.0-202104231732/vm-sound-null.so
-file path=usr/lib/squeak/5.0-202104231732/vm-sound-pulse.so
-hardlink path=usr/share/man/man1/inisqueak.1 target=squeak.1
-file path=usr/share/man/man1/squeak.1
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/squeak
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900/vm-sound-pulse.so
+file path=usr/lib/squeak/5.0-202105050900/B3DAcceleratorPlugin.so
+file path=usr/lib/squeak/5.0-202105050900/DESPlugin.so
+file path=usr/lib/squeak/5.0-202105050900/FileAttributesPlugin.so
+file path=usr/lib/squeak/5.0-202105050900/ImmX11Plugin.so
+file path=usr/lib/squeak/5.0-202105050900/LocalePlugin.so
+file path=usr/lib/squeak/5.0-202105050900/MD5Plugin.so
+file path=usr/lib/squeak/5.0-202105050900/SHA2Plugin.so
+file path=usr/lib/squeak/5.0-202105050900/Squeak3D.so
+file path=usr/lib/squeak/5.0-202105050900/SqueakFFIPrims.so
+file path=usr/lib/squeak/5.0-202105050900/SqueakSSL.so
+file path=usr/lib/squeak/5.0-202105050900/UUIDPlugin.so
+file path=usr/lib/squeak/5.0-202105050900/UnicodePlugin.so
+file path=usr/lib/squeak/5.0-202105050900/UnixOSProcessPlugin.so
+file path=usr/lib/squeak/5.0-202105050900/XDisplayControlPlugin.so
+file path=usr/lib/squeak/5.0-202105050900/squeak
+file path=usr/lib/squeak/5.0-202105050900/vm-display-X11.so
+file path=usr/lib/squeak/5.0-202105050900/vm-display-null.so
+file path=usr/lib/squeak/5.0-202105050900/vm-sound-null.so
+file path=usr/lib/squeak/5.0-202105050900/vm-sound-pulse.so
+file path=usr/share/man/man1/inisqueak.1
+hardlink path=usr/share/man/man1/squeak.1 target=inisqueak.1
 file path=usr/squeak

--- a/components/runtime/squeak5/manifests/stack-spur-display-X11.p5m
+++ b/components/runtime/squeak5/manifests/stack-spur-display-X11.p5m
@@ -14,13 +14,25 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/squeak-5-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-set name=pkg.renamed value=true
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+
+# for the sound plugins, we only package vm-sound-pulse
+# we do not package vm-sound-OSS and vm-sound-Sun
+# on my machine, vm-sound-Sun compiles, but it does not work
+
+# the minimal installation consists of the stack-spur-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
 
 depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+

--- a/components/runtime/squeak5/manifests/stack-spur-nodisplay.p5m
+++ b/components/runtime/squeak5/manifests/stack-spur-nodisplay.p5m
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file inisqueak5 path=usr/bin/inisqueak5
+file squeak.ips path=usr/bin/squeak5
+file usr/bin/ckformat path=usr/bin/ckformat5
+file path=usr/lib/squeak/$(PLUGIN_REV)/squeak mode=0555
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/squeak mode=0555
+file usr/doc/squeak/COPYING path=usr/share/doc/squeak-$(IPS_COMPONENT_VERSION)/COPYING
+file usr/doc/squeak/COPYRIGHT path=usr/share/doc/squeak-$(IPS_COMPONENT_VERSION)/COPYRIGHT
+file usr/doc/squeak/LICENSE path=usr/share/doc/squeak-$(IPS_COMPONENT_VERSION)/LICENSE
+file usr/share/man/man1/squeak.1 path=usr/share/man/man1/squeak5.1
+
+# use hardlink (squeak wrapper script may have issue with symlink)
+
+hardlink path=usr/bin/squeak target=squeak5 mediator=squeak \
+    mediator-implementation=stack-spur mediator-version=5
+hardlink path=usr/bin/inisqueak target=inisqueak5 mediator=squeak \
+    mediator-implementation=stack-spur mediator-version=5
+hardlink path=usr/bin/ckformat target=ckformat5 mediator=squeak \
+    mediator-implementation=stack-spur mediator-version=5
+hardlink path=usr/share/man/man1/squeak.1 target=squeak5.1 mediator=squeak \
+    mediator-implementation=stack-spur mediator-version=5
+

--- a/components/runtime/squeak5/manifests/stack-spur.p5m
+++ b/components/runtime/squeak5/manifests/stack-spur.p5m
@@ -14,14 +14,23 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/squeak-5c-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-set name=pkg.renamed value=true
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+# for the sound plugins, we only package vm-sound-pulse
+# we do not package vm-sound-OSS and vm-sound-Sun
+# on my machine, vm-sound-Sun compiles, but it does not work
+
+# the minimal installation consists of the stack-spur-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak5/patches/02-sqSCCSVersion.patch
+++ b/components/runtime/squeak5/patches/02-sqSCCSVersion.patch
@@ -1,15 +1,15 @@
---- opensmalltalk-vm-sun-v5.0.28/platforms/Cross/vm/sqSCCSVersion.h	Fri Apr 23 19:32:22 2021
-+++ p0/opensmalltalk-vm-sun-v5.0.28/platforms/Cross/vm/sqSCCSVersion.h	Sat Apr 24 06:52:48 2021
+--- opensmalltalk-vm-sun-v5.0.29/platforms/Cross/vm/sqSCCSVersion.h	Wed May  5 11:00:40 2021
++++ p0/opensmalltalk-vm-sun-v5.0.29/platforms/Cross/vm/sqSCCSVersion.h	Fri May  7 09:27:11 2021
 @@ -28,13 +28,13 @@
  
  #if SUBVERSION
  # define PREFIX "r"
 -static char SvnRawRevisionString[] = "$Rev$";
-+static char SvnRawRevisionString[] = "$Rev: 202104231732 $";
++static char SvnRawRevisionString[] = "$Rev: 202105050900 $";
  # define REV_START (SvnRawRevisionString + 6)
  
 -static char SvnRawRevisionDate[] = "$Date$";
-+static char SvnRawRevisionDate[] = "$Date: Fri Apr 23 19:32:22 2021 +0200 $";
++static char SvnRawRevisionDate[] = "$Date: Wed May 5 11:00:40 2021 +0200 $";
  # define DATE_START (SvnRawRevisionDate + 7)
  
 -static char SvnRawRepositoryURL[] = "$URL$";
@@ -22,11 +22,11 @@
  #elif GIT
  # define PREFIX ""
 -static char GitRawRevisionString[] = "$Rev$";
-+static char GitRawRevisionString[] = "$Rev: 202104231732 $";
++static char GitRawRevisionString[] = "$Rev: 202105050900 $";
  # define REV_START (GitRawRevisionString + 6)
  
 -static char GitRawRevisionDate[] = "$Date$";
-+static char GitRawRevisionDate[] = "$Date: Fri Apr 23 19:32:22 2021 +0200 $";
++static char GitRawRevisionDate[] = "$Date: Wed May 5 11:00:40 2021 +0200 $";
  # define DATE_START (GitRawRevisionDate + 7)
  
 -static char GitRawRepositoryURL[] = "$URL$";
@@ -34,7 +34,7 @@
  # define URL_START (GitRawRepositoryURL + 6)
  
 -static char GitRawRevisionShortHash[] = "$CommitHash$";
-+static char GitRawRevisionShortHash[] = "$CommitHash: d26a86313 $";
++static char GitRawRevisionShortHash[] = "$CommitHash: 42a6469b9 $";
  # define SHORTHASH_START (GitRawRevisionShortHash + 13)
  
  static char *

--- a/components/runtime/squeak5/patches/03-sqPluginsSCCSVersion.patch
+++ b/components/runtime/squeak5/patches/03-sqPluginsSCCSVersion.patch
@@ -1,11 +1,11 @@
---- opensmalltalk-vm-sun-v5.0.28/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri Apr 23 19:32:22 2021
-+++ p0/opensmalltalk-vm-sun-v5.0.28/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sat Apr 24 06:52:48 2021
+--- opensmalltalk-vm-sun-v5.0.29/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Wed May  5 11:00:40 2021
++++ p0/opensmalltalk-vm-sun-v5.0.29/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri May  7 09:27:11 2021
 @@ -9,10 +9,10 @@
   */
  
  #if SUBVERSION
 -static char SvnRawPluginsRevisionString[] = "$Rev$";
-+static char SvnRawPluginsRevisionString[] = "$Rev: 202104231732 $";
++static char SvnRawPluginsRevisionString[] = "$Rev: 202105050900 $";
  # define PLUGINS_REV_START (SvnRawPluginsRevisionString + 6)
  
 -static char SvnRawPluginsRepositoryURL[] = "$URL$";
@@ -18,7 +18,7 @@
  # undef URL_START
  #elif GIT
 -static char GitRawPluginsRevisionString[] = "$Rev$";
-+static char GitRawPluginsRevisionString[] = "$Rev: 202104231732 $";
++static char GitRawPluginsRevisionString[] = "$Rev: 202105050900 $";
  # define PLUGINS_REV_START (GitRawPluginsRevisionString + 6)
  
 -static char GitRawPluginsRepositoryURL[] = "$URL$";

--- a/components/runtime/squeak5/pkg5
+++ b/components/runtime/squeak5/pkg5
@@ -20,9 +20,12 @@
         "x11/library/mesa"
     ],
     "fmris": [
+        "runtime/smalltalk/stack-spur",
+        "runtime/smalltalk/stack-spur-display-X11",
+        "runtime/smalltalk/stack-spur-nodisplay",
         "runtime/squeak-5",
         "runtime/squeak-5-display-X11",
         "runtime/squeak-5-nodisplay"
     ],
-    "name": "squeak-5"
+    "name": "stack-spur"
 }

--- a/components/runtime/squeak5/squeak-5-display-X11.p5m
+++ b/components/runtime/squeak5/squeak-5-display-X11.p5m
@@ -21,28 +21,7 @@ set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license squeak.license license='MIT'
-license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+set name=pkg.renamed value=true
 
-<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
-
-# the minimal installation consists of the squeak-5-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/squeak-5-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-X11.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/Squeak3D.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-X11.so

--- a/components/runtime/squeak5/squeak-5.p5m
+++ b/components/runtime/squeak5/squeak-5.p5m
@@ -14,37 +14,14 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/squeak-5@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license squeak.license license='MIT'
-license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+set name=pkg.renamed value=true
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-# the minimal installation consists of the squeak-5-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/squeak-5-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-pulse.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/LocalePlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/UUIDPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/UnicodePlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-pulse.so

--- a/components/runtime/squeak5/squeak.ips
+++ b/components/runtime/squeak5/squeak.ips
@@ -8,7 +8,7 @@
 
 CK=/usr/bin/ckformat
 DBX=
-PLUGIN_REV=5.0-202104231732
+PLUGIN_REV=5.0-202105050900
 LIB32=/usr/lib/squeak/$PLUGIN_REV
 LIB64=/usr/lib/amd64/squeak/$PLUGIN_REV
 

--- a/components/runtime/squeak5/stack-spur-display-X11.p5m
+++ b/components/runtime/squeak5/stack-spur-display-X11.p5m
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+
+# for the sound plugins, we only package vm-sound-pulse
+# we do not package vm-sound-OSS and vm-sound-Sun
+# on my machine, vm-sound-Sun compiles, but it does not work
+
+# the minimal installation consists of the stack-spur-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-X11.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/Squeak3D.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-X11.so

--- a/components/runtime/squeak5/stack-spur-nodisplay.p5m
+++ b/components/runtime/squeak5/stack-spur-nodisplay.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/squeak-5-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -45,3 +45,15 @@ hardlink path=usr/bin/ckformat target=ckformat5 mediator=squeak \
 hardlink path=usr/share/man/man1/squeak.1 target=squeak5.1 mediator=squeak \
     mediator-implementation=stack-spur mediator-version=5
 
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-null.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/DESPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/MD5Plugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SHA2Plugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/UnixOSProcessPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-null.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-null.so

--- a/components/runtime/squeak5/stack-spur.p5m
+++ b/components/runtime/squeak5/stack-spur.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/squeak-5-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,15 +24,27 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
-
 # for the sound plugins, we only package vm-sound-pulse
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
 
-# the minimal installation consists of the squeak-5-nodisplay package
+# the minimal installation consists of the stack-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
-depend type=require fmri=pkg:/runtime/squeak-5-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-pulse.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/LocalePlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/UUIDPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/UnicodePlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-pulse.so

--- a/components/runtime/squeak5/tools/classify.pl
+++ b/components/runtime/squeak5/tools/classify.pl
@@ -7,18 +7,18 @@
 # this script is used
 #
 # the script "classifies" plugins into currently 3 categories:
-#  - squeak-5-nodisplay (only libc,libm math,libpthread, ksh)
-#  - squeak-5-display-X11 (only x11,xext,xrender)
-#  - squeak-5 (ssl,ffi,pulseaudio freetype2,gnome, everything else)
+#  - stack-spur-nodisplay (only libc,libm math,libpthread, ksh)
+#  - stack-spur-display-X11 (only x11,xext,xrender)
+#  - stack-spur (ssl,ffi,pulseaudio freetype2,gnome, everything else)
 #
 # ./classify.pl < sample2.p5m
 #
 
-open(NODISPLAY,">>","squeak-5-nodisplay.p5m") || die "Can't open squeak-5-nodisplay.p5m";
+open(NODISPLAY,">>","stack-spur-nodisplay.p5m") || die "Can't open stack-spur-nodisplay.p5m";
 
-open(X11,">>","squeak-5-display-X11.p5m") || die "Can't open squeak-5-display-X11.p5m";
+open(X11,">>","stack-spur-display-X11.p5m") || die "Can't open stack-spur-display-X11.p5m";
 
-open(REST,">>","squeak-5.p5m") || die "Can't open squeak-5.p5m";
+open(REST,">>","stack-spur.p5m") || die "Can't open stack-spur.p5m";
 
 while (<>) {
 	if (/^#/) {

--- a/components/runtime/squeak5c/Makefile
+++ b/components/runtime/squeak5c/Makefile
@@ -14,7 +14,7 @@
 
 
 #
-# Package Makefile for the "OpenSmalltalk Cog Spur" Squeak Smalltalk V5 system
+# Package Makefile for the "OpenSmalltalk Cog Spur" Squeak Smalltalk system
 # See http://squeak.org and http://opensmalltalk.org
 #
 
@@ -27,13 +27,13 @@ include ../../../make-rules/shared-macros.mk
 # we use 5.0.<n> for VMMaker.oscog-eem.<n>
 # sometimes the Stack VM is generated from a different VMMaker as the Cog VM
 
-COMPONENT_NAME=		squeak-5c
-COMPONENT_VERSION=	5.0.2954
-GIT_TAG=		sun-v5.0.28
-PLUGIN_REV=		5.0-202104231732-cog
-COMPONENT_SUMMARY=	The Cog Implementation of the Squeak V5 Smalltalk Virtual Machine
+COMPONENT_NAME=		cog-spur
+COMPONENT_VERSION=	5.0.2957
+GIT_TAG=		sun-v5.0.29
+PLUGIN_REV=		5.0-202105050900-cog
+COMPONENT_SUMMARY=	The Squeak OpenSmalltalk Cog Spur Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
-COMPONENT_FMRI=		runtime/squeak-5c
+COMPONENT_FMRI=		runtime/smalltalk/cog-spur
 COMPONENT_CLASSIFICATION=	Development/Other Languages
 
 # See http://wiki.squeak.org/squeak/933
@@ -44,7 +44,7 @@ COMPONENT_LICENSE_FILE=	squeak5.license
 
 COMPONENT_SRC=		opensmalltalk-vm-$(GIT_TAG)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:26ec608fdf69879bc8f8aae7c615af2a4888feaf7c26f9262b510ec08d147413
+COMPONENT_ARCHIVE_HASH=	sha256:6975d8be2d8f4cf80c6f5ca60f14550325b6406f3be7b1bcd3e16cead7c86210
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 TEST_TARGET= $(NO_TESTS)
@@ -105,9 +105,9 @@ COMPONENT_POST_INSTALL_ACTION = \
 #
 
 rebuild-manifests::
-	cp manifests/squeak-5c.p5m squeak-5c.p5m
-	cp manifests/squeak-5c-display-X11.p5m squeak-5c-display-X11.p5m
-	cp manifests/squeak-5c-nodisplay.p5m squeak-5c-nodisplay.p5m
+	cp manifests/cog-spur.p5m cog-spur.p5m
+	cp manifests/cog-spur-display-X11.p5m cog-spur-display-X11.p5m
+	cp manifests/cog-spur-nodisplay.p5m cog-spur-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m
 	tools/pluginrev.sh $(PLUGIN_REV) <sample-manifest.p5m >sample.p5m
 	tools/classify.pl <sample.p5m

--- a/components/runtime/squeak5c/cog-spur-display-X11.p5m
+++ b/components/runtime/squeak5c/cog-spur-display-X11.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,13 +24,25 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+
 # for the sound plugins, we only package vm-sound-pulse
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
 
-# the minimal installation consists of the squeak-5-nodisplay package
+# the minimal installation consists of the cog-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
-depend type=require fmri=pkg:/runtime/squeak-5-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-X11.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/Squeak3D.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-X11.so

--- a/components/runtime/squeak5c/cog-spur-nodisplay.p5m
+++ b/components/runtime/squeak5c/cog-spur-nodisplay.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/squeak-5c-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -46,3 +46,15 @@ hardlink path=usr/bin/ckformat target=ckformat5c mediator=squeak \
 hardlink path=usr/share/man/man1/squeak.1 target=squeak5c.1 mediator=squeak \
     mediator-implementation=cog-spur mediator-version=5
 
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-null.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/DESPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/MD5Plugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SHA2Plugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/UnixOSProcessPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-null.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-null.so

--- a/components/runtime/squeak5c/cog-spur.p5m
+++ b/components/runtime/squeak5c/cog-spur.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/squeak-5c-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -30,9 +30,23 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
 
-# the minimal installation consists of the squeak-5c-nodisplay package
+# the minimal installation consists of the cog-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
-depend type=require fmri=pkg:/runtime/squeak-5c-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-pulse.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/LocalePlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/UUIDPlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/UnicodePlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-pulse.so

--- a/components/runtime/squeak5c/manifests/cog-spur-display-X11.p5m
+++ b/components/runtime/squeak5c/manifests/cog-spur-display-X11.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -30,9 +30,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
 
-# the minimal installation consists of the squeak-5c-nodisplay package
+# the minimal installation consists of the cog-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
-depend type=require fmri=pkg:/runtime/squeak-5c-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak5c/manifests/cog-spur-nodisplay.p5m
+++ b/components/runtime/squeak5c/manifests/cog-spur-nodisplay.p5m
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020,2021 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file inisqueak5c path=usr/bin/inisqueak5c
+file squeak.ips path=usr/bin/squeak5c
+file usr/bin/ckformat path=usr/bin/ckformat5c
+file path=usr/lib/squeak/$(PLUGIN_REV)/squeak mode=0555
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/squeak mode=0555
+
+file usr/doc/squeak/COPYING path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/COPYING
+file usr/doc/squeak/COPYRIGHT path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/COPYRIGHT
+file usr/doc/squeak/LICENSE path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/LICENSE
+file usr/share/man/man1/squeak.1 path=usr/share/man/man1/squeak5c.1
+
+# use hardlink (squeak wrapper script may have issue with symlink)
+
+hardlink path=usr/bin/squeak target=squeak5c mediator=squeak \
+    mediator-implementation=cog-spur mediator-version=5
+hardlink path=usr/bin/inisqueak target=inisqueak5c mediator=squeak \
+    mediator-implementation=cog-spur mediator-version=5
+hardlink path=usr/bin/ckformat target=ckformat5c mediator=squeak \
+    mediator-implementation=cog-spur mediator-version=5
+hardlink path=usr/share/man/man1/squeak.1 target=squeak5c.1 mediator=squeak \
+    mediator-implementation=cog-spur mediator-version=5
+

--- a/components/runtime/squeak5c/manifests/cog-spur.p5m
+++ b/components/runtime/squeak5c/manifests/cog-spur.p5m
@@ -14,14 +14,25 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/squeak-5c-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-set name=pkg.renamed value=true
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+
+# for the sound plugins, we only package vm-sound-pulse
+# we do not package vm-sound-OSS and vm-sound-Sun
+# on my machine, vm-sound-Sun compiles, but it does not work
+
+# the minimal installation consists of the cog-spur-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
 
 depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak5c/manifests/sample-manifest.p5m
+++ b/components/runtime/squeak5c/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -32,44 +32,44 @@ file path=usr/doc/squeak/LICENSE
 file path=usr/doc/squeak/README.Contributing
 file path=usr/doc/squeak/README.Keyboard
 file path=usr/doc/squeak/README.Sound
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/B3DAcceleratorPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/DESPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/ImmX11Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/MD5Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/SHA2Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/UnixOSProcessPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/XDisplayControlPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/squeak
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/vm-display-X11.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/vm-display-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/vm-sound-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202104231732-cog/vm-sound-pulse.so
-file path=usr/lib/squeak/5.0-202104231732-cog/B3DAcceleratorPlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/DESPlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/FileAttributesPlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/ImmX11Plugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/LocalePlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/MD5Plugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/SHA2Plugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/Squeak3D.so
-file path=usr/lib/squeak/5.0-202104231732-cog/SqueakFFIPrims.so
-file path=usr/lib/squeak/5.0-202104231732-cog/SqueakSSL.so
-file path=usr/lib/squeak/5.0-202104231732-cog/UUIDPlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/UnicodePlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/UnixOSProcessPlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/XDisplayControlPlugin.so
-file path=usr/lib/squeak/5.0-202104231732-cog/squeak
-file path=usr/lib/squeak/5.0-202104231732-cog/vm-display-X11.so
-file path=usr/lib/squeak/5.0-202104231732-cog/vm-display-null.so
-file path=usr/lib/squeak/5.0-202104231732-cog/vm-sound-null.so
-file path=usr/lib/squeak/5.0-202104231732-cog/vm-sound-pulse.so
-hardlink path=usr/share/man/man1/inisqueak.1 target=squeak.1
-file path=usr/share/man/man1/squeak.1
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/squeak
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202105050900-cog/vm-sound-pulse.so
+file path=usr/lib/squeak/5.0-202105050900-cog/B3DAcceleratorPlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/DESPlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/FileAttributesPlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/ImmX11Plugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/LocalePlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/MD5Plugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/SHA2Plugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/Squeak3D.so
+file path=usr/lib/squeak/5.0-202105050900-cog/SqueakFFIPrims.so
+file path=usr/lib/squeak/5.0-202105050900-cog/SqueakSSL.so
+file path=usr/lib/squeak/5.0-202105050900-cog/UUIDPlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/UnicodePlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/UnixOSProcessPlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/XDisplayControlPlugin.so
+file path=usr/lib/squeak/5.0-202105050900-cog/squeak
+file path=usr/lib/squeak/5.0-202105050900-cog/vm-display-X11.so
+file path=usr/lib/squeak/5.0-202105050900-cog/vm-display-null.so
+file path=usr/lib/squeak/5.0-202105050900-cog/vm-sound-null.so
+file path=usr/lib/squeak/5.0-202105050900-cog/vm-sound-pulse.so
+file path=usr/share/man/man1/inisqueak.1
+hardlink path=usr/share/man/man1/squeak.1 target=inisqueak.1
 file path=usr/squeak

--- a/components/runtime/squeak5c/patches/02-sqSCCSVersion.patch
+++ b/components/runtime/squeak5c/patches/02-sqSCCSVersion.patch
@@ -1,15 +1,15 @@
---- opensmalltalk-vm-sun-v5.0.28/platforms/Cross/vm/sqSCCSVersion.h	Fri Apr 23 19:32:22 2021
-+++ p0/opensmalltalk-vm-sun-v5.0.28/platforms/Cross/vm/sqSCCSVersion.h	Sat Apr 24 07:02:11 2021
+--- opensmalltalk-vm-sun-v5.0.29/platforms/Cross/vm/sqSCCSVersion.h	Wed May  5 11:00:40 2021
++++ p0/opensmalltalk-vm-sun-v5.0.29/platforms/Cross/vm/sqSCCSVersion.h	Fri May  7 13:32:51 2021
 @@ -28,13 +28,13 @@
  
  #if SUBVERSION
  # define PREFIX "r"
 -static char SvnRawRevisionString[] = "$Rev$";
-+static char SvnRawRevisionString[] = "$Rev: 202104231732-cog $";
++static char SvnRawRevisionString[] = "$Rev: 202105050900-cog $";
  # define REV_START (SvnRawRevisionString + 6)
  
 -static char SvnRawRevisionDate[] = "$Date$";
-+static char SvnRawRevisionDate[] = "$Date: Fri Apr 23 19:32:22 2021 +0200 $";
++static char SvnRawRevisionDate[] = "$Date: Wed May 5 11:00:40 2021 +0200 $";
  # define DATE_START (SvnRawRevisionDate + 7)
  
 -static char SvnRawRepositoryURL[] = "$URL$";
@@ -22,11 +22,11 @@
  #elif GIT
  # define PREFIX ""
 -static char GitRawRevisionString[] = "$Rev$";
-+static char GitRawRevisionString[] = "$Rev: 202104231732-cog $";
++static char GitRawRevisionString[] = "$Rev: 202105050900-cog $";
  # define REV_START (GitRawRevisionString + 6)
  
 -static char GitRawRevisionDate[] = "$Date$";
-+static char GitRawRevisionDate[] = "$Date: Fri Apr 23 19:32:22 2021 +0200 $";
++static char GitRawRevisionDate[] = "$Date: Wed May 5 11:00:40 2021 +0200 $";
  # define DATE_START (GitRawRevisionDate + 7)
  
 -static char GitRawRepositoryURL[] = "$URL$";
@@ -34,7 +34,7 @@
  # define URL_START (GitRawRepositoryURL + 6)
  
 -static char GitRawRevisionShortHash[] = "$CommitHash$";
-+static char GitRawRevisionShortHash[] = "$CommitHash: d26a86313 $";
++static char GitRawRevisionShortHash[] = "$CommitHash: 42a6469b9 $";
  # define SHORTHASH_START (GitRawRevisionShortHash + 13)
  
  static char *

--- a/components/runtime/squeak5c/patches/03-sqPluginsSCCSVersion.patch
+++ b/components/runtime/squeak5c/patches/03-sqPluginsSCCSVersion.patch
@@ -1,11 +1,11 @@
---- opensmalltalk-vm-sun-v5.0.28/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri Apr 23 19:32:22 2021
-+++ p0/opensmalltalk-vm-sun-v5.0.28/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sat Apr 24 07:02:11 2021
+--- opensmalltalk-vm-sun-v5.0.29/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Wed May  5 11:00:40 2021
++++ p0/opensmalltalk-vm-sun-v5.0.29/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri May  7 13:32:51 2021
 @@ -9,10 +9,10 @@
   */
  
  #if SUBVERSION
 -static char SvnRawPluginsRevisionString[] = "$Rev$";
-+static char SvnRawPluginsRevisionString[] = "$Rev: 202104231732-cog $";
++static char SvnRawPluginsRevisionString[] = "$Rev: 202105050900-cog $";
  # define PLUGINS_REV_START (SvnRawPluginsRevisionString + 6)
  
 -static char SvnRawPluginsRepositoryURL[] = "$URL$";
@@ -18,7 +18,7 @@
  # undef URL_START
  #elif GIT
 -static char GitRawPluginsRevisionString[] = "$Rev$";
-+static char GitRawPluginsRevisionString[] = "$Rev: 202104231732-cog $";
++static char GitRawPluginsRevisionString[] = "$Rev: 202105050900-cog $";
  # define PLUGINS_REV_START (GitRawPluginsRevisionString + 6)
  
 -static char GitRawPluginsRepositoryURL[] = "$URL$";

--- a/components/runtime/squeak5c/pkg5
+++ b/components/runtime/squeak5c/pkg5
@@ -20,9 +20,12 @@
         "x11/library/mesa"
     ],
     "fmris": [
+        "runtime/smalltalk/cog-spur",
+        "runtime/smalltalk/cog-spur-display-X11",
+        "runtime/smalltalk/cog-spur-nodisplay",
         "runtime/squeak-5c",
         "runtime/squeak-5c-display-X11",
         "runtime/squeak-5c-nodisplay"
     ],
-    "name": "squeak-5c"
+    "name": "cog-spur"
 }

--- a/components/runtime/squeak5c/squeak-5c-nodisplay.p5m
+++ b/components/runtime/squeak5c/squeak-5c-nodisplay.p5m
@@ -21,40 +21,7 @@ set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license squeak.license license='MIT'
-license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+set name=pkg.renamed value=true
 
-file inisqueak5c path=usr/bin/inisqueak5c
-file squeak.ips path=usr/bin/squeak5c
-file usr/bin/ckformat path=usr/bin/ckformat5c
-file path=usr/lib/squeak/$(PLUGIN_REV)/squeak mode=0555
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/squeak mode=0555
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file usr/doc/squeak/COPYING path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/COPYING
-file usr/doc/squeak/COPYRIGHT path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/COPYRIGHT
-file usr/doc/squeak/LICENSE path=usr/share/doc/squeak-cog-$(IPS_COMPONENT_VERSION)/LICENSE
-file usr/share/man/man1/squeak.1 path=usr/share/man/man1/squeak5c.1
-
-# use hardlink (squeak wrapper script may have issue with symlink)
-
-hardlink path=usr/bin/squeak target=squeak5c mediator=squeak \
-    mediator-implementation=cog-spur mediator-version=5
-hardlink path=usr/bin/inisqueak target=inisqueak5c mediator=squeak \
-    mediator-implementation=cog-spur mediator-version=5
-hardlink path=usr/bin/ckformat target=ckformat5c mediator=squeak \
-    mediator-implementation=cog-spur mediator-version=5
-hardlink path=usr/share/man/man1/squeak.1 target=squeak5c.1 mediator=squeak \
-    mediator-implementation=cog-spur mediator-version=5
-
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/DESPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/MD5Plugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SHA2Plugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnixOSProcessPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-null.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-null.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/DESPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/MD5Plugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SHA2Plugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/UnixOSProcessPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-null.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-null.so

--- a/components/runtime/squeak5c/squeak-5c.p5m
+++ b/components/runtime/squeak5c/squeak-5c.p5m
@@ -14,39 +14,14 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/squeak-5c@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license squeak.license license='MIT'
-license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+set name=pkg.renamed value=true
 
-<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
-
-# the minimal installation consists of the squeak-5c-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/squeak-5c-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-pulse.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/LocalePlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/UUIDPlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/UnicodePlugin.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-pulse.so

--- a/components/runtime/squeak5c/squeak.ips
+++ b/components/runtime/squeak5c/squeak.ips
@@ -8,7 +8,7 @@
 
 CK=/usr/bin/ckformat5c
 DBX=
-PLUGIN_REV=5.0-202104231732-cog
+PLUGIN_REV=5.0-202105050900-cog
 LIB32=/usr/lib/squeak/$PLUGIN_REV
 LIB64=/usr/lib/amd64/squeak/$PLUGIN_REV
 

--- a/components/runtime/squeak5c/tools/classify.pl
+++ b/components/runtime/squeak5c/tools/classify.pl
@@ -7,18 +7,18 @@
 # this script is used
 #
 # the script "classifies" plugins into currently 3 categories:
-#  - squeak-5c-nodisplay (only libc,libm math,libpthread, ksh)
-#  - squeak-5c-display-X11 (only x11,xext,xrender)
-#  - squeak-5c (ssl,ffi,pulseaudio freetype2,gnome, everything else)
+#  - cog-spur-nodisplay (only libc,libm math,libpthread, ksh)
+#  - cog-spur-display-X11 (only x11,xext,xrender)
+#  - cog-spur (ssl,ffi,pulseaudio freetype2,gnome, everything else)
 #
 # ./classify.pl < sample2.p5m
 #
 
-open(NODISPLAY,">>","squeak-5c-nodisplay.p5m") || die "Can't open squeak-5c-nodisplay.p5m";
+open(NODISPLAY,">>","cog-spur-nodisplay.p5m") || die "Can't open cog-spur-nodisplay.p5m";
 
-open(X11,">>","squeak-5c-display-X11.p5m") || die "Can't open squeak-5c-display-X11.p5m";
+open(X11,">>","cog-spur-display-X11.p5m") || die "Can't open cog-spur-display-X11.p5m";
 
-open(REST,">>","squeak-5c.p5m") || die "Can't open squeak-5c.p5m";
+open(REST,">>","cog-spur.p5m") || die "Can't open cog-spur.p5m";
 
 while (<>) {
 	if (/^#/) {


### PR DESCRIPTION

Rename squeak-5 to opensmalltalk/stack-spur
Rename squeak-5c to opensmalltalk/cog-spur

Update to opensmalltalk oscog-eem.2957  (the version 5.0.2957 corresponds to the VMMaker oscog-eem.2957)
