### PR TITLE
ccache: ccache-update-symlinks.sh: fix matching of shorter prog names (e.g. "gcc" is not "gcc-10")

### DIFF
--- a/components/developer/ccache/Makefile
+++ b/components/developer/ccache/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ccache
 COMPONENT_VERSION=	3.3.4
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	http://ccache.samba.org/
 COMPONENT_DOWNLOAD_URL=	http://samba.org/ftp/$(COMPONENT_NAME)/
 COMPONENT_DOCUMENTATION_URL =	http://ccache.samba.org/manual.html
@@ -52,3 +52,4 @@ REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += file/gnu-coreutils

--- a/components/developer/ccache/manifests/sample-manifest.p5m
+++ b/components/developer/ccache/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/developer/ccache/pkg5
+++ b/components/developer/ccache/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "file/gnu-coreutils",
         "library/zlib",
         "shell/ksh93",
         "system/library",


### PR DESCRIPTION
Also runtime needs `realpath` from unlisted dependency