### PR TITLE
New python module lazy_object_proxy, version 1.6.0

### DIFF
--- a/components/python/lazy_object_proxy/Makefile
+++ b/components/python/lazy_object_proxy/Makefile
@@ -1,0 +1,70 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 Gary Mills
+#
+
+BUILD_BITS = 64
+BUILD_STYLE= setup.py
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		lazy_object_proxy
+ARCH_NAME=		python-lazy-object-proxy
+COMPONENT_VERSION=	1.6.0
+COMPONENT_FMRI=         library/python/lazy_object_proxy
+COMPONENT_CLASSIFICATION=Development/Python
+COMPONENT_PROJECT_URL=	https://github.com/ionelmc/$(ARCH_NAME)
+COMPONENT_SRC=		$(ARCH_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+  sha256:e97c0edc4b59e392befad3986377769bc33285dab027b78adecd74d9fbd4acaf
+COMPONENT_ARCHIVE_URL= \
+  https://github.com/ionelmc/$(ARCH_NAME)/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_LICENSE=      BSD
+
+PYTHON_VERSIONS=	3.7 3.9
+
+include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_TEST_DIR =    $(SOURCE_DIR)/tests
+COMPONENT_TEST_CMD =    $(PYTHON) -m pytest
+COMPONENT_TEST_ARGS =
+
+# Typical failures for test target:
+#=========================== short test summary info ============================
+#...
+#ERROR test_lazy_object_proxy.py::test_perf[slots]
+#ERROR test_lazy_object_proxy.py::test_perf[cext]
+#ERROR test_lazy_object_proxy.py::test_perf[simple]
+#ERROR test_lazy_object_proxy.py::test_perf[django]
+#ERROR test_lazy_object_proxy.py::test_perf[objproxies]
+#ERROR test_lazy_object_proxy.py::test_proto[SimpleProxy]
+#ERROR test_lazy_object_proxy.py::test_proto[LocalsSimpleProxy]
+#ERROR test_lazy_object_proxy.py::test_proto[CachedPropertyProxy]
+#ERROR test_lazy_object_proxy.py::test_proto[LocalsCachedPropertyProxy]
+#= 1504 passed, 284 skipped, 36 xfailed, 42 xpassed, 12 warnings, 9 errors in 5.95s =
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/python-37
+REQUIRED_PACKAGES += runtime/python-39
+REQUIRED_PACKAGES += system/library

--- a/components/python/lazy_object_proxy/lazy_object_proxy-PYVER.p5m
+++ b/components/python/lazy_object_proxy/lazy_object_proxy-PYVER.p5m
@@ -1,0 +1,46 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Gary Mills
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="A fast and thorough lazy object proxy"
+set name=com.oracle.info.description value="A fast and thorough lazy object proxy"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/not-zip-safe
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/_version.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/cext.so
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/compat.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/simple.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/slots.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/utils.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/utils_py3.py
+
+# force a dependency on the Python runtime
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# force a dependency on the lazy_object_proxy package
+depend type=require \
+    fmri=library/python/lazy_object_proxy@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/python/lazy_object_proxy/lazy_object_proxy.license
+++ b/components/python/lazy_object_proxy/lazy_object_proxy.license
@@ -1,0 +1,21 @@
+BSD 2-Clause License
+
+Copyright (c) 2014-2019, Ionel Cristian Mărieș
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/python/lazy_object_proxy/manifests/generic-manifest.p5m
+++ b/components/python/lazy_object_proxy/manifests/generic-manifest.p5m
@@ -1,0 +1,31 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2021 <contributor>
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/not-zip-safe
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/_version.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/cext.cpython-37m.so
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/compat.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/simple.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/slots.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/utils.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/utils_py3.py
+file path=usr/lib/python$(PYVER)/vendor-packages/lazy_object_proxy/cext.cpython-39.so

--- a/components/python/lazy_object_proxy/manifests/sample-manifest.p5m
+++ b/components/python/lazy_object_proxy/manifests/sample-manifest.p5m
@@ -1,0 +1,50 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.7.egg-info/PKG-INFO
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.7.egg-info/SOURCES.txt
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.7.egg-info/dependency_links.txt
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.7.egg-info/not-zip-safe
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.7.egg-info/top_level.txt
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/__init__.py
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/_version.py
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/cext.cpython-37m.so
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/compat.py
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/simple.py
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/slots.py
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/utils.py
+file path=usr/lib/python3.7/vendor-packages/lazy_object_proxy/utils_py3.py
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.9.egg-info/not-zip-safe
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/__init__.py
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/_version.py
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/cext.cpython-39.so
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/compat.py
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/simple.py
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/slots.py
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/utils.py
+file path=usr/lib/python3.9/vendor-packages/lazy_object_proxy/utils_py3.py

--- a/components/python/lazy_object_proxy/patches/01-imp-deprecated.patch
+++ b/components/python/lazy_object_proxy/patches/01-imp-deprecated.patch
@@ -1,0 +1,20 @@
+--- python-lazy-object-proxy-1.6.0/tests/test_lazy_object_proxy.py-orig	Mon Mar 22 10:06:24 2021
++++ python-lazy-object-proxy-1.6.0/tests/test_lazy_object_proxy.py	Mon Jul 19 08:03:19 2021
+@@ -1,7 +1,7 @@
+ from __future__ import print_function
+ 
+ import gc
+-import imp
++import types
+ import os
+ import pickle
+ import platform
+@@ -31,7 +31,7 @@
+     pass
+ """
+ 
+-objects = imp.new_module('objects')
++objects = types.ModuleType('objects')
+ exec_(OBJECTS_CODE, objects.__dict__, objects.__dict__)
+ 
+ 

--- a/components/python/lazy_object_proxy/patches/02-cfg-pylint.patch
+++ b/components/python/lazy_object_proxy/patches/02-cfg-pylint.patch
@@ -1,0 +1,10 @@
+--- python-lazy-object-proxy-1.6.0/setup.cfg-orig	Mon Mar 22 10:06:24 2021
++++ python-lazy-object-proxy-1.6.0/setup.cfg	Mon Jul 19 12:52:48 2021
+@@ -24,6 +24,7 @@
+     *_test.py
+     tests.py
+ markers =
++    benchmark: Baseline of pylint performance.
+     xfail_subclass: Expected test to fail with a subclass of Proxy.
+     xfail_simple: Expected test to fail on the `simple` implementation.
+ addopts =

--- a/components/python/lazy_object_proxy/pkg5
+++ b/components/python/lazy_object_proxy/pkg5
@@ -1,0 +1,15 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "runtime/python-37",
+        "runtime/python-39",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "library/python/lazy_object_proxy-37",
+        "library/python/lazy_object_proxy-39",
+        "library/python/lazy_object_proxy"
+    ],
+    "name": "lazy_object_proxy"
+}


### PR DESCRIPTION
This PR adds the lazy_object_proxy packages, version 1.6.0 .  The product is a fast and thorough lazy object proxy, used in situations where you want to call a function the first time the proxy object is used.  It is the second of two packages required by the astroid package, which is in turn required by recent versions of pylint.

The python module is known as lazy_object_proxy, but the archive file unpacks to python-lazy-object-proxy-1.6.0 .  This discrepancy is corrected in Makefile .  Packages are built for python 3.7 and 3.9 .  All files are new, including Makefile, the manifest lazy_object_proxy-PYVER.p5m, the two manifests manifests/generic-manifest.p5m and manifests/sample-manifest.p5m, and the two patches in the patches directory.  Both patches affect only the built-in tests.

Note that the manifest lazy_object_proxy-PYVER.p5m contains a file named cext.so .  This file is magically renamed to cext.cpython-37m.so or cext.cpython-39.so, as appropriate, during the publish operation.  The magic is accomplished by a built-in transform.  The build, install, and publish steps were all successful.  The built-in tests require that pytest be installed.  Typical results, showing 36 xfailed and 1504 passed tests, are included in the Makefile.
