### PR TITLE
zlib: use default optimization & add test results

### DIFF
--- a/components/library/zlib/Makefile
+++ b/components/library/zlib/Makefile
@@ -24,25 +24,23 @@
 # Copyright (c) 2013  Erol Zavidic. All rights reserved.
 #
 
+BUILD_BITS= 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zlib
 COMPONENT_VERSION=	1.2.11
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_SUMMARY=	The Zip compression library
-COMPONENT_PROJECT_URL=	http://www.zlib.net/
+COMPONENT_PROJECT_URL=	https://zlib.net/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	\
-    sha256:c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-COMPONENT_ARCHIVE_URL=	http://downloads.sourceforge.net/project/libpng/zlib/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= sha256:c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+COMPONENT_ARCHIVE_URL=	https://downloads.sourceforge.net/project/libpng/zlib/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	library/zlib
 COMPONENT_CLASSIFICATION=	System/Libraries
 COMPONENT_LICENSE=	zlib license
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 # Zlib won't build without cloning. We need also to get rid of default
 # Makefile and get our own version of zconf.h to avoid interactions
@@ -51,9 +49,6 @@ COMPONENT_PRE_CONFIGURE_ACTION = ( \
 	$(CLONEY) $(SOURCE_DIR) $(@D); \
 	$(RM) $(@D)/Makefile $(@D)/zconf.h; \
 	$(CP) $(SOURCE_DIR)/zconf.h $(@D) )
-
-#Fixes firefox crash with new zlib, don't remove until proper fix
-gcc_OPT="-O2"
 
 # Also, the x86 architecture does not require alignment for multi-byte
 # loads, so we can define UNALIGNED_OK for x86
@@ -79,10 +74,5 @@ CONFIGURE_ENV += LDSHARED="$(CC) $(CFLAGS) -G"
 # to allow Zlib detect capability of creating shared libraries.
 COMPONENT_BUILD_ARGS = LDSHARED="$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-z -Wl,text -Wl,-h -Wl,libz.so.1 $(LD_OPTIONS_SO) -Wl,-M -Wl,../../mapfile -L."
 
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/library/zlib/manifests/sample-manifest.p5m
+++ b/components/library/zlib/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,13 +28,10 @@ file path=usr/lib/$(MACH64)/libz.a
 link path=usr/lib/$(MACH64)/libz.so target=libz.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/libz.so.$(COMPONENT_VERSION)
 link path=usr/lib/$(MACH64)/libz.so.1 target=libz.so.$(COMPONENT_VERSION)
-file path=usr/lib/$(MACH64)/llib-lz.ln
 file path=usr/lib/$(MACH64)/pkgconfig/zlib.pc
 file path=usr/lib/libz.a
 link path=usr/lib/libz.so target=libz.so.$(COMPONENT_VERSION)
 file path=usr/lib/libz.so.$(COMPONENT_VERSION)
 link path=usr/lib/libz.so.1 target=libz.so.$(COMPONENT_VERSION)
-file path=usr/lib/llib-lz
-file path=usr/lib/llib-lz.ln
 file path=usr/lib/pkgconfig/zlib.pc
 file path=usr/share/man/man3/zlib.3

--- a/components/library/zlib/pkg5
+++ b/components/library/zlib/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [

--- a/components/library/zlib/test/results-32.master
+++ b/components/library/zlib/test/results-32.master
@@ -1,0 +1,32 @@
+make[1]: Entering directory '$(@D)'
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0x55
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib test OK ***
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0x55
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib shared test OK ***
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0x55
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib 64-bit test OK ***
+make[1]: Leaving directory '$(@D)'

--- a/components/library/zlib/test/results-64.master
+++ b/components/library/zlib/test/results-64.master
@@ -1,0 +1,32 @@
+make[1]: Entering directory '$(@D)'
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0xa9
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib test OK ***
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0xa9
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib shared test OK ***
+hello world
+zlib version 1.2.11 = 0x12b0, compile flags = 0xa9
+uncompress(): hello, hello!
+gzread(): hello, hello!
+gzgets() after gzseek:  hello!
+inflate(): hello, hello!
+large_inflate(): OK
+after inflateSync(): hello, hello!
+inflate with dictionary: hello, hello!
+		*** zlib 64-bit test OK ***
+make[1]: Leaving directory '$(@D)'

--- a/components/library/zlib/zlib.p5m
+++ b/components/library/zlib/zlib.p5m
@@ -22,18 +22,19 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+<transform file path=.*/lib/.+\.a$ -> drop>
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
 
 file libz.3.sunman path=usr/share/man/man3/libz.3
 
 file path=usr/include/zconf.h
 file path=usr/include/zlib.h
-#file path=usr/lib/$(MACH64)/libz.a
+file path=usr/lib/$(MACH64)/libz.a
 link path=usr/lib/$(MACH64)/libz.so target=libz.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/libz.so.$(COMPONENT_VERSION)
 link path=usr/lib/$(MACH64)/libz.so.1 target=libz.so.$(COMPONENT_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/zlib.pc
-#file path=usr/lib/libz.a
+file path=usr/lib/libz.a
 link path=usr/lib/libz.so target=libz.so.$(COMPONENT_VERSION)
 file path=usr/lib/libz.so.$(COMPONENT_VERSION)
 link path=usr/lib/libz.so.1 target=libz.so.$(COMPONENT_VERSION)


### PR DESCRIPTION
There has been a discussion in oi-dev regarding the old -O2 settings that has been added for firefox.
The latest firefox works just fine with -O3 so the consensus was to remove the local override.