### PR TITLE
Cherry-pick ftpuser fix from solaris-userland

### DIFF
--- a/transforms/defaults
+++ b/transforms/defaults
@@ -59,6 +59,11 @@
 <transform dir path=usr/g\+\+/lib/java/javadoc$ -> default group other>
 
 #
+# Users added by our packages should be blocked from ftp access by default
+#
+<transform user -> default ftpuser false>
+
+#
 # Changes to zoneinfo files on live systems need to trigger a refresh of
 # the timezone reloader.  See tzreload(1m).
 #


### PR DESCRIPTION
33381975 Users delivered by Userland packages should have ftpuser attribute set