### PR TITLE
chezmoi: add version 2.7.3

### DIFF
--- a/components/sysutils/chezmoi/Makefile
+++ b/components/sysutils/chezmoi/Makefile
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Benjamin S. Osenbach
+#
+BUILD_BITS=64 # for binaries or 32_and_64 for libraries
+BUILD_STYLE=justmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=chezmoi
+COMPONENT_VERSION=2.7.3
+COMPONENT_SUMMARY=Manage your dotfiles across multiple diverse machines, securely.
+COMPONENT_PROJECT_URL=https://github.com/twpayne/chezmoi
+COMPONENT_FMRI=application/chezmoi
+COMPONENT_CLASSIFICATION=Applications/System Utilities
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=https://github.com/twpayne/chezmoi/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=sha256:a9dbaa9bd55f1c1e1c82c7ae5b7b1933f907703d5bd9976b2c14321b8c1e0d90
+COMPONENT_LICENSE=MIT
+COMPONENT_LICENSE_FILE=chezmoi.license
+TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
+include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_BUILD_ENV += GOOS="illumos"
+COMPONENT_BUILD_ENV += GOPATH="$(SOURCE_DIR)/gopath"
+COMPONENT_BUILD_ENV += GOBIN="$(PROTO_DIR)/usr/bin"
+
+COMPONENT_INSTALL_ENV += GOOS="illumos"
+COMPONENT_INSTALL_ENV += GOPATH="$(SOURCE_DIR)/gopath"
+COMPONENT_INSTALL_ENV += GOBIN="$(PROTO_DIR)/usr/bin"
+
+# Go doesn't like symbolic links, so copy the source directory
+COMPONENT_COPY_ACTION=(cp -rL $(SOURCE_DIR)/* $(@D))
+
+# Build dependencies
+REQUIRED_PACKAGES+=developer/golang
+REQUIRED_PACKAGES+=developer/versioning/git
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/sysutils/chezmoi/chezmoi.license
+++ b/components/sysutils/chezmoi/chezmoi.license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Tom Payne
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/components/sysutils/chezmoi/chezmoi.p5m
+++ b/components/sysutils/chezmoi/chezmoi.p5m
@@ -1,0 +1,25 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 Benjamin S. Osenbach
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/chezmoi

--- a/components/sysutils/chezmoi/manifests/sample-manifest.p5m
+++ b/components/sysutils/chezmoi/manifests/sample-manifest.p5m
@@ -1,0 +1,25 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/chezmoi

--- a/components/sysutils/chezmoi/patches/01-only-build-illumos.patch
+++ b/components/sysutils/chezmoi/patches/01-only-build-illumos.patch
@@ -1,0 +1,25 @@
+#Chezmoi by default uses git to find the version it is built from. This does not work as we download a tarball copy from Github and build inside oi-userland, thus we remove the version embedding here
+--- chezmoi-2.7.3/Makefile.orig	2021-10-22 15:34:17.000000000 +0000
++++ chezmoi-2.7.3/Makefile	2021-10-29 09:59:04.758384704 +0000
+@@ -2,17 +2,15 @@
+ GOLANGCI_LINT_VERSION=$(shell grep GOLANGCI_LINT_VERSION: .github/workflows/main.yml | awk '{ print $$2 }')
+ 
+ .PHONY: default
+-default: run build test lint format
++default: build
+ 
+ .PHONY: install
+ install:
+-	go install -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags) \
+-		-X main.commit=$(shell git rev-parse HEAD) \
+-		-X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
+-		-X main.builtBy=source"
++	go install
+ 
+ .PHONY: build
+-build: build-darwin build-freebsd build-linux build-windows
++build:
++	GOARCH=amd64 ${GO} build -o /dev/null .
+ 
+ .PHONY: build-darwin
+ build-darwin:

--- a/components/sysutils/chezmoi/pkg5
+++ b/components/sysutils/chezmoi/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "developer/golang",
+        "developer/versioning/git",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "application/chezmoi"
+    ],
+    "name": "chezmoi"
+}


### PR DESCRIPTION
Adding `chezmoi`, a utility to securely synchronize configuration files (aka "dotfiles") across multiple OSes

The main developer has worked specifically to support illumos (see https://github.com/twpayne/chezmoi/releases/tag/v2.7.3)