### PR TITLE
psycopg2: update to 2.9.1 and obsolete python-2.7 & 3.5 versions

### DIFF
--- a/components/python/psycopg2/Makefile
+++ b/components/python/psycopg2/Makefile
@@ -14,38 +14,39 @@
 # Copyright 2015, PALO Richard.
 #
 
-BUILD_STYLE=setup.py
-BUILD_BITS=32_and_64
+BUILD_STYLE=	setup.py
+BUILD_BITS=		32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= 	psycopg2
-COMPONENT_VERSION= 	2.8.4
-COMPONENT_REVISION=	3
+COMPONENT_VERSION= 	2.9.1
 COMPONENT_SUMMARY= 	Python-PostgreSQL Database Adapter
 COMPONENT_SRC= 		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= 	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= \
-	sha256:f898e5cc0a662a9e12bde6f931263a1bbd350cfb18e1d5336a12927851825bb6
-COMPONENT_ARCHIVE_URL= \
-	$(call pypi_url)
-COMPONENT_PROJECT_URL = https://pypi.python.org/pypi/psycopg2
+COMPONENT_ARCHIVE_HASH=	sha256:de5303a6f1d0a7a34b9d40e4d3bef684ccc44a49bbe3eb85e3c0bffb4a131b7c
+COMPONENT_ARCHIVE_URL=	$(call pypi_url)
+COMPONENT_PROJECT_URL=	https://pypi.python.org/pypi/psycopg2
+COMPONENT_FMRI=		library/python/psycopg2
+COMPONENT_CLASSIFICATION=	System/Databases
+COMPONENT_LICENSE=	LGPLv3
 
-PYTHON_VERSIONS=	2.7 3.5
+PYTHON_VERSIONS=	3.7 3.9
 
 TEST_TARGET=$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 
 # Don't depend on host default pg_config
-PATH=           $(PG_BINDIR.$(BITS)):/usr/sbin:/usr/bin
+PATH				=	$(PG_BINDIR.$(BITS)):$(PATH.illumos)
 
-LDFLAGS+=   -L$(PG_LIBDIR.$(BITS))   -R$(PG_LIBDIR.$(BITS))
-COMPONENT_BUILD_ENV     +=      LDFLAGS="$(LDFLAGS)"
+LDFLAGS 			+=	-L$(PG_LIBDIR.$(BITS)) -R$(PG_LIBDIR.$(BITS))
+COMPONENT_BUILD_ENV	+=	LDFLAGS="$(LDFLAGS)"
 
-REQUIRED_PACKAGES += $(PG_DEVELOPER_PKG)
+# Manually added build dependencies
+REQUIRED_PACKAGES	+= $(PG_DEVELOPER_PKG)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(PG_LIBRARY_PKG)
-REQUIRED_PACKAGES += runtime/python-27
-REQUIRED_PACKAGES += runtime/python-35
+REQUIRED_PACKAGES += runtime/python-37
+REQUIRED_PACKAGES += runtime/python-39
 REQUIRED_PACKAGES += system/library

--- a/components/python/psycopg2/history
+++ b/components/python/psycopg2/history
@@ -1,4 +1,6 @@
 library/python/psycopg2-34@2.8.4,5.11-2020.0.1.1
+library/python/psycopg2-27@2.8.4,5.11-2020.0.1.4
+library/python/psycopg2-35@2.8.4,5.11-2020.0.1.4
 library/python-2/psycopg2-26@2.6.1,5.11-2016.0.1.0
 library/python-2/psycopg2@2.6.1,5.11-2016.0.1.0 library/python/psycopg2
-library/python-2/psycopg2-27@2.6.1,5.11-2016.0.1.0 library/python/psycopg2-27
+library/python-2/psycopg2-27@2.6.1,5.11-2016.0.1.0

--- a/components/python/psycopg2/manifests/generic-manifest.p5m
+++ b/components/python/psycopg2/manifests/generic-manifest.p5m
@@ -7,20 +7,14 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-#
-# Copyright 2016 Alexander Pyhalov
-# Copyright 2021 Andreas Wacknitz
-#
-
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+# Copyright 2021 <contributor>
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
-
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
@@ -28,7 +22,7 @@ file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2-$(COMPONENT_VERSION)-p
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/_ipaddress.py
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/_json.py
-file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/_psycopg.so
+file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/_psycopg.cpython-37m.so
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/_range.py
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/errorcodes.py
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/errors.py
@@ -37,12 +31,4 @@ file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/extras.py
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/pool.py
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/sql.py
 file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/tz.py
-#file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/_psycopg.so
-
-# force a dependency on the Python $(PYVER) runtime
-depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
-    pkg.debug.depend.path=usr/bin
-
-# force a dependency on the psycopg2 package
-depend type=require \
-    fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+file path=usr/lib/python$(PYVER)/vendor-packages/psycopg2/_psycopg.cpython-39.so

--- a/components/python/psycopg2/manifests/sample-manifest.p5m
+++ b/components/python/psycopg2/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,40 +22,35 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/lib/python2.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py2.7.egg-info/PKG-INFO
-file path=usr/lib/python2.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py2.7.egg-info/SOURCES.txt
-file path=usr/lib/python2.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py2.7.egg-info/dependency_links.txt
-file path=usr/lib/python2.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py2.7.egg-info/top_level.txt
-file path=usr/lib/python2.7/vendor-packages/psycopg2/64/_psycopg.so
-file path=usr/lib/python2.7/vendor-packages/psycopg2/__init__.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/_ipaddress.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/_json.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/_lru_cache.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/_psycopg.so
-file path=usr/lib/python2.7/vendor-packages/psycopg2/_range.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/compat.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/errorcodes.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/errors.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/extensions.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/extras.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/pool.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/sql.py
-file path=usr/lib/python2.7/vendor-packages/psycopg2/tz.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.5.egg-info/PKG-INFO
-file path=usr/lib/python3.5/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.5.egg-info/SOURCES.txt
-file path=usr/lib/python3.5/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.5.egg-info/dependency_links.txt
-file path=usr/lib/python3.5/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
-file path=usr/lib/python3.5/vendor-packages/psycopg2/__init__.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/_ipaddress.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/_json.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/_lru_cache.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/_psycopg.cpython-35m.so
-file path=usr/lib/python3.5/vendor-packages/psycopg2/_range.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/compat.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/errorcodes.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/errors.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/extensions.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/extras.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/pool.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/sql.py
-file path=usr/lib/python3.5/vendor-packages/psycopg2/tz.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.7.egg-info/PKG-INFO
+file path=usr/lib/python3.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.7.egg-info/SOURCES.txt
+file path=usr/lib/python3.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.7.egg-info/dependency_links.txt
+file path=usr/lib/python3.7/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.7.egg-info/top_level.txt
+file path=usr/lib/python3.7/vendor-packages/psycopg2/__init__.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/_ipaddress.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/_json.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/_psycopg.cpython-37m.so
+file path=usr/lib/python3.7/vendor-packages/psycopg2/_range.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/errorcodes.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/errors.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/extensions.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/extras.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/pool.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/sql.py
+file path=usr/lib/python3.7/vendor-packages/psycopg2/tz.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/psycopg2-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
+file path=usr/lib/python3.9/vendor-packages/psycopg2/__init__.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/_ipaddress.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/_json.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/_psycopg.cpython-39.so
+file path=usr/lib/python3.9/vendor-packages/psycopg2/_range.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/errorcodes.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/errors.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/extensions.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/extras.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/pool.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/sql.py
+file path=usr/lib/python3.9/vendor-packages/psycopg2/tz.py

--- a/components/python/psycopg2/pkg5
+++ b/components/python/psycopg2/pkg5
@@ -3,14 +3,14 @@
         "SUNWcs",
         "database/postgres-96/developer",
         "database/postgres-96/library",
-        "runtime/python-27",
-        "runtime/python-35",
+        "runtime/python-37",
+        "runtime/python-39",
         "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "library/python/psycopg2-27",
-        "library/python/psycopg2-35",
+        "library/python/psycopg2-37",
+        "library/python/psycopg2-39",
         "library/python/psycopg2"
     ],
     "name": "psycopg2"

--- a/components/python/psycopg2/psycopg2.license
+++ b/components/python/psycopg2/psycopg2.license
@@ -1,167 +1,49 @@
-		   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+psycopg2 and the LGPL
+---------------------
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+psycopg2 is free software: you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
+psycopg2 is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+License for more details.
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+In addition, as a special exception, the copyright holders give
+permission to link this program with the OpenSSL library (or with
+modified versions of OpenSSL that use the same license as OpenSSL),
+and distribute linked combinations including the two.
 
-  0. Additional Definitions. 
+You must obey the GNU Lesser General Public License in all respects for
+all of the code used other than OpenSSL. If you modify file(s) with this
+exception, you may extend this exception to your version of the file(s),
+but you are not obligated to do so. If you do not wish to do so, delete
+this exception statement from your version. If you delete this exception
+statement from all source files in the program, then also delete it here.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version. 
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+You should have received a copy of the GNU Lesser General Public License
+along with psycopg2 (see the doc/ directory.)
+If not, see <https://www.gnu.org/licenses/>.
 
 
+Alternative licenses
+--------------------
+
+The following BSD-like license applies (at your option) to the files following
+the pattern ``psycopg/adapter*.{h,c}`` and ``psycopg/microprotocol*.{h,c}``:
+
+ Permission is granted to anyone to use this software for any purpose,
+ including commercial applications, and to alter it and redistribute it
+ freely, subject to the following restrictions:
+
+ 1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this
+    software in a product, an acknowledgment in the product documentation
+    would be appreciated but is not required.
+
+ 2. Altered source versions must be plainly marked as such, and must not
+    be misrepresented as being the original software.
+
+ 3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
Python-2.7 and 3.5 aren't supported by psycopg2 anymore so I removed them.
We don't seem to have any dependent package on them despite barman.