### PR TITLE
openssl: fix links

### DIFF
--- a/components/library/openssl/openssl-1.0.2/Makefile
+++ b/components/library/openssl/openssl-1.0.2/Makefile
@@ -36,7 +36,7 @@ COMPONENT_VERSION =	1.0.2u
 # Version for IPS. It is easier to do it manually than convert the letter to a
 # number while taking into account that there might be no letter at all.
 IPS_COMPONENT_VERSION = 1.0.2.21
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_FMRI =	library/security/openssl
 COMPONENT_SUMMARY =	OpenSSL - a Toolkit for Secure Sockets Layer (SSL v2/v3) and Transport Layer (TLS v1) protocols and general purpose cryptographic library
 COMPONENT_CLASSIFICATION = System/Security

--- a/components/library/openssl/openssl-1.0.2/openssl-1.0.2.p5m
+++ b/components/library/openssl/openssl-1.0.2/openssl-1.0.2.p5m
@@ -71,10 +71,10 @@ link path=usr/lib/libcrypto.so target=libcrypto.so.1.0.0 mediator=openssl
 link path=usr/lib/libssl.so target=libssl.so.1.0.0 mediator=openssl
 
 # Default directory (compatibility)
-link path=lib/openssl/default target=../../../usr/openssl/1.0/lib
+link path=lib/openssl/default target=../../usr/openssl/1.0/lib
 
 # Engines directory (compatibility)
-link path=lib/openssl/engines target=../../../usr/openssl/1.0/lib/engines
+link path=lib/openssl/engines target=../../usr/openssl/1.0/lib/engines
 
 # OpenSSL binaries
 <transform file path=usr/openssl/1.0/bin/.* -> default mode 0555>


### PR DESCRIPTION
Checking the links in /lib/openssl/ revealed that there is one "../" too much in the targets. 