### PR TITLE
add editor/nano to the minimal install

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	44
+COMPONENT_REVISION=	45
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -119,6 +119,7 @@ depend type=require fmri=driver/storage/vioblk
 depend type=require fmri=driver/usb
 depend type=require fmri=driver/usb/ugen
 depend type=require fmri=driver/xvm/pv
+depend type=require fmri=editor/nano
 depend type=require fmri=editor/vim/vim-core
 depend type=require fmri=install/beadm
 depend type=require fmri=locale/en


### PR DESCRIPTION
Add `editor/nano` to the minimal system install.

This was discussed on the mailing list in early January of 2021.