### PR TITLE
libp11: fix conflicting manifest actions

### DIFF
--- a/components/library/libp11/Makefile
+++ b/components/library/libp11/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libp11
 COMPONENT_VERSION=	0.4.11
+COMPONENT_REVISION=	1
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_FMRI=		library/security/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	System/Security
@@ -61,6 +62,6 @@ COMPONENT_PRE_INSTALL_ACTION = (\
 
 CONFIGURE_OPTIONS +=	--with-enginesdir=$(DEFENGINESDIR_$(BITS))
 
-REQUIRED_PACKAGES += SUNWcs
-REQUIRED_PACKAGES += system/library
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/security/openssl
+REQUIRED_PACKAGES += system/library

--- a/components/library/libp11/libp11.p5m
+++ b/components/library/libp11/libp11.p5m
@@ -42,12 +42,19 @@ file README.md path=usr/share/doc/libp11/README.libp11
 file path=usr/share/doc/libp11/NEWS
 
 # OpenSSL engine:
-file path=lib/openssl/default/engines/$(MACH64)/pkcs11.so
-link path=lib/openssl/default/engines/$(MACH64)/libpkcs11.so target=pkcs11.so
-link path=lib/openssl/engines/$(MACH64)/pkcs11.so target=../../default/engines/$(MACH64)/pkcs11.so
-link path=lib/openssl/engines/$(MACH64)/libpkcs11.so target=pkcs11.so
+# Using the lib paths doesn't work because they are only symbolic links provided by the openssl-1.0 package.
+# IPS doesn't allow us to use them:
+#file path=lib/openssl/default/engines/$(MACH64)/pkcs11.so
+#link path=lib/openssl/default/engines/$(MACH64)/libpkcs11.so target=pkcs11.so
+#link path=lib/openssl/engines/$(MACH64)/pkcs11.so target=../../default/engines/$(MACH64)/pkcs11.so
+#link path=lib/openssl/engines/$(MACH64)/libpkcs11.so target=pkcs11.so
+#file path=lib/openssl/default/engines/pkcs11.so
+#link path=lib/openssl/default/engines/libpkcs11.so target=pkcs11.so
+#link path=lib/openssl/engines/pkcs11.so target=../default/engines/pkcs11.so
+#link path=lib/openssl/engines/libpkcs11.so target=pkcs11.so
+# Instead, we'll use the regular paths:
+file lib/openssl/default/engines/$(MACH64)/pkcs11.so path=usr/openssl/1.0/lib/$(MACH64)/engines/pkcs11.so
+link path=usr/openssl/1.0/lib/$(MACH64)/engines/libpkcs11.so target=pkcs11.so pkg.linted.userland.action002.0=true
 
-file path=lib/openssl/default/engines/pkcs11.so
-link path=lib/openssl/default/engines/libpkcs11.so target=pkcs11.so
-link path=lib/openssl/engines/pkcs11.so target=../default/engines/pkcs11.so
-link path=lib/openssl/engines/libpkcs11.so target=pkcs11.so
+file lib/openssl/default/engines/pkcs11.so path=usr/openssl/1.0/lib/engines/pcks11.so
+link path=usr/openssl/1.0/lib/engines/libpkcs11.so target=pkcs11.so pkg.linted.userland.action002.0=true

--- a/components/library/libp11/pkg5
+++ b/components/library/libp11/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "library/security/openssl",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
Without these changes libp11 cannot be installed and the installation on the build server doesn't look correct as the pkcs11.so files are missing from the engines folders.
