### PR TITLE
pytest: fix mediator

### DIFF
--- a/components/python/pytest/Makefile
+++ b/components/python/pytest/Makefile
@@ -29,7 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pytest
 COMPONENT_VERSION=	6.1.2
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_FMRI=		library/python/pytest
 COMPONENT_CLASSIFICATION=Development/Python
 COMPONENT_SUMMARY=	pytest: simple powerful testing with Python

--- a/components/python/pytest/pkg5
+++ b/components/python/pytest/pkg5
@@ -7,7 +7,8 @@
         "library/python/setuptools-39",
         "runtime/python-35",
         "runtime/python-37",
-        "runtime/python-39"
+        "runtime/python-39",
+        "shell/ksh93"
     ],
     "fmris": [
         "library/python/pytest-35",

--- a/components/python/pytest/pytest-PYVER.p5m
+++ b/components/python/pytest/pytest-PYVER.p5m
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2021 Aurelien Larcher
+# Copyright 2021 Nona Hansel
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -37,9 +38,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 #
 file path=usr/bin/py.test-$(PYVER)
 file path=usr/bin/pytest-$(PYVER)
-link path=usr/bin/py.test target=py.test-$(PYVER) mediator=python \
+link path=usr/bin/py.test target=py.test-$(PYVER) mediator=python3 \
     mediator-version=$(PYVER)
-link path=usr/bin/pytest target=pytest-$(PYVER) mediator=python \
+link path=usr/bin/pytest target=pytest-$(PYVER) mediator=python3 \
     mediator-version=$(PYVER)
 file path=usr/lib/python$(PYVER)/vendor-packages/_pytest/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/_pytest/_argcomplete.py


### PR DESCRIPTION
Pytest is build only for Python3 therefore the mediator needs to be set to Python3 otherwise the link `/usr/bin/pytest` doesn't exist.
