### PR TITLE
Upgraded to ntfs-3g_ntfsprogs 2021.8.22

### DIFF
--- a/components/sysutils/ntfsprogs/Makefile
+++ b/components/sysutils/ntfsprogs/Makefile
@@ -13,20 +13,21 @@
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
 # Copyright 2016 Adam Stevko.  All rights reserved.
 # Copyright 2017 Andreas Grueninger, Grueninger GmbH, (grueni). All rights reserved.
+# Copyright 2021 Jean-Pierre André. All rights reserved.
 #
 
 BUILD_BITS=32
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= ntfs-3g_ntfsprogs
-IPS_COMPONENT_VERSION= 2017.3.23
-COMPONENT_VERSION= $(IPS_COMPONENT_VERSION)AR.5
+IPS_COMPONENT_VERSION= 2021.8.22
+COMPONENT_VERSION= $(IPS_COMPONENT_VERSION)
 COMPONENT_SUMMARY= ntfsprogs - Utilities that provide access to NTFS
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tgz
-COMPONENT_ARCHIVE_HASH= sha256:04ccf583b495806cefb71850e5899e50aed5e7bf23365259f2badaa9af21e5ed
-COMPONENT_ARCHIVE_URL= http://jp-andre.pagesperso-orange.fr/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://www.tuxera.com/community/ntfs-3g-download/
+COMPONENT_ARCHIVE_HASH= sha256:55b883aa05d94b2ec746ef3966cb41e66bed6db99f22ddd41d1b8b94bb202efb
+COMPONENT_ARCHIVE_URL= https://tuxera.com/opensource/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL = https://github.com/tuxera/ntfs-3g/
 COMPONENT_FMRI= system/file-system/ntfsprogs
 COMPONENT_CLASSIFICATION= System/Administration and Configuration
 COMPONENT_LICENSE= GPLv2, LGPLv2

--- a/components/sysutils/ntfsprogs/manifests/sample-manifest.p5m
+++ b/components/sysutils/ntfsprogs/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -71,9 +71,9 @@ file path=usr/include/ntfs-3g/unistr.h
 file path=usr/include/ntfs-3g/volume.h
 file path=usr/include/ntfs-3g/xattrs.h
 file path=usr/lib/libntfs-3g.a
-link path=usr/lib/libntfs-3g.so target=libntfs-3g.so.885.0.0
-link path=usr/lib/libntfs-3g.so.885 target=libntfs-3g.so.885.0.0
-file path=usr/lib/libntfs-3g.so.885.0.0
+link path=usr/lib/libntfs-3g.so target=libntfs-3g.so.89.0.0
+link path=usr/lib/libntfs-3g.so.89 target=libntfs-3g.so.89.0.0
+file path=usr/lib/libntfs-3g.so.89.0.0
 file path=usr/lib/pkgconfig/libntfs-3g.pc
 file path=usr/sbin/mkntfs
 file path=usr/sbin/ntfsclone

--- a/components/sysutils/ntfsprogs/ntfsprogs.p5m
+++ b/components/sysutils/ntfsprogs/ntfsprogs.p5m
@@ -12,6 +12,7 @@
 # Copyright 2014 Alexander Pyhalov. All rights reserved.
 # Copyright 2016 Adam Stevko. All rights reserved.
 # Copyright 2017 Andreas Grueninger, Grueninger GmbH, (grueni). All rights reserved.
+# Copyright 2021 Jean-Pierre André. All rights reserved.
 #
 
 <transform file path=usr/lib/fs/ntfs-3g/(.*) -> default mode 0555>
@@ -77,9 +78,9 @@ file path=usr/include/ntfs-3g/types.h
 file path=usr/include/ntfs-3g/unistr.h
 file path=usr/include/ntfs-3g/volume.h
 file path=usr/include/ntfs-3g/xattrs.h
-link path=usr/lib/libntfs-3g.so target=libntfs-3g.so.885.0.0
-link path=usr/lib/libntfs-3g.so.885 target=libntfs-3g.so.885.0.0
-file path=usr/lib/libntfs-3g.so.885.0.0
+link path=usr/lib/libntfs-3g.so target=libntfs-3g.so.89.0.0
+link path=usr/lib/libntfs-3g.so.89 target=libntfs-3g.so.89.0.0
+file path=usr/lib/libntfs-3g.so.89.0.0
 file path=usr/lib/pkgconfig/libntfs-3g.pc
 file path=usr/sbin/mkntfs
 file path=usr/sbin/ntfsclone


### PR DESCRIPTION
This fixes vulnerability threats caused by maliciously tampered NTFS
partitions
See : https://sourceforge.net/p/ntfs-3g/mailman/message/37343528/