### PR TITLE
rebuild vlc for updated ffmpeg and new dep libdav1d

### DIFF
--- a/components/encumbered/vlc/Makefile
+++ b/components/encumbered/vlc/Makefile
@@ -19,6 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= vlc
 COMPONENT_VERSION= 3.0.16
+COMPONENT_REVISION= 1
 COMPONENT_FMRI = media/vlc
 COMPONENT_CLASSIFICATION = Applications/Sound and Video
 COMPONENT_SUMMARY= Cross-platform media player and streaming server
@@ -197,10 +198,10 @@ COMPONENT_POST_INSTALL_ACTION = \
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += audio/faad2
 REQUIRED_PACKAGES += audio/mpg123
 REQUIRED_PACKAGES += audio/twolame
+REQUIRED_PACKAGES += codec/dav1d
 REQUIRED_PACKAGES += codec/flac
 REQUIRED_PACKAGES += codec/libtheora
 REQUIRED_PACKAGES += codec/speex
@@ -251,6 +252,7 @@ REQUIRED_PACKAGES += library/video/x265
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += runtime/lua
 REQUIRED_PACKAGES += shell/ksh93
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/fontconfig
 REQUIRED_PACKAGES += system/library/freetype-2

--- a/components/encumbered/vlc/manifests/sample-manifest.p5m
+++ b/components/encumbered/vlc/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -255,6 +255,7 @@ file path=usr/lib/$(MACH64)/vlc/plugins/codec/libavcodec_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcc_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcdg_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcvdsub_plugin.so
+file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdav1d_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdca_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libddummy_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdvbsub_plugin.so

--- a/components/encumbered/vlc/pkg5
+++ b/components/encumbered/vlc/pkg5
@@ -4,6 +4,7 @@
         "audio/faad2",
         "audio/mpg123",
         "audio/twolame",
+        "codec/dav1d",
         "codec/flac",
         "codec/libtheora",
         "codec/speex",

--- a/components/encumbered/vlc/vlc.p5m
+++ b/components/encumbered/vlc/vlc.p5m
@@ -273,6 +273,7 @@ file path=usr/lib/$(MACH64)/vlc/plugins/codec/libavcodec_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcc_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcdg_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcvdsub_plugin.so
+file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdav1d_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdca_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libddummy_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdvbsub_plugin.so


### PR DESCRIPTION
Because of the update of ffmpeg, vlc needed to be rebuilt.  Since I also added a new AV1 library, `dav1d` before building `ffmpeg`, `vlc` also picked up that new option.

- bump `COMPONENT_REVISION`
- update `manifests/sample-manifest` for the single new action related to `dav1d`
- re-run `gmake REQUIRED_PACKAGES`, which picked up the new dependency on `codec/dav1d`

No other changes were made.