### PR TITLE
mozilla-nspr: update to 4.32

### DIFF
--- a/components/library/mozilla-nspr/Makefile
+++ b/components/library/mozilla-nspr/Makefile
@@ -18,11 +18,11 @@ BUILD_BITS=			32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         nspr
-COMPONENT_VERSION=      4.31
+COMPONENT_VERSION=      4.32
 COMPONENT_PROJECT_URL=  https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:5729da87d5fbf1584b72840751e0c6f329b5d541850cacd1b61652c95015abc8
+COMPONENT_ARCHIVE_HASH= sha256:bb6bf4f534b9559cf123dcdc6f9cd8167de950314a90a88b2a329c16836e7f6c
 COMPONENT_ARCHIVE_URL=  https://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$(COMPONENT_VERSION)/src/$(COMPONENT_ARCHIVE)
 
 include $(WS_MAKE_RULES)/common.mk


### PR DESCRIPTION
- sample-manifest didn't change
- gmake test run fine