### PR TITLE
New python module wrapt, version 1.12.1

### DIFF
--- a/components/python/wrapt/Makefile
+++ b/components/python/wrapt/Makefile
@@ -1,0 +1,62 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 Gary Mills
+#
+
+BUILD_BITS = 64
+BUILD_STYLE= setup.py
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		wrapt
+COMPONENT_VERSION=	1.12.1
+COMPONENT_FMRI=         library/python/wrapt
+COMPONENT_CLASSIFICATION=Development/Python
+COMPONENT_PROJECT_URL=	https://github.com/GrahamDumpleton/wrapt
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+  sha256:19f2043e05b76ce9b68971b387bfd8eed50c2ee1c9c0bd230edc422fec753917
+COMPONENT_ARCHIVE_URL= \
+  https://github.com/GrahamDumpleton/$(COMPONENT_NAME)/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_LICENSE=      BSD
+
+PYTHON_VERSIONS=	3.7 3.9
+
+include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_TEST_DIR =    $(SOURCE_DIR)/tests
+COMPONENT_TEST_CMD =    $(PYTHON) -m pytest
+COMPONENT_TEST_ARGS =
+
+# Typical failures for test target:
+#=========================== short test summary info ============================
+#FAILED test_outer_classmethod.py::TestCallingOuterClassMethod::test_class_call_function
+#FAILED test_outer_classmethod.py::TestCallingOuterClassMethod::test_instance_call_function
+#FAILED test_synchronized_lock.py::TestSynchronized::test_synchronized_outer_classmethod
+#================== 3 failed, 371 passed, 55 warnings in 1.47s ==================
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/python-37
+REQUIRED_PACKAGES += runtime/python-39
+REQUIRED_PACKAGES += system/library

--- a/components/python/wrapt/manifests/sample-manifest.p5m
+++ b/components/python/wrapt/manifests/sample-manifest.p5m
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python3.7/vendor-packages/wrapt-$(COMPONENT_VERSION)-py3.7.egg-info
+file path=usr/lib/python3.7/vendor-packages/wrapt/__init__.py
+file path=usr/lib/python3.7/vendor-packages/wrapt/_wrappers.cpython-37m.so
+file path=usr/lib/python3.7/vendor-packages/wrapt/decorators.py
+file path=usr/lib/python3.7/vendor-packages/wrapt/importer.py
+file path=usr/lib/python3.7/vendor-packages/wrapt/wrappers.py
+file path=usr/lib/python3.9/vendor-packages/wrapt-$(COMPONENT_VERSION)-py3.9.egg-info
+file path=usr/lib/python3.9/vendor-packages/wrapt/__init__.py
+file path=usr/lib/python3.9/vendor-packages/wrapt/_wrappers.cpython-39.so
+file path=usr/lib/python3.9/vendor-packages/wrapt/decorators.py
+file path=usr/lib/python3.9/vendor-packages/wrapt/importer.py
+file path=usr/lib/python3.9/vendor-packages/wrapt/wrappers.py

--- a/components/python/wrapt/pkg5
+++ b/components/python/wrapt/pkg5
@@ -1,0 +1,15 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "runtime/python-37",
+        "runtime/python-39",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "library/python/wrapt-37",
+        "library/python/wrapt-39",
+        "library/python/wrapt"
+    ],
+    "name": "wrapt"
+}

--- a/components/python/wrapt/wrapt-PYVER.p5m
+++ b/components/python/wrapt/wrapt-PYVER.p5m
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Gary Mills
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="A transparent object proxy for Python $(PYVER)"
+set name=com.oracle.info.description value="A transparent object proxy for Python $(PYVER)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/wrapt-$(COMPONENT_VERSION)-py$(PYVER).egg-info
+file path=usr/lib/python$(PYVER)/vendor-packages/wrapt/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/wrapt/_wrappers.so
+file path=usr/lib/python$(PYVER)/vendor-packages/wrapt/decorators.py
+file path=usr/lib/python$(PYVER)/vendor-packages/wrapt/importer.py
+file path=usr/lib/python$(PYVER)/vendor-packages/wrapt/wrappers.py
+
+# force a dependency on the Python runtime
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# force a dependency on the wrapt package
+depend type=require \
+    fmri=library/python/wrapt@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/python/wrapt/wrapt.license
+++ b/components/python/wrapt/wrapt.license
@@ -1,0 +1,24 @@
+Copyright (c) 2013-2019, Graham Dumpleton
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This PR adds the wrapt packages, version 1.12.1 .  The product is a transparent object proxy for Python, used for the construction of function wrappers and decorator functions.  It is one of two packages required by the astroid package, which is in turn required by recent versions of pylint.  Packages are built for python 3.7 and 3.9 .  All files are new, including Makefile, the manifest wrapt-PYVER.p5m, and manifests/sample-manifest.p5m .

The build, install, and publish steps were all successful.  The built-in tests require that pytest be installed.  Typical results, showing 3 failed and 371 passed tests, are included in the Makefile.
