### PR TITLE
nspr: update to 4.31

### DIFF
--- a/components/library/mozilla-nspr/Makefile
+++ b/components/library/mozilla-nspr/Makefile
@@ -18,11 +18,11 @@ BUILD_BITS=			32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         nspr
-COMPONENT_VERSION=      4.30
+COMPONENT_VERSION=      4.31
 COMPONENT_PROJECT_URL=  https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:8d4cd8f8409484dc4c3d31e180354bfc506573eccf86cd691106a1ef7edc913b
+COMPONENT_ARCHIVE_HASH= sha256:5729da87d5fbf1584b72840751e0c6f329b5d541850cacd1b61652c95015abc8
 COMPONENT_ARCHIVE_URL=  https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$(COMPONENT_VERSION)/src/$(COMPONENT_ARCHIVE)
 
 include $(WS_MAKE_RULES)/common.mk

--- a/components/library/mozilla-nspr/pkg5
+++ b/components/library/mozilla-nspr/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "shell/ksh93",
         "system/library",
         "text/xmlto"
     ],


### PR DESCRIPTION
desktop still works (eg. pidgin).