### PR TITLE
chezmoi: update to v2.7.5

### DIFF
--- a/components/sysutils/chezmoi/Makefile
+++ b/components/sysutils/chezmoi/Makefile
@@ -16,7 +16,7 @@ BUILD_STYLE=justmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=chezmoi
-COMPONENT_VERSION=2.7.3
+COMPONENT_VERSION=2.7.5
 COMPONENT_SUMMARY=Manage your dotfiles across multiple diverse machines, securely.
 COMPONENT_PROJECT_URL=https://github.com/twpayne/chezmoi
 COMPONENT_FMRI=application/chezmoi
@@ -24,7 +24,7 @@ COMPONENT_CLASSIFICATION=Applications/System Utilities
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=https://github.com/twpayne/chezmoi/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=sha256:a9dbaa9bd55f1c1e1c82c7ae5b7b1933f907703d5bd9976b2c14321b8c1e0d90
+COMPONENT_ARCHIVE_HASH=sha256:ed9de88a851cbbb2acce77e13615fe45a19350112f58d9acc268b2ff4961d8ab
 COMPONENT_LICENSE=MIT
 COMPONENT_LICENSE_FILE=chezmoi.license
 TEST_TARGET=$(NO_TESTS) # if no testsuite enabled

--- a/components/sysutils/chezmoi/patches/01-only-build-illumos.patch
+++ b/components/sysutils/chezmoi/patches/01-only-build-illumos.patch
@@ -1,24 +1,26 @@
-#Chezmoi by default uses git to find the version it is built from. This does not work as we download a tarball copy from Github and build inside oi-userland, thus we remove the version embedding here
---- chezmoi-2.7.3/Makefile.orig	2021-10-22 15:34:17.000000000 +0000
-+++ chezmoi-2.7.3/Makefile	2021-10-29 09:59:04.758384704 +0000
-@@ -2,17 +2,15 @@
+--- chezmoi-2.7.5/Makefile.orig	2021-11-07 09:04:07.000000000 +0000
++++ chezmoi-2.7.5/Makefile	2021-11-09 05:58:33.783358142 +0000
+@@ -2,12 +2,11 @@
  GOLANGCI_LINT_VERSION=$(shell grep GOLANGCI_LINT_VERSION: .github/workflows/main.yml | awk '{ print $$2 }')
  
  .PHONY: default
--default: run build test lint format
-+default: build
+-default: run build-all test lint format
++default: build-all
  
  .PHONY: install
  install:
 -	go install -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags) \
 -		-X main.commit=$(shell git rev-parse HEAD) \
--		-X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
--		-X main.builtBy=source"
-+	go install
++	go install -ldflags "-X main.version=2.7.5\
+ 		-X main.date=$(shell date -u +%Y-%m-%dT%H:%M:%SZ) \
+ 		-X main.builtBy=source"
  
- .PHONY: build
--build: build-darwin build-freebsd build-linux build-windows
-+build:
+@@ -19,7 +18,8 @@
+ 		-X main.builtBy=source"
+ 
+ .PHONY: build-all
+-build-all: build-darwin build-freebsd build-linux build-windows
++build-all:
 +	GOARCH=amd64 ${GO} build -o /dev/null .
  
  .PHONY: build-darwin


### PR DESCRIPTION
Updating `chezmoi`, a utility to synchronize configuration files (aka "dotfiles")

This update also trims down my old patch file so that more metadata can successfully be included. It should make the component easier to maintain in the future