### PR TITLE
ca-certificates: remove expired DST Root CA X3

### DIFF
--- a/components/openindiana/ca-certificates/Makefile
+++ b/components/openindiana/ca-certificates/Makefile
@@ -13,6 +13,7 @@
 # Copyright 2016 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
 # Copyright 2021 Till Wegmueller
+# Copyright 2021 David Stes
 #
 
 include ../../../make-rules/shared-macros.mk
@@ -21,6 +22,7 @@ COMPONENT_NAME= ca-certificates
 COMPONENT_VERSION_MAJOR=3
 COMPONENT_VERSION_MINOR=71
 COMPONENT_VERSION=	$(COMPONENT_VERSION_MAJOR).$(COMPONENT_VERSION_MINOR)
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Common CA certificates
 COMPONENT_SRC=		nss-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz

--- a/components/openindiana/ca-certificates/ca-certificates.p5m
+++ b/components/openindiana/ca-certificates/ca-certificates.p5m
@@ -77,7 +77,7 @@ file path=etc/certs/CA/Comodo_AAA_Services_root.pem
 file path=etc/certs/CA/Cybertrust_Global_Root.pem
 file path=etc/certs/CA/D-TRUST_Root_Class_3_CA_2_2009.pem
 file path=etc/certs/CA/D-TRUST_Root_Class_3_CA_2_EV_2009.pem
-file path=etc/certs/CA/DST_Root_CA_X3.pem
+# file path=etc/certs/CA/DST_Root_CA_X3.pem
 file path=etc/certs/CA/DigiCert_Assured_ID_Root_CA.pem
 file path=etc/certs/CA/DigiCert_Assured_ID_Root_G2.pem
 file path=etc/certs/CA/DigiCert_Assured_ID_Root_G3.pem
@@ -220,7 +220,7 @@ link path=etc/openssl/certs/2ae6433e.0 \
     target=../../certs/CA/CA_Disig_Root_R2.pem
 link path=etc/openssl/certs/2b349938.0 \
     target=../../certs/CA/AffirmTrust_Commercial.pem
-link path=etc/openssl/certs/2e5ac55d.0 target=../../certs/CA/DST_Root_CA_X3.pem
+# link path=etc/openssl/certs/2e5ac55d.0 target=../../certs/CA/DST_Root_CA_X3.pem
 link path=etc/openssl/certs/32888f65.0 \
     target=../../certs/CA/Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem
 link path=etc/openssl/certs/349f2832.0 target=../../certs/CA/EC-ACC.pem

--- a/components/openindiana/ca-certificates/manifests/sample-manifest.p5m
+++ b/components/openindiana/ca-certificates/manifests/sample-manifest.p5m
@@ -55,7 +55,6 @@ file path=etc/certs/CA/Comodo_AAA_Services_root.pem
 file path=etc/certs/CA/Cybertrust_Global_Root.pem
 file path=etc/certs/CA/D-TRUST_Root_Class_3_CA_2_2009.pem
 file path=etc/certs/CA/D-TRUST_Root_Class_3_CA_2_EV_2009.pem
-file path=etc/certs/CA/DST_Root_CA_X3.pem
 file path=etc/certs/CA/DigiCert_Assured_ID_Root_CA.pem
 file path=etc/certs/CA/DigiCert_Assured_ID_Root_G2.pem
 file path=etc/certs/CA/DigiCert_Assured_ID_Root_G3.pem
@@ -198,7 +197,6 @@ link path=etc/openssl/certs/2ae6433e.0 \
     target=../../certs/CA/CA_Disig_Root_R2.pem
 link path=etc/openssl/certs/2b349938.0 \
     target=../../certs/CA/AffirmTrust_Commercial.pem
-link path=etc/openssl/certs/2e5ac55d.0 target=../../certs/CA/DST_Root_CA_X3.pem
 link path=etc/openssl/certs/32888f65.0 \
     target=../../certs/CA/Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem
 link path=etc/openssl/certs/349f2832.0 target=../../certs/CA/EC-ACC.pem


### PR DESCRIPTION
Could be interesting as a temporary update until December 2021

https://bugzilla.mozilla.org/show_bug.cgi?id=1733560
https://bugzilla.mozilla.org/show_bug.cgi?id=1733003

The problem for Squeak Smalltalk is that the certificate of https://squeak.org is signed by DST Root CA X3 which expired in September 2021.

The article https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/  blog explains that either openssl should be updated to 1.0.2.zb or some other workaround implemented because openssl 1.0.2 (unlike openssl 1.1 ?) prefers the "OpenSSL 1.0.2 which always prefers the untrusted chain"  instead of the trusted chain X1.