### PR TITLE
freetype-2: update to 2.11.0

### DIFF
--- a/components/library/freetype/Makefile
+++ b/components/library/freetype/Makefile
@@ -19,16 +19,14 @@ BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           freetype
-COMPONENT_VERSION=        2.10.4
+COMPONENT_VERSION=        2.11.0
 COMPONENT_FMRI=           system/library/freetype-2
 COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_SUMMARY=  	FreeType 2 font engine
 COMPONENT_SRC=      	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= \
-	sha256:86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784
-COMPONENT_ARCHIVE_URL= \
-	https://download.savannah.gnu.org/releases/freetype/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= sha256:8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
+COMPONENT_ARCHIVE_URL=	https://download.savannah.gnu.org/releases/freetype/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://freetype.org/
 COMPONENT_LICENSE=      The FreeType Project License
 COMPONENT_LICENSE_FILE= freetype-2.license
@@ -56,10 +54,10 @@ COMPONENT_PREP_ACTION = ( cd $(@D); \
 		-i include/freetype/config/ftoption.h ) 
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += compress/bzip2
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/brotli
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library

--- a/components/library/freetype/freetype-2.p5m
+++ b/components/library/freetype/freetype-2.p5m
@@ -55,6 +55,7 @@ file path=usr/include/freetype2/freetype/ftimage.h
 file path=usr/include/freetype2/freetype/ftincrem.h
 file path=usr/include/freetype2/freetype/ftlcdfil.h
 file path=usr/include/freetype2/freetype/ftlist.h
+file path=usr/include/freetype2/freetype/ftlogging.h
 file path=usr/include/freetype2/freetype/ftlzw.h
 file path=usr/include/freetype2/freetype/ftmac.h
 file path=usr/include/freetype2/freetype/ftmm.h
@@ -78,13 +79,13 @@ file path=usr/include/freetype2/freetype/ttnameid.h
 file path=usr/include/freetype2/freetype/tttables.h
 file path=usr/include/freetype2/freetype/tttags.h
 file path=usr/include/freetype2/ft2build.h
-link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.17.4
-link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.17.4
-file path=usr/lib/$(MACH64)/libfreetype.so.6.17.4
+link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.18.0
+link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.18.0
+file path=usr/lib/$(MACH64)/libfreetype.so.6.18.0
 file path=usr/lib/$(MACH64)/pkgconfig/freetype2.pc
-link path=usr/lib/libfreetype.so target=libfreetype.so.6.17.4
-link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.17.4
-file path=usr/lib/libfreetype.so.6.17.4
+link path=usr/lib/libfreetype.so target=libfreetype.so.6.18.0
+link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.18.0
+file path=usr/lib/libfreetype.so.6.18.0
 file path=usr/lib/pkgconfig/freetype2.pc
 file path=usr/share/aclocal/freetype2.m4
 file path=usr/share/man/man1/freetype-config.1

--- a/components/library/freetype/manifests/sample-manifest.p5m
+++ b/components/library/freetype/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -54,6 +54,7 @@ file path=usr/include/freetype2/freetype/ftimage.h
 file path=usr/include/freetype2/freetype/ftincrem.h
 file path=usr/include/freetype2/freetype/ftlcdfil.h
 file path=usr/include/freetype2/freetype/ftlist.h
+file path=usr/include/freetype2/freetype/ftlogging.h
 file path=usr/include/freetype2/freetype/ftlzw.h
 file path=usr/include/freetype2/freetype/ftmac.h
 file path=usr/include/freetype2/freetype/ftmm.h
@@ -77,13 +78,13 @@ file path=usr/include/freetype2/freetype/ttnameid.h
 file path=usr/include/freetype2/freetype/tttables.h
 file path=usr/include/freetype2/freetype/tttags.h
 file path=usr/include/freetype2/ft2build.h
-link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.17.4
-link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.17.4
-file path=usr/lib/$(MACH64)/libfreetype.so.6.17.4
+link path=usr/lib/$(MACH64)/libfreetype.so target=libfreetype.so.6.18.0
+link path=usr/lib/$(MACH64)/libfreetype.so.6 target=libfreetype.so.6.18.0
+file path=usr/lib/$(MACH64)/libfreetype.so.6.18.0
 file path=usr/lib/$(MACH64)/pkgconfig/freetype2.pc
-link path=usr/lib/libfreetype.so target=libfreetype.so.6.17.4
-link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.17.4
-file path=usr/lib/libfreetype.so.6.17.4
+link path=usr/lib/libfreetype.so target=libfreetype.so.6.18.0
+link path=usr/lib/libfreetype.so.6 target=libfreetype.so.6.18.0
+file path=usr/lib/libfreetype.so.6.18.0
 file path=usr/lib/pkgconfig/freetype2.pc
 file path=usr/share/aclocal/freetype2.m4
 file path=usr/share/man/man1/freetype-config.1

--- a/components/library/freetype/pkg5
+++ b/components/library/freetype/pkg5
@@ -6,6 +6,7 @@
         "library/brotli",
         "library/c++/harfbuzz",
         "library/zlib",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
desktop apps (libreoffice, dia, emacs, ...) still work