### PR TITLE
sbcl: temporarily disable build because it stalls on build server

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -21,4 +21,6 @@
 # disabled for a particular reason. The format is:
 # # <reason why is package disabled>
 # /^package$/d
-# 
+#
+# Building sbcl stalls within internal tests. Even reverting to a former version doesn't fix that: 
+/^runtime\/sbcl$/d


### PR DESCRIPTION
Our build server doesn't finish the build job of sbcl (even reverting to the previous version doesn't help):
Build stalls here:
...
Doing 20 pending tests of 20 tests total.
 SB-CONCURRENCY-TEST::FRLOCK.1 SB-CONCURRENCY-TEST::QUEUE.1
 SB-CONCURRENCY-TEST::QUEUE.2 SB-CONCURRENCY-TEST::QUEUE.3
 SB-CONCURRENCY-TEST::QUEUE.4 SB-CONCURRENCY-TEST::QUEUE.5
 SB-CONCURRENCY-TEST::QUEUE.T.1 SB-CONCURRENCY-TEST::QUEUE.T.2
 SB-CONCURRENCY-TEST::QUEUE.T.3 SB-CONCURRENCY-TEST::MAILBOX-TRIVIA.1
 SB-CONCURRENCY-TEST::MAILBOX-TRIVIA.2 SB-CONCURRENCY-TEST::MAILBOX-TRIVIA.3
 SB-CONCURRENCY-TEST::MAILBOX-TIMEOUTS SB-CONCURRENCY-TEST::GATE.0
