### PR TITLE
openconnect: remove dependency libp11

### DIFF
--- a/components/network/openconnect/Makefile
+++ b/components/network/openconnect/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		openconnect
 COMPONENT_VERSION=	8.10
+COMPONENT_REVISION=	1
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_FMRI=		network/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	Applications/Internet
@@ -61,14 +62,12 @@ CONFIGURE_OPTIONS +=	--libexecdir=/usr/lib/$(MACH64)
 
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += network/vpnc-scripts
-REQUIRED_PACKAGES += library/desktop/p11-kit
 REQUIRED_PACKAGES += driver/network/header-tun
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/libproxy
 REQUIRED_PACKAGES += library/libxml2
 REQUIRED_PACKAGES += library/lz4
-REQUIRED_PACKAGES += library/security/libp11
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library

--- a/components/network/openconnect/pkg5
+++ b/components/network/openconnect/pkg5
@@ -2,14 +2,13 @@
     "dependencies": [
         "SUNWcs",
         "driver/network/header-tun",
-        "library/desktop/p11-kit",
         "library/libproxy",
         "library/libxml2",
         "library/lz4",
-        "library/security/libp11",
         "library/security/openssl",
         "library/zlib",
         "network/vpnc-scripts",
+        "shell/ksh93",
         "system/library",
         "system/library/security/gss"
     ],


### PR DESCRIPTION
With update openssl to version 1.1 we disable all extra engines like solaris-userland it does. 
So we drop also the engine libp11. The only package which has an IPS dependency is openconnect. For openconnect it is a weak dependency, so if it is not avail it will not used and should not raise any complains. 
Beside openssl also gnutls could use libp11, but there are no package dependnecies.