### PR TITLE
libglvnd: update to 1.3.4

### DIFF
--- a/components/x11/libglvnd/Makefile
+++ b/components/x11/libglvnd/Makefile
@@ -16,17 +16,15 @@ BUILD_BITS=64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libglvnd
-COMPONENT_VERSION=	1.3.0
+COMPONENT_VERSION=	1.3.4
 COMPONENT_SUMMARY=	The GL Vendor-Neutral Dispatch library
 COMPONENT_PROJECT_URL=	https://github.com/NVIDIA/libglvnd
 COMPONENT_FMRI=		x11/library/libglvnd	
 COMPONENT_CLASSIFICATION=System/X11
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_URL= \
-  https://github.com/NVIDIA/libglvnd/archive/v$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH= \
-  sha256:fabf98e72e172a1402617f5daade4dd79c752a77ab1688e0c1a0ffc49605040f
+COMPONENT_ARCHIVE_URL=	https://github.com/NVIDIA/libglvnd/archive/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=	sha256:8f4218d7cdaf89d5b7eced818e810ccbc76f4bb9cba36d66eddac5a7ca892bab
 COMPONENT_LICENSE=	MIT
 
 include $(WS_MAKE_RULES)/common.mk

--- a/components/x11/libglvnd/pkg5
+++ b/components/x11/libglvnd/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "shell/ksh93",
         "system/library",
         "x11/library/libx11"
     ],


### PR DESCRIPTION
sample-manifest didn't change.

I don't know how to test this package as there doesn't seem to be any package that depends on it.
For me gmake test fails early (as it does on 1.3.0) with
===============================================
   libglvnd 1.3.4: src/OpenGL/test-suite.log
===============================================

# TOTAL: 1
# PASS:  0
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: ogl-symbol-check.sh
=========================

../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _DYNAMIC
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _GLOBAL_OFFSET_TABLE_
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _PROCEDURE_LINKAGE_TABLE_
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _edata
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _end
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _etext
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _fini
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _init
../../src/OpenGL/.libs/libOpenGL.so: unknown symbol exported: _lib_version
FAIL ogl-symbol-check.sh (exit status: 1)