### PR TITLE
new component dav1d, a fast, open AV1 decoder

### DIFF
--- a/components/encumbered/dav1d/Makefile
+++ b/components/encumbered/dav1d/Makefile
@@ -1,0 +1,57 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 (c) Tim Mooney. All rights reserved.
+#
+BUILD_BITS=		64_and_32
+BUILD_STYLE=		meson
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		dav1d
+COMPONENT_VERSION=	0.9.2
+COMPONENT_FMRI=		codec/dav1d
+COMPONENT_SUMMARY=	A fast, cross-platform AV1 decoder
+COMPONENT_CLASSIFICATION=System/Multimedia Libraries
+COMPONENT_PROJECT_URL=	https://code.videolan.org/videolan/dav1d
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL= \
+	$(COMPONENT_PROJECT_URL)/-/archive/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:59a5fc9cc5d8ea780ad71ede6d589ed33fb5179d87780dcf80a00ee854952935
+COMPONENT_LICENSE=	BSD 2-Clause Simplified License
+
+include $(WS_MAKE_RULES)/encumbered.mk
+include $(WS_MAKE_RULES)/common.mk
+
+CONFIGURE_OPTIONS += -Denable_asm=true
+
+unexport SHELLOPTS
+# (first) delete the timing information from any line
+# delete the "exit status N", it can cause issues too
+# print lines that start with " N/NNN"
+# print everything between "^Ok:" and "^Timeout:"
+# delete the ninja log-related stuff at the end
+COMPONENT_TEST_TRANSFORMS += \
+	'-n ' \
+	'-e "s/[ 	]*[0-9][0-9]*\.[0-9][0-9]s//" ' \
+	'-e "s/[ 	]*exit status [0-9][0-9]*//" ' \
+	'-e "/^[ 	]*[0-9][0-9]*\/[0-9][0-9]* /p" ' \
+	'-e "/^Summary of/p" ' \
+	'-e "/^Ok:/,/^Timeout:/p" ' \
+	'-e "/^Full log written.*/,/^ninja: build stopped.*/d" '
+
+# build requirement
+REQUIRED_PACKAGES += developer/assembler/nasm
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/encumbered/dav1d/dav1d.license
+++ b/components/encumbered/dav1d/dav1d.license
@@ -1,0 +1,23 @@
+Copyright © 2018-2019, VideoLAN and dav1d authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/encumbered/dav1d/dav1d.p5m
+++ b/components/encumbered/dav1d/dav1d.p5m
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# skip the 32 bit binary
+#file path=usr/bin/$(MACH32)/dav1d
+file path=usr/bin/dav1d
+file path=usr/include/dav1d/common.h
+file path=usr/include/dav1d/data.h
+file path=usr/include/dav1d/dav1d.h
+file path=usr/include/dav1d/headers.h
+file path=usr/include/dav1d/picture.h
+file path=usr/include/dav1d/version.h
+link path=usr/lib/$(MACH64)/libdav1d.so target=libdav1d.so.5
+link path=usr/lib/$(MACH64)/libdav1d.so.5 target=libdav1d.so.5.1.1
+file path=usr/lib/$(MACH64)/libdav1d.so.5.1.1
+file path=usr/lib/$(MACH64)/pkgconfig/dav1d.pc
+link path=usr/lib/libdav1d.so target=libdav1d.so.5
+link path=usr/lib/libdav1d.so.5 target=libdav1d.so.5.1.1
+file path=usr/lib/libdav1d.so.5.1.1
+file path=usr/lib/pkgconfig/dav1d.pc

--- a/components/encumbered/dav1d/manifests/sample-manifest.p5m
+++ b/components/encumbered/dav1d/manifests/sample-manifest.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/$(MACH32)/dav1d
+file path=usr/bin/dav1d
+file path=usr/include/dav1d/common.h
+file path=usr/include/dav1d/data.h
+file path=usr/include/dav1d/dav1d.h
+file path=usr/include/dav1d/headers.h
+file path=usr/include/dav1d/picture.h
+file path=usr/include/dav1d/version.h
+link path=usr/lib/$(MACH64)/libdav1d.so target=libdav1d.so.5
+link path=usr/lib/$(MACH64)/libdav1d.so.5 target=libdav1d.so.5.1.1
+file path=usr/lib/$(MACH64)/libdav1d.so.5.1.1
+file path=usr/lib/$(MACH64)/pkgconfig/dav1d.pc
+link path=usr/lib/libdav1d.so target=libdav1d.so.5
+link path=usr/lib/libdav1d.so.5 target=libdav1d.so.5.1.1
+file path=usr/lib/libdav1d.so.5.1.1
+file path=usr/lib/pkgconfig/dav1d.pc

--- a/components/encumbered/dav1d/patches/01-meson-dlsym.patch
+++ b/components/encumbered/dav1d/patches/01-meson-dlsym.patch
@@ -1,0 +1,15 @@
+
+Illumos has dlsym(), let meson detect it.
+
+diff -ur dav1d-0.9.2.orig/meson.build dav1d-0.9.2/meson.build
+--- dav1d-0.9.2.orig/meson.build	2021-09-03 09:42:36.000000000 +0000
++++ dav1d-0.9.2/meson.build	2021-10-31 03:10:51.254571251 +0000
+@@ -161,7 +176,7 @@
+ endif
+ 
+ libdl_dependency = []
+-if host_machine.system() == 'linux'
++if host_machine.system() == 'linux' or host_machine.system() == 'sunos'
+     libdl_dependency = cc.find_library('dl', required : false)
+     if cc.has_function('dlsym', prefix : '#include <dlfcn.h>', args : test_args, dependencies : libdl_dependency)
+         cdata.set('HAVE_DLSYM', 1)

--- a/components/encumbered/dav1d/pkg5
+++ b/components/encumbered/dav1d/pkg5
@@ -1,0 +1,15 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "developer/assembler/nasm",
+        "developer/build/meson",
+        "developer/build/ninja",
+        "shell/ksh93",
+        "system/library",
+        "system/library/math"
+    ],
+    "fmris": [
+        "codec/dav1d"
+    ],
+    "name": "dav1d"
+}

--- a/components/encumbered/dav1d/test/results-32.master
+++ b/components/encumbered/dav1d/test/results-32.master
@@ -1,0 +1,12 @@
+1/6 dav1d:checkasm / checkasm      OK
+2/6 dav1d:headers / common.h_test  OK
+3/6 dav1d:headers / data.h_test    OK
+4/6 dav1d:headers / dav1d.h_test   OK
+5/6 dav1d:headers / headers.h_test OK
+6/6 dav1d:headers / picture.h_test OK
+Ok:                 6   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   

--- a/components/encumbered/dav1d/test/results-64.master
+++ b/components/encumbered/dav1d/test/results-64.master
@@ -1,0 +1,12 @@
+1/6 dav1d:checkasm / checkasm      OK
+2/6 dav1d:headers / common.h_test  OK
+3/6 dav1d:headers / data.h_test    OK
+4/6 dav1d:headers / dav1d.h_test   OK
+5/6 dav1d:headers / headers.h_test OK
+6/6 dav1d:headers / picture.h_test OK
+Ok:                 6   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   


### PR DESCRIPTION
This is a new component, a multimedia library 'dav1d' for the AV1 format.

The [Wikipedia article on AV1](https://en.wikipedia.org/wiki/AV1) has good information on both its openness and its adoption by many popular streaming services.

This is set to become a dependency for my next PR (update ffmpeg to 4.4.1) and for the rebuild of VLC required by the ffmpeg
update.

The AV1 codec is very open and this library is BSD 2-clause, so there should be no need for this to be in "encumbered".

I asked on the oi-dev mailing list a few days ago for direction about what belongs in codec/ and what belongs elsewhere and didn't get any responses, so I went ahead and put this in codec/dav1d  .  If you have objections to codec/dav1d, that's fine, I'll take direction for where you would prefer it.