### PR TITLE
librsvg: update test results

### DIFF
--- a/components/library/librsvg/test/results-all.master
+++ b/components/library/librsvg/test/results-all.master
@@ -10,21 +10,21 @@ PASS: rsvg-test 6 /rsvg/reftest/bugs/403357.svg
 PASS: rsvg-test 7 /rsvg/reftest/bugs/476507.svg
 PASS: rsvg-test 8 /rsvg/reftest/bugs/548494.svg
 PASS: rsvg-test 9 /rsvg/reftest/bugs/563933.svg
-FAIL: rsvg-test 10 /rsvg/reftest/bugs/587721-text-transform.svg
+PASS: rsvg-test 10 /rsvg/reftest/bugs/587721-text-transform.svg
 PASS: rsvg-test 11 /rsvg/reftest/bugs/603550-mask-luminance.svg
 PASS: rsvg-test 12 /rsvg/reftest/bugs/738367.svg
 FAIL: rsvg-test 13 /rsvg/reftest/bugs/749415.svg
 PASS: rsvg-test 14 /rsvg/reftest/bugs/761175-recursive-masks.svg
 FAIL: rsvg-test 15 /rsvg/reftest/bugs/777834-empty-text-children.svg
-FAIL: rsvg-test 16 /rsvg/reftest/svg1.1/masking-intro-01-f.svg
+PASS: rsvg-test 16 /rsvg/reftest/svg1.1/masking-intro-01-f.svg
 FAIL: rsvg-test 17 /rsvg/reftest/svg1.1/masking-mask-01-b.svg
-FAIL: rsvg-test 18 /rsvg/reftest/svg1.1/masking-mask-02-f.svg
-FAIL: rsvg-test 19 /rsvg/reftest/svg1.1/masking-opacity-01-b.svg
-FAIL: rsvg-test 20 /rsvg/reftest/svg1.1/masking-path-01-b.svg
-FAIL: rsvg-test 21 /rsvg/reftest/svg1.1/masking-path-02-b.svg
-FAIL: rsvg-test 22 /rsvg/reftest/svg1.1/masking-path-03-b.svg
-FAIL: rsvg-test 23 /rsvg/reftest/svg1.1/masking-path-04-b.svg
-FAIL: rsvg-test 24 /rsvg/reftest/svg1.1/struct-cond-03-t.svg
+PASS: rsvg-test 18 /rsvg/reftest/svg1.1/masking-mask-02-f.svg
+PASS: rsvg-test 19 /rsvg/reftest/svg1.1/masking-opacity-01-b.svg
+PASS: rsvg-test 20 /rsvg/reftest/svg1.1/masking-path-01-b.svg
+PASS: rsvg-test 21 /rsvg/reftest/svg1.1/masking-path-02-b.svg
+PASS: rsvg-test 22 /rsvg/reftest/svg1.1/masking-path-03-b.svg
+PASS: rsvg-test 23 /rsvg/reftest/svg1.1/masking-path-04-b.svg
+PASS: rsvg-test 24 /rsvg/reftest/svg1.1/struct-cond-03-t.svg
 ERROR: rsvg-test - exited with status 1
 PASS: crash 1 /crash/785276-empty.svg
 PASS: crash 2 /crash/785276-short-file.svg
@@ -70,9 +70,9 @@ PASS: errors 4 /errors/instancing_limit/308-use-self-ref.svg
 PASS: errors 5 /errors/instancing_limit/308-recursive-use.svg
 PASS: errors 6 /errors/instancing_limit/308-doubly-recursive-use.svg
 # TOTAL: 71
-# PASS:  57
+# PASS:  66
 # SKIP:  0
 # XFAIL: 0
-# FAIL:  13
+# FAIL:  4
 # XPASS: 0
 # ERROR: 1


### PR DESCRIPTION
This simply fixes the test results and should not create a new version.