### PR TITLE
texinfo: update to 6.8

### DIFF
--- a/components/text/texinfo/Makefile
+++ b/components/text/texinfo/Makefile
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2019, Michal Nowak
+# Copyright (c) 2021, Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -29,14 +30,13 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		texinfo
-COMPONENT_VERSION=	6.7
-COMPONENT_REVISION=	1
-COMPONENT_PROJECT_URL=	http://www.gnu.org/software/texinfo/
+COMPONENT_VERSION=	6.8
+COMPONENT_PROJECT_URL=	https://www.gnu.org/software/texinfo/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:988403c1542d15ad044600b909997ba3079b10e03224c61188117f3676b02caa
-COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/texinfo/$(COMPONENT_ARCHIVE)
+	sha256:8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4
+COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/gnu/texinfo/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		text/texinfo
 
 include $(WS_MAKE_RULES)/common.mk
@@ -72,5 +72,6 @@ REQUIRED_PACKAGES += library/ncurses
 REQUIRED_PACKAGES += runtime/perl-524
 REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += shell/bash
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library

--- a/components/text/texinfo/manifests/sample-manifest.p5m
+++ b/components/text/texinfo/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -133,9 +133,13 @@ file path=usr/share/texinfo/Texinfo/XSLoader.pm
 file path=usr/share/texinfo/htmlxref.cnf
 file path=usr/share/texinfo/init/book.pm
 file path=usr/share/texinfo/init/chm.pm
+file path=usr/share/texinfo/init/highlight_syntax.pm
 file path=usr/share/texinfo/init/html32.pm
 file path=usr/share/texinfo/init/latex2html.pm
 file path=usr/share/texinfo/init/tex4ht.pm
+file path=usr/share/texinfo/js/info.css
+file path=usr/share/texinfo/js/info.js
+file path=usr/share/texinfo/js/modernizr.js
 file path=usr/share/texinfo/lib/Text-Unidecode/lib/Text/Unidecode.pm
 file path=usr/share/texinfo/lib/Text-Unidecode/lib/Text/Unidecode/x00.pm
 file path=usr/share/texinfo/lib/Text-Unidecode/lib/Text/Unidecode/x01.pm
@@ -463,6 +467,7 @@ file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/RecodeData/VISCII.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/RecodeData/_Encode.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/TextDomain.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/Util.pm
+file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/gettext_dumb.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/gettext_pp.pm
 file path=usr/share/texinfo/texindex.awk
 file path=usr/share/texinfo/texinfo.dtd

--- a/components/text/texinfo/pkg5
+++ b/components/text/texinfo/pkg5
@@ -6,6 +6,7 @@
         "runtime/perl-524",
         "runtime/python-35",
         "shell/bash",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [

--- a/components/text/texinfo/test/results-all.master
+++ b/components/text/texinfo/test/results-all.master
@@ -90,7 +90,7 @@ PASS: t/echo-area-no-completions.sh
 PASS: t/multiple-completions.sh
 PASS: t/help.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
 # TOTAL: 85
 # PASS:  85
@@ -162,7 +162,7 @@ PASS: ii-0055-test
 PASS: ii-0056-test
 PASS: ii-0057-test
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
 # TOTAL: 57
 # PASS:  57
@@ -178,7 +178,7 @@ Making check in tp
 Making check in .
 /usr/gnu/bin/make  check-TESTS
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
 # TOTAL: 0
 # PASS:  0
@@ -197,6 +197,7 @@ PASS: test_scripts/formatting_test_redefine_need.sh
 PASS: test_scripts/formatting_split_nocopying_split_dev_null.sh
 PASS: test_scripts/formatting_simplest_test_css.sh
 PASS: test_scripts/sectioning_sectioning_directions.sh
+PASS: test_scripts/sectioning_sectioning_directions_split_chapter.sh
 PASS: test_scripts/indices_nodes_before_top_and_sections_html_chapter.sh
 PASS: test_scripts/indices_nodes_before_top_and_sections_html_chapter_nodes.sh
 PASS: test_scripts/indices_index_special_region.sh
@@ -248,11 +249,15 @@ PASS: test_scripts/contents_double_contents_inline.sh
 PASS: test_scripts/contents_double_contents_inline_chapter.sh
 PASS: test_scripts/contents_double_contents_inline_section.sh
 PASS: test_scripts/contents_double_contents_inline_nodes.sh
+PASS: test_scripts/contents_double_contents_after_title.sh
+PASS: test_scripts/contents_double_contents_after_title_no_texi2html.sh
 PASS: test_scripts/contents_no_content_inline.sh
 PASS: test_scripts/contents_no_content_do_contents_inline.sh
 PASS: test_scripts/contents_no_content_setcatpage_inline.sh
 PASS: test_scripts/contents_no_content_setcatpage_do_contents_inline.sh
 PASS: test_scripts/contents_double_contents_book.sh
+PASS: test_scripts/contents_double_contents_after_title_book.sh
+PASS: test_scripts/contents_double_contents_after_title_book_chapter.sh
 PASS: test_scripts/contents_contents_and_parts.sh
 PASS: test_scripts/contents_contents_at_begin_info.sh
 PASS: test_scripts/contents_contents_at_end_info.sh
@@ -267,6 +272,7 @@ PASS: test_scripts/layout_formatting_weird_quotes.sh
 PASS: test_scripts/layout_formatting_html.sh
 PASS: test_scripts/layout_formatting_html_nodes.sh
 PASS: test_scripts/layout_formatting_plaintext.sh
+PASS: test_scripts/layout_formatting_mathjax.sh
 PASS: test_scripts/layout_formatting_html32.sh
 PASS: test_scripts/layout_formatting_regions.sh
 PASS: test_scripts/layout_formatting_exotic.sh
@@ -281,18 +287,22 @@ SKIP: test_scripts/tex_html_tex_notex.sh
 SKIP: test_scripts/tex_html_tex_httex.sh
 SKIP: test_scripts/tex_html_tex_accents_httex.sh
 SKIP: test_scripts/tex_html_tex_accents_l2h.sh
+SKIP: test_scripts/tex_html_tex_gdef_httex.sh
+SKIP: test_scripts/tex_html_tex_gdef_l2h.sh
 SKIP: test_scripts/tex_html_tex_complex_httex.sh
 SKIP: test_scripts/tex_html_tex_complex_l2h.sh
+SKIP: test_scripts/tex_html_tex_eqalign_httex.sh
+SKIP: test_scripts/tex_html_tex_eqalign_l2h.sh
 SKIP: test_scripts/tex_html_math_not_closed.sh
 SKIP: test_scripts/tex_html_tex_not_closed.sh
 SKIP: test_scripts/tex_html_tex_in_copying.sh
 SKIP: test_scripts/tex_html_formatting_singular.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
-# TOTAL: 96
-# PASS:  83
-# SKIP:  13
+# TOTAL: 106
+# PASS:  89
+# SKIP:  17
 # XFAIL: 0
 # FAIL:  0
 # XPASS: 0
@@ -303,7 +313,7 @@ Making check in many_input_files
 SKIP: tex_l2h.sh
 SKIP: tex_t4ht.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
 # TOTAL: 2
 # PASS:  0
@@ -317,7 +327,7 @@ Making check in Pod-Simple-Texinfo
 /usr/gnu/bin/make  check-TESTS
 PASS: prove.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
 # TOTAL: 1
 # PASS:  1
@@ -331,7 +341,7 @@ Making check in texindex
 /usr/gnu/bin/make  check-TESTS
 PASS: tests/ti-helpversion.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
 # TOTAL: 1
 # PASS:  1
@@ -345,7 +355,7 @@ Making check in util
 /usr/gnu/bin/make  check-TESTS
 PASS: tests/texi2dvi_helpversion.sh
 ============================================================================
-Testsuite summary for GNU Texinfo 6.7
+Testsuite summary for GNU Texinfo 6.8
 ============================================================================
 # TOTAL: 1
 # PASS:  1
@@ -359,3 +369,4 @@ Making check in doc
 Making check in tp_api
 /usr/gnu/bin/make  check-am
 Making check in man
+Making check in js

--- a/components/text/texinfo/texinfo.p5m
+++ b/components/text/texinfo/texinfo.p5m
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2019, Michal Nowak
+# Copyright (c) 2021, Nona Hansel
 #
 # Note for the next texinfo maintainer:
 # if "file path=usr/lib/$(MACH64)/charset.alias" is in your texinfo.p5m file,
@@ -159,9 +160,13 @@ file path=usr/share/texinfo/Texinfo/XSLoader.pm
 file path=usr/share/texinfo/htmlxref.cnf
 file path=usr/share/texinfo/init/book.pm
 file path=usr/share/texinfo/init/chm.pm
+file path=usr/share/texinfo/init/highlight_syntax.pm
 file path=usr/share/texinfo/init/html32.pm
 file path=usr/share/texinfo/init/latex2html.pm
 file path=usr/share/texinfo/init/tex4ht.pm
+file path=usr/share/texinfo/js/info.css
+file path=usr/share/texinfo/js/info.js
+file path=usr/share/texinfo/js/modernizr.js
 file path=usr/share/texinfo/lib/Text-Unidecode/lib/Text/Unidecode.pm
 file path=usr/share/texinfo/lib/Text-Unidecode/lib/Text/Unidecode/x00.pm
 file path=usr/share/texinfo/lib/Text-Unidecode/lib/Text/Unidecode/x01.pm
@@ -489,6 +494,7 @@ file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/RecodeData/VISCII.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/RecodeData/_Encode.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/TextDomain.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/Util.pm
+file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/gettext_dumb.pm
 file path=usr/share/texinfo/lib/libintl-perl/lib/Locale/gettext_pp.pm
 file path=usr/share/texinfo/texindex.awk
 file path=usr/share/texinfo/texinfo.dtd


### PR DESCRIPTION
It buids, installs and publishes fine. Test ran fine, too.
When installed locally, I tested it with this `random_file.texi`:
```  
@titlepage
@title The FOOGOL Language
@subtitle A User's Guide for GNU FOOGOL
@subtitle Edition 1.23
@subtitle July, 1994
@author Arnold D. Robbins
@c Include the Distribution inside the titlepage
@c environment so that headings are turned off.
@c Headings on and off do not work.
@page
@vskip 0pt plus 1filll
Copyright @copyright{} 1994 Free Software Foundation, Inc.
@sp 2
This is Edition 1.23 of @cite{The FOOGOL Language}, @* for the 3.21
version of the GNU implementation of FOOGOL.
@sp 2
Published by the Free Software Foundation @*
675 Massachusetts Avenue @*
Cambridge, MA 02139-3309 USA @*
Phone: +1-617-876-3296 @*
Printed copies are available for $20 each.
Permission is granted ...
@end titlepage
```
using these commands:
`makeinfo --html random_file.texi`
`makeinfo --xml random_file.texi`
and it worked.