### PR TITLE
rebuild for updated ffpmeg dependency

### DIFF
--- a/components/encumbered/minidlna/Makefile
+++ b/components/encumbered/minidlna/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= minidlna
 COMPONENT_VERSION= 1.2.1
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY=  MiniDLNA DLNA/UPnP-AV media server
 COMPONENT_PROJECT_URL= https://sourceforge.net/projects/minidlna/
 COMPONENT_FMRI= media/minidlna
@@ -54,6 +55,7 @@ REQUIRED_PACKAGES += image/library/libjpeg8-turbo
 REQUIRED_PACKAGES += library/audio/libid3tag
 REQUIRED_PACKAGES += library/libogg
 REQUIRED_PACKAGES += library/libvorbis
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += video/ffmpeg

--- a/components/encumbered/minidlna/pkg5
+++ b/components/encumbered/minidlna/pkg5
@@ -8,6 +8,7 @@
         "library/audio/libid3tag",
         "library/libogg",
         "library/libvorbis",
+        "shell/ksh93",
         "system/library",
         "video/ffmpeg"
     ],


### PR DESCRIPTION
Rebuild minidlna because its dependency `ffmpeg` was updated from 3.2.14 to 4.4.1 via PR #7260 .

Bump `COMPONENT_REVISION`.  `Makefile` and `pkg5` picked up a new `shell/ksh93` dependency, but that was the only change.

There is a `minidlna-1.3.0`, but it's going to take additional effort to update to that.  I didn't want to slow down the other rebuild and update to `gst-libav1` by detouring into `minidlna`, especially since I don't know how much it's used.