### PR TITLE
gcc: strip the DWARF (but not symbol tables) from the resulting binaries

### DIFF
--- a/make-rules/gcc-component.mk
+++ b/make-rules/gcc-component.mk
@@ -101,6 +101,8 @@ FCFLAGS= -O2
 COMMON_ENV=  LD_OPTIONS="-zignore -zcombreloc -i"
 COMMON_ENV+= LD_FOR_TARGET=/usr/bin/ld
 COMMON_ENV+= LD_FOR_HOST=/usr/bin/ld
+COMMON_ENV+= STRIP="/usr/bin/strip -x"
+COMMON_ENV+= STRIP_FOR_TARGET="/usr/bin/strip -x"
 COMMON_ENV+= LD=/usr/bin/ld
 
 CONFIGURE_ENV+= $(COMMON_ENV)
@@ -132,6 +134,9 @@ CONFIGURE_OPTIONS+= $(CONFIGURE_OPTIONS.$(MACH))
 
 # Set path to library install prefix
 CONFIGURE_OPTIONS+= LDFLAGS="-R$(CONFIGURE_PREFIX)/lib"
+
+# Strip the resulting binaries
+COMPONENT_INSTALL_TARGETS = install-strip
 
 COMPONENT_POST_INSTALL_ACTION = \
   $(RM) -r $(PROTO_DIR)$(CONFIGURE_PREFIX)/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include-fixed


### PR DESCRIPTION
This strips the resulting GCC binaries of DWARF (but not the symbol tables, which we want to keep).  Saving _lots_ of download.

I've checked that the 10 binaries seem good, and am currently building 5 (the oldest using gcc-component).  I haven't run the test suites since we're not changing behaviour.  It could really use someone with more horsepower and OI knowledge making sure I didn't screw anything up.

(figures from a compressed filesystem, so fairly similar to what would go over the wire during install/upgrade)
```
; du -sh {build/prototype/i386,}/usr/gcc/10/
247M	build/prototype/i386/usr/gcc/10/
970M	/usr/gcc/10/
```