### PR TITLE
wget: update to 1.21.2

### DIFF
--- a/components/web/wget/Makefile
+++ b/components/web/wget/Makefile
@@ -28,15 +28,13 @@ USE_OPENSSL11=yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         wget
-COMPONENT_VERSION=      1.21.1
-COMPONENT_REVISION=     1
+COMPONENT_VERSION=      1.21.2
 COMPONENT_PROJECT_URL=  https://www.gnu.org/software/wget/
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.lz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:db9bbe5347e6faa06fc78805eeb808b268979455ead9003a608569c9d4fc90ad
+	sha256:1727a330a86acacb3e57615ce268f5f29978bf7adec4abe6a30d370207bc91b3
 COMPONENT_ARCHIVE_URL=  https://ftp.gnu.org/gnu/wget/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	utility/wget
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/web/wget/manifests/sample-manifest.p5m
+++ b/components/web/wget/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -68,6 +68,7 @@ file path=usr/share/locale/it/LC_MESSAGES/wget.mo
 file path=usr/share/locale/ja/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ja/LC_MESSAGES/wget.mo
 file path=usr/share/locale/ko/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/ko/LC_MESSAGES/wget.mo
 file path=usr/share/locale/lt/LC_MESSAGES/wget.mo
 file path=usr/share/locale/ms/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/nb/LC_MESSAGES/wget-gnulib.mo

--- a/components/web/wget/pkg5
+++ b/components/web/wget/pkg5
@@ -7,6 +7,7 @@
         "library/perl-5/http-message",
         "library/security/openssl-11",
         "library/zlib",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [

--- a/components/web/wget/test/results-64.master
+++ b/components/web/wget/test/results-64.master
@@ -13,6 +13,7 @@ PASS: Test-cookies-401.px
 PASS: Test-E-k-K.px
 PASS: Test-E-k.px
 PASS: Test-ftp.px
+PASS: Test-ftp-dir.px
 PASS: Test-ftp-pasv-fail.px
 PASS: Test-ftp-bad-list.px
 PASS: Test-ftp-recursive.px
@@ -83,8 +84,8 @@ PASS: Test-204.px
 PASS: Test-ftp-pasv-not-supported.px
 ============================================================================
 ============================================================================
-# TOTAL: 93
-# PASS:  83
+# TOTAL: 94
+# PASS:  84
 # SKIP:  10
 # XFAIL: 0
 # FAIL:  0

--- a/components/web/wget/wget.p5m
+++ b/components/web/wget/wget.p5m
@@ -82,6 +82,7 @@ file path=usr/share/locale/it/LC_MESSAGES/wget.mo
 file path=usr/share/locale/ja/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/ja/LC_MESSAGES/wget.mo
 file path=usr/share/locale/ko/LC_MESSAGES/wget-gnulib.mo
+file path=usr/share/locale/ko/LC_MESSAGES/wget.mo
 file path=usr/share/locale/lt/LC_MESSAGES/wget.mo
 file path=usr/share/locale/ms/LC_MESSAGES/wget-gnulib.mo
 file path=usr/share/locale/nb/LC_MESSAGES/wget-gnulib.mo


### PR DESCRIPTION
It builds, installs and publishes fine. Tests ran fine, too.
When installed locally, I tested it with `wget URL` and it worked.