### PR TITLE
Add Python py3c package

### DIFF
--- a/components/python/py3c/Makefile
+++ b/components/python/py3c/Makefile
@@ -1,0 +1,66 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Klaus Ziegler
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           py3c
+COMPONENT_VERSION=        1.3
+COMPONENT_PROJECT_URL=    https://pypi.org/project/py3c/#files
+COMPONENT_FMRI=           library/python/py3c
+COMPONENT_CLASSIFICATION= Development/Python
+COMPONENT_LICENSE=        MIT
+
+GIT=git
+GIT_REPO=https://github.com/encukou/py3c.git
+GIT_BRANCH=master
+GIT_CHANGESET=HEAD
+
+COMPONENT_PREP_GIT=no
+include $(WS_MAKE_RULES)/ips.mk
+
+SOURCE_DIR= $(COMPONENT_NAME)
+CLOBBER_PATHS= $(COMPONENT_NAME)
+PYTHON= python3.9
+
+$(SOURCE_DIR)/.downloaded: $(ARCHIVES:%=$(USERLAND_ARCHIVES)%)
+	@[ -d $(SOURCE_DIR) ] || \
+	$(GIT) clone $(GIT_REPO)
+	@cd $(SOURCE_DIR); $(GIT) checkout $(GIT_BRANCH); $(GIT) pull \
+	  $(GIT_REPO); $(GIT) log -1 --format=%H > .downloaded
+
+download:: $(SOURCE_DIR)/.downloaded
+
+prep: $(SOURCE_DIR)/.downloaded
+
+build: prep install
+
+install: prep
+	mkdir -p $(PROTO_DIR)
+	mkdir -p $(PROTO_DIR)$(USRINCDIR)/$(PYTHON)/py3c && \
+	mkdir -p $(PROTO_DIR)$(USRLIBDIR64)/pkgconfig && \
+	cp -p $(SOURCE_DIR)/include/py3c.h $(PROTO_DIR)$(USRINCDIR)/$(PYTHON) && \
+	cp -rp $(SOURCE_DIR)/include/py3c/* $(PROTO_DIR)$(USRINCDIR)/$(PYTHON)/py3c && \
+	sed \
+		-e "/^# Template/d" \
+		-e "/^# Requires/d" \
+		-e 's#@includedir@#/usr/include/python3.9#g' \
+		-e "s@^#Requires: python3@Requires: python-3.9@g" \
+		-e "/^#Requires/d" $(SOURCE_DIR)/py3c.pc.in > \
+	$(PROTO_DIR)$(USRLIBDIR64)/pkgconfig/py3c.pc
+
+clean:
+	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
+
+clobber::	clean
+	$(RM) -r $(CLOBBER_PATHS)

--- a/components/python/py3c/manifests/sample-manifest.p5m
+++ b/components/python/py3c/manifests/sample-manifest.p5m
@@ -1,0 +1,31 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Klaus Ziegler
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION)
+set name=pkg.summary value="port C extensions to Python 3"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/python3.9/py3c.h
+file path=usr/include/python3.9/py3c/capsulethunk.h
+file path=usr/include/python3.9/py3c/comparison.h
+file path=usr/include/python3.9/py3c/compat.h
+file path=usr/include/python3.9/py3c/fileshim.h
+file path=usr/include/python3.9/py3c/py3shims.h
+file path=usr/include/python3.9/py3c/tpflags.h
+file path=usr/lib/$(MACH64)/pkgconfig/py3c.pc

--- a/components/python/py3c/pkg5
+++ b/components/python/py3c/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "library/python/py3c"
+    ],
+    "name": "py3c"
+}

--- a/components/python/py3c/py3c.license
+++ b/components/python/py3c/py3c.license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015, py3c contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/python/py3c/py3c.p5m
+++ b/components/python/py3c/py3c.p5m
@@ -1,0 +1,31 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Klaus Ziegler
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION)
+set name=pkg.summary value="port C extensions to Python 3"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/python3.9/py3c.h
+file path=usr/include/python3.9/py3c/capsulethunk.h
+file path=usr/include/python3.9/py3c/comparison.h
+file path=usr/include/python3.9/py3c/compat.h
+file path=usr/include/python3.9/py3c/fileshim.h
+file path=usr/include/python3.9/py3c/py3shims.h
+file path=usr/include/python3.9/py3c/tpflags.h
+file path=usr/lib/$(MACH64)/pkgconfig/py3c.pc


### PR DESCRIPTION
This new package: library/python/py3c is needed to build the new subversion 1.14.1 package
