### PR TITLE
Add c-ares 1.17.2 needed for wireshark 3.4

### DIFF
--- a/components/library/c-ares/Makefile
+++ b/components/library/c-ares/Makefile
@@ -1,0 +1,39 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020, Oracle and/or its affiliates.
+#
+BUILD_BITS= 64_and_32
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		c-ares
+COMPONENT_VERSION=	1.17.2
+COMPONENT_PROJECT_URL=	https://c-ares.haxx.se/
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:4803c844ce20ce510ef0eb83f8ea41fa24ecaae9d280c468c582d2bb25b3913d
+COMPONENT_ARCHIVE_URL=	https://c-ares.haxx.se/download/$(COMPONENT_ARCHIVE)
+
+TEST_TARGET= $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/library/c-ares/c-ares.license
+++ b/components/library/c-ares/c-ares.license
@@ -1,0 +1,13 @@
+Copyright (c) 2007 - 2018, Daniel Stenberg with many contributors, see AUTHORS
+file.
+
+Copyright 1998 by the Massachusetts Institute of Technology.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted, provided that
+the above copyright notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting documentation, and that
+the name of M.I.T. not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior permission.
+M.I.T. makes no representations about the suitability of this software for any
+purpose.  It is provided "as is" without express or implied warranty.

--- a/components/library/c-ares/libcares.p5m
+++ b/components/library/c-ares/libcares.p5m
@@ -1,0 +1,104 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2020, Oracle and/or its affiliates.
+#
+
+<transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
+set name=pkg.fmri \
+    value=pkg:/library/libcares@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="c-ares - C library for asynchronous DNS requests"
+set name=pkg.description \
+    value="c-ares is a C library for asynchronous DNS requests including name resolves"
+set name=info.classification \
+    value=org.opensolaris.category.2008:System/Libraries
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+file path=usr/include/ares.h
+file path=usr/include/ares_build.h
+file path=usr/include/ares_dns.h
+file path=usr/include/ares_rules.h
+file path=usr/include/ares_version.h
+link path=usr/lib/$(MACH64)/libcares.so target=libcares.so.2.4.3
+link path=usr/lib/$(MACH64)/libcares.so.2 target=libcares.so.2.4.3
+file path=usr/lib/$(MACH64)/libcares.so.2.4.3
+file path=usr/lib/$(MACH64)/pkgconfig/libcares.pc
+link path=usr/lib/libcares.so target=libcares.so.2.4.3
+link path=usr/lib/libcares.so.2 target=libcares.so.2.4.3
+file path=usr/lib/libcares.so.2.4.3
+file path=usr/lib/pkgconfig/libcares.pc
+file path=usr/share/man/man3/ares_cancel.3
+file path=usr/share/man/man3/ares_create_query.3
+file path=usr/share/man/man3/ares_destroy.3
+file path=usr/share/man/man3/ares_destroy_options.3
+file path=usr/share/man/man3/ares_dup.3
+file path=usr/share/man/man3/ares_expand_name.3
+file path=usr/share/man/man3/ares_expand_string.3
+file path=usr/share/man/man3/ares_fds.3
+file path=usr/share/man/man3/ares_free_data.3
+file path=usr/share/man/man3/ares_free_hostent.3
+file path=usr/share/man/man3/ares_free_string.3
+file path=usr/share/man/man3/ares_freeaddrinfo.3
+file path=usr/share/man/man3/ares_get_servers.3
+file path=usr/share/man/man3/ares_get_servers_ports.3
+file path=usr/share/man/man3/ares_getaddrinfo.3
+file path=usr/share/man/man3/ares_gethostbyaddr.3
+file path=usr/share/man/man3/ares_gethostbyname.3
+file path=usr/share/man/man3/ares_gethostbyname_file.3
+file path=usr/share/man/man3/ares_getnameinfo.3
+file path=usr/share/man/man3/ares_getsock.3
+file path=usr/share/man/man3/ares_inet_ntop.3
+file path=usr/share/man/man3/ares_inet_pton.3
+file path=usr/share/man/man3/ares_init.3
+file path=usr/share/man/man3/ares_init_options.3
+file path=usr/share/man/man3/ares_library_cleanup.3
+file path=usr/share/man/man3/ares_library_init.3
+file path=usr/share/man/man3/ares_library_init_android.3
+file path=usr/share/man/man3/ares_library_initialized.3
+file path=usr/share/man/man3/ares_mkquery.3
+file path=usr/share/man/man3/ares_parse_a_reply.3
+file path=usr/share/man/man3/ares_parse_aaaa_reply.3
+file path=usr/share/man/man3/ares_parse_mx_reply.3
+file path=usr/share/man/man3/ares_parse_naptr_reply.3
+file path=usr/share/man/man3/ares_parse_ns_reply.3
+file path=usr/share/man/man3/ares_parse_ptr_reply.3
+file path=usr/share/man/man3/ares_parse_soa_reply.3
+file path=usr/share/man/man3/ares_parse_srv_reply.3
+file path=usr/share/man/man3/ares_parse_txt_reply.3
+file path=usr/share/man/man3/ares_process.3
+file path=usr/share/man/man3/ares_query.3
+file path=usr/share/man/man3/ares_save_options.3
+file path=usr/share/man/man3/ares_search.3
+file path=usr/share/man/man3/ares_send.3
+file path=usr/share/man/man3/ares_set_local_dev.3
+file path=usr/share/man/man3/ares_set_local_ip4.3
+file path=usr/share/man/man3/ares_set_local_ip6.3
+file path=usr/share/man/man3/ares_set_servers.3
+file path=usr/share/man/man3/ares_set_servers_csv.3
+file path=usr/share/man/man3/ares_set_servers_ports.3
+file path=usr/share/man/man3/ares_set_servers_ports_csv.3
+file path=usr/share/man/man3/ares_set_socket_callback.3
+file path=usr/share/man/man3/ares_set_socket_configure_callback.3
+file path=usr/share/man/man3/ares_set_socket_functions.3
+file path=usr/share/man/man3/ares_set_sortlist.3
+file path=usr/share/man/man3/ares_strerror.3
+file path=usr/share/man/man3/ares_timeout.3
+file path=usr/share/man/man3/ares_version.3
+license c-ares.license license=MIT

--- a/components/library/c-ares/manifests/sample-manifest.p5m
+++ b/components/library/c-ares/manifests/sample-manifest.p5m
@@ -1,0 +1,97 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/ares.h
+file path=usr/include/ares_build.h
+file path=usr/include/ares_dns.h
+file path=usr/include/ares_rules.h
+file path=usr/include/ares_version.h
+file path=usr/lib/$(MACH64)/libcares.a
+link path=usr/lib/$(MACH64)/libcares.so target=libcares.so.2.4.3
+link path=usr/lib/$(MACH64)/libcares.so.2 target=libcares.so.2.4.3
+file path=usr/lib/$(MACH64)/libcares.so.2.4.3
+file path=usr/lib/$(MACH64)/pkgconfig/libcares.pc
+file path=usr/lib/libcares.a
+link path=usr/lib/libcares.so target=libcares.so.2.4.3
+link path=usr/lib/libcares.so.2 target=libcares.so.2.4.3
+file path=usr/lib/libcares.so.2.4.3
+file path=usr/lib/pkgconfig/libcares.pc
+file path=usr/share/man/man3/ares_cancel.3
+file path=usr/share/man/man3/ares_create_query.3
+file path=usr/share/man/man3/ares_destroy.3
+file path=usr/share/man/man3/ares_destroy_options.3
+file path=usr/share/man/man3/ares_dup.3
+file path=usr/share/man/man3/ares_expand_name.3
+file path=usr/share/man/man3/ares_expand_string.3
+file path=usr/share/man/man3/ares_fds.3
+file path=usr/share/man/man3/ares_free_data.3
+file path=usr/share/man/man3/ares_free_hostent.3
+file path=usr/share/man/man3/ares_free_string.3
+file path=usr/share/man/man3/ares_freeaddrinfo.3
+file path=usr/share/man/man3/ares_get_servers.3
+file path=usr/share/man/man3/ares_get_servers_ports.3
+file path=usr/share/man/man3/ares_getaddrinfo.3
+file path=usr/share/man/man3/ares_gethostbyaddr.3
+file path=usr/share/man/man3/ares_gethostbyname.3
+file path=usr/share/man/man3/ares_gethostbyname_file.3
+file path=usr/share/man/man3/ares_getnameinfo.3
+file path=usr/share/man/man3/ares_getsock.3
+file path=usr/share/man/man3/ares_inet_ntop.3
+file path=usr/share/man/man3/ares_inet_pton.3
+file path=usr/share/man/man3/ares_init.3
+file path=usr/share/man/man3/ares_init_options.3
+file path=usr/share/man/man3/ares_library_cleanup.3
+file path=usr/share/man/man3/ares_library_init.3
+file path=usr/share/man/man3/ares_library_init_android.3
+file path=usr/share/man/man3/ares_library_initialized.3
+file path=usr/share/man/man3/ares_mkquery.3
+file path=usr/share/man/man3/ares_parse_a_reply.3
+file path=usr/share/man/man3/ares_parse_aaaa_reply.3
+file path=usr/share/man/man3/ares_parse_caa_reply.3
+file path=usr/share/man/man3/ares_parse_mx_reply.3
+file path=usr/share/man/man3/ares_parse_naptr_reply.3
+file path=usr/share/man/man3/ares_parse_ns_reply.3
+file path=usr/share/man/man3/ares_parse_ptr_reply.3
+file path=usr/share/man/man3/ares_parse_soa_reply.3
+file path=usr/share/man/man3/ares_parse_srv_reply.3
+file path=usr/share/man/man3/ares_parse_txt_reply.3
+file path=usr/share/man/man3/ares_process.3
+file path=usr/share/man/man3/ares_query.3
+file path=usr/share/man/man3/ares_save_options.3
+file path=usr/share/man/man3/ares_search.3
+file path=usr/share/man/man3/ares_send.3
+file path=usr/share/man/man3/ares_set_local_dev.3
+file path=usr/share/man/man3/ares_set_local_ip4.3
+file path=usr/share/man/man3/ares_set_local_ip6.3
+file path=usr/share/man/man3/ares_set_servers.3
+file path=usr/share/man/man3/ares_set_servers_csv.3
+file path=usr/share/man/man3/ares_set_servers_ports.3
+file path=usr/share/man/man3/ares_set_servers_ports_csv.3
+file path=usr/share/man/man3/ares_set_socket_callback.3
+file path=usr/share/man/man3/ares_set_socket_configure_callback.3
+file path=usr/share/man/man3/ares_set_socket_functions.3
+file path=usr/share/man/man3/ares_set_sortlist.3
+file path=usr/share/man/man3/ares_strerror.3
+file path=usr/share/man/man3/ares_timeout.3
+file path=usr/share/man/man3/ares_version.3

--- a/components/library/c-ares/pkg5
+++ b/components/library/c-ares/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "library/libcares"
+    ],
+    "name": "c-ares"
+}


### PR DESCRIPTION
This is an import of mostly the Solaris userland package only amended it to the OI structure. This is a pre-requirement for wireshark 3.4 although 3.2 will also use it when available.