### PR TITLE
add mozjs-78

### DIFF
--- a/components/library/mozjs-78/Makefile
+++ b/components/library/mozjs-78/Makefile
@@ -1,0 +1,89 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+#
+
+# parfait is a bit unhappy (24796622)
+export PARFAIT_BUILD=no
+
+BUILD_BITS =		64
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		mozjs
+COMPONENT_VERSION=	78.11.0
+COMPONENT_PROJECT_URL=	https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_ARCHIVE_HASH= sha256:5ad54ac2b0368b9748e08756658eb988d65e5bb088d91baf43267486bcbf1d26
+# Upstream no longer delivers mozjs archives; it needs to be extracted from
+# the firefox archive instead. Archives are hence only available directly in
+# the Userland package cache, and no online alternative is available.
+# Check the gnome releng location for tarballs if available
+#COMPONENT_ARCHIVE_URL=	http://ftp.cse.buffalo.edu/pub/Gnome/teams/releng/tarballs-needing-help/mozjs/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://download.gnome.org/teams/releng/tarballs-needing-help/mozjs/$(COMPONENT_ARCHIVE)
+
+
+CXXFLAGS +=		-std=c++17
+GCC_VERSION=	10
+GNU_ARCH=		x86_64-sun-solaris
+
+# Only used during build process.
+PYTHON_VERSION= 3.7
+PYTHON_VERSIONS= 3.7
+
+# Tests hook up need work
+TEST_TARGET = $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+
+# configure script is not at root of source tree.
+CONFIGURE_SCRIPT= $(SOURCE_DIR)/js/src/configure
+
+CONFIGURE_ENV += PYTHON="$(PYTHON)"
+CONFIGURE_ENV += PYTHON3="$(PYTHON)"
+CONFIGURE_ENV += LDSHARED="$(CC) -shared"
+CONFIGURE_ENV += NSPR_CONFIG="/usr/bin/pkg-config nspr"
+
+CONFIGURE_OPTIONS = --prefix=/usr
+CONFIGURE_OPTIONS += --libdir=$(USRLIBDIR64)
+
+CONFIGURE_OPTIONS += --target=$(GNU_ARCH)
+CONFIGURE_OPTIONS += --disable-jemalloc
+CONFIGURE_OPTIONS += --enable-ctypes
+CONFIGURE_OPTIONS += --disable-tests
+CONFIGURE_OPTIONS += --with-intl-api
+# Resulting packages are a few hundred megabytes larger without this!
+CONFIGURE_OPTIONS += --enable-install-strip
+CONFIGURE_OPTIONS += --enable-readline
+CONFIGURE_OPTIONS += --enable-shared-js
+CONFIGURE_OPTIONS += --enable-system-ffi
+CONFIGURE_OPTIONS += --with-system-icu
+CONFIGURE_OPTIONS += --with-system-zlib
+CONFIGURE_OPTIONS += --enable-strip
+CONFIGURE_OPTIONS += --with-system-nspr
+LDFLAGS += -z gnu-version-script-compat
+
+# js coredumps on sparc - see bug 24935318
+ifeq ($(MACH), sparc)
+LD_EXEC_OPTIONS += -M $(WS_COMPONENTS)/desktop/polkit/mapfile
+COMPONENT_BUILD_ENV += LD_EXEC_OPTIONS="$(LD_EXEC_OPTIONS)"
+COMPONENT_INSTALL_ENV += LD_EXEC_OPTIONS="$(LD_EXEC_OPTIONS)"
+endif
+

--- a/components/library/mozjs-78/mozjs-78.license
+++ b/components/library/mozjs-78/mozjs-78.license
@@ -1,0 +1,807 @@
+
+Please see the file toolkit/content/license.html for the copyright licensing conditions attached to this codebase, including copies of the licenses concerned.
+
+You are not granted rights or licenses to the trademarks of the Mozilla Foundation or any party, including without limitation the Firefox name or logo.
+
+For more information, see: http://www.mozilla.org/foundation/licensing.html
+
+--
+Mozilla Public License
+Version 2.0
+1. Definitions
+
+1.1. ?Contributor?
+
+    means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
+1.2. ?Contributor Version?
+
+    means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor?s Contribution.
+1.3. ?Contribution?
+
+    means Covered Software of a particular Contributor.
+1.4. ?Covered Software?
+
+    means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
+1.5. ?Incompatible With Secondary Licenses?
+
+    means
+
+	   that the initial Contributor has attached the notice described in Exhibit B to the Covered Software; or
+
+	   that the Covered Software was made available under the terms of version 1.1 or earlier of the License, but not also under the terms of a Secondary License.
+
+1.6. ?Executable Form?
+
+    means any form of the work other than Source Code Form.
+1.7. ?Larger Work?
+
+    means a work that combines Covered Software with other material, in a separate file or files, that is not Covered Software.
+1.8. ?License?
+
+    means this document.
+1.9. ?Licensable?
+
+    means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this License.
+1.10. ?Modifications?
+
+    means any of the following:
+
+	   any file in Source Code Form that results from an addition to, deletion from, or modification of the contents of Covered Software; or
+
+	   any new file in Source Code Form that contains any Covered Software.
+
+1.11. ?Patent Claims? of a Contributor
+
+    means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent Licensable by such Contributor that would be infringed, but for the grant of the License, by the making, using, selling, offering for sale, having made, import, or transfer of either its Contributions or its Contributor Version.
+1.12. ?Secondary License?
+
+    means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses.
+1.13. ?Source Code Form?
+
+    means the form of the work preferred for making modifications.
+1.14. ?You? (or ?Your?)
+
+    means an individual or a legal entity exercising rights under this License. For legal entities, ?You? includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, ?control? means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+    under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
+
+    under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become effective for each Contribution on the date the Contributor first distributes such Contribution.
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this License. No additional rights or licenses will be implied from the distribution or licensing of Covered Software under this License. Notwithstanding Section 2.1(b) above, no patent license is granted by a Contributor:
+
+    for any code that a Contributor has removed from Covered Software; or
+
+    for infringements caused by: (i) Your and any other third party?s modifications of Covered Software, or (ii) the combination of its Contributions with other software (except as part of its Contributor Version); or
+
+    under Patent Claims infringed by Covered Software in the absence of its Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to distribute the Covered Software under a subsequent version of this License (see Section 10.2) or under the terms of a Secondary License (if permitted under the terms of Section 3.3).
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions are its original creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by this License.
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
+3. Responsibilities
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients? rights in the Source Code Form.
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+    such Covered Software must also be made available in Source Code Form, as described in Section 3.1, and You must inform recipients of the Executable Form how they can obtain a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and
+
+    You may distribute such Executable Form under the terms of this License, or sublicense it under different terms, provided that the license for the Executable Form does not attempt to limit or alter the recipients? rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice, provided that You also comply with the requirements of this License for the Covered Software. If the Larger Work is a combination of Covered Software with a work governed by one or more Secondary Licenses, and the Covered Software is not Incompatible With Secondary Licenses, this License permits You to additionally distribute such Covered Software under the terms of such Secondary License(s), so that the recipient of the Larger Work may, at their option, further distribute the Covered Software under the terms of either this License or such Secondary License(s).
+3.4. Notices
+
+You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.
+4. Inability to Comply Due to Statute or Regulation
+
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.
+6. Disclaimer of Warranty
+
+Covered Software is provided under this License on an ?as is? basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer.
+7. Limitation of Liability
+
+Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party?s negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.
+8. Litigation
+
+Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party?s ability to bring cross-claims or counter-claims.
+9. Miscellaneous
+
+This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.
+10. Versions of the License
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of the License under which You originally received the Covered Software, or under the terms of any subsequent version published by the license steward.
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create a new license for such software, you may create and use a modified version of this License if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this License).
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms of this version of the License, the notice described in Exhibit B of this License must be attached.
+Exhibit A - Source Code Form License Notice
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+Exhibit B - ?Incompatible With Secondary Licenses? Notice
+
+    This Source Code Form is ?Incompatible With Secondary Licenses?, as defined by the Mozilla Public License, v. 2.0.
+
+
+----
+mozjs-60.2.3//js/src/jit/WasmBCE.h:
+mozjs-60.2.3//js/src/wasm/AsmJS.cpp:
+mozjs-60.2.3//js/src/wasm/WasmBinaryIterator.cpp
+
+ Copyright 2014 Mozilla Foundation
+ Copyright 2015 Mozilla Foundation
+ Copyright 2016 Mozilla Foundation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+----
+				    Apache License
+			      Version 2.0, January 2004
+			   http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+	 "License" shall mean the terms and conditions for use, reproduction,
+	 and distribution as defined by Sections 1 through 9 of this document.
+
+	 "Licensor" shall mean the copyright owner or entity authorized by
+	 the copyright owner that is granting the License.
+
+	 "Legal Entity" shall mean the union of the acting entity and all
+	 other entities that control, are controlled by, or are under common
+	 control with that entity. For the purposes of this definition,
+	 "control" means (i) the power, direct or indirect, to cause the
+	 direction or management of such entity, whether by contract or
+	 otherwise, or (ii) ownership of fifty percent (50%) or more of the
+	 outstanding shares, or (iii) beneficial ownership of such entity.
+
+	 "You" (or "Your") shall mean an individual or Legal Entity
+	 exercising permissions granted by this License.
+
+	 "Source" form shall mean the preferred form for making modifications,
+	 including but not limited to software source code, documentation
+	 source, and configuration files.
+
+	 "Object" form shall mean any form resulting from mechanical
+	 transformation or translation of a Source form, including but
+	 not limited to compiled object code, generated documentation,
+	 and conversions to other media types.
+
+	 "Work" shall mean the work of authorship, whether in Source or
+	 Object form, made available under the License, as indicated by a
+	 copyright notice that is included in or attached to the work
+	 (an example is provided in the Appendix below).
+
+	 "Derivative Works" shall mean any work, whether in Source or Object
+	 form, that is based on (or derived from) the Work and for which the
+	 editorial revisions, annotations, elaborations, or other modifications
+	 represent, as a whole, an original work of authorship. For the purposes
+	 of this License, Derivative Works shall not include works that remain
+	 separable from, or merely link (or bind by name) to the interfaces of,
+	 the Work and Derivative Works thereof.
+
+	 "Contribution" shall mean any work of authorship, including
+	 the original version of the Work and any modifications or additions
+	 to that Work or Derivative Works thereof, that is intentionally
+	 submitted to Licensor for inclusion in the Work by the copyright owner
+	 or by an individual or Legal Entity authorized to submit on behalf of
+	 the copyright owner. For the purposes of this definition, "submitted"
+	 means any form of electronic, verbal, or written communication sent
+	 to the Licensor or its representatives, including but not limited to
+	 communication on electronic mailing lists, source code control systems,
+	 and issue tracking systems that are managed by, or on behalf of, the
+	 Licensor for the purpose of discussing and improving the Work, but
+	 excluding communication that is conspicuously marked or otherwise
+	 designated in writing by the copyright owner as "Not a Contribution."
+
+	 "Contributor" shall mean Licensor and any individual or Legal Entity
+	 on behalf of whom a Contribution has been received by Licensor and
+	 subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+	 this License, each Contributor hereby grants to You a perpetual,
+	 worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+	 copyright license to reproduce, prepare Derivative Works of,
+	 publicly display, publicly perform, sublicense, and distribute the
+	 Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+	 this License, each Contributor hereby grants to You a perpetual,
+	 worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+	 (except as stated in this section) patent license to make, have made,
+	 use, offer to sell, sell, import, and otherwise transfer the Work,
+	 where such license applies only to those patent claims licensable
+	 by such Contributor that are necessarily infringed by their
+	 Contribution(s) alone or by combination of their Contribution(s)
+	 with the Work to which such Contribution(s) was submitted. If You
+	 institute patent litigation against any entity (including a
+	 cross-claim or counterclaim in a lawsuit) alleging that the Work
+	 or a Contribution incorporated within the Work constitutes direct
+	 or contributory patent infringement, then any patent licenses
+	 granted to You under this License for that Work shall terminate
+	 as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+	 Work or Derivative Works thereof in any medium, with or without
+	 modifications, and in Source or Object form, provided that You
+	 meet the following conditions:
+
+	 (a) You must give any other recipients of the Work or
+	     Derivative Works a copy of this License; and
+
+	 (b) You must cause any modified files to carry prominent notices
+	     stating that You changed the files; and
+
+	 (c) You must retain, in the Source form of any Derivative Works
+	     that You distribute, all copyright, patent, trademark, and
+	     attribution notices from the Source form of the Work,
+	     excluding those notices that do not pertain to any part of
+	     the Derivative Works; and
+
+	 (d) If the Work includes a "NOTICE" text file as part of its
+	     distribution, then any Derivative Works that You distribute must
+	     include a readable copy of the attribution notices contained
+	     within such NOTICE file, excluding those notices that do not
+	     pertain to any part of the Derivative Works, in at least one
+	     of the following places: within a NOTICE text file distributed
+	     as part of the Derivative Works; within the Source form or
+	     documentation, if provided along with the Derivative Works; or,
+	     within a display generated by the Derivative Works, if and
+	     wherever such third-party notices normally appear. The contents
+	     of the NOTICE file are for informational purposes only and
+	     do not modify the License. You may add Your own attribution
+	     notices within Derivative Works that You distribute, alongside
+	     or as an addendum to the NOTICE text from the Work, provided
+	     that such additional attribution notices cannot be construed
+	     as modifying the License.
+
+	 You may add Your own copyright statement to Your modifications and
+	 may provide additional or different license terms and conditions
+	 for use, reproduction, or distribution of Your modifications, or
+	 for any such Derivative Works as a whole, provided Your use,
+	 reproduction, and distribution of the Work otherwise complies with
+	 the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+	 any Contribution intentionally submitted for inclusion in the Work
+	 by You to the Licensor shall be under the terms and conditions of
+	 this License, without any additional terms or conditions.
+	 Notwithstanding the above, nothing herein shall supersede or modify
+	 the terms of any separate license agreement you may have executed
+	 with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+	 names, trademarks, service marks, or product names of the Licensor,
+	 except as required for reasonable and customary use in describing the
+	 origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+	 agreed to in writing, Licensor provides the Work (and each
+	 Contributor provides its Contributions) on an "AS IS" BASIS,
+	 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+	 implied, including, without limitation, any warranties or conditions
+	 of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+	 PARTICULAR PURPOSE. You are solely responsible for determining the
+	 appropriateness of using or redistributing the Work and assume any
+	 risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+	 whether in tort (including negligence), contract, or otherwise,
+	 unless required by applicable law (such as deliberate and grossly
+	 negligent acts) or agreed to in writing, shall any Contributor be
+	 liable to You for damages, including any direct, indirect, special,
+	 incidental, or consequential damages of any character arising as a
+	 result of this License or out of the use or inability to use the
+	 Work (including but not limited to damages for loss of goodwill,
+	 work stoppage, computer failure or malfunction, or any and all
+	 other commercial damages or losses), even if such Contributor
+	 has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+	 the Work or Derivative Works thereof, You may choose to offer,
+	 and charge a fee for, acceptance of support, warranty, indemnity,
+	 or other liability obligations and/or rights consistent with this
+	 License. However, in accepting such obligations, You may act only
+	 on Your own behalf and on Your sole responsibility, not on behalf
+	 of any other Contributor, and only if You agree to indemnify,
+	 defend, and hold each Contributor harmless for any liability
+	 incurred by, or claims asserted against, such Contributor by reason
+	 of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+	 To apply the Apache License to your work, attach the following
+	 boilerplate notice, with the fields enclosed by brackets "[]"
+	 replaced with your own identifying information. (Don't include
+	 the brackets!)  The text should be enclosed in the appropriate
+	 comment syntax for the file format. We also recommend that a
+	 file or class name and description of purpose be included on the
+	 same "printed page" as the copyright notice for easier
+	 identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	  http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+----
+
+mozjs-60.2.3//js/src/ctypes/libffi/src/aarch64/ffi.c:
+
+ Copyright (c) 2009, 2010, 2011, 2012 ARM Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+``Software''), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----
+
+Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-----
+
+   ffi_common.h - Copyright (C) 2011, 2012, 2013  Anthony Green
+		     Copyright (C) 2007  Free Software Foundation, Inc
+		     Copyright (c) 1996  Red Hat, Inc.
+ Portions created by the Initial Developer are Copyright (C) 2009
+ Copyright (c) 2009, 2010, 2011, 2012 ARM Ltd.
+   ffi.c - Copyright (c) 2012  Anthony Green
+	      Copyright (c) 1998, 2001, 2007, 2008  Red Hat, Inc.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   ffi.c - Copyright (c) 2013  Synopsys, Inc. (www.synopsys.com)
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 2013	Synopsys, Inc. (www.synopsys.com)
+   ffi.c - Copyright (c) 2011 Timothy Wall
+	      Copyright (c) 2011 Plausible Labs Cooperative, Inc.
+	      Copyright (c) 2011 Anthony Green
+	   Copyright (c) 2011 Free Software Foundation
+	      Copyright (c) 1998, 2008, 2011  Red Hat, Inc.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 2010	CodeSourcery
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+  gentramp.sh - Copyright (c) 2010, Plausible Labs Cooperative, Inc.
+  Copyright (c) 2010, Plausible Labs Cooperative, Inc.
+   ffi.c - Copyright (c) 2011  Anthony Green
+	      Copyright (c) 2009  Bradley Smith <brad@brad-smith.co.uk>
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 2009	Bradley Smith <brad@brad-smith.co.uk>
+   ffi.c - Copyright (c) 2012  Alexandre K. I. de Mendonca <alexandre.keunecke@gmail.com>,
+   ffitarget.h - Copyright (c) 2012	Alexandre K. I. de Mendonca <alexandre.keunecke@gmail.com>
+   closures.c - Copyright (c) 2007, 2009, 2010  Red Hat, Inc.
+		   Copyright (C) 2007, 2009, 2010 Free Software Foundation, Inc
+		   Copyright (c) 2011 Plausible Labs Cooperative, Inc.
+   ffi.c - Copyright (c) 1998 Cygnus Solutions
+	      Copyright (c) 2004 Simon Posnjak
+	   Copyright (c) 2005 Axis Communications AB
+	   Copyright (C) 2007 Free Software Foundation, Inc.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   debug.c - Copyright (c) 1996 Red Hat, Inc.
+   ffi.c - Copyright (C) 2004  Anthony Green
+   Copyright (C) 2007  Free Software Foundation, Inc.
+	   Copyright (C) 2008  Red Hat, Inc.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2004  Red Hat, Inc.
+   ffi.c - Copyright (c) 1998, 2007, 2008, 2012 Red Hat, Inc.
+	   Copyright (c) 2000 Hewlett Packard Company
+	   Copyright (c) 2011 Anthony Green
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   ia64_flags.h - Copyright (c) 2000 Hewlett Packard Company
+   java_raw_api.c - Copyright (c) 1999, 2007, 2008  Red Hat, Inc.
+   ffi.c - Copyright (c) 2004  Renesas Technology
+	      Copyright (c) 2008  Red Hat, Inc.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 2004	Renesas Technology.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+ Copyright (c) 2013 Miodrag Vallat.	<miod@openbsd.org>
+ Copyright (c) 2013 Miodrag Vallat.	<miod@openbsd.org>
+  ffi.c - Copyright (c) 2013 Imagination Technologies
+   ffitarget.h - Copyright (c) 2013 Imagination Technologies Ltd.
+   ffi.c - Copyright (c) 2012, 2013 Xilinx, Inc
+   ffitarget.h - Copyright (c) 2012, 2013 Xilinx, Inc
+   ffi.c - Copyright (c) 2011  Anthony Green
+	      Copyright (c) 2008  David Daney
+	      Copyright (c) 1996, 2007, 2008, 2011  Red Hat, Inc.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   ffi.c - Copyright (C) 2012, 2013	Anthony Green
+   ffitarget.h - Copyright (c) 2012, 2013  Anthony Green
+   Copyright (c) 2013 Mentor Graphics.
+   Copyright (c) 2013 Mentor Graphics.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   asm.h - Copyright (c) 1998 Geoffrey Keating
+   ffi.c - Copyright (C) 2013 IBM
+	      Copyright (C) 2011 Anthony Green
+	      Copyright (C) 2011 Kyle Moffett
+	      Copyright (C) 2008 Red Hat, Inc
+	      Copyright (C) 2007, 2008 Free Software Foundation, Inc
+	   Copyright (c) 1998 Geoffrey Keating
+   Copyright (C) 1998 Geoffrey Keating
+   Copyright (C) 2001 John Hornkvist
+   Copyright (C) 2002, 2006, 2007, 2009, 2010 Free Software Foundation, Inc.
+   ffi_linux64.c - Copyright (C) 2013 IBM
+		      Copyright (C) 2011 Anthony Green
+		      Copyright (C) 2011 Kyle Moffett
+		      Copyright (C) 2008 Red Hat, Inc
+		      Copyright (C) 2007, 2008 Free Software Foundation, Inc
+		      Copyright (c) 1998 Geoffrey Keating
+   ffi_powerpc.h - Copyright (C) 2013 IBM
+		      Copyright (C) 2011 Anthony Green
+		      Copyright (C) 2011 Kyle Moffett
+		      Copyright (C) 2008 Red Hat, Inc
+		      Copyright (C) 2007, 2008 Free Software Foundation, Inc
+		      Copyright (c) 1998 Geoffrey Keating
+   ffi_sysv.c - Copyright (C) 2013 IBM
+		   Copyright (C) 2011 Anthony Green
+		   Copyright (C) 2011 Kyle Moffett
+		   Copyright (C) 2008 Red Hat, Inc
+		   Copyright (C) 2007, 2008 Free Software Foundation, Inc
+		   Copyright (c) 1998 Geoffrey Keating
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (C) 2007, 2008, 2010 Free Software Foundation, Inc
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   prep_cif.c - Copyright (c) 2011, 2012  Anthony Green
+		   Copyright (c) 1996, 1998, 2007  Red Hat, Inc.
+   raw_api.c - Copyright (c) 1999, 2008  Red Hat, Inc.
+   ffi.c - Copyright (c) 2000, 2007 Software AG
+	      Copyright (c) 2008 Red Hat, Inc
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   ffi.c - Copyright (c) 2002-2008, 2012 Kaz Kojima
+	      Copyright (c) 2008 Red Hat, Inc.
+   ffitarget.h - Copyright (c) 2012 Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   ffi.c - Copyright (c) 2003, 2004, 2006, 2007, 2012 Kaz Kojima
+	      Copyright (c) 2008 Anthony Green
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   ffi.c - Copyright (c) 2011, 2013 Anthony Green
+	      Copyright (c) 1996, 2003-2004, 2007-2008 Red Hat, Inc.
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003  Red Hat, Inc.
+   ffi.c - Copyright (c) 2012 Tilera Corp.
+   ffitarget.h - Copyright (c) 2012 Tilera Corp.
+   types.c - Copyright (c) 1996, 1998  Red Hat, Inc.
+ Copyright (c) 2013 Miodrag Vallat.	<miod@openbsd.org>
+ Copyright (c) 2013 Miodrag Vallat.	<miod@openbsd.org>
+   ffi.c - Copyright (c) 1996, 1998, 1999, 2001, 2007, 2008	Red Hat, Inc.
+	      Copyright (c) 2002  Ranjit Mathew
+	      Copyright (c) 2002  Bo Thorsen
+	      Copyright (c) 2002  Roger Sayle
+	      Copyright (C) 2008, 2010	Free Software Foundation, Inc.
+   ffi64.c - Copyright (c) 2013  The Written Word, Inc.
+		Copyright (c) 2011  Anthony Green
+		Copyright (c) 2008, 2010  Red Hat, Inc.
+		Copyright (c) 2002, 2007  Bo Thorsen <bo@suse.de>
+   ffitarget.h - Copyright (c) 2012	Anthony Green
+		    Copyright (c) 1996-2003, 2010  Red Hat, Inc.
+		    Copyright (C) 2008	Free Software Foundation, Inc.
+   ffi.c - Copyright (c) 2013 Tensilica, Inc.
+   ffitarget.h - Copyright (c) 2013 Tensilica, Inc.
+ Copyright (c) 1991, 2000, 2001 by Lucent Technologies.
+ Copyright 1992,1993 Simmule Turner and Rich Salz.  All rights reserved.
+ Copyright 2012 the V8 project authors. All rights reserved.
+ Copyright 2011 the V8 project authors. All rights reserved.
+ Copyright 2009 the V8 project authors. All rights reserved.
+ Copyright (C) 2008 Apple Inc. All rights reserved.
+ Copyright 2016 Mozilla Foundation
+ Copyright 2012 the V8 project authors. All rights reserved.
+ Copyright 2007-2008 the V8 project authors. All rights reserved.
+ Copyright 2018 Mozilla Foundation
+ Copyright 2015, ARM Limited
+ Copyright 2014, ARM Limited
+ Copyright 2013, ARM Limited
+ Copyright 2013, ARM Limited
+  Copyright (c) 2005-2014 Intel Corporation. All rights reserved.
+ Copyright 2014 Mozilla Foundation
+ Copyright 2015 Mozilla Foundation
+ Copyright 2015 Mozilla Foundation
+ Copyright 2017 Mozilla Foundation
+ Copyright 2017 Mozilla Foundation
+ Copyright 2016 Mozilla Foundation
+ Copyright (c) 2013 Google Inc. All rights reserved.
+ Copyright (c) 2011 Google Inc. All rights reserved.
+ Copyright (c) 2011 Google Inc. All rights reserved.
+ Copyright (c) 2012 Google Inc. All rights reserved.
+ Copyright (c) 2010 Google Inc. All rights reserved.
+ Copyright (c) 2014 Google Inc. All rights reserved.
+ Copyright (c) 2015 Google Inc. All rights reserved.
+ Copyright (c) 2011 Google Inc. All rights reserved.
+ Copyright (c) 2009 Google Inc. All rights reserved.
+ Copyright 2015 The Chromium Authors. All rights reserved.
+ Copyright 2015 The Chromium Authors. All rights reserved.
+ Copyright 2013 Google Inc. All rights reserved.
+ Copyright (c) 2016 Google Inc. All rights reserved.
+ Copyright (c) 2016 Google Inc. All rights reserved.
+ Copyright (c) 2016 The Chromium Authors. All rights reserved.
+ Copyright (c) 2016 The Chromium Authors. All rights reserved.
+ Copyright (c) 2012 Google Inc. All rights reserved.
+ Copyright (C) 2006-2008 Jason Evans <jasone@FreeBSD.org>.
+ Copyright (C) 2007-2017 Mozilla Foundation.
+ Copyright (C) 2006-2008 Jason Evans <jasone@FreeBSD.org>.
+ Copyright (C) 2008 Jason Evans <jasone@FreeBSD.org>.
+ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+ Copyright 2010 the V8 project authors. All rights reserved.
+ Copyright 2006-2008 the V8 project authors. All rights reserved.
+ Copyright 2010 the V8 project authors. All rights reserved.
+   Copyright (C) 2011-2017, Yann Collet.
+  Copyright (C) 2011-2017, Yann Collet.
+ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+ Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ Copyright (C) 2004 by Sun Microsystems, Inc. All rights reserved.
+ Copyright (c) 2011 David Schultz <das@FreeBSD.ORG>
+ Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ Copyright (c) 2004 David Schultz <das@FreeBSD.ORG>
+ Copyright (C) 1995-2011, 2016 Mark Adler
+ Copyright (C) 1995-2005, 2014, 2016 Jean-loup Gailly, Mark Adler
+ Copyright (C) 1995-2006, 2010, 2011, 2012, 2016 Mark Adler
+ Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+ Copyright (C) 1995-2016 Jean-loup Gailly
+ Copyright (C) 2004, 2010 Mark Adler
+ Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013, 2016 Mark Adler
+ Copyright (C) 2004-2017 Mark Adler
+ Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013, 2016 Mark Adler
+ Copyright (C) 2004-2017 Mark Adler
+ Copyright (C) 1995-2016 Mark Adler
+ Copyright (C) 1995-2017 Mark Adler
+ Copyright (C) 1995-2003, 2010 Mark Adler
+ Copyright (C) 1995-2016 Mark Adler
+ Copyright (C) 1995-2016 Mark Adler
+ Copyright (C) 1995-2017 Mark Adler
+ Copyright (C) 1995-2005, 2010 Mark Adler
+ Copyright (C) 1995-2017 Jean-loup Gailly
+ Copyright (C) 1995-2003, 2010, 2014, 2016 Jean-loup Gailly, Mark Adler
+ Copyright (C) 1995-2016 Jean-loup Gailly, Mark Adler
+  Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+ Copyright (C) 1995-2017 Jean-loup Gailly
+ Copyright (C) 1995-2016 Jean-loup Gailly, Mark Adler
+ copywrite	       "Copyright (c) 1998 Netscape Communications Corporation. All Rights Reserved",
+ copywrite	       "Copyright (c) 1998 Netscape Communications Corporation. All Rights Reserved",
+ copywrite	       "Copyright (c) 1998 Netscape Communications Corporation. All Rights Reserved",
+ Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+Copyright (C) 1987, 1988 Student Information Processing Board of the
+ Copyright (c) 1991, 2000, 2001 by Lucent Technologies.
+ Copyright (c) 1983, 1990, 1993
+ Portions Copyright (c) 1993 by Digital Equipment Corporation.
+ Copyright (c) 2004 by Internet Systems Consortium, Inc. ("ISC")
+ Portions Copyright (c) 1996-1999 by Internet Software Consortium.
+ Copyright (c) 1991, 2000, 2001 by Lucent Technologies.
+Copyright 1987, 1988 by the Student Information Processing Board
+ copywrite	       "Copyright (c) 1998 Netscape Communications Corporation. All Rights Reserved",
+ Copyright (c) 2009, Giampaolo Rodola', Landry Breuil (OpenBSD).
+ Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+ Copyright (c) 2009, Jay Loden, Giampaolo Rodola'. All rights reserved.
+ Copyright (c) 2017, Arnon Yaari
+ Copyright (c) 2015, Ryo ONODERA.
+ Copyright (c) 2009, Giampaolo Rodola'.
+ Copyright (c) 2015, Ryo ONODERA.
+ Copyright (c) 2009, Giampaolo Rodola', Landry Breuil.
+ Copyright (c) 2009, Giampaolo Rodola', Oleksii Shevchuk.
+ Copyright (c) 2009, Giampaolo Rodola', Jeff Tang. All rights reserved.
+ Copyright (c) 2009, Giampaolo Rodola', Jeff Tang. All rights reserved.
+ Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+ Copyright (c) 2009, Giampaolo Rodola'. All rights reserved.
+ Copyright (c) 2002-2003 ActiveState Corp.
+
+---
+
+attrs/LICENSE:Copyright (c) 2015 Hynek Schlawack
+blessings/LICENSE:Copyright (c) 2011 Erik Rose
+cbor2/LICENSE.txt:Copyright (c) Alex Gronholm
+configobj/configobj.py:# Copyright (C) 2005-2010 Michael Foord, Nicola Larosa
+configobj/setup.py:# Copyright (C) 2005-2010 Michael Foord, Mark Andrews, Nicola Larosa
+configobj/validate.py:# Copyright (C) 2005-2010 Michael Foord, Mark Andrews, Nicola Larosa
+futures/LICENSE:Copyright 2009 Brian Quinlan. All rights reserved.
+hglib/LICENSE:Copyright (c) 2011 Matt Mackall and other contributors
+mock-1.0.0/LICENSE.txt:Copyright (c) 2003-2012, Michael Foord
+mock-1.0.0/mock.py:# Copyright (C) 2007-2012 Michael Foord & the mock team
+mock-1.0.0/setup.py:# Copyright (C) 2007-2012 Michael Foord & the mock team
+psutil/LICENSE:Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'
+psutil/setup.py:# Copyright (c) 2009 Giampaolo Rodola'. All rights reserved.
+pyasn1-modules/CHANGES.txt:* Copyright added to source files
+pyasn1-modules/LICENSE.txt:Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+pyasn1-modules/README.md:Copyright (c) 2005-2017, [Ilya Etingof](mailto:etingof@gmail.com).
+pyasn1-modules/setup.py:# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+pyasn1/CHANGES.rst:- Copyright notice added to non-trivial source code files.
+pyasn1/LICENSE.rst:Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+pyasn1/README.md:Copyright (c) 2005-2017, [Ilya Etingof](mailto:etingof@gmail.com).
+pyasn1/setup.py:# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+PyECC/README.md:Copyright (c) 2010-2015 Toni Mattis
+PyECC/setup.py:# Copyright 2007 The Python-Twitter Developers
+pylru/pylru.py:# Copyright (C) 2006, 2009, 2010, 2011 Jay Hutchinson
+pystache/LICENSE:Copyright (C) 2012 Chris Jerdonek.	All rights reserved.
+pystache/LICENSE:Copyright (c) 2009 Chris Wanstrath
+pystache/setup_description.rst:Copyright (C) 2012 Chris Jerdonek. All rights reserved.
+pystache/setup_description.rst:Copyright (c) 2009 Chris Wanstrath
+pyyaml/LICENSE:Copyright (c) 2006 Kirill Simonov
+requests-unixsocket/LICENSE:   2. Grant of Copyright License. Subject to the terms and conditions of
+requests-unixsocket/LICENSE:   Copyright {yyyy} {name of copyright owner}
+requests/LICENSE:Copyright 2015 Kenneth Reitz
+requests/NOTICE:Copyright 2008-2011 Andrey Petrov and contributors (see CONTRIBUTORS.txt),
+rsa/LICENSE:Copyright 2011 Sybren A. Stuvel <sybren@stuvel.eu>
+six/LICENSE:Copyright (c) 2010-2015 Benjamin Peterson
+six/six.py:# Copyright (c) 2010-2015 Benjamin Peterson
+virtualenv/LICENSE.txt:Copyright (c) 2007 Ian Bicking and Contributors
+virtualenv/LICENSE.txt:Copyright (c) 2009 Ian Bicking, The Open Planning Project
+virtualenv/LICENSE.txt:Copyright (c) 2011-2016 The virtualenv developers
+which/build.py:# Copyright (c) 2002-2005 ActiveState
+which/launcher.cpp: * Copyright (c) 2002-2003 ActiveState Corp.
+which/LICENSE.txt:Copyright (c) 2002-2005 ActiveState Corp.
+which/Makefile.win:# Copyright (c) 2002-2003 ActiveState Corp.
+which/setup.py:# Copyright (c) 2002-2005 ActiveState Corp.
+which/which.py:# Copyright (c) 2002-2005 ActiveState Corp.
+
+
+
+---  mock ---
+
+Copyright (c) 2003-2012, Michael Foord
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--- cbor2 --- 
+This is the MIT license: http://www.opensource.org/licenses/mit-license.php
+
+Copyright (c) Alex Grönholm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+---rsa-
+
+Copyright 2011 Sybren A. Stüvel <sybren@stuvel.eu>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/components/library/mozjs-78/mozjs-78.p5m
+++ b/components/library/mozjs-78/mozjs-78.p5m
@@ -1,0 +1,301 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+#
+
+<transform file path=usr.*/man/.+ -> \
+    default mangler.man.stability "pass-through volatile">
+
+# move js-config to correct location
+#<transform file path=usr/bin/js\$\(COMPONENT_VERSION\)-config -> \
+#    set action.hash %(path)>
+#<transform file path=usr/bin/js\$\(COMPONENT_VERSION\)-config -> \
+#    edit path bin/js bin/\$\(MACH64\)/js>
+#
+## allow 64-bit object in 32-bit path
+#<transform file path=usr/bin/js\$\(COMPONENT_VERSION\) -> \
+#    set pkg.linted.userland.action001.2 true>
+
+# drop static library (with a weird extension)
+<transform file path=usr/lib/\$\(MACH64\)/libjs_static.ajs$ -> drop>
+
+set name=pkg.fmri \
+    value=pkg:/library/libmozjs-78@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary \
+    value="Mozilla's SpiderMonkey engine JavaScript library v78"
+set name=pkg.description \
+    value="SpiderMonkey is Mozilla's JavaScript engine written in C/C++. It is used in various Mozilla products, including Firefox"
+set name=pkg.linted.userland.action001.3 value=true
+set name=info.classification \
+    value="org.opensolaris.category.2008:Development/Other Languages"
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+file usr/bin/js$(COMPONENT_VERSION)-config \
+    path=usr/bin/$(MACH64)/js$(COMPONENT_VERSION)-config
+file path=usr/bin/js$(COMPONENT_VERSION) pkg.linted.userland.action001.2=true
+file path=usr/include/mozjs-78/BaseProfiler.h
+file path=usr/include/mozjs-78/double-conversion/double-conversion.h
+file path=usr/include/mozjs-78/double-conversion/double-to-string.h
+file path=usr/include/mozjs-78/double-conversion/string-to-double.h
+file path=usr/include/mozjs-78/double-conversion/utils.h
+file path=usr/include/mozjs-78/encoding_rs_mem.h
+file path=usr/include/mozjs-78/fdlibm.h
+file path=usr/include/mozjs-78/js-config.h
+file path=usr/include/mozjs-78/js.msg
+file path=usr/include/mozjs-78/js/AllocPolicy.h
+file path=usr/include/mozjs-78/js/AllocationRecording.h
+file path=usr/include/mozjs-78/js/Array.h
+file path=usr/include/mozjs-78/js/ArrayBuffer.h
+file path=usr/include/mozjs-78/js/ArrayBufferMaybeShared.h
+file path=usr/include/mozjs-78/js/BigInt.h
+file path=usr/include/mozjs-78/js/BinASTFormat.h
+file path=usr/include/mozjs-78/js/BuildId.h
+file path=usr/include/mozjs-78/js/CallArgs.h
+file path=usr/include/mozjs-78/js/CallNonGenericMethod.h
+file path=usr/include/mozjs-78/js/CharacterEncoding.h
+file path=usr/include/mozjs-78/js/Class.h
+file path=usr/include/mozjs-78/js/ComparisonOperators.h
+file path=usr/include/mozjs-78/js/CompilationAndEvaluation.h
+file path=usr/include/mozjs-78/js/CompileOptions.h
+file path=usr/include/mozjs-78/js/ContextOptions.h
+file path=usr/include/mozjs-78/js/Conversions.h
+file path=usr/include/mozjs-78/js/Date.h
+file path=usr/include/mozjs-78/js/Debug.h
+file path=usr/include/mozjs-78/js/Equality.h
+file path=usr/include/mozjs-78/js/ErrorReport.h
+file path=usr/include/mozjs-78/js/Exception.h
+file path=usr/include/mozjs-78/js/ForOfIterator.h
+file path=usr/include/mozjs-78/js/GCAPI.h
+file path=usr/include/mozjs-78/js/GCAnnotations.h
+file path=usr/include/mozjs-78/js/GCHashTable.h
+file path=usr/include/mozjs-78/js/GCPolicyAPI.h
+file path=usr/include/mozjs-78/js/GCTypeMacros.h
+file path=usr/include/mozjs-78/js/GCVariant.h
+file path=usr/include/mozjs-78/js/GCVector.h
+file path=usr/include/mozjs-78/js/HashTable.h
+file path=usr/include/mozjs-78/js/HeapAPI.h
+file path=usr/include/mozjs-78/js/Id.h
+file path=usr/include/mozjs-78/js/Initialization.h
+file path=usr/include/mozjs-78/js/JSON.h
+file path=usr/include/mozjs-78/js/LocaleSensitive.h
+file path=usr/include/mozjs-78/js/MemoryFunctions.h
+file path=usr/include/mozjs-78/js/MemoryMetrics.h
+file path=usr/include/mozjs-78/js/Modules.h
+file path=usr/include/mozjs-78/js/OffThreadScriptCompilation.h
+file path=usr/include/mozjs-78/js/Principals.h
+file path=usr/include/mozjs-78/js/Printf.h
+file path=usr/include/mozjs-78/js/ProfilingCategory.h
+file path=usr/include/mozjs-78/js/ProfilingFrameIterator.h
+file path=usr/include/mozjs-78/js/ProfilingStack.h
+file path=usr/include/mozjs-78/js/Promise.h
+file path=usr/include/mozjs-78/js/PropertyDescriptor.h
+file path=usr/include/mozjs-78/js/PropertySpec.h
+file path=usr/include/mozjs-78/js/ProtoKey.h
+file path=usr/include/mozjs-78/js/Proxy.h
+file path=usr/include/mozjs-78/js/Realm.h
+file path=usr/include/mozjs-78/js/RealmOptions.h
+file path=usr/include/mozjs-78/js/RefCounted.h
+file path=usr/include/mozjs-78/js/RegExp.h
+file path=usr/include/mozjs-78/js/RegExpFlags.h
+file path=usr/include/mozjs-78/js/RequiredDefines.h
+file path=usr/include/mozjs-78/js/Result.h
+file path=usr/include/mozjs-78/js/RootingAPI.h
+file path=usr/include/mozjs-78/js/SavedFrameAPI.h
+file path=usr/include/mozjs-78/js/SharedArrayBuffer.h
+file path=usr/include/mozjs-78/js/SliceBudget.h
+file path=usr/include/mozjs-78/js/SourceText.h
+file path=usr/include/mozjs-78/js/StableStringChars.h
+file path=usr/include/mozjs-78/js/Stream.h
+file path=usr/include/mozjs-78/js/StructuredClone.h
+file path=usr/include/mozjs-78/js/SweepingAPI.h
+file path=usr/include/mozjs-78/js/Symbol.h
+file path=usr/include/mozjs-78/js/TraceKind.h
+file path=usr/include/mozjs-78/js/TraceLoggerAPI.h
+file path=usr/include/mozjs-78/js/TracingAPI.h
+file path=usr/include/mozjs-78/js/Transcoding.h
+file path=usr/include/mozjs-78/js/TypeDecls.h
+file path=usr/include/mozjs-78/js/UbiNode.h
+file path=usr/include/mozjs-78/js/UbiNodeBreadthFirst.h
+file path=usr/include/mozjs-78/js/UbiNodeCensus.h
+file path=usr/include/mozjs-78/js/UbiNodeDominatorTree.h
+file path=usr/include/mozjs-78/js/UbiNodePostOrder.h
+file path=usr/include/mozjs-78/js/UbiNodeShortestPaths.h
+file path=usr/include/mozjs-78/js/UbiNodeUtils.h
+file path=usr/include/mozjs-78/js/UniquePtr.h
+file path=usr/include/mozjs-78/js/Utility.h
+file path=usr/include/mozjs-78/js/Value.h
+file path=usr/include/mozjs-78/js/ValueArray.h
+file path=usr/include/mozjs-78/js/Vector.h
+file path=usr/include/mozjs-78/js/Warnings.h
+file path=usr/include/mozjs-78/js/WeakMapPtr.h
+file path=usr/include/mozjs-78/js/Wrapper.h
+file path=usr/include/mozjs-78/js/experimental/CodeCoverage.h
+file path=usr/include/mozjs-78/js/experimental/SourceHook.h
+file path=usr/include/mozjs-78/jsapi.h
+file path=usr/include/mozjs-78/jsfriendapi.h
+file path=usr/include/mozjs-78/jspubtd.h
+file path=usr/include/mozjs-78/jstypes.h
+file path=usr/include/mozjs-78/malloc_decls.h
+file path=usr/include/mozjs-78/mozilla/Algorithm.h
+file path=usr/include/mozjs-78/mozilla/Alignment.h
+file path=usr/include/mozjs-78/mozilla/AllocPolicy.h
+file path=usr/include/mozjs-78/mozilla/AlreadyAddRefed.h
+file path=usr/include/mozjs-78/mozilla/Array.h
+file path=usr/include/mozjs-78/mozilla/ArrayUtils.h
+file path=usr/include/mozjs-78/mozilla/Assertions.h
+file path=usr/include/mozjs-78/mozilla/Atomics.h
+file path=usr/include/mozjs-78/mozilla/Attributes.h
+file path=usr/include/mozjs-78/mozilla/AutoProfilerLabel.h
+file path=usr/include/mozjs-78/mozilla/BaseProfilerCounts.h
+file path=usr/include/mozjs-78/mozilla/BaseProfilerDetail.h
+file path=usr/include/mozjs-78/mozilla/BinarySearch.h
+file path=usr/include/mozjs-78/mozilla/BlocksRingBuffer.h
+file path=usr/include/mozjs-78/mozilla/BloomFilter.h
+file path=usr/include/mozjs-78/mozilla/Buffer.h
+file path=usr/include/mozjs-78/mozilla/BufferList.h
+file path=usr/include/mozjs-78/mozilla/Casting.h
+file path=usr/include/mozjs-78/mozilla/ChaosMode.h
+file path=usr/include/mozjs-78/mozilla/Char16.h
+file path=usr/include/mozjs-78/mozilla/CheckedInt.h
+file path=usr/include/mozjs-78/mozilla/CompactPair.h
+file path=usr/include/mozjs-78/mozilla/Compiler.h
+file path=usr/include/mozjs-78/mozilla/Compression.h
+file path=usr/include/mozjs-78/mozilla/DbgMacro.h
+file path=usr/include/mozjs-78/mozilla/DebugOnly.h
+file path=usr/include/mozjs-78/mozilla/Decimal.h
+file path=usr/include/mozjs-78/mozilla/DefineEnum.h
+file path=usr/include/mozjs-78/mozilla/DoubleConversion.h
+file path=usr/include/mozjs-78/mozilla/DoublyLinkedList.h
+file path=usr/include/mozjs-78/mozilla/EndianUtils.h
+file path=usr/include/mozjs-78/mozilla/EnumSet.h
+file path=usr/include/mozjs-78/mozilla/EnumTypeTraits.h
+file path=usr/include/mozjs-78/mozilla/EnumeratedArray.h
+file path=usr/include/mozjs-78/mozilla/EnumeratedRange.h
+file path=usr/include/mozjs-78/mozilla/FStream.h
+file path=usr/include/mozjs-78/mozilla/FastBernoulliTrial.h
+file path=usr/include/mozjs-78/mozilla/FloatingPoint.h
+file path=usr/include/mozjs-78/mozilla/FunctionRef.h
+file path=usr/include/mozjs-78/mozilla/FunctionTypeTraits.h
+file path=usr/include/mozjs-78/mozilla/GuardObjects.h
+file path=usr/include/mozjs-78/mozilla/HashFunctions.h
+file path=usr/include/mozjs-78/mozilla/HashTable.h
+file path=usr/include/mozjs-78/mozilla/HelperMacros.h
+file path=usr/include/mozjs-78/mozilla/InitializedOnce.h
+file path=usr/include/mozjs-78/mozilla/IntegerPrintfMacros.h
+file path=usr/include/mozjs-78/mozilla/IntegerRange.h
+file path=usr/include/mozjs-78/mozilla/IntegerTypeTraits.h
+file path=usr/include/mozjs-78/mozilla/JSONWriter.h
+file path=usr/include/mozjs-78/mozilla/JsRust.h
+file path=usr/include/mozjs-78/mozilla/Latin1.h
+file path=usr/include/mozjs-78/mozilla/Likely.h
+file path=usr/include/mozjs-78/mozilla/LinkedList.h
+file path=usr/include/mozjs-78/mozilla/MacroArgs.h
+file path=usr/include/mozjs-78/mozilla/MacroForEach.h
+file path=usr/include/mozjs-78/mozilla/MathAlgorithms.h
+file path=usr/include/mozjs-78/mozilla/Maybe.h
+file path=usr/include/mozjs-78/mozilla/MaybeOneOf.h
+file path=usr/include/mozjs-78/mozilla/MemoryChecking.h
+file path=usr/include/mozjs-78/mozilla/MemoryReporting.h
+file path=usr/include/mozjs-78/mozilla/MmapFaultHandler.h
+file path=usr/include/mozjs-78/mozilla/ModuloBuffer.h
+file path=usr/include/mozjs-78/mozilla/NonDereferenceable.h
+file path=usr/include/mozjs-78/mozilla/NotNull.h
+file path=usr/include/mozjs-78/mozilla/Opaque.h
+file path=usr/include/mozjs-78/mozilla/OperatorNewExtensions.h
+file path=usr/include/mozjs-78/mozilla/Path.h
+file path=usr/include/mozjs-78/mozilla/PlatformConditionVariable.h
+file path=usr/include/mozjs-78/mozilla/PlatformMutex.h
+file path=usr/include/mozjs-78/mozilla/PodOperations.h
+file path=usr/include/mozjs-78/mozilla/Poison.h
+file path=usr/include/mozjs-78/mozilla/PowerOfTwo.h
+file path=usr/include/mozjs-78/mozilla/Printf.h
+file path=usr/include/mozjs-78/mozilla/ProfileBufferChunk.h
+file path=usr/include/mozjs-78/mozilla/ProfileBufferChunkManager.h
+file path=usr/include/mozjs-78/mozilla/ProfileBufferChunkManagerSingle.h
+file path=usr/include/mozjs-78/mozilla/ProfileBufferChunkManagerWithLocalLimit.h
+file path=usr/include/mozjs-78/mozilla/ProfileBufferControlledChunkManager.h
+file path=usr/include/mozjs-78/mozilla/ProfileBufferEntrySerialization.h
+file path=usr/include/mozjs-78/mozilla/ProfileBufferIndex.h
+file path=usr/include/mozjs-78/mozilla/ProfileChunkedBuffer.h
+file path=usr/include/mozjs-78/mozilla/RandomNum.h
+file path=usr/include/mozjs-78/mozilla/Range.h
+file path=usr/include/mozjs-78/mozilla/RangedArray.h
+file path=usr/include/mozjs-78/mozilla/RangedPtr.h
+file path=usr/include/mozjs-78/mozilla/ReentrancyGuard.h
+file path=usr/include/mozjs-78/mozilla/RefCountType.h
+file path=usr/include/mozjs-78/mozilla/RefCounted.h
+file path=usr/include/mozjs-78/mozilla/RefPtr.h
+file path=usr/include/mozjs-78/mozilla/Result.h
+file path=usr/include/mozjs-78/mozilla/ResultExtensions.h
+file path=usr/include/mozjs-78/mozilla/ReverseIterator.h
+file path=usr/include/mozjs-78/mozilla/RollingMean.h
+file path=usr/include/mozjs-78/mozilla/SHA1.h
+file path=usr/include/mozjs-78/mozilla/SPSCQueue.h
+file path=usr/include/mozjs-78/mozilla/Saturate.h
+file path=usr/include/mozjs-78/mozilla/ScopeExit.h
+file path=usr/include/mozjs-78/mozilla/Scoped.h
+file path=usr/include/mozjs-78/mozilla/SegmentedVector.h
+file path=usr/include/mozjs-78/mozilla/SharedLibrary.h
+file path=usr/include/mozjs-78/mozilla/SmallPointerArray.h
+file path=usr/include/mozjs-78/mozilla/Span.h
+file path=usr/include/mozjs-78/mozilla/SplayTree.h
+file path=usr/include/mozjs-78/mozilla/Sprintf.h
+file path=usr/include/mozjs-78/mozilla/StackWalk.h
+file path=usr/include/mozjs-78/mozilla/StaticAnalysisFunctions.h
+file path=usr/include/mozjs-78/mozilla/TaggedAnonymousMemory.h
+file path=usr/include/mozjs-78/mozilla/Tainting.h
+file path=usr/include/mozjs-78/mozilla/TemplateLib.h
+file path=usr/include/mozjs-78/mozilla/TextUtils.h
+file path=usr/include/mozjs-78/mozilla/ThreadLocal.h
+file path=usr/include/mozjs-78/mozilla/ThreadSafeWeakPtr.h
+file path=usr/include/mozjs-78/mozilla/TimeStamp.h
+file path=usr/include/mozjs-78/mozilla/ToString.h
+file path=usr/include/mozjs-78/mozilla/Tuple.h
+file path=usr/include/mozjs-78/mozilla/TypeTraits.h
+file path=usr/include/mozjs-78/mozilla/TypedEnumBits.h
+file path=usr/include/mozjs-78/mozilla/Types.h
+file path=usr/include/mozjs-78/mozilla/UniquePtr.h
+file path=usr/include/mozjs-78/mozilla/UniquePtrExtensions.h
+file path=usr/include/mozjs-78/mozilla/Unused.h
+file path=usr/include/mozjs-78/mozilla/Utf8.h
+file path=usr/include/mozjs-78/mozilla/Variant.h
+file path=usr/include/mozjs-78/mozilla/Vector.h
+file path=usr/include/mozjs-78/mozilla/WeakPtr.h
+file path=usr/include/mozjs-78/mozilla/WrappingOperations.h
+file path=usr/include/mozjs-78/mozilla/XorShift128PlusRNG.h
+file path=usr/include/mozjs-78/mozilla/cxxalloc.h
+file path=usr/include/mozjs-78/mozilla/fallible.h
+file path=usr/include/mozjs-78/mozilla/glue/Debug.h
+file path=usr/include/mozjs-78/mozilla/glue/WinUtils.h
+file path=usr/include/mozjs-78/mozilla/leb128iterator.h
+file path=usr/include/mozjs-78/mozilla/mozalloc.h
+file path=usr/include/mozjs-78/mozilla/mozalloc_abort.h
+file path=usr/include/mozjs-78/mozilla/mozalloc_oom.h
+file path=usr/include/mozjs-78/mozjemalloc_types.h
+file path=usr/include/mozjs-78/mozmemory.h
+file path=usr/include/mozjs-78/mozmemory_wrap.h
+file path=usr/lib/$(MACH64)/libmozjs-78.so
+file path=usr/lib/$(MACH64)/pkgconfig/mozjs-78.pc
+license mozjs-78.license license="MPLv2, LGPLv2, BSD"

--- a/components/library/mozjs-78/patches/01-build-fix.patch
+++ b/components/library/mozjs-78/patches/01-build-fix.patch
@@ -1,0 +1,15 @@
+--- mozjs-78.4.0/js/moz.configure
++++ mozjs-78.4.0/js/moz.configure
+@@ -696,10 +696,10 @@ def editline(js_shell, is_windows, compi
+ js_option('--enable-readline', help='Link js shell to system readline library',
+           when=editline)
+ 
+-has_readline = check_symbol('readline', flags=['-lreadline'], when='--enable-readline',
++has_readline = check_symbol('readline', flags=['-lreadline', '-lcurses'], when='--enable-readline',
+                             onerror=lambda: die('No system readline library found'))
+ 
+-set_config('EDITLINE_LIBS', ['-lreadline'], when=has_readline)
++set_config('EDITLINE_LIBS', ['-lreadline', '-lcurses'], when=has_readline)
+ 
+ @depends('--enable-readline', editline, when=editline)
+ def bundled_editline(readline, editline):

--- a/components/library/mozjs-78/patches/02-sparc.patch
+++ b/components/library/mozjs-78/patches/02-sparc.patch
@@ -1,0 +1,28 @@
+https://bugzilla.mozilla.org/show_bug.cgi?id=1391072
+
+Patch included to build both 32 and 64-bits on sparc
+
+--- mozjs-78.4.0/build/autoconf/config.guess
++++ mozjs-78.4.0/build/autoconf/config.guess
+@@ -391,7 +391,20 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAM
+ 	echo sparc-hal-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
+ 	exit ;;
+     sun4*:SunOS:5.*:* | tadpole*:SunOS:5.*:*)
+-	echo sparc-sun-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
++        eval $set_cc_for_build
++        SUN_ARCH=sparc
++        # If there is a compiler, see if it is configured for 64-bit objects.
++        # Note that the Sun cc does not turn __LP64__ into 1 like gcc does.
++        # This test works for both compilers.
++        if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
++            if (echo '#ifdef __sparcv9'; echo IS_64BIT_ARCH; echo '#endif') | \
++                (CCOPTS= $CC_FOR_BUILD -E - 2>/dev/null) | \
++                grep IS_64BIT_ARCH >/dev/null
++            then
++                SUN_ARCH=sparc64
++            fi
++        fi
++	echo ${SUN_ARCH}-sun-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
+ 	exit ;;
+     i86pc:AuroraUX:5.*:* | i86xen:AuroraUX:5.*:*)
+ 	echo i386-pc-auroraux"$UNAME_RELEASE"

--- a/components/library/mozjs-78/patches/03-rustc-target.patch
+++ b/components/library/mozjs-78/patches/03-rustc-target.patch
@@ -1,0 +1,19 @@
+New rust x86_64-pc-solaris target issue.
+
+https://github.com/rust-lang/rust/issues/68214
+
+--- a/build/moz.configure/rust.configure
++++ b/build/moz.configure/rust.configure
+@@ -257,6 +257,12 @@
+             elif not candidates:
+                 return None
+ 
++            # There are two candidates after adding new alias via:
++            # https://github.com/rust-lang/rust/issues/40531
++            if host_or_target.kernel == 'SunOS':
++                if host_or_target.cpu == 'x86_64':
++                    return candidates[1].rust_target
++
+             # We have multiple candidates. There are two cases where we can try to
+             # narrow further down using extra information from the build system.
+             # - For windows targets, correlate with the C compiler type


### PR DESCRIPTION
mozjs-78 is needed by polkit, which in turn is needed by newer mate-control-center.