### PR TITLE
squeak,cog-spur: split ssl plugin in its own pkg

### DIFF
--- a/components/runtime/squeak4/Makefile
+++ b/components/runtime/squeak4/Makefile
@@ -49,7 +49,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.19.6
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -113,6 +113,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 
 rebuild-manifests::
 	cp manifests/squeak.p5m squeak.p5m
+	cp manifests/squeak-ssl.p5m squeak-ssl.p5m
 	cp manifests/squeak-display-X11.p5m squeak-display-X11.p5m
 	cp manifests/squeak-nodisplay.p5m squeak-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m

--- a/components/runtime/squeak4/manifests/squeak-ssl.p5m
+++ b/components/runtime/squeak4/manifests/squeak-ssl.p5m
@@ -13,8 +13,7 @@
 # Copyright 2020, 2021 David Stes
 #
 
-
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,14 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
+depend type=require fmri=pkg:/runtime/smalltalk/squeak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-# the minimal installation consists of the stack-spur-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak4/manifests/squeak.p5m
+++ b/components/runtime/squeak4/manifests/squeak.p5m
@@ -30,5 +30,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
+depend type=require fmri=pkg:/runtime/smalltalk/squeak-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 depend type=require fmri=pkg:/runtime/smalltalk/squeak-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak4/pkg5
+++ b/components/runtime/squeak4/pkg5
@@ -22,7 +22,8 @@
     "fmris": [
         "runtime/smalltalk/squeak",
         "runtime/smalltalk/squeak-display-X11",
-        "runtime/smalltalk/squeak-nodisplay"
+        "runtime/smalltalk/squeak-nodisplay",
+        "runtime/smalltalk/squeak-ssl"
     ],
     "name": "squeak"
 }

--- a/components/runtime/squeak4/squeak-ssl.p5m
+++ b/components/runtime/squeak4/squeak-ssl.p5m
@@ -13,8 +13,7 @@
 # Copyright 2020, 2021 David Stes
 #
 
-
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,14 +23,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
+depend type=require fmri=pkg:/runtime/smalltalk/squeak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-# the minimal installation consists of the stack-spur-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
 
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakSSL

--- a/components/runtime/squeak4/squeak.p5m
+++ b/components/runtime/squeak4/squeak.p5m
@@ -30,6 +30,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
+depend type=require fmri=pkg:/runtime/smalltalk/squeak-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 depend type=require fmri=pkg:/runtime/smalltalk/squeak-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.DBusPlugin
@@ -40,7 +41,6 @@ file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Mpeg3Plugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.RomePlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ScratchPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UUIDPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnicodePlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-custom
@@ -54,7 +54,6 @@ file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.Mpeg3Plugin path=us
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.RomePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.RomePlugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ScratchPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ScratchPlugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakFFIPrims path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakSSL path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UUIDPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UUIDPlugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.UnicodePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.UnicodePlugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-display-custom path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-custom

--- a/components/runtime/squeak4/tools/classify.pl
+++ b/components/runtime/squeak4/tools/classify.pl
@@ -24,6 +24,8 @@ open(NODISPLAY,">>","squeak-nodisplay.p5m") || die "Can't open squeak-nodisplay.
 
 open(X11,">>","squeak-display-X11.p5m") || die "Can't open squeak-display-X11.p5m";
 
+open(SSL,">>","squeak-ssl.p5m") || die "Can't open squeak-ssl.p5m";
+
 open(REST,">>","squeak.p5m") || die "Can't open squeak.p5m";
 
 while (<>) {
@@ -60,6 +62,8 @@ while (<>) {
 			print X11 $_;
 		} elsif (/Squeak3D/) {
 			print X11 $_;
+		} elsif (/SqueakSSL/) {
+			print SSL $_;
 		} elsif (/B3DAcceleratorPlugin/) {
 			print X11 $_;
 		} elsif (/UnixOSProcessPlugin/) {

--- a/components/runtime/squeak5/Makefile
+++ b/components/runtime/squeak5/Makefile
@@ -35,7 +35,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		stack-spur
 COMPONENT_VERSION=	5.0.2957
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 GIT_TAG=		sun-v5.0.29
 PLUGIN_REV=		5.0-202105050900
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
@@ -55,10 +55,6 @@ COMPONENT_ARCHIVE_HASH=	sha256:6975d8be2d8f4cf80c6f5ca60f14550325b6406f3be7b1bcd
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 TEST_TARGET= $(NO_TESTS)
-
-# some builds seem to be broken with -Bdirect
-# but issue is not reproducable
-# LD_B_DIRECT=
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -82,8 +78,7 @@ CPPFLAGS += $(CPP_LARGEFILES)
 
 # the default CFLAGS.gcc will be -m64 -O3 but this does not work for us
 # opensmalltalk code is not compatible with the gcc optimizer -O2 or higher
-# also the -g (debug) flag is intentional, perhaps omit-frame-pointer issues
-gcc_OPT=		-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0
+gcc_OPT=		-DAIO_DEBUG -DNDEBUG -DDEBUGVM=0
 
 CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/config/configure
 CONFIGURE_OPTIONS +=	--with-vmversion=5.0
@@ -115,6 +110,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 
 rebuild-manifests::
 	cp manifests/stack-spur.p5m stack-spur.p5m
+	cp manifests/stack-spur-ssl.p5m stack-spur-ssl.p5m
 	cp manifests/stack-spur-display-X11.p5m stack-spur-display-X11.p5m
 	cp manifests/stack-spur-nodisplay.p5m stack-spur-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m

--- a/components/runtime/squeak5/manifests/stack-spur-ssl.p5m
+++ b/components/runtime/squeak5/manifests/stack-spur-ssl.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,14 +24,5 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
-
-# the minimal installation consists of the stack-spur-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak5/pkg5
+++ b/components/runtime/squeak5/pkg5
@@ -22,7 +22,8 @@
     "fmris": [
         "runtime/smalltalk/stack-spur",
         "runtime/smalltalk/stack-spur-display-X11",
-        "runtime/smalltalk/stack-spur-nodisplay"
+        "runtime/smalltalk/stack-spur-nodisplay",
+        "runtime/smalltalk/stack-spur-ssl"
     ],
     "name": "stack-spur"
 }

--- a/components/runtime/squeak5/squeak.ips
+++ b/components/runtime/squeak5/squeak.ips
@@ -1,54 +1,180 @@
 #!/bin/sh
-#
-# Loosely based on Ian Piumarta's SqueakV4 wrapper script
-# this script also uses the 'ckformat' binary to check the Squeak image
-# and then launches a 32bit or 64bit vm (based on ckformat)
-#
-# The script then sets the LD_LIBRARY_PATH to the SQUEAK_PLUGINS directory.
+# 
+# Launch squeakvm from the command line or a menu script, with a good
+# plugin path, text encodings and pulseaudio kludge
+# 
+# Last edited: 2013-11-13 19:51:35 by piumarta on emilia
 
-CK=/usr/bin/ckformat
-DBX=
+PATH=/usr/bin:/bin
 PLUGIN_REV=5.0-202105050900
-LIB32=/usr/lib/squeak/$PLUGIN_REV
-LIB64=/usr/lib/amd64/squeak/$PLUGIN_REV
 
-if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
-	SQUEAK_PLUGINS="$LIB32"
-	export SQUEAK_PLUGINS
+realpath () {
+    path="$1"
+    while test -L "${path}"; do
+	dir=`dirname "${path}"`
+	dir=`cd "${dir}" && pwd -P`
+	path=`basename "${path}"`
+	path=`ls -l "${dir}/${path}" | sed 's,.* -> ,,'`
+	if test `expr "${path}" : "/"` -eq 0; then
+	    path="${dir}/${path}"
+	fi
+    done
+    if test -d "${path}"; then
+	(cd "${path}" && pwd -P)
+    else
+	dir=`dirname "${path}"`
+	base=`basename "${path}"`
+	(cd "${dir}" && echo "`pwd -P`/${base}")
+    fi
+}
+
+bindir=`realpath "${0}"`
+bindir=`dirname  "${bindir}"`
+prefix=`dirname  "${bindir}"`
+libdir="${prefix}/lib/squeak"
+plgdir="${libdir}/$PLUGIN_REV"
+useoss="false"
+ck="ckformat"
+squeakvm="squeak"
+squeakvm64="squeak"
+plgd64="${prefix}/lib/amd64/squeak/$PLUGIN_REV"
+cogvm=""
+cogvm64=""
+vm=""
+plugins=""
+wrapper=""
+image=""
+format=""
+info=""
+jit=""
+
+# look for VM options affecting this script's behaviour
+
+options () {
+    while test "$#" -gt "0"; do
+	case $1 in
+	    -vm-sound*)     useoss="false";;
+	    -vm)            shift; case "$1" in sound*) useoss="false"; esac;;
+            -image-info)    info="true";;
+	    --)		    break;;
+	    *)		    if test ! "$image" -a \( -f "$1.image" -o -f "$1" \); then image="$1"; fi;;
+	esac
+	shift
+    done
+}
+
+case "$1" in
+    -jit)	jit=$1; shift; squeakvm=""; squeakvm64="";;
+    -nojit)	jit=$1; shift; cogvm=""; cogvm64="";;
+esac
+
+options "$@"
+
+# try to find the image file format
+
+if   test -x "${plgd64}/${ck}"; then ck="${plgd64}/${ck}"
+elif test -x "${plgdir}/${ck}"; then ck="${plgdir}/${ck}"
+elif test -x "${libdir}/${ck}"; then ck="${libdir}/${ck}"
+elif test -x "${bindir}/${ck}"; then ck="${bindir}/${ck}"
+elif test -x "`which ${ck}`";	then ck="`which ${ck}`"
 fi
 
-while test "$#" -gt "0"; do
-case $1 in
-  -dbx)
-	DBX='dbx -C'
-        ;;
-  -gdb)
-	DBX='gdb'
-        ;;
-  --)   break;; # pass to VM
-   *)   if test ! "$image" -a \( -f "$1.image" -o -f "$1" \); then image="$1"; fi;;
-esac
-shift
-done
+if test   -z "${image}";	then image="${SQUEAK_IMAGE}"; fi
+if test   -z "${image}";	then image="squeak";	      fi
+if test   -f "${image}.image";	then image="${image}.image";  fi
 
-# set the image
+if test "${info}"; then
+    if test ! -x "${ck}"; then
+	echo "cannot find executable file: ${ck}" >&2
+	exit 1
+    fi
+    if test ! -f "${image}"; then
+	echo "cannot find image file: ${image}" >&2
+	exit 1
+    fi
+    exec "${ck}" "${image}"
+fi
 
-if test   -z "${image}";        then image="${SQUEAK_IMAGE}"; fi
-if test   -z "${image}";        then image="squeak";          fi
-if test   -f "${image}.image";  then image="${image}.image";  fi
-
-if test -x "${CK}" -a -f "${image}"; then
-    format=`"${CK}" "${image}"`
+if test -x "${ck}" -a -f "${image}"; then
+    format=`"${ck}" "${image}"`
     case "${format}" in
-        6521) 
-  	  export SQUEAK_PLUGINS="$LIB32";;
-        68021)  
-  	  export SQUEAK_PLUGINS="$LIB64";;
-        *)  echo "Unknown Squeak image format ${format}";exit 0;;
+	6521)	vms="${squeakvm}";;
+	68021)	vms="${squeakvm64}"; plgdir="${plgd64}";;
+	*)	vms="${squeakvm}";;
     esac
 else
-    echo "No image found, run default VM with args"
+    vms="${squeakvm}" # no image found, run default VM with args
 fi
 
-LD_LIBRARY_PATH="${SQUEAK_PLUGINS}:${LD_LIBRARY_PATH}" exec $DBX "$SQUEAK_PLUGINS/squeak" $image
+# find the vm and set the plugin path
 
+if test -z "${vms}"; then
+    echo "cannot find VM to run image '${image}' with option '${jit}'" >&2
+    exit 1
+fi
+
+for avm in ${vms}; do
+    #echo CHECKING ${avm}
+    if test -x "${plgdir}/${avm}"; then	# bin/squeak -> lib/squeak/x.y-z/squeakvm
+	vm="${plgdir}/${avm}"
+	plugins="${plgdir}"
+	break;
+    elif test -x "${bindir}/${avm}"; then	# bld/squeak -> bld/squeakvm
+	vm="${bindir}/${avm}"
+	plugins="${bindir}/%n"
+	break;
+    elif test -x "`which ${avm}`"; then
+	vm="`which ${avm}`"
+	plugins=""
+	break;
+    fi
+done
+
+if test -z "${vm}"; then
+    echo "cannot find executable file: ${vms}" >&2
+    exit 1
+fi
+
+# command-line overrides environment, so communicate anything we decide here via the environment
+
+if test -z "${SQUEAK_PATHENC}";  then SQUEAK_PATHENC="UTF-8";  export SQUEAK_PATHENC;  fi
+if test -z "${SQUEAK_ENCODING}"; then SQUEAK_ENCODING="UTF-8"; export SQUEAK_ENCODING; fi
+
+if test -z "${SQUEAK_PLUGINS}"; then
+    if test -n "${plugins}"; then
+	SQUEAK_PLUGINS="${plugins}"
+	export SQUEAK_PLUGINS
+    fi
+fi
+
+# deal with pulseaudio if it is running
+
+if test -z "${SQUEAK_VM}"; then
+    if ${useoss}; then
+	if pulseaudio --check 2>/dev/null; then
+	    if padsp true 2>/dev/null; then
+		wrapper="padsp"
+		SQUEAK_VM="sound-OSS"
+		export SQUEAK_VM
+	    fi
+	fi
+    fi
+fi
+
+# fix broken locales
+
+if test -z "$LC_ALL"; then
+    LC_ALL="$LANG"
+    export LC_ALL
+fi
+
+# debug output
+
+if test "0$SQUEAK_DEBUG" -gt "0"; then
+    set | fgrep SQUEAK_
+    set -x
+fi
+
+# run the vm
+
+exec ${wrapper} "${vm}" "$@"

--- a/components/runtime/squeak5/stack-spur-ssl.p5m
+++ b/components/runtime/squeak5/stack-spur-ssl.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,14 +24,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-# the minimal installation consists of the stack-spur-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so

--- a/components/runtime/squeak5/stack-spur.p5m
+++ b/components/runtime/squeak5/stack-spur.p5m
@@ -32,19 +32,18 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
+depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/LocalePlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UUIDPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnicodePlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-pulse.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/LocalePlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/UUIDPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/UnicodePlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-pulse.so

--- a/components/runtime/squeak5/tools/classify.pl
+++ b/components/runtime/squeak5/tools/classify.pl
@@ -18,6 +18,8 @@ open(NODISPLAY,">>","stack-spur-nodisplay.p5m") || die "Can't open stack-spur-no
 
 open(X11,">>","stack-spur-display-X11.p5m") || die "Can't open stack-spur-display-X11.p5m";
 
+open(SSL,">>","stack-spur-ssl.p5m") || die "Can't open stack-spur-ssl.p5m";
+
 open(REST,">>","stack-spur.p5m") || die "Can't open stack-spur.p5m";
 
 while (<>) {
@@ -58,6 +60,8 @@ while (<>) {
 			print X11 $_;
 		} elsif (/Squeak3D/) {
 			print X11 $_;
+		} elsif (/SqueakSSL/) {
+			print SSL $_;
 		} elsif (/B3DAcceleratorPlugin/) {
 			print X11 $_;
 		} elsif (/UnixOSProcessPlugin/) {

--- a/components/runtime/squeak5c/Makefile
+++ b/components/runtime/squeak5c/Makefile
@@ -29,7 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.2957
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 GIT_TAG=		sun-v5.0.29
 PLUGIN_REV=		5.0-202105050900-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine
@@ -49,10 +49,6 @@ COMPONENT_ARCHIVE_HASH=	sha256:6975d8be2d8f4cf80c6f5ca60f14550325b6406f3be7b1bcd
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 TEST_TARGET= $(NO_TESTS)
-
-# some builds seem to be broken with -Bdirect
-# but issue is not reproducable
-# LD_B_DIRECT=
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -76,8 +72,7 @@ CPPFLAGS += $(CPP_LARGEFILES)
 
 # the default CFLAGS.gcc will be -m64 -O3 but this does not work for us
 # opensmalltalk code is not compatible with the gcc optimizer -O2 or higher
-# also the -g (debug) flag is intentional, perhaps omit-frame-pointer issues
-gcc_OPT=		-g -DAIO_DEBUG -DNDEBUG -DDEBUGVM=0 -DCOGMTVM=0
+gcc_OPT=		-DAIO_DEBUG -DNDEBUG -DDEBUGVM=0 -DCOGMTVM=0
 
 CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/config/configure
 CONFIGURE_OPTIONS +=	--without-npsqueak
@@ -107,6 +102,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 
 rebuild-manifests::
 	cp manifests/cog-spur.p5m cog-spur.p5m
+	cp manifests/cog-spur-ssl.p5m cog-spur-ssl.p5m
 	cp manifests/cog-spur-display-X11.p5m cog-spur-display-X11.p5m
 	cp manifests/cog-spur-nodisplay.p5m cog-spur-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m

--- a/components/runtime/squeak5c/cog-spur-ssl.p5m
+++ b/components/runtime/squeak5c/cog-spur-ssl.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,14 +24,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-# the minimal installation consists of the stack-spur-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so

--- a/components/runtime/squeak5c/cog-spur.p5m
+++ b/components/runtime/squeak5c/cog-spur.p5m
@@ -34,19 +34,18 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/LocalePlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UUIDPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/UnicodePlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-sound-pulse.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/FileAttributesPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/LocalePlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakFFIPrims.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/UUIDPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/UnicodePlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/vm-sound-pulse.so

--- a/components/runtime/squeak5c/manifests/cog-spur-ssl.p5m
+++ b/components/runtime/squeak5c/manifests/cog-spur-ssl.p5m
@@ -14,7 +14,7 @@
 #
 
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,14 +24,5 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# for the sound plugins, we only package vm-sound-pulse
-# we do not package vm-sound-OSS and vm-sound-Sun
-# on my machine, vm-sound-Sun compiles, but it does not work
-
-# the minimal installation consists of the stack-spur-nodisplay package
-# which can run "headless" squeak -nodisplay images
-# with only minimal installation requirements (only ksh, libc, math)
-
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak5c/manifests/cog-spur.p5m
+++ b/components/runtime/squeak5c/manifests/cog-spur.p5m
@@ -34,5 +34,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # which can run "headless" squeak -nodisplay images
 # with only minimal installation requirements (only ksh, libc, math)
 
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 

--- a/components/runtime/squeak5c/pkg5
+++ b/components/runtime/squeak5c/pkg5
@@ -22,7 +22,8 @@
     "fmris": [
         "runtime/smalltalk/cog-spur",
         "runtime/smalltalk/cog-spur-display-X11",
-        "runtime/smalltalk/cog-spur-nodisplay"
+        "runtime/smalltalk/cog-spur-nodisplay",
+        "runtime/smalltalk/cog-spur-ssl"
     ],
     "name": "cog-spur"
 }

--- a/components/runtime/squeak5c/squeak.ips
+++ b/components/runtime/squeak5c/squeak.ips
@@ -1,54 +1,180 @@
 #!/bin/sh
-#
-# Loosely based on Ian Piumarta's SqueakV4 wrapper script
-# this script also uses the 'ckformat' binary to check the Squeak image
-# and then launches a 32bit or 64bit vm (based on ckformat)
-#
-# The script then sets the LD_LIBRARY_PATH to the SQUEAK_PLUGINS directory.
+# 
+# Launch squeakvm from the command line or a menu script, with a good
+# plugin path, text encodings and pulseaudio kludge
+# 
+# Last edited: 2013-11-13 19:51:35 by piumarta on emilia
 
-CK=/usr/bin/ckformat5c
-DBX=
+PATH=/usr/bin:/bin
 PLUGIN_REV=5.0-202105050900-cog
-LIB32=/usr/lib/squeak/$PLUGIN_REV
-LIB64=/usr/lib/amd64/squeak/$PLUGIN_REV
 
-if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
-	SQUEAK_PLUGINS="$LIB32"
-	export SQUEAK_PLUGINS
+realpath () {
+    path="$1"
+    while test -L "${path}"; do
+	dir=`dirname "${path}"`
+	dir=`cd "${dir}" && pwd -P`
+	path=`basename "${path}"`
+	path=`ls -l "${dir}/${path}" | sed 's,.* -> ,,'`
+	if test `expr "${path}" : "/"` -eq 0; then
+	    path="${dir}/${path}"
+	fi
+    done
+    if test -d "${path}"; then
+	(cd "${path}" && pwd -P)
+    else
+	dir=`dirname "${path}"`
+	base=`basename "${path}"`
+	(cd "${dir}" && echo "`pwd -P`/${base}")
+    fi
+}
+
+bindir=`realpath "${0}"`
+bindir=`dirname  "${bindir}"`
+prefix=`dirname  "${bindir}"`
+libdir="${prefix}/lib/squeak"
+plgdir="${libdir}/$PLUGIN_REV"
+useoss="false"
+ck="ckformat"
+squeakvm="squeak"
+squeakvm64="squeak"
+plgd64="${prefix}/lib/amd64/squeak/$PLUGIN_REV"
+cogvm=""
+cogvm64=""
+vm=""
+plugins=""
+wrapper=""
+image=""
+format=""
+info=""
+jit=""
+
+# look for VM options affecting this script's behaviour
+
+options () {
+    while test "$#" -gt "0"; do
+	case $1 in
+	    -vm-sound*)     useoss="false";;
+	    -vm)            shift; case "$1" in sound*) useoss="false"; esac;;
+            -image-info)    info="true";;
+	    --)		    break;;
+	    *)		    if test ! "$image" -a \( -f "$1.image" -o -f "$1" \); then image="$1"; fi;;
+	esac
+	shift
+    done
+}
+
+case "$1" in
+    -jit)	jit=$1; shift; squeakvm=""; squeakvm64="";;
+    -nojit)	jit=$1; shift; cogvm=""; cogvm64="";;
+esac
+
+options "$@"
+
+# try to find the image file format
+
+if   test -x "${plgd64}/${ck}"; then ck="${plgd64}/${ck}"
+elif test -x "${plgdir}/${ck}"; then ck="${plgdir}/${ck}"
+elif test -x "${libdir}/${ck}"; then ck="${libdir}/${ck}"
+elif test -x "${bindir}/${ck}"; then ck="${bindir}/${ck}"
+elif test -x "`which ${ck}`";	then ck="`which ${ck}`"
 fi
 
-while test "$#" -gt "0"; do
-case $1 in
-  -dbx)
-	DBX='dbx -C'
-        ;;
-  -gdb)
-	DBX='gdb'
-        ;;
-  --)   break;; # pass to VM
-   *)   if test ! "$image" -a \( -f "$1.image" -o -f "$1" \); then image="$1"; fi;;
-esac
-shift
-done
+if test   -z "${image}";	then image="${SQUEAK_IMAGE}"; fi
+if test   -z "${image}";	then image="squeak";	      fi
+if test   -f "${image}.image";	then image="${image}.image";  fi
 
-# set the image
+if test "${info}"; then
+    if test ! -x "${ck}"; then
+	echo "cannot find executable file: ${ck}" >&2
+	exit 1
+    fi
+    if test ! -f "${image}"; then
+	echo "cannot find image file: ${image}" >&2
+	exit 1
+    fi
+    exec "${ck}" "${image}"
+fi
 
-if test   -z "${image}";        then image="${SQUEAK_IMAGE}"; fi
-if test   -z "${image}";        then image="squeak";          fi
-if test   -f "${image}.image";  then image="${image}.image";  fi
-
-if test -x "${CK}" -a -f "${image}"; then
-    format=`"${CK}" "${image}"`
+if test -x "${ck}" -a -f "${image}"; then
+    format=`"${ck}" "${image}"`
     case "${format}" in
-        6521) 
-  	  export SQUEAK_PLUGINS="$LIB32";;
-        68021)  
-  	  export SQUEAK_PLUGINS="$LIB64";;
-        *)  echo "Unknown Squeak image format ${format}";exit 0;;
+	6521)	vms="${squeakvm}";;
+	68021)	vms="${squeakvm64}"; plgdir="${plgd64}";;
+	*)	vms="${squeakvm}";;
     esac
 else
-    echo "No image found, run default VM with args"
+    vms="${squeakvm}" # no image found, run default VM with args
 fi
 
-LD_LIBRARY_PATH="${SQUEAK_PLUGINS}:${LD_LIBRARY_PATH}" exec $DBX "$SQUEAK_PLUGINS/squeak" $image
+# find the vm and set the plugin path
 
+if test -z "${vms}"; then
+    echo "cannot find VM to run image '${image}' with option '${jit}'" >&2
+    exit 1
+fi
+
+for avm in ${vms}; do
+    #echo CHECKING ${avm}
+    if test -x "${plgdir}/${avm}"; then	# bin/squeak -> lib/squeak/x.y-z/squeakvm
+	vm="${plgdir}/${avm}"
+	plugins="${plgdir}"
+	break;
+    elif test -x "${bindir}/${avm}"; then	# bld/squeak -> bld/squeakvm
+	vm="${bindir}/${avm}"
+	plugins="${bindir}/%n"
+	break;
+    elif test -x "`which ${avm}`"; then
+	vm="`which ${avm}`"
+	plugins=""
+	break;
+    fi
+done
+
+if test -z "${vm}"; then
+    echo "cannot find executable file: ${vms}" >&2
+    exit 1
+fi
+
+# command-line overrides environment, so communicate anything we decide here via the environment
+
+if test -z "${SQUEAK_PATHENC}";  then SQUEAK_PATHENC="UTF-8";  export SQUEAK_PATHENC;  fi
+if test -z "${SQUEAK_ENCODING}"; then SQUEAK_ENCODING="UTF-8"; export SQUEAK_ENCODING; fi
+
+if test -z "${SQUEAK_PLUGINS}"; then
+    if test -n "${plugins}"; then
+	SQUEAK_PLUGINS="${plugins}"
+	export SQUEAK_PLUGINS
+    fi
+fi
+
+# deal with pulseaudio if it is running
+
+if test -z "${SQUEAK_VM}"; then
+    if ${useoss}; then
+	if pulseaudio --check 2>/dev/null; then
+	    if padsp true 2>/dev/null; then
+		wrapper="padsp"
+		SQUEAK_VM="sound-OSS"
+		export SQUEAK_VM
+	    fi
+	fi
+    fi
+fi
+
+# fix broken locales
+
+if test -z "$LC_ALL"; then
+    LC_ALL="$LANG"
+    export LC_ALL
+fi
+
+# debug output
+
+if test "0$SQUEAK_DEBUG" -gt "0"; then
+    set | fgrep SQUEAK_
+    set -x
+fi
+
+# run the vm
+
+exec ${wrapper} "${vm}" "$@"

--- a/components/runtime/squeak5c/tools/classify.pl
+++ b/components/runtime/squeak5c/tools/classify.pl
@@ -18,6 +18,8 @@ open(NODISPLAY,">>","cog-spur-nodisplay.p5m") || die "Can't open cog-spur-nodisp
 
 open(X11,">>","cog-spur-display-X11.p5m") || die "Can't open cog-spur-display-X11.p5m";
 
+open(SSL,">>","cog-spur-ssl.p5m") || die "Can't open cog-spur-ssl.p5m";
+
 open(REST,">>","cog-spur.p5m") || die "Can't open cog-spur.p5m";
 
 while (<>) {
@@ -58,6 +60,8 @@ while (<>) {
 			print X11 $_;
 		} elsif (/Squeak3D/) {
 			print X11 $_;
+		} elsif (/SqueakSSL/) {
+			print SSL $_;
 		} elsif (/B3DAcceleratorPlugin/) {
 			print X11 $_;
 		} elsif (/UnixOSProcessPlugin/) {


### PR DESCRIPTION
installation of cog-spur-ssl  gives a basic minimal runtime with the SSL plugin but without any other plugins