### PR TITLE
docbook: fix docbook-catalog-install.sh …

### DIFF
--- a/components/docbook/docbook/Makefile
+++ b/components/docbook/docbook/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= docbook
 COMPONENT_VERSION= 2.30.0
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_SUMMARY= docbook SGML and XML stylesheets
 
 include ../../../make-rules/ips.mk

--- a/components/docbook/docbook/files/docbook-catalog-install.sh
+++ b/components/docbook/docbook/files/docbook-catalog-install.sh
@@ -258,6 +258,12 @@ CATALOG=/etc/xml/docbook-xmlcatalog
 
 if [ -w $CATALOG ]
 then
+	if [ ! -s $CATALOG ]
+	then
+		# Empty or missing file confuses further "add" operations
+		/usr/bin/xmlcatalog --create > $CATALOG
+	fi
+
 	# DocBook XML V4.1.2
 	/usr/bin/xmlcatalog --noout --add "public" \
 		"ISO 8879:1986//ENTITIES Publishing//EN" \


### PR DESCRIPTION
…(used in svc:/application/desktop-cache/docbook-catalog-update:default) for edge case of zero-sized lost catalog file

Not sure what got my system to have an /etc/xml/docbook-xmlcatalog file zero-sized, possibly some untimely reboot? But anyhow, recovering from that to be able to build manpages again took a while of docs reading and trussing :)