### PR TITLE
fetchmail: update to 6.4.19, remove Python

### DIFF
--- a/components/mail/fetchmail/Makefile
+++ b/components/mail/fetchmail/Makefile
@@ -22,54 +22,36 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2018, Michal Nowak
+# Copyright 2021, Nona Hansel
 #
 
-PREFERRED_BITS=64
-
+BUILD_BITS= 64
+USE_OPENSSL11= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		fetchmail
-COMPONENT_VERSION=	6.3.26
-COMPONENT_REVISION=	3
+COMPONENT_VERSION=	6.4.19
+COMPONENT_DESCRIPTION=	Full-featured, robust, well-documented remote-mail retrieval and forwarding utility
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:1c724a4e48c47e84981aef0da31cf01e0334c99b295d907d0d21d31674762a23
-COMPONENT_ARCHIVE_URL=	http://sourceforge.net/projects/$(COMPONENT_NAME).berlios/files/$(COMPONENT_ARCHIVE)/download
+    sha256:cd8d11a3d103e50caa2ec64bcda6307eb3d0783a4d4dfd88e668b81aaf9d6b5f
+COMPONENT_ARCHIVE_URL= https://sourceforge.net/projects/$(COMPONENT_NAME)/files/branch_6.4/$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.xz/download 
 COMPONENT_PROJECT_URL=	http://www.fetchmail.info/
-COMPONENT_BUGDB=	utility/fetchmail
 COMPONENT_FMRI=		mail/fetchmail
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET=	$(TEST_64)
+include $(WS_MAKE_RULES)/common.mk
 
-CONFIGURE_OPTIONS  +=		am_cv_python_pythondir="$(PYTHON_VENDOR_PACKAGES)"
 CONFIGURE_OPTIONS  +=		--with-kerberos5
-CONFIGURE_OPTIONS  +=		--with-ssl
+# configure detects OpenSSL 1.0 despite USE_OPENSSL11 being set
+CONFIGURE_OPTIONS  +=		--with-ssl=/usr/openssl/1.1/
 CONFIGURE_OPTIONS  +=		--enable-NTLM
 
-CONFIGURE_ENV += PYTHON=$(PYTHON)
+# Block the fetchmailconf build - this option is taken from configure.ac
+CONFIGURE_ENV += PYTHON=:
 
-# We don't have any .so files, so we want to ship the .py and .pyc files in
-# the same place as we would for 32-bit.
-PYTHON_VENDOR_PACKAGES.64 =	$(PYTHON_VENDOR_PACKAGES.32)
-
-ASLR_MODE = $(ASLR_ENABLE)
-
-COMPONENT_POST_INSTALL_ACTION = \
-    $(PYTHON) -m compileall $(PROTO_DIR)/$(PYTHON_VENDOR_PACKAGES)
-
-# common targets
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
-
-REQUIRED_PACKAGES += SUNWcs
-REQUIRED_PACKAGES += library/python-2/tkinter-27
-REQUIRED_PACKAGES += library/security/openssl
-REQUIRED_PACKAGES += runtime/python-27
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/security/openssl-11
 REQUIRED_PACKAGES += service/security/kerberos-5
 REQUIRED_PACKAGES += system/library

--- a/components/mail/fetchmail/fetchmail.p5m
+++ b/components/mail/fetchmail/fetchmail.p5m
@@ -20,9 +20,9 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2018, Michal Nowak
+# Copyright 2021, Nona Hansel
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
 set name=pkg.fmri \
     value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary \
@@ -34,37 +34,31 @@ set name=info.classification \
     value=org.opensolaris.category.2008:Applications/Internet
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
-set name=org.opensolaris.arc-caseid value=PSARC/2008/135
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license fetchmail.license license=GPLv2
+
 file path=usr/bin/fetchmail
-file path=usr/bin/fetchmailconf
-file path=usr/lib/python2.7/vendor-packages/fetchmailconf.py \
-    pkg.tmp.autopyc=false
-file path=usr/lib/python2.7/vendor-packages/fetchmailconf.pyc
+#file path=usr/bin/fetchmailconf
 file path=usr/share/locale/ca/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/cs/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/da/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/de/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/el/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/en_GB/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/eo/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/es/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/fi/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/fr/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/gl/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/id/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/it/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/ja/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/nl/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/pl/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/pt_BR/LC_MESSAGES/fetchmail.mo
+file path=usr/share/locale/ro/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/ru/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/sk/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/sq/LC_MESSAGES/fetchmail.mo
+file path=usr/share/locale/sr/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/sv/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/tr/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/vi/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/fetchmail.mo
 file path=usr/share/man/man1/fetchmail.1
-file path=usr/share/man/man1/fetchmailconf.1
-license fetchmail.license license=GPLv2
+#file path=usr/share/man/man1/fetchmailconf.1

--- a/components/mail/fetchmail/manifests/sample-manifest.p5m
+++ b/components/mail/fetchmail/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,29 +24,24 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/fetchmail
 file path=usr/bin/fetchmailconf
-file path=usr/lib/python2.7/vendor-packages/fetchmailconf.py
 file path=usr/share/locale/ca/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/cs/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/da/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/de/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/el/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/en_GB/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/eo/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/es/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/fi/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/fr/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/gl/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/id/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/it/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/ja/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/nl/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/pl/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/pt_BR/LC_MESSAGES/fetchmail.mo
+file path=usr/share/locale/ro/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/ru/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/sk/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/sq/LC_MESSAGES/fetchmail.mo
+file path=usr/share/locale/sr/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/sv/LC_MESSAGES/fetchmail.mo
-file path=usr/share/locale/tr/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/vi/LC_MESSAGES/fetchmail.mo
 file path=usr/share/locale/zh_CN/LC_MESSAGES/fetchmail.mo
 file path=usr/share/man/man1/fetchmail.1

--- a/components/mail/fetchmail/pkg5
+++ b/components/mail/fetchmail/pkg5
@@ -1,10 +1,9 @@
 {
     "dependencies": [
         "SUNWcs",
-        "library/python-2/tkinter-27",
-        "library/security/openssl",
-        "runtime/python-27",
+        "library/security/openssl-11",
         "service/security/kerberos-5",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
This new version builds, installs and publishes fine. When installed locally, I tested it with this `.fetchmailrc` file:
```
set logfile /export/home/user_name/fetchmail.log
poll imap.seznam.cz protocol IMAP
    user "mail_address" is user_name here
    password "my_passwd"
    keep
    ssl
```
and I ran commands from man page: https://www.fetchmail.info/fetchmail-man.html#4
```
env LC_ALL=C fetchmail -V -v --nodetach --nosyslog
env LC_ALL=C fetchmail -vvv  --nodetach --nosyslog
```
and it worked - it fetched my mail using imap or pop3. I wasn't able to test it with gmail because it looks like gmail has another layer of security and it would require some setting on the gmail's side.

Building fetchmail with `fetchmailconf.py`  was very problematic. Therefore, I blocked it and this way avoids depending on Python. Fedora did similar thing: https://src.fedoraproject.org/rpms/fetchmail/blob/rawhide/f/fetchmail.spec#_49 