### PR TITLE
add py3c

### DIFF
--- a/components/library/py3c/Makefile
+++ b/components/library/py3c/Makefile
@@ -1,0 +1,76 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Klaus Ziegler
+#
+
+BUILD_STYLE = setup.py
+BUILD_BITS=NO_ARCH
+PYTHON3_ONLY=yes
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           py3c
+COMPONENT_VERSION=        1.3.1
+COMPONENT_SUMMARY=	  port C extensions to Python 3
+COMPONENT_PROJECT_URL=    https://py3c.readthedocs.io/en/latest/
+COMPONENT_SRC=		  $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	  $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_URL=	  https://github.com/encukou/py3c/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:f3e138623a87cde2cd7d8e98b51447e033d43a3f639c5054185c859fa1888727
+COMPONENT_FMRI=           library/py3c
+COMPONENT_CLASSIFICATION= Development/Python
+COMPONENT_LICENSE=        MIT
+
+TEST_TARGET= $(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
+
+#
+# if upgrading py3c package, please double
+# check the contents of both:
+#
+# build/prototype/<uname -p>/usr/lib/python3.x/*
+# build/prototype/<uname -p>/usr/include/python3.x/*
+#
+# by hashing out the next 2(4) COMPONENT_POST_INSTALL_ACTION lines,
+# as of version 1.3.1 there isn't much usefull python stuff in there.
+# The main purpose for which the py3c package is needed for, is to be
+# able to compile subversion 1.14.1 and newer, that's why we need
+# the include files from py3c in the standard location, so they
+# can be used by compilers and or all versions of python.
+
+COMPONENT_POST_INSTALL_ACTION += \
+	$(RM) -r $(PROTO_DIR)$(USRINCDIR)/python* ;
+COMPONENT_POST_INSTALL_ACTION += \
+	$(RM) -r $(PROTO_DIR)$(USRLIBDIR)/python* ;
+
+COMPONENT_POST_INSTALL_ACTION += \
+	$(MKDIR) -p $(PROTO_DIR)$(USRINCDIR)/py3c ;
+COMPONENT_POST_INSTALL_ACTION += \
+	$(MKDIR) -p $(PROTO_DIR)$(USRLIBDIR)/pkgconfig ;
+COMPONENT_POST_INSTALL_ACTION += \
+	$(CP) $(COMPONENT_SRC)/include/py3c.h $(PROTO_DIR)$(USRINCDIR) ;
+COMPONENT_POST_INSTALL_ACTION += \
+	$(CP) -rp $(COMPONENT_SRC)/include/py3c/* $(PROTO_DIR)$(USRINCDIR)/py3c ;
+COMPONENT_POST_INSTALL_ACTION += \
+	sed \
+		-e '/^\# Template/d' \
+		-e '/^\# Requires/d' \
+		-e '/^\#Requires/d' \
+		-e 's\#@includedir@\#/usr/include\#g' $(COMPONENT_SRC)/py3c.pc.in > \
+	$(PROTO_DIR)$(USRLIBDIR)/pkgconfig/py3c.pc ;
+
+# Build requirements.
+REQUIRED_PACKAGES += runtime/python-35
+REQUIRED_PACKAGES += runtime/python-37
+REQUIRED_PACKAGES += runtime/python-39

--- a/components/library/py3c/manifests/sample-manifest.p5m
+++ b/components/library/py3c/manifests/sample-manifest.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/py3c.h
+file path=usr/include/py3c/capsulethunk.h
+file path=usr/include/py3c/comparison.h
+file path=usr/include/py3c/compat.h
+file path=usr/include/py3c/fileshim.h
+file path=usr/include/py3c/py3shims.h
+file path=usr/include/py3c/tpflags.h
+file path=usr/lib/pkgconfig/py3c.pc

--- a/components/library/py3c/pkg5
+++ b/components/library/py3c/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "runtime/python-35",
+        "runtime/python-37",
+        "runtime/python-39",
+        "shell/ksh93"
+    ],
+    "fmris": [
+        "library/py3c"
+    ],
+    "name": "py3c"
+}

--- a/components/library/py3c/py3c.license
+++ b/components/library/py3c/py3c.license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015, py3c contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/library/py3c/py3c.p5m
+++ b/components/library/py3c/py3c.p5m
@@ -1,0 +1,31 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Klaus Ziegler
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(COMPONENT_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/py3c.h
+file path=usr/include/py3c/capsulethunk.h
+file path=usr/include/py3c/comparison.h
+file path=usr/include/py3c/compat.h
+file path=usr/include/py3c/fileshim.h
+file path=usr/include/py3c/py3shims.h
+file path=usr/include/py3c/tpflags.h
+file path=usr/lib/pkgconfig/py3c.pc


### PR DESCRIPTION
Subversion 1.14.0 on wards needs the include files of py3c to be able to build it's Python module, for details please look at:
https://subversion.apache.org/docs/release-notes/1.14#py3c
The py3c package itself, as of version 1.3.1 does not deliver any Python specific/use full code just include files, so this package
places these include files in /usr/include in order to be used by compilers and or all Python versions without needing to set
any specific CPPFLAGS.
