### PR TITLE
mlocate: use group id 98 instead of already used gid 95.

### DIFF
--- a/components/sysutils/mlocate/Makefile
+++ b/components/sysutils/mlocate/Makefile
@@ -27,6 +27,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         mlocate
 COMPONENT_VERSION=      0.26
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=      mlocate - A utility for finding files by name quickly
 COMPONENT_FMRI=         file/mlocate 
 COMPONENT_CLASSIFICATION=Applications/System Utilities

--- a/components/sysutils/mlocate/mlocate.p5m
+++ b/components/sysutils/mlocate/mlocate.p5m
@@ -23,7 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 dir  path=var/cache/mlocate group=mlocate
-group groupname=mlocate gid=95
+group groupname=mlocate gid=98
 
 file path=etc/updatedb.conf mode=0644 overlay=allow preserve=true
 file path=usr/bin/locate group=mlocate mode=2555

--- a/doc/reserved_uids_and_gids.md
+++ b/doc/reserved_uids_and_gids.md
@@ -127,9 +127,10 @@ GID   | Group name
 90    | postgres
 91    | barman
 92    | bacula
-95    | mlocate
+95    | slocate
 96    | unknown
 97    | pkg5srv
+98    | mlocate
 60001 | nobody
 60002 | noaccess
 65534 | nogroup


### PR DESCRIPTION
while I was a producing a new ISO for SPARC, distro constructor told be GID 95 is already used by group slocate, which belongs to the illumos-gate, therefore GID for package mlocate  needs to be amended. The next free GID 98 was choosen for this porpose.