### PR TITLE
New python module mccabe, version 0.6.1

### DIFF
--- a/components/python/mccabe/Makefile
+++ b/components/python/mccabe/Makefile
@@ -1,0 +1,65 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 Gary Mills
+#
+
+BUILD_STYLE=	setup.py
+BUILD_BITS=	NO_ARCH
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		mccabe
+COMPONENT_VERSION=	0.6.1
+# COMPONENT_REVISION=	0
+COMPONENT_PROJECT_URL=	https://github.com/PyCQA/mccabe
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:2748af6516175b94be318cd8226fa50b5339b9dc886bce378ac2afb37a157524
+COMPONENT_ARCHIVE_URL=	https://github.com/PyCQA/$(COMPONENT_NAME)/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_BUGDB=	python-mod/mccabe
+
+# Set python version used by this product
+PYTHON_VERSION=		3.9
+PYTHON_VERSIONS=	3.9
+
+include $(WS_MAKE_RULES)/common.mk
+
+# The tests are run using python 3.9 only and require that the
+# python-39 package is installed (does not have to be the default python).
+# The pytest-39 and hypothesis-39 packages must also be installed
+
+# Use the python 3.9 libraries (via PYTHONPATH setting) for testing.
+test: PYTHON_VERSION=3.9
+
+COMPONENT_TEST_DIR = $(COMPONENT_SRC)
+COMPONENT_TEST_CMD = $(PYTHON) -m pytest
+COMPONENT_TEST_ARGS =
+
+# Typical results for test target:
+#collected 14 items
+#test_mccabe.py ..............                                            [100%]
+#============================== 14 passed in 0.07s =============================
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/python-39

--- a/components/python/mccabe/manifests/sample-manifest.p5m
+++ b/components/python/mccabe/manifests/sample-manifest.p5m
@@ -1,0 +1,31 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/entry_points.txt
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/not-zip-safe
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
+file path=usr/lib/python3.9/vendor-packages/mccabe.py

--- a/components/python/mccabe/mccabe-39.p5m
+++ b/components/python/mccabe/mccabe-39.p5m
@@ -1,0 +1,56 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2021 Gary Mills
+#
+
+set name=pkg.fmri \
+    value=pkg:/library/python/mccabe-39@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.description \
+    value="McCabe complexity checker"
+set name=pkg.summary value="McCabe complexity checker"
+set name=com.oracle.info.description value="The mccabe Python 3.9 module"
+set name=com.oracle.info.tpno value=8268
+set name=info.classification \
+    value=org.opensolaris.category.2008:Development/Python
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.arc-caseid \
+    value=LSARC/2009/298
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/entry_points.txt
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/not-zip-safe
+file path=usr/lib/python3.9/vendor-packages/mccabe-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
+
+file path=usr/lib/python3.9/vendor-packages/mccabe.py
+
+license mccabe.license license=Expat
+
+# force a dependency on the Python 3.9 runtime
+depend fmri=__TBD pkg.debug.depend.file=python3.9 \
+       pkg.debug.depend.path=usr/bin type=require
+
+# force a dependency on the mccabe package
+depend fmri=library/python/mccabe@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) \
+    type=require

--- a/components/python/mccabe/mccabe.license
+++ b/components/python/mccabe/mccabe.license
@@ -1,0 +1,25 @@
+Copyright © <year> Ned Batchelder
+Copyright © 2011-2013 Tarek Ziade <tarek@ziade.org>
+Copyright © 2013 Florent Xicluna <florent.xicluna@gmail.com>
+
+Licensed under the terms of the Expat License
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/python/mccabe/mccabe.p5m
+++ b/components/python/mccabe/mccabe.p5m
@@ -1,0 +1,42 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2021 Gary Mills
+#
+
+set name=pkg.fmri \
+    value=pkg:/library/python/mccabe@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.description \
+    value="McCabe complexity checker"
+set name=pkg.summary value="McCabe complexity checker"
+set name=com.oracle.info.description value="the mccabe Python module"
+set name=com.oracle.info.tpno value=8268
+set name=info.classification \
+    value=org.opensolaris.category.2008:Development/Python
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.arc-caseid \
+    value=LSARC/2009/298
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+license mccabe.license license=Expat
+
+depend fmri=library/python/mccabe-39@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) \
+    predicate=runtime/python-39 \
+    type=conditional

--- a/components/python/mccabe/pkg5
+++ b/components/python/mccabe/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "runtime/python-39",
+        "shell/ksh93"
+    ],
+    "fmris": [
+        "library/python/mccabe",
+        "library/python/mccabe-39"
+    ],
+    "name": "mccabe"
+}


### PR DESCRIPTION
This PR adds the package mccabe, version 0.6.1 .  The product is the McCabe complexity checker, used to detect over-complex code.  It is the last of the packages required by recent versions of pylint.  This package allows pylint to be upgraded to the current version.  The package is only built for python 3.9, the same as pylint will be.  All files are new, including Makefile, the manifests mccabe-39.p5m and mccabe.p5m, and manifests/sample-manifest.p5m .  There are no patches.

"gmake REQUIRED_PACKAGES" had no effect.  The build, install, and publish steps were all successful.  The built-in tests require that pytest and hypothesis be installed.  Typical results, showing 14 passed tests with no failures, are included in the Makefile.
