### PR TITLE
libsodium: update to 1.0.18

### DIFF
--- a/components/library/libsodium/Makefile
+++ b/components/library/libsodium/Makefile
@@ -11,29 +11,28 @@
 
 #
 # Copyright 2018 Alexander Pyhalov
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
+BUILD_BITS=64_and_32
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libsodium
-COMPONENT_VERSION= 1.0.16
-COMPONENT_REVISION= 1
+COMPONENT_VERSION= 1.0.18
 COMPONENT_SUMMARY= Sodium crypto library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533
+  sha256:6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
 COMPONENT_ARCHIVE_URL= \
-  https://github.com/jedisct1/libsodium/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+  https://download.libsodium.org/$(COMPONENT_NAME)/releases/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://download.libsodium.org/doc/
 COMPONENT_FMRI= library/security/libsodium
 COMPONENT_CLASSIFICATION= System/Security
 COMPONENT_LICENSE = ISC
 COMPONENT_LICENSE_FILE = LICENSE
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 # pynacl tests dump core with -O3
 gcc_OPT = -O2
@@ -52,14 +51,5 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "/Leaving directory/d"' \
 	'-e "/Entering directory/d"'
 
-build: $(BUILD_32_and_64)
-
-install: $(INSTALL_32_and_64)
-
-test: $(TEST_32_and_64)
-
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/library/libsodium/libsodium.p5m
+++ b/components/library/libsodium/libsodium.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2018 Alexander Pyhalov
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -37,6 +38,7 @@ file path=usr/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
 file path=usr/include/sodium/crypto_core_ed25519.h
 file path=usr/include/sodium/crypto_core_hchacha20.h
 file path=usr/include/sodium/crypto_core_hsalsa20.h
+file path=usr/include/sodium/crypto_core_ristretto255.h
 file path=usr/include/sodium/crypto_core_salsa20.h
 file path=usr/include/sodium/crypto_core_salsa2012.h
 file path=usr/include/sodium/crypto_core_salsa208.h
@@ -57,6 +59,7 @@ file path=usr/include/sodium/crypto_pwhash_scryptsalsa208sha256.h
 file path=usr/include/sodium/crypto_scalarmult.h
 file path=usr/include/sodium/crypto_scalarmult_curve25519.h
 file path=usr/include/sodium/crypto_scalarmult_ed25519.h
+file path=usr/include/sodium/crypto_scalarmult_ristretto255.h
 file path=usr/include/sodium/crypto_secretbox.h
 file path=usr/include/sodium/crypto_secretbox_xchacha20poly1305.h
 file path=usr/include/sodium/crypto_secretbox_xsalsa20poly1305.h
@@ -78,16 +81,16 @@ file path=usr/include/sodium/crypto_verify_32.h
 file path=usr/include/sodium/crypto_verify_64.h
 file path=usr/include/sodium/export.h
 file path=usr/include/sodium/randombytes.h
-file path=usr/include/sodium/randombytes_salsa20_random.h
+file path=usr/include/sodium/randombytes_internal_random.h
 file path=usr/include/sodium/randombytes_sysrandom.h
 file path=usr/include/sodium/runtime.h
 file path=usr/include/sodium/utils.h
 file path=usr/include/sodium/version.h
-link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.23.1.0
-link path=usr/lib/$(MACH64)/libsodium.so.23 target=libsodium.so.23.1.0
-file path=usr/lib/$(MACH64)/libsodium.so.23.1.0
+link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.23.3.0
+link path=usr/lib/$(MACH64)/libsodium.so.23 target=libsodium.so.23.3.0
+file path=usr/lib/$(MACH64)/libsodium.so.23.3.0
 file path=usr/lib/$(MACH64)/pkgconfig/libsodium.pc
-link path=usr/lib/libsodium.so target=libsodium.so.23.1.0
-link path=usr/lib/libsodium.so.23 target=libsodium.so.23.1.0
-file path=usr/lib/libsodium.so.23.1.0
+link path=usr/lib/libsodium.so target=libsodium.so.23.3.0
+link path=usr/lib/libsodium.so.23 target=libsodium.so.23.3.0
+file path=usr/lib/libsodium.so.23.3.0
 file path=usr/lib/pkgconfig/libsodium.pc

--- a/components/library/libsodium/manifests/sample-manifest.p5m
+++ b/components/library/libsodium/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -37,6 +37,7 @@ file path=usr/include/sodium/crypto_box_curve25519xsalsa20poly1305.h
 file path=usr/include/sodium/crypto_core_ed25519.h
 file path=usr/include/sodium/crypto_core_hchacha20.h
 file path=usr/include/sodium/crypto_core_hsalsa20.h
+file path=usr/include/sodium/crypto_core_ristretto255.h
 file path=usr/include/sodium/crypto_core_salsa20.h
 file path=usr/include/sodium/crypto_core_salsa2012.h
 file path=usr/include/sodium/crypto_core_salsa208.h
@@ -57,6 +58,7 @@ file path=usr/include/sodium/crypto_pwhash_scryptsalsa208sha256.h
 file path=usr/include/sodium/crypto_scalarmult.h
 file path=usr/include/sodium/crypto_scalarmult_curve25519.h
 file path=usr/include/sodium/crypto_scalarmult_ed25519.h
+file path=usr/include/sodium/crypto_scalarmult_ristretto255.h
 file path=usr/include/sodium/crypto_secretbox.h
 file path=usr/include/sodium/crypto_secretbox_xchacha20poly1305.h
 file path=usr/include/sodium/crypto_secretbox_xsalsa20poly1305.h
@@ -78,16 +80,16 @@ file path=usr/include/sodium/crypto_verify_32.h
 file path=usr/include/sodium/crypto_verify_64.h
 file path=usr/include/sodium/export.h
 file path=usr/include/sodium/randombytes.h
-file path=usr/include/sodium/randombytes_salsa20_random.h
+file path=usr/include/sodium/randombytes_internal_random.h
 file path=usr/include/sodium/randombytes_sysrandom.h
 file path=usr/include/sodium/runtime.h
 file path=usr/include/sodium/utils.h
 file path=usr/include/sodium/version.h
-link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.23.1.0
-link path=usr/lib/$(MACH64)/libsodium.so.23 target=libsodium.so.23.1.0
-file path=usr/lib/$(MACH64)/libsodium.so.23.1.0
+link path=usr/lib/$(MACH64)/libsodium.so target=libsodium.so.23.3.0
+link path=usr/lib/$(MACH64)/libsodium.so.23 target=libsodium.so.23.3.0
+file path=usr/lib/$(MACH64)/libsodium.so.23.3.0
 file path=usr/lib/$(MACH64)/pkgconfig/libsodium.pc
-link path=usr/lib/libsodium.so target=libsodium.so.23.1.0
-link path=usr/lib/libsodium.so.23 target=libsodium.so.23.1.0
-file path=usr/lib/libsodium.so.23.1.0
+link path=usr/lib/libsodium.so target=libsodium.so.23.3.0
+link path=usr/lib/libsodium.so.23 target=libsodium.so.23.3.0
+file path=usr/lib/libsodium.so.23.3.0
 file path=usr/lib/pkgconfig/libsodium.pc

--- a/components/library/libsodium/pkg5
+++ b/components/library/libsodium/pkg5
@@ -1,9 +1,8 @@
 {
     "dependencies": [
         "SUNWcs",
-        "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "shell/ksh93",
+        "system/library"
     ],
     "fmris": [
         "library/security/libsodium"

--- a/components/library/libsodium/test/results-32.master
+++ b/components/library/libsodium/test/results-32.master
@@ -1,5 +1,7 @@
 PASS: aead_aes256gcm
+PASS: aead_aes256gcm2
 PASS: aead_chacha20poly1305
+PASS: aead_chacha20poly13052
 PASS: aead_xchacha20poly1305
 PASS: auth
 PASS: auth2
@@ -37,7 +39,7 @@ PASS: misuse
 PASS: onetimeauth
 PASS: onetimeauth2
 PASS: onetimeauth7
-PASS: pwhash
+PASS: pwhash_argon2i
 PASS: pwhash_argon2id
 PASS: randombytes
 PASS: scalarmult
@@ -45,6 +47,7 @@ PASS: scalarmult2
 PASS: scalarmult5
 PASS: scalarmult6
 PASS: scalarmult7
+PASS: scalarmult8
 PASS: secretbox
 PASS: secretbox2
 PASS: secretbox7
@@ -64,15 +67,19 @@ PASS: stream4
 PASS: verify1
 PASS: sodium_utils2
 PASS: sodium_utils3
+PASS: core_ed25519
+PASS: core_ristretto255
 PASS: pwhash_scrypt
 PASS: pwhash_scrypt_ll
+PASS: scalarmult_ed25519
+PASS: scalarmult_ristretto255
 PASS: siphashx24
 PASS: xchacha20
 ============================================================================
-Testsuite summary for libsodium 1.0.14
+Testsuite summary for libsodium 1.0.18
 ============================================================================
-# TOTAL: 70
-# PASS:  70
+# TOTAL: 77
+# PASS:  77
 # SKIP:  0
 # XFAIL: 0
 # FAIL:  0

--- a/components/library/libsodium/test/results-64.master
+++ b/components/library/libsodium/test/results-64.master
@@ -1,5 +1,7 @@
 PASS: aead_aes256gcm
+PASS: aead_aes256gcm2
 PASS: aead_chacha20poly1305
+PASS: aead_chacha20poly13052
 PASS: aead_xchacha20poly1305
 PASS: auth
 PASS: auth2
@@ -37,7 +39,7 @@ PASS: misuse
 PASS: onetimeauth
 PASS: onetimeauth2
 PASS: onetimeauth7
-PASS: pwhash
+PASS: pwhash_argon2i
 PASS: pwhash_argon2id
 PASS: randombytes
 PASS: scalarmult
@@ -45,6 +47,7 @@ PASS: scalarmult2
 PASS: scalarmult5
 PASS: scalarmult6
 PASS: scalarmult7
+PASS: scalarmult8
 PASS: secretbox
 PASS: secretbox2
 PASS: secretbox7
@@ -64,15 +67,19 @@ PASS: stream4
 PASS: verify1
 PASS: sodium_utils2
 PASS: sodium_utils3
+PASS: core_ed25519
+PASS: core_ristretto255
 PASS: pwhash_scrypt
 PASS: pwhash_scrypt_ll
+PASS: scalarmult_ed25519
+PASS: scalarmult_ristretto255
 PASS: siphashx24
 PASS: xchacha20
 ============================================================================
-Testsuite summary for libsodium 1.0.14
+Testsuite summary for libsodium 1.0.18
 ============================================================================
-# TOTAL: 70
-# PASS:  70
+# TOTAL: 77
+# PASS:  77
 # SKIP:  0
 # XFAIL: 0
 # FAIL:  0


### PR DESCRIPTION
Update `libsodium` from 1.0.16 to 1.0.18.

One library symbol was renamed between 1.0.16 and 1.0.18 (`randombytes_salsa20` -> `randombytes_internal`) so to be safe I'll have pull requests for rebuilds for

- `library/c++/zeromq`
- `service/network/dns/dnscrypt-proxy`
- `service/network/dns/powerdns-recursor`
- `pynacl`
- `remmina`

A few new header files with libsodium 1.0.18, mainly related to "the Ristretto group", some updated tests.

PRs for the rebuilds will follow.