### PR TITLE
fix kvm after integration of illumos#13915

### DIFF
--- a/components/openindiana/kvm/patches/installctx.patch
+++ b/components/openindiana/kvm/patches/installctx.patch
@@ -1,0 +1,19 @@
+--- illumos-kvm-9ad0cc7792fc1f0e0fc8985ba8810362707b9b20/kvm.c.orig	2021-07-04 10:01:54.031699404 +0000
++++ illumos-kvm-9ad0cc7792fc1f0e0fc8985ba8810362707b9b20/kvm.c	2021-07-04 10:42:21.906737194 +0000
+@@ -489,11 +489,15 @@
+ void
+ vcpu_load(struct kvm_vcpu *vcpu)
+ {
++    struct ctxop *ctx;
++
+ 	mutex_enter(&vcpu->mutex);
++    
++    ctx = installctx_preallocate();
+ 
+ 	kpreempt_disable();
+ 	installctx(curthread, vcpu, kvm_ctx_save, kvm_ctx_restore, NULL,
+-	    NULL, NULL, NULL);
++	    NULL, NULL, NULL, ctx);
+ 
+ 	kvm_arch_vcpu_load(vcpu, CPU->cpu_id);
+ 	kvm_ringbuf_record(&vcpu->kvcpu_ringbuf,


### PR DESCRIPTION
The patch has been created according to flag day message https://illumos.topicbox.com/groups/discuss/T38b7ddf6f14b64a6/flag-day-for-kernel-modules-that-call-installctx