### PR TITLE
neofetch: add version 7.1.0

### DIFF
--- a/components/sysutils/neofetch/Makefile
+++ b/components/sysutils/neofetch/Makefile
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Benjamin S. Osenbach
+#
+
+BUILD_BITS=64 # for binaries or 32_and_64 for libraries
+BUILD_STYLE=justmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=neofetch
+COMPONENT_VERSION=7.1.0
+COMPONENT_SUMMARY= A command-line system information tool written in bash 3.2+
+COMPONENT_PROJECT_URL=https://github.com/dylanaraps/neofetch
+COMPONENT_FMRI=application/neofetch
+COMPONENT_CLASSIFICATION=Applications/System Utilities
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=https://github.com/dylanaraps/neofetch/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=sha256:58a95e6b714e41efc804eca389a223309169b2def35e57fa934482a6b47c27e7
+COMPONENT_LICENSE=MIT
+COMPONENT_LICENSE_FILE=neofetch.license
+TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
+include $(WS_MAKE_RULES)/common.mk
+
+# Build dependencies
+REQUIRED_PACKAGES+=shell/bash
+# Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs

--- a/components/sysutils/neofetch/manifests/sample-manifest.p5m
+++ b/components/sysutils/neofetch/manifests/sample-manifest.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/neofetch
+file path=usr/share/man/man1/neofetch.1

--- a/components/sysutils/neofetch/neofetch.license
+++ b/components/sysutils/neofetch/neofetch.license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2020 Dylan Araps
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/sysutils/neofetch/neofetch.p5m
+++ b/components/sysutils/neofetch/neofetch.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Benjamin S. Osenbach
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/neofetch
+file path=usr/share/man/man1/neofetch.1

--- a/components/sysutils/neofetch/patches/01-fix-pkginfo.patch
+++ b/components/sysutils/neofetch/patches/01-fix-pkginfo.patch
@@ -1,0 +1,11 @@
+--- neofetch-7.1.0/neofetch.orig	2020-08-02 11:37:41.000000000 +0000
++++ neofetch-7.1.0/neofetch	2021-05-28 10:44:45.728131406 +0000
+@@ -1545,6 +1545,9 @@
+             case $kernel_name in
+                 FreeBSD|DragonFly) has pkg && tot pkg info ;;
+ 
++		SunOS)
++			has pkg && tot pkg list ;;
++
+                 *)
+                     has pkg && dir /var/db/pkg/*

--- a/components/sysutils/neofetch/pkg5
+++ b/components/sysutils/neofetch/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/bash",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "application/neofetch"
+    ],
+    "name": "neofetch"
+}


### PR DESCRIPTION
Adding `neofetch`, a bash utility for displaying system information