### PR TITLE
text/jq: disable assertions, so normal user errors give messages rather than cores

### DIFF
--- a/components/text/jq/Makefile
+++ b/components/text/jq/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         jq
 COMPONENT_VERSION=      1.6
-COMPONENT_REVISION= 	1
+COMPONENT_REVISION= 	2
 COMPONENT_SUMMARY=      jq - lightweight and flexible command-line JSON processor
 COMPONENT_PROJECT_URL=	https://stedolan.github.io/jq/
 COMPONENT_FMRI=         text/jq
@@ -40,6 +40,7 @@ COMPONENT_PRE_CONFIGURE_ACTION = ($(CLONEY) $(SOURCE_DIR) $(@D); cd $(@D))
 #COMPONENT_PRE_CONFIGURE_ACTION = ($(CLONEY) $(SOURCE_DIR) $(@D); cd $(@D); autoreconf -fi)
 
 CONFIGURE_ENV += CFLAGS="$(CFLAGS) $(CPP_XPG6MODE)"
+COMPONENT_BUILD_ARGS += CFLAGS="$(CFLAGS) $(CPP_XPG6MODE) -DNDEBUG=1"
 
 CONFIGURE_OPTIONS += --disable-valgrind
 CONFIGURE_OPTIONS += --with-oniguruma=/usr


### PR DESCRIPTION
This is the thing I was complaining about recently.  If we build with assertions enabled, regular user errors drop cores.

before:
```
ssh code.illumos.org gerrit query --all-approvals --format=JSON 1750 | jq '.patchSets[-1].approvals[] | "\(.by.name) <\(.by.email)>"'
"Andy Fiddaman <andy@omnios.org>"
"Toomas Soome <tsoome@me.com>"
"Peter Tribble <peter.tribble@gmail.com>"
"Yuri Pankov <ypankov@tintri.com>"
Assertion failed: cb == jq_util_input_next_input_cb, file src/util.c, line 371, function jq_util_input_get_position
```

after:
```
ssh code.illumos.org gerrit query --all-approvals --format=JSON 1750 | build/amd64/jq '.patchSets[-1].approvals[] | "\(.by.name) <\(.by.email)>"'
"Andy Fiddaman <andy@omnios.org>"
"Toomas Soome <tsoome@me.com>"
"Peter Tribble <peter.tribble@gmail.com>"
"Yuri Pankov <ypankov@tintri.com>"
jq: error (at \200/\241): Cannot iterate over null (null)
```

Which is at least very slightly more useful (but gives the impression it's also buggy, given the junk characters).