### PR TITLE
libarchive: update to 3.5.2

### DIFF
--- a/components/library/libarchive/Makefile
+++ b/components/library/libarchive/Makefile
@@ -25,11 +25,10 @@
 
 PREFERRED_BITS=		64
 BUILD_BITS=		32_and_64
-
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libarchive
-COMPONENT_VERSION=	3.5.1
+COMPONENT_VERSION=	3.5.2
 COMPONENT_SUMMARY=	multi-format archive and compression library
 COMPONENT_DESCRIPTION=	The libarchive(3LIB) library provides a flexible\
  interface for reading and writing archives in various formats such as\
@@ -41,7 +40,7 @@ COMPONENT_DESCRIPTION=	The libarchive(3LIB) library provides a flexible\
 COMPONENT_SRC=		libarchive-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://www.libarchive.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:9015d109ec00bb9ae1a384b172bf2fc1dff41e2c66e5a9eeddf933af9db37f5a
+COMPONENT_ARCHIVE_HASH=	sha256:5f245bd5176bc5f67428eb0aa497e09979264a153a074d35416521a5b8e86189
 COMPONENT_ARCHIVE_URL= https://www.libarchive.org/downloads/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=        library/libarchive
 COMPONENT_CLASSIFICATION=       System/Libraries

--- a/components/library/libarchive/pkg5
+++ b/components/library/libarchive/pkg5
@@ -9,6 +9,7 @@
         "library/security/openssl",
         "library/zlib",
         "print/filter/ghostscript",
+        "shell/ksh93",
         "system/library",
         "text/groff"
     ],


### PR DESCRIPTION
- sample-manifest didn't change
- gmake test run fine