### PR TITLE
squeak: move VectorEnginePlugin for Cuis into separate package

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -29,7 +29,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.2967
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 GIT_TAG=		sun-v5.0.30
 PLUGIN_REV=		5.0-202106151423-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine
@@ -107,6 +107,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 rebuild-manifests::
 	cp manifests/cog-spur.p5m cog-spur.p5m
 	cp manifests/cog-spur-ssl.p5m cog-spur-ssl.p5m
+	cp manifests/cog-spur-vep.p5m cog-spur-vep.p5m
 	cp manifests/cog-spur-display-X11.p5m cog-spur-display-X11.p5m
 	cp manifests/cog-spur-nodisplay.p5m cog-spur-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m

--- a/components/runtime/smalltalk/cog-spur/cog-spur-display-X11.p5m
+++ b/components/runtime/smalltalk/cog-spur/cog-spur-display-X11.p5m
@@ -39,12 +39,10 @@ depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONE
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-X11.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/Squeak3D.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-X11.so

--- a/components/runtime/smalltalk/cog-spur/cog-spur-ssl.p5m
+++ b/components/runtime/smalltalk/cog-spur/cog-spur-ssl.p5m
@@ -15,7 +15,7 @@
 
 
 set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/runtime/smalltalk/cog-spur/cog-spur-vep.p5m
+++ b/components/runtime/smalltalk/cog-spur/cog-spur-vep.p5m
@@ -14,8 +14,8 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -24,7 +24,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so

--- a/components/runtime/smalltalk/cog-spur/manifests/cog-spur-ssl.p5m
+++ b/components/runtime/smalltalk/cog-spur/manifests/cog-spur-ssl.p5m
@@ -15,7 +15,7 @@
 
 
 set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/runtime/smalltalk/cog-spur/manifests/cog-spur-vep.p5m
+++ b/components/runtime/smalltalk/cog-spur/manifests/cog-spur-vep.p5m
@@ -14,8 +14,8 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -24,7 +24,5 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so

--- a/components/runtime/smalltalk/cog-spur/pkg5
+++ b/components/runtime/smalltalk/cog-spur/pkg5
@@ -23,7 +23,8 @@
         "runtime/smalltalk/cog-spur",
         "runtime/smalltalk/cog-spur-display-X11",
         "runtime/smalltalk/cog-spur-nodisplay",
-        "runtime/smalltalk/cog-spur-ssl"
+        "runtime/smalltalk/cog-spur-ssl",
+        "runtime/smalltalk/cog-spur-vep"
     ],
     "name": "cog-spur"
 }

--- a/components/runtime/smalltalk/cog-spur/tools/classify.pl
+++ b/components/runtime/smalltalk/cog-spur/tools/classify.pl
@@ -19,6 +19,7 @@ open(NODISPLAY,">>","cog-spur-nodisplay.p5m") || die "Can't open cog-spur-nodisp
 open(X11,">>","cog-spur-display-X11.p5m") || die "Can't open cog-spur-display-X11.p5m";
 
 open(SSL,">>","cog-spur-ssl.p5m") || die "Can't open cog-spur-ssl.p5m";
+open(VEP,">>","cog-spur-vep.p5m") || die "Can't open cog-spur-vep.p5m";
 
 open(REST,">>","cog-spur.p5m") || die "Can't open cog-spur.p5m";
 
@@ -75,7 +76,7 @@ while (<>) {
 		} elsif (/XDisplayControlPlugin/) {
 			print X11 $_;
 		} elsif (/VectorEnginePlugin/) {
-			print X11 $_;
+			print VEP $_;
 		} elsif (/vm-sound-null/) {
 			print NODISPLAY $_;
 		} elsif (/vm-display-null/) {

--- a/components/runtime/smalltalk/squeak/Makefile
+++ b/components/runtime/smalltalk/squeak/Makefile
@@ -49,7 +49,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.19.6
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -113,6 +113,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 
 rebuild-manifests::
 	cp manifests/squeak.p5m squeak.p5m
+	cp manifests/squeak-vep.p5m squeak-vep.p5m
 	cp manifests/squeak-ssl.p5m squeak-ssl.p5m
 	cp manifests/squeak-display-X11.p5m squeak-display-X11.p5m
 	cp manifests/squeak-nodisplay.p5m squeak-nodisplay.p5m

--- a/components/runtime/smalltalk/squeak/manifests/squeak-ssl.p5m
+++ b/components/runtime/smalltalk/squeak/manifests/squeak-ssl.p5m
@@ -14,7 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/runtime/smalltalk/squeak/manifests/squeak-vep.p5m
+++ b/components/runtime/smalltalk/squeak/manifests/squeak-vep.p5m
@@ -13,9 +13,8 @@
 # Copyright 2020, 2021 David Stes
 #
 
-
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -24,7 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/squeak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
+

--- a/components/runtime/smalltalk/squeak/pkg5
+++ b/components/runtime/smalltalk/squeak/pkg5
@@ -23,7 +23,8 @@
         "runtime/smalltalk/squeak",
         "runtime/smalltalk/squeak-display-X11",
         "runtime/smalltalk/squeak-nodisplay",
-        "runtime/smalltalk/squeak-ssl"
+        "runtime/smalltalk/squeak-ssl",
+        "runtime/smalltalk/squeak-vep"
     ],
     "name": "squeak"
 }

--- a/components/runtime/smalltalk/squeak/squeak-display-X11.p5m
+++ b/components/runtime/smalltalk/squeak/squeak-display-X11.p5m
@@ -39,7 +39,6 @@ file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ClipboardExtendedPlu
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.HostWindowPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ImmX11Plugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Squeak3D
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.VectorEnginePlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.XDisplayControlPlugin
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-X11
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.B3DAcceleratorPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.B3DAcceleratorPlugin
@@ -47,6 +46,5 @@ file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ClipboardExtendedPl
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.HostWindowPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.HostWindowPlugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.ImmX11Plugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.ImmX11Plugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.Squeak3D path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.Squeak3D
-file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.VectorEnginePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.VectorEnginePlugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.XDisplayControlPlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.XDisplayControlPlugin
 file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.vm-display-X11 path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.vm-display-X11

--- a/components/runtime/smalltalk/squeak/squeak-ssl.p5m
+++ b/components/runtime/smalltalk/squeak/squeak-ssl.p5m
@@ -14,7 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -27,4 +27,4 @@ depend type=require fmri=pkg:/runtime/smalltalk/squeak-nodisplay@$(IPS_COMPONENT
 
 
 file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL
-file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakSSL
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.SqueakSSL path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.SqueakSSL

--- a/components/runtime/smalltalk/squeak/squeak-vep.p5m
+++ b/components/runtime/smalltalk/squeak/squeak-vep.p5m
@@ -13,9 +13,8 @@
 # Copyright 2020, 2021 David Stes
 #
 
-
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -24,7 +23,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/squeak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
+
+file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.VectorEnginePlugin
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/so.VectorEnginePlugin path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/so.VectorEnginePlugin

--- a/components/runtime/smalltalk/squeak/tools/amd64-p5m.sh
+++ b/components/runtime/smalltalk/squeak/tools/amd64-p5m.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for f in squeak.p5m squeak-display-X11.p5m squeak-nodisplay.p5m
+for f in squeak.p5m squeak-display-X11.p5m squeak-nodisplay.p5m squeak-ssl.p5m squeak-vep.p5m
 do
   tools/amd64.pl < $f > $f.out
   mv $f.out $f

--- a/components/runtime/smalltalk/squeak/tools/classify.pl
+++ b/components/runtime/smalltalk/squeak/tools/classify.pl
@@ -24,6 +24,8 @@ open(NODISPLAY,">>","squeak-nodisplay.p5m") || die "Can't open squeak-nodisplay.
 
 open(X11,">>","squeak-display-X11.p5m") || die "Can't open squeak-display-X11.p5m";
 
+open(VEP,">>","squeak-vep.p5m") || die "Can't open squeak-vep.p5m";
+
 open(SSL,">>","squeak-ssl.p5m") || die "Can't open squeak-ssl.p5m";
 
 open(REST,">>","squeak.p5m") || die "Can't open squeak.p5m";
@@ -69,7 +71,7 @@ while (<>) {
 		} elsif (/UnixOSProcessPlugin/) {
 			print NODISPLAY $_;
 		} elsif (/VectorEnginePlugin/) {
-			print X11 $_;
+			print VEP $_;
 		} elsif (/XDisplayControlPlugin/) {
 			print X11 $_;
 		} elsif (/vm-sound-null/) {

--- a/components/runtime/smalltalk/stack-spur/Makefile
+++ b/components/runtime/smalltalk/stack-spur/Makefile
@@ -35,7 +35,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		stack-spur
 COMPONENT_VERSION=	5.0.2967
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 GIT_TAG=		sun-v5.0.30
 PLUGIN_REV=		5.0-202106151423
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
@@ -115,6 +115,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 rebuild-manifests::
 	cp manifests/stack-spur.p5m stack-spur.p5m
 	cp manifests/stack-spur-ssl.p5m stack-spur-ssl.p5m
+	cp manifests/stack-spur-vep.p5m stack-spur-vep.p5m
 	cp manifests/stack-spur-display-X11.p5m stack-spur-display-X11.p5m
 	cp manifests/stack-spur-nodisplay.p5m stack-spur-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur-ssl.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur-ssl.p5m
@@ -15,7 +15,7 @@
 
 
 set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur-vep.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur-vep.p5m
@@ -14,8 +14,8 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -26,5 +26,3 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so

--- a/components/runtime/smalltalk/stack-spur/pkg5
+++ b/components/runtime/smalltalk/stack-spur/pkg5
@@ -23,7 +23,8 @@
         "runtime/smalltalk/stack-spur",
         "runtime/smalltalk/stack-spur-display-X11",
         "runtime/smalltalk/stack-spur-nodisplay",
-        "runtime/smalltalk/stack-spur-ssl"
+        "runtime/smalltalk/stack-spur-ssl",
+        "runtime/smalltalk/stack-spur-vep"
     ],
     "name": "stack-spur"
 }

--- a/components/runtime/smalltalk/stack-spur/stack-spur-display-X11.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur-display-X11.p5m
@@ -39,12 +39,10 @@ depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPO
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
 file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/vm-display-X11.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/B3DAcceleratorPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/ImmX11Plugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/Squeak3D.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/XDisplayControlPlugin.so
 file path=usr/lib/squeak/$(PLUGIN_REV)/vm-display-X11.so

--- a/components/runtime/smalltalk/stack-spur/stack-spur-vep.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur-vep.p5m
@@ -14,8 +14,8 @@
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -26,5 +26,5 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/SqueakSSL.so
-file path=usr/lib/squeak/$(PLUGIN_REV)/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so
+file path=usr/lib/squeak/$(PLUGIN_REV)/VectorEnginePlugin.so

--- a/components/runtime/smalltalk/stack-spur/tools/classify.pl
+++ b/components/runtime/smalltalk/stack-spur/tools/classify.pl
@@ -19,6 +19,7 @@ open(NODISPLAY,">>","stack-spur-nodisplay.p5m") || die "Can't open stack-spur-no
 open(X11,">>","stack-spur-display-X11.p5m") || die "Can't open stack-spur-display-X11.p5m";
 
 open(SSL,">>","stack-spur-ssl.p5m") || die "Can't open stack-spur-ssl.p5m";
+open(VEP,">>","stack-spur-vep.p5m") || die "Can't open stack-spur-vep.p5m";
 
 open(REST,">>","stack-spur.p5m") || die "Can't open stack-spur.p5m";
 
@@ -75,7 +76,7 @@ while (<>) {
 		} elsif (/XDisplayControlPlugin/) {
 			print X11 $_;
 		} elsif (/VectorEnginePlugin/) {
-			print X11 $_;
+			print VEP $_;
 		} elsif (/vm-sound-null/) {
 			print NODISPLAY $_;
 		} elsif (/vm-display-null/) {


### PR DESCRIPTION
The VEP (=VectorEnginePlugin) for Cuis can be installed or uninstalled as required.

Uninstalling the VEP can be useful in order to test the native Smalltalk code.

The VEP is translated Smalltalk code (into C ) which increases speed but sometimes it can be useful to test the natvie Smalltalk code as well.

Also this commit fixes a patch in the SSL plugin (for the 64bit case in Squeak classic VM which is not used a lot as the V3 images are mostly 32bit anyway)