### PR TITLE
New python module isort, version 5.9.3

### DIFF
--- a/components/python/isort/Makefile
+++ b/components/python/isort/Makefile
@@ -1,0 +1,85 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 Gary Mills
+#
+
+BUILD_STYLE=	setup.py
+BUILD_BITS=	NO_ARCH
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		isort
+COMPONENT_VERSION=	5.9.3
+# COMPONENT_REVISION=	0
+COMPONENT_PROJECT_URL=	https://github.com/PyCQA/isort
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:0ad5e0ec066302c7aece422b2675b81abe7e417dbf64b18438ca8b79219540dd
+COMPONENT_ARCHIVE_URL=	https://github.com/PyCQA/$(COMPONENT_NAME)/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_BUGDB=	python-mod/isort
+
+# Set python version used by this product
+PYTHON_VERSION=		3.9
+PYTHON_VERSIONS=	3.9
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Copy in a minimal setup.py
+COMPONENT_PRE_BUILD_ACTION = $(CP) OI/setup.py $(COMPONENT_SRC)
+
+# The tests are run using python 3.9 only and require that the
+# python-39 package is installed (does not have to be the default python).
+# The pytest-39, hypothesis-39, and sortedcontainers-39 packages must
+# also be installed
+
+# Use the python 3.9 libraries (via PYTHONPATH setting) for testing.
+test: PYTHON_VERSION=3.9
+
+COMPONENT_TEST_DIR = $(COMPONENT_SRC)/tests
+COMPONENT_TEST_CMD = $(PYTHON) -m pytest
+COMPONENT_TEST_ARGS =
+
+# Disable test files that have import failures because these python
+# modules are not available in OI: libcst colorama pylama black
+COMPONENT_PRE_TEST_ACTION = \
+( cd $(COMPONENT_TEST_DIR); \
+  for F in integration/test_hypothesmith.py unit/test_format.py unit/test_pylama_isort.py unit/profiles/test_black.py; \
+  do \
+    test -f $$F && $(MV) $$F $$F-not; \
+  done )
+
+# Typical failures for test target:
+#============================ short test summary info ============================
+#FAILED integration/test_setting_combinations.py::test_isort_is_idempotent - is...
+#FAILED integration/test_setting_combinations.py::test_isort_doesnt_lose_imports_or_comments
+#...
+#FAILED unit/test_ticketed_features.py::test_isort_literals_issue_1358 - isort....
+#FAILED unit/test_ticketed_features.py::test_sort_configurable_sort_issue_1732
+#ERROR benchmark/test_api.py::test_sort_file
+#ERROR benchmark/test_api.py::test_sort_file_in_place
+#ERROR unit/test_main.py::test_sort_imports_error_handling
+#= 13 failed, 502 passed, 1 skipped, 76 warnings, 3 errors in 329.14s (0:05:29) ==
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/python-39

--- a/components/python/isort/OI/setup.py
+++ b/components/python/isort/OI/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(
+    name='isort',
+    version='5.9.3',
+    description='A Python utility / library to sort imports',
+    url='https://github.com/PyCQA/isort',
+    packages=['isort'],
+)

--- a/components/python/isort/isort-39.p5m
+++ b/components/python/isort/isort-39.p5m
@@ -1,0 +1,80 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2021 Gary Mills
+#
+
+set name=pkg.fmri \
+    value=pkg:/library/python/isort-39@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.description \
+    value="Isort is a Python utility / library to sort imports alphabetically"
+set name=pkg.summary value="Quickly sort all your imports"
+set name=com.oracle.info.description value="The isort Python 3.9 module"
+set name=com.oracle.info.tpno value=8268
+set name=info.classification \
+    value=org.opensolaris.category.2008:Development/Python
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.arc-caseid \
+    value=LSARC/2009/298
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
+
+file path=usr/lib/python3.9/vendor-packages/isort/__init__.py
+file path=usr/lib/python3.9/vendor-packages/isort/__main__.py
+file path=usr/lib/python3.9/vendor-packages/isort/_version.py
+file path=usr/lib/python3.9/vendor-packages/isort/api.py
+file path=usr/lib/python3.9/vendor-packages/isort/comments.py
+file path=usr/lib/python3.9/vendor-packages/isort/core.py
+file path=usr/lib/python3.9/vendor-packages/isort/exceptions.py
+file path=usr/lib/python3.9/vendor-packages/isort/files.py
+file path=usr/lib/python3.9/vendor-packages/isort/format.py
+file path=usr/lib/python3.9/vendor-packages/isort/hooks.py
+file path=usr/lib/python3.9/vendor-packages/isort/identify.py
+file path=usr/lib/python3.9/vendor-packages/isort/io.py
+file path=usr/lib/python3.9/vendor-packages/isort/literal.py
+file path=usr/lib/python3.9/vendor-packages/isort/logo.py
+file path=usr/lib/python3.9/vendor-packages/isort/main.py
+file path=usr/lib/python3.9/vendor-packages/isort/output.py
+file path=usr/lib/python3.9/vendor-packages/isort/parse.py
+file path=usr/lib/python3.9/vendor-packages/isort/place.py
+file path=usr/lib/python3.9/vendor-packages/isort/profiles.py
+file path=usr/lib/python3.9/vendor-packages/isort/pylama_isort.py
+file path=usr/lib/python3.9/vendor-packages/isort/sections.py
+file path=usr/lib/python3.9/vendor-packages/isort/settings.py
+file path=usr/lib/python3.9/vendor-packages/isort/setuptools_commands.py
+file path=usr/lib/python3.9/vendor-packages/isort/sorting.py
+file path=usr/lib/python3.9/vendor-packages/isort/utils.py
+file path=usr/lib/python3.9/vendor-packages/isort/wrap.py
+file path=usr/lib/python3.9/vendor-packages/isort/wrap_modes.py
+
+license isort.license license=MIT
+
+# force a dependency on the Python 3.9 runtime
+depend fmri=__TBD pkg.debug.depend.file=python3.9 \
+       pkg.debug.depend.path=usr/bin type=require
+
+# force a dependency on the isort package
+depend fmri=library/python/isort@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) \
+    type=require

--- a/components/python/isort/isort.license
+++ b/components/python/isort/isort.license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Timothy Edmund Crosley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/components/python/isort/isort.p5m
+++ b/components/python/isort/isort.p5m
@@ -1,0 +1,42 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2021 Gary Mills
+#
+
+set name=pkg.fmri \
+    value=pkg:/library/python/isort@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.description \
+    value="Isort is a Python utility / library to sort imports alphabetically"
+set name=pkg.summary value="Quickly sort all your imports"
+set name=com.oracle.info.description value="the isort Python module"
+set name=com.oracle.info.tpno value=8268
+set name=info.classification \
+    value=org.opensolaris.category.2008:Development/Python
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.arc-caseid \
+    value=LSARC/2009/298
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+license isort.license license=MIT
+
+depend fmri=library/python/isort-39@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) \
+    predicate=runtime/python-39 \
+    type=conditional

--- a/components/python/isort/manifests/sample-manifest.p5m
+++ b/components/python/isort/manifests/sample-manifest.p5m
@@ -1,0 +1,55 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/isort-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
+file path=usr/lib/python3.9/vendor-packages/isort/__init__.py
+file path=usr/lib/python3.9/vendor-packages/isort/__main__.py
+file path=usr/lib/python3.9/vendor-packages/isort/_version.py
+file path=usr/lib/python3.9/vendor-packages/isort/api.py
+file path=usr/lib/python3.9/vendor-packages/isort/comments.py
+file path=usr/lib/python3.9/vendor-packages/isort/core.py
+file path=usr/lib/python3.9/vendor-packages/isort/exceptions.py
+file path=usr/lib/python3.9/vendor-packages/isort/files.py
+file path=usr/lib/python3.9/vendor-packages/isort/format.py
+file path=usr/lib/python3.9/vendor-packages/isort/hooks.py
+file path=usr/lib/python3.9/vendor-packages/isort/identify.py
+file path=usr/lib/python3.9/vendor-packages/isort/io.py
+file path=usr/lib/python3.9/vendor-packages/isort/literal.py
+file path=usr/lib/python3.9/vendor-packages/isort/logo.py
+file path=usr/lib/python3.9/vendor-packages/isort/main.py
+file path=usr/lib/python3.9/vendor-packages/isort/output.py
+file path=usr/lib/python3.9/vendor-packages/isort/parse.py
+file path=usr/lib/python3.9/vendor-packages/isort/place.py
+file path=usr/lib/python3.9/vendor-packages/isort/profiles.py
+file path=usr/lib/python3.9/vendor-packages/isort/pylama_isort.py
+file path=usr/lib/python3.9/vendor-packages/isort/sections.py
+file path=usr/lib/python3.9/vendor-packages/isort/settings.py
+file path=usr/lib/python3.9/vendor-packages/isort/setuptools_commands.py
+file path=usr/lib/python3.9/vendor-packages/isort/sorting.py
+file path=usr/lib/python3.9/vendor-packages/isort/utils.py
+file path=usr/lib/python3.9/vendor-packages/isort/wrap.py
+file path=usr/lib/python3.9/vendor-packages/isort/wrap_modes.py

--- a/components/python/isort/pkg5
+++ b/components/python/isort/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "runtime/python-39",
+        "shell/ksh93"
+    ],
+    "fmris": [
+        "library/python/isort",
+        "library/python/isort-39"
+    ],
+    "name": "isort"
+}


### PR DESCRIPTION
This PR adds the package isort, version 5.9.3 .  The product is a Python utility / library to sort imports alphabetically, used to quickly sort all imports.  It is one of the packages required by recent versions of pylint.  This package allows pylint to be upgraded to the current version.  The package is only built for python 3.9, the same as pylint will be.  All files are new, including Makefile, the manifests isort-39.p5m and isort.p5m and manifests/sample-manifest.p5m .  There are no patches.

"gmake REQUIRED_PACKAGES" had no effect.  The build, install, and publish steps were all successful.  The built-in tests require that pytest and hypothesis be installed.  Typical results, showing 13 failed, 502 passed tests, are included in the Makefile.

