### PR TITLE
ggrep: update to 3.7

### DIFF
--- a/components/text/ggrep/Makefile
+++ b/components/text/ggrep/Makefile
@@ -21,7 +21,7 @@
 #
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2020, Michal Nowak
-# Copyright (c) 2020, Nona Hansel
+# Copyright (c) 2020-2021, Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -29,16 +29,16 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		grep
-COMPONENT_VERSION=	3.6
+COMPONENT_VERSION=	3.7
 COMPONENT_FMRI=		text/gnu-grep
 COMPONENT_SUMMARY= 	GNU grep utilities
 COMPONENT_CLASSIFICATION= Applications/System Utilities
-COMPONENT_PROJECT_URL=	http://gnu.org/software/grep/
+COMPONENT_PROJECT_URL=	https://gnu.org/software/grep/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:667e15e8afe189e93f9f21a7cd3a7b3f776202f417330b248c2ad4f997d9373e
-COMPONENT_ARCHIVE_URL=	http://ftp.gnu.org/gnu/grep/$(COMPONENT_ARCHIVE)
+	sha256:5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c
+COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/gnu/grep/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3, FDLv1.3
 
 include $(WS_MAKE_RULES)/common.mk
@@ -71,10 +71,11 @@ COMPONENT_TEST_TRANSFORMS += \
 # Since version 3.4, GNU grep is needed for build.
 REQUIRED_PACKAGES += text/gnu-grep
 # Testsuite requirements
+REQUIRED_PACKAGES += developer/versioning/cvs
 REQUIRED_PACKAGES += locale/tr
 REQUIRED_PACKAGES += locale/ru-extra
+REQUIRED_PACKAGES += locale/zh_cn-extra
 # Auto-generated dependencies
-REQUIRED_PACKAGES += SUNWcs
-REQUIRED_PACKAGES += library/libsigsegv
 REQUIRED_PACKAGES += library/pcre
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library

--- a/components/text/ggrep/pkg5
+++ b/components/text/ggrep/pkg5
@@ -1,10 +1,12 @@
 {
     "dependencies": [
         "SUNWcs",
-        "library/libsigsegv",
+        "developer/versioning/cvs",
         "library/pcre",
         "locale/ru-extra",
         "locale/tr",
+        "locale/zh_cn-extra",
+        "shell/ksh93",
         "system/library",
         "text/gnu-grep"
     ],

--- a/components/text/ggrep/test/results-64.master
+++ b/components/text/ggrep/test/results-64.master
@@ -45,6 +45,7 @@ PASS: foad1
 PASS: grep-dev-null
 PASS: grep-dev-null-out
 PASS: grep-dir
+PASS: hash-collision-perf
 PASS: help-version
 PASS: high-bit-range
 PASS: in-eq-out-infloop
@@ -114,8 +115,8 @@ PASS: word-multibyte
 PASS: write-error-msg
 PASS: yesno
 PASS: z-anchor-newline
-# TOTAL: 116
-# PASS:  100
+# TOTAL: 117
+# PASS:  101
 # SKIP:  14
 # XFAIL: 2
 # FAIL:  0
@@ -135,6 +136,7 @@ PASS: test-c-ctype
 PASS: test-c-stack.sh
 PASS: test-c-stack2.sh
 PASS: test-c-strcase.sh
+PASS: test-calloc-gnu
 PASS: test-chdir
 PASS: test-cloexec
 PASS: test-close
@@ -146,6 +148,7 @@ PASS: test-dfa-match.sh
 PASS: test-dirent
 PASS: test-dup
 PASS: test-dup2
+PASS: test-dynarray
 PASS: test-environ
 PASS: test-errno
 PASS: test-exclude1.sh
@@ -171,6 +174,7 @@ PASS: test-fopen
 PASS: test-fpending.sh
 PASS: test-fputc
 PASS: test-fread
+PASS: test-free
 PASS: test-fstat
 PASS: test-fstatat
 PASS: test-ftruncate.sh
@@ -239,6 +243,7 @@ PASS: test-raise
 PASS: test-rawmemchr
 PASS: test-read
 PASS: test-realloc-gnu
+PASS: test-reallocarray
 PASS: test-regex
 PASS: test-sched
 PASS: test-select
@@ -254,6 +259,10 @@ PASS: test-setsockopt
 PASS: test-sigaction
 PASS: test-signal-h
 PASS: test-sigprocmask
+PASS: test-sigsegv-catch-segv1
+PASS: test-sigsegv-catch-segv2
+PASS: test-sigsegv-catch-stackoverflow1
+PASS: test-sigsegv-catch-stackoverflow2
 PASS: test-sleep
 PASS: test-snprintf
 PASS: test-sockets
@@ -314,8 +323,8 @@ PASS: test-wcwidth
 PASS: test-xalloc-die.sh
 PASS: test-xstrtoimax.sh
 PASS: test-xstrtol.sh
-# TOTAL: 193
-# PASS:  184
+# TOTAL: 201
+# PASS:  192
 # SKIP:  9
 # XFAIL: 0
 # FAIL:  0


### PR DESCRIPTION
It built, installed and published fine. All new tests passed.

When installed locally, I tested it with `ggrep -R random_string random_dir` and it worked.