### PR TITLE
Upgrade of dtrace/toolkit to python 3.7

### DIFF
--- a/components/developer/dtracetoolkit/Makefile
+++ b/components/developer/dtracetoolkit/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2021 Gary Mills
 # Copyright (c) 2014 Alexander Pyhalov
 #
 
@@ -16,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		DTraceToolkit
 COMPONENT_VERSION=	0.99
-COMPONENT_REVISION=	4	
+COMPONENT_REVISION=	5	
 COMPONENT_PROJECT_URL=	http://www.brendangregg.com/dtracetoolkit.html
 COMPONENT_SUMMARY=	A collection of opensource dtrace scripts
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/developer/dtracetoolkit/dtracetoolkit.p5m
+++ b/components/developer/dtracetoolkit/dtracetoolkit.p5m
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2021 Gary Mills
 # Copyright 2014 Alexander Pyhalov. All rights reserved.
 #
 
@@ -28,10 +29,10 @@ license License license='CDDL v1.0'
 <transform file path=opt/DTT/Code/.*\.rb$ -> default mode 0555>
 <transform file path=opt/DTT/Code/.*\.sh$ -> default mode 0555>
 
-# Depend on python-27 explicitly, so we can disconnect userland from
-# python-26 once and for all.
+# Depend on python-37 explicitly, so we can disconnect userland from
+# python-27 once and for all.
 <transform file path=opt/DTT/.*\.py$ -> default pkg.depend.bypass-generate .*>
-depend fmri=runtime/python-27 type=require
+depend fmri=runtime/python-37 type=require
 
 file path=opt/DTT/Apps/Readme
 file path=opt/DTT/Apps/httpdstat.d

--- a/components/developer/dtracetoolkit/manifests/sample-manifest.p5m
+++ b/components/developer/dtracetoolkit/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -273,7 +273,9 @@ file path=opt/DTT/Code/Perl/hello_strict.pl
 file path=opt/DTT/Code/Perl/hello_strict.pl.~1~
 file path=opt/DTT/Code/Php/func_abc.php
 file path=opt/DTT/Code/Python/func_abc.py
+file path=opt/DTT/Code/Python/func_abc.py.~1~
 file path=opt/DTT/Code/Python/func_slow.py
+file path=opt/DTT/Code/Python/func_slow.py.~1~
 file path=opt/DTT/Code/Readme
 file path=opt/DTT/Code/Ruby/func_abc.rb
 file path=opt/DTT/Code/Ruby/func_abc.rb.~1~

--- a/components/developer/dtracetoolkit/patches/python3.patch
+++ b/components/developer/dtracetoolkit/patches/python3.patch
@@ -1,0 +1,55 @@
+--- DTraceToolkit-0.99/Code/Python/func_abc.py-orig	Sat Sep 15 00:48:11 2007
++++ DTraceToolkit-0.99/Code/Python/func_abc.py	Fri Jun 25 12:55:38 2021
+@@ -1,18 +1,18 @@
+-#!/usr/bin/python
++#!/usr/bin/python3.7
+ 
+ import time
+ 
+ def func_c():
+-	print "Function C"	
++	print("Function C")	
+ 	time.sleep(1)
+ 
+ def func_b():
+-	print "Function B"
++	print("Function B")
+ 	time.sleep(1)
+ 	func_c()
+ 
+ def func_a():
+-	print "Function A"
++	print("Function A")
+ 	time.sleep(1)
+ 	func_b()
+ 
+--- DTraceToolkit-0.99/Code/Python/func_slow.py-orig	Sat Sep 15 00:48:11 2007
++++ DTraceToolkit-0.99/Code/Python/func_slow.py	Fri Jun 25 12:56:04 2021
+@@ -1,7 +1,7 @@
+-#!/usr/bin/python
++#!/usr/bin/python3.7
+ 
+ def func_c():
+-	print "Function C"
++	print("Function C")
+ 	i = 0
+ 	while (i < 3000000):
+ 		i = i + 1
+@@ -8,7 +8,7 @@
+ 		j = i + 1
+ 
+ def func_b():
+-	print "Function B"
++	print("Function B")
+ 	i = 0
+ 	while (i < 2000000):
+ 		i = i + 1
+@@ -16,7 +16,7 @@
+ 	func_c()
+ 
+ def func_a():
+-	print "Function A"
++	print("Function A")
+ 	i = 0
+ 	while (i < 1000000):
+ 		i = i + 1

--- a/components/developer/dtracetoolkit/patches/shebang.patch
+++ b/components/developer/dtracetoolkit/patches/shebang.patch
@@ -87,21 +87,3 @@ diff -ur DTraceToolkit-0.99/Code/Shell/func_waste.sh DTraceToolkit-0.99-1/Code/S
  
  func_c()
  {
-diff -ruN DTraceToolkit-0.99.orig/Code/Python/func_abc.py DTraceToolkit-0.99/Code/Python/func_abc.py
---- DTraceToolkit-0.99.orig/Code/Python/func_abc.py	2007-09-15 09:48:11.000000000 +0400
-+++ DTraceToolkit-0.99/Code/Python/func_abc.py	2016-08-17 15:13:28.470546645 +0300
-@@ -1,4 +1,4 @@
--#!/usr/bin/python
-+#!/usr/bin/python2.7
- 
- import time
- 
-diff -ruN DTraceToolkit-0.99.orig/Code/Python/func_slow.py DTraceToolkit-0.99/Code/Python/func_slow.py
---- DTraceToolkit-0.99.orig/Code/Python/func_slow.py	2007-09-15 09:48:11.000000000 +0400
-+++ DTraceToolkit-0.99/Code/Python/func_slow.py	2016-08-17 15:13:36.355687977 +0300
-@@ -1,4 +1,4 @@
--#!/usr/bin/python
-+#!/usr/bin/python2.7
- 
- def func_c():
- 	print "Function C"

--- a/components/developer/dtracetoolkit/pkg5
+++ b/components/developer/dtracetoolkit/pkg5
@@ -5,6 +5,7 @@
         "runtime/perl-522",
         "runtime/perl-524",
         "runtime/ruby-23",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
The entire purpose of this PR is removal of the dependancy of developer/dtrace/toolkit on python-2 .  The DTraceToolkit itself is a collection of tools written using DTrace for the Solaris 10[tm] OS by Sun Microsystems[tm]. Most of these scripts will also work on illumos and OI.  There is no software upgrade in this PR.  The version remains at 0.99 .  The python version, used by the software, is upgraded from 2.7 to 3.7 .

The only significant change to Makefile is to increment COMPONENT_REVISION .  The patch patches/shebang.patch is revised to omit the python changes.  A new patch patches/python3.patch incorporates all changes for the two python scripts.  The only significant change to the manifest dtracetoolkit.p5m is the change to the python dependancy.

The build, install, and publish operations were all successful.  There are no built-in tests.  However, I did try some of the most useful dtrace scripts after I had installed the package.  The scripts all seemed to work normally.
