### PR TITLE
pipdeptree: fix mediator

### DIFF
--- a/components/python/pipdeptree/Makefile
+++ b/components/python/pipdeptree/Makefile
@@ -21,6 +21,7 @@
 
 #
 # Copyright 2021 Aurelien Larcher
+# Copyright 2021 Nona Hansel
 #
 
 BUILD_BITS=NO_ARCH
@@ -29,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pipdeptree
 COMPONENT_VERSION=	2.0.0
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		library/python/pipdeptree
 COMPONENT_CLASSIFICATION=Development/Python
 COMPONENT_SUMMARY=	Command line utility to show dependency tree of packages

--- a/components/python/pipdeptree/pipdeptree-PYVER.p5m
+++ b/components/python/pipdeptree/pipdeptree-PYVER.p5m
@@ -8,6 +8,8 @@
 # http://www.illumos.org/license/CDDL.
 
 # Copyright 2021 Aurelien Larcher
+# Copyright 2021 Nona Hansel
+#
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
@@ -20,7 +22,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=.*/bin/ -> set pkg.depend.bypass-generate .*metadata.* >
 
 file path=usr/bin/pipdeptree-$(PYVER)
-link path=usr/bin/pipdeptree target=pipdeptree-$(PYVER) mediator=python \
+link path=usr/bin/pipdeptree target=pipdeptree-$(PYVER) mediator=python3 \
     mediator-version=$(PYVER)
 file path=usr/lib/python$(PYVER)/vendor-packages/pipdeptree-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
 file path=usr/lib/python$(PYVER)/vendor-packages/pipdeptree-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt

--- a/components/python/pipdeptree/pkg5
+++ b/components/python/pipdeptree/pkg5
@@ -6,7 +6,8 @@
         "library/python/setuptools-39",
         "runtime/python-35",
         "runtime/python-37",
-        "runtime/python-39"
+        "runtime/python-39",
+        "shell/ksh93"
     ],
     "fmris": [
         "library/python/pipdeptree-35",


### PR DESCRIPTION
Pipdeptree is build only for Python3 therefore the mediator needs to be set to Python3 otherwise the link `/usr/bin/pipdeptree` doesn't exist.