### PR TITLE
gst-plugins-ugly1: update to 1.18.5

### DIFF
--- a/components/encumbered/gst-plugins-ugly1/Makefile
+++ b/components/encumbered/gst-plugins-ugly1/Makefile
@@ -12,34 +12,32 @@
 #
 # Copyright 2016-2018 Aurelien Larcher.  All rights reserved.
 # Copyright 2019 Michal Nowak
+# Copyright 2021 Tim Mooney.  All rights reserved.
 #
 
 BUILD_BITS= 32_and_64
+BUILD_STYLE=	meson
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME= gst-plugins-ugly1
-COMPONENT_VERSION= 1.16.2
-COMPONENT_SUMMARY= GNOME streaming media framework plugins
+COMPONENT_NAME=		gst-plugins-ugly1
+COMPONENT_VERSION=	1.18.5
+COMPONENT_SUMMARY=	GNOME streaming media framework plugins
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
-COMPONENT_FMRI= library/audio/gstreamer1/plugin/ugly
-COMPONENT_SRC_NAME= gst-plugins-ugly
-COMPONENT_SRC= $(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
+COMPONENT_FMRI=		library/audio/gstreamer1/plugin/ugly
+COMPONENT_SRC_NAME=	gst-plugins-ugly
+COMPONENT_SRC=		$(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:5500415b865e8b62775d4742cbb9f37146a50caecfc0e7a6fc0160d3c560fbca
+  sha256:df32803e98f8a9979373fa2ca7e05e62f977b1097576d3a80619d9f5c69f66d9
 COMPONENT_ARCHIVE_URL= \
   https://gstreamer.freedesktop.org/src/$(COMPONENT_SRC_NAME)/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = https://gstreamer.freedesktop.org/
-COMPONENT_LICENSE= LGPLv2
+COMPONENT_PROJECT_URL=	https://gstreamer.freedesktop.org/
+COMPONENT_LICENSE=	LGPLv2
 
 include $(WS_MAKE_RULES)/encumbered.mk
 include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_PREP_ACTION = ( cd $(SOURCE_DIR) && aclocal -I ./m4 -I./common/m4 &&\
-                          autoheader &&\
-                          automake -a -f -c --gnu &&\
-                          autoconf )
 gcc_OPT = -O2
 
 PATH = $(PATH.gnu)
@@ -47,32 +45,35 @@ PATH = $(PATH.gnu)
 CFLAGS += -I/usr/X11/include/mesa
 CFLAGS += -I/usr/X11/include
 
+# no introspection or examples here
 CONFIGURE_OPTIONS += --sysconfdir=/etc
-CONFIGURE_OPTIONS += --disable-examples
-CONFIGURE_OPTIONS += --enable-external
-CONFIGURE_OPTIONS += --enable-orc
-CONFIGURE_OPTIONS += --with-default-audiosrc=autoaudiosrc
-CONFIGURE_OPTIONS += --with-default-audiosink=autoaudiosink
-CONFIGURE_OPTIONS += --with-default-videosink=autovideosink
+CONFIGURE_OPTIONS += -Dorc=enabled
+CONFIGURE_OPTIONS += -Dpackage-origin="https://github.com/OpenIndiana/oi-userland"
 
 # CFLAGS are not passed to compiler when g-ir-scanner is used
+COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 COMPONENT_BUILD_ENV += CXXFLAGS="$(CXXFLAGS)"
+COMPONENT_INSTALL_ENV += CC="$(CC)"
 COMPONENT_INSTALL_ENV += CFLAGS="$(CFLAGS)"
 COMPONENT_INSTALL_ENV += CXXFLAGS="$(CXXFLAGS)"
 
 COMPONENT_INSTALL_ENV += GCONF_DISABLE_MAKEFILE_SCHEMA_INSTALL=1
 
 unexport SHELLOPTS
-COMPONENT_TEST_TRANSFORMS= \
+# (first) delete the timing information from any line
+# delete the "exit status N", it can cause issues too
+# print lines that start with " N/NNN"
+# print everything between "^Ok:" and "^Timeout:"
+# delete the ninja log-related stuff at the end
+COMPONENT_TEST_TRANSFORMS += \
 	'-n ' \
-	'-e "/TOTAL/p" ' \
-	'-e "/PASS/p" '  \
-	'-e "/SKIP/p" '  \
-	'-e "/XFAIL/p" ' \
-	'-e "/FAIL/p" '  \
-	'-e "/XPASS/p" ' \
-	'-e "/ERROR/p" '
+	'-e "s/[ 	]*[0-9][0-9]*\.[0-9][0-9]s//" ' \
+	'-e "s/[ 	]*exit status [0-9][0-9]*//" ' \
+	'-e "/^[ 	]*[0-9][0-9]*\/[0-9][0-9]* /p" ' \
+	'-e "/^Summary of/p" ' \
+	'-e "/^Ok:/,/^Timeout:/p" ' \
+	'-e "/^Full log written.*/,/^ninja: build stopped.*/d" '
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += codec/opencore-amr

--- a/components/encumbered/gst-plugins-ugly1/gst-plugins-ugly1.p5m
+++ b/components/encumbered/gst-plugins-ugly1/gst-plugins-ugly1.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright 2017 Aurelien Larcher
 # Copyright 2019 Michal Nowak
+# Copyright 2021 Tim Mooney.  All rights reserved
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/encumbered/gst-plugins-ugly1/manifests/sample-manifest.p5m
+++ b/components/encumbered/gst-plugins-ugly1/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/encumbered/gst-plugins-ugly1/pkg5
+++ b/components/encumbered/gst-plugins-ugly1/pkg5
@@ -2,6 +2,8 @@
     "dependencies": [
         "SUNWcs",
         "codec/opencore-amr",
+        "developer/build/meson",
+        "developer/build/ninja",
         "library/audio/gstreamer1",
         "library/audio/gstreamer1/plugin/base",
         "library/audio/liba52",
@@ -10,6 +12,7 @@
         "library/video/libdvdread",
         "library/video/libmpeg2",
         "library/video/x264",
+        "shell/ksh93",
         "system/library",
         "system/library/orc"
     ],

--- a/components/encumbered/gst-plugins-ugly1/test/results-32.master
+++ b/components/encumbered/gst-plugins-ugly1/test/results-32.master
@@ -1,14 +1,11 @@
-PASS: generic/states
-PASS: elements/amrnbenc
-PASS: elements/mpeg2dec
-PASS: elements/x264enc
-PASS: elements/xingmux
-# TOTAL: 5
-# PASS:  5
-# SKIP:  0
-# XFAIL: 0
-# XFAIL: 0
-# FAIL:  0
-# XPASS: 0
-# XPASS: 0
-# ERROR: 0
+1/5 elements_x264enc  OK
+2/5 elements_xingmux  OK
+3/5 generic_states    OK
+4/5 elements_amrnbenc OK
+5/5 elements_mpeg2dec OK
+Ok:                 5   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   

--- a/components/encumbered/gst-plugins-ugly1/test/results-64.master
+++ b/components/encumbered/gst-plugins-ugly1/test/results-64.master
@@ -1,14 +1,11 @@
-PASS: generic/states
-PASS: elements/amrnbenc
-PASS: elements/mpeg2dec
-PASS: elements/x264enc
-PASS: elements/xingmux
-# TOTAL: 5
-# PASS:  5
-# SKIP:  0
-# XFAIL: 0
-# XFAIL: 0
-# FAIL:  0
-# XPASS: 0
-# XPASS: 0
-# ERROR: 0
+1/5 elements_x264enc  OK
+2/5 elements_xingmux  OK
+3/5 generic_states    OK
+4/5 elements_amrnbenc OK
+5/5 elements_mpeg2dec OK
+Ok:                 5   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   


### PR DESCRIPTION
Final component update in the batch for gstreamer1: gst-plugins-ugly1

Same main changes as the previous ones: switch to meson and update the test transforms.

This ended up being the easiest of all the updates.  No installed paths or dependencies changed, and all the package tests are still passing.