### PR TITLE
cog-spur: fix alignment mmap

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -29,6 +29,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.3033
+COMPONENT_REVISION=	1
 GIT_TAG=		sun-v5.0.34
 PLUGIN_REV=		5.0-202108131754-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine

--- a/components/runtime/smalltalk/cog-spur/patches/09-sqUnixSpurMemory.patch
+++ b/components/runtime/smalltalk/cog-spur/patches/09-sqUnixSpurMemory.patch
@@ -1,11 +1,25 @@
---- opensmalltalk-vm-sun-v5.0.33/platforms/unix/vm/sqUnixSpurMemory.c	Sat Aug  7 09:21:27 2021
-+++ p0/opensmalltalk-vm-sun-v5.0.33/platforms/unix/vm/sqUnixSpurMemory.c	Sun Aug  8 13:48:39 2021
-@@ -100,7 +100,7 @@
- # if __OpenBSD__
- #	define MAP_FLAGS	(MAP_ANON | MAP_PRIVATE | MAP_STACK)
- # else
--#	define MAP_FLAGS	(MAP_ANON | MAP_PRIVATE)
-+#	define MAP_FLAGS	(MAP_32BIT | MAP_ANON | MAP_PRIVATE)
- # endif
+--- opensmalltalk-vm-sun-v5.0.34/platforms/unix/vm/sqUnixSpurMemory.c	Fri Aug 13 19:54:42 2021
++++ p0/opensmalltalk-vm-sun-v5.0.34/platforms/unix/vm/sqUnixSpurMemory.c	Sun Aug 15 14:11:58 2021
+@@ -277,16 +277,21 @@
+ {
+ 	void *hint = sbrk(0); // a hint of the lowest possible address for mmap
+ 	void *result;
++	char *address;
++	unsigned long alignment;
  
- static int min(int x, int y) { return (x < y) ? x : y; }
+ 	pageSize = getpagesize();
+ 	pageMask = ~(pageSize - 1);
+ 
++	alignment = max(pageSize,1024*1024);
++	address = (char *)(((usqInt)hint + alignment - 1) & ~(alignment - 1));
++
+ #if !defined(MAP_JIT)
+ # define MAP_JIT 0
+ #endif
+ 
+ 	*desiredSize = roundUpToPage(*desiredSize);
+-	result =   mmap(hint, *desiredSize,
++	result =   mmap(address, *desiredSize,
+ #if DUAL_MAPPED_CODE_ZONE
+ 					PROT_READ | PROT_EXEC,
+ #else


### PR DESCRIPTION

cog-spur :  fix 32bit build

cog-spur : fix full 64bit addressing for the 64bit build

This version delivers a patch that restores alignment for mmap calls for the JIT codezone.   For some reason Eliot seems to have removed that around July 24 and since then cogvm had issues on OpenIndiana.