### PR TITLE
zeromq: rebuild for libsodium update

### DIFF
--- a/components/library/libzmq/Makefile
+++ b/components/library/libzmq/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libzmq
 COMPONENT_VERSION= 4.3.4
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= Open source message queue optimised for performance
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
@@ -45,8 +46,8 @@ COMPONENT_PREP_ACTION = \
 COMPONENT_PRE_CONFIGURE_ACTION =	($(CLONEY) $(SOURCE_DIR) $(@D))
 
 # Build docs just once (for one ARCH), parameter varies from version to version
-CONFIGURE_OPTIONS.32 +=	--with-documentation --with-docs
-CONFIGURE_OPTIONS.64 +=	--without-documentation --without-docs
+CONFIGURE_OPTIONS.32 +=	--with-docs
+CONFIGURE_OPTIONS.64 +=	--without-docs
 
 CONFIGURE_OPTIONS +=	--enable-static=no
 CONFIGURE_OPTIONS +=	--with-libsodium
@@ -67,8 +68,9 @@ COMPONENT_TEST_TRANSFORMS += \
 # Necessary for tests
 unexport SHELLOPTS
 
-# Build time dependencies
+# Build time dependencies (both needed for documentation)
 REQUIRED_PACKAGES +=text/asciidoc
+REQUIRED_PACKAGES +=text/xmlto
 
 # Auto-generated dependencies
 # Auto-generated dependencies

--- a/components/library/libzmq/pkg5
+++ b/components/library/libzmq/pkg5
@@ -6,7 +6,8 @@
         "system/library",
         "system/library/g++-7-runtime",
         "system/library/gcc-7-runtime",
-        "text/asciidoc"
+        "text/asciidoc",
+        "text/xmlto"
     ],
     "fmris": [
         "library/c++/zeromq"

--- a/components/library/libzmq/test/results-all.master
+++ b/components/library/libzmq/test/results-all.master
@@ -82,6 +82,7 @@ PASS: tests/test_use_fd
 PASS: tests/test_zmq_poll_fd
 PASS: tests/test_timeo
 PASS: tests/test_filter_ipc
+PASS: tests/test_fork
 SKIP: tests/test_bind_null_fuzzer
 SKIP: tests/test_connect_null_fuzzer
 SKIP: tests/test_bind_fuzzer
@@ -94,8 +95,8 @@ SKIP: tests/test_connect_curve_fuzzer
 SKIP: tests/test_z85_decode_fuzzer
 SKIP: tests/test_connect_ws_fuzzer
 SKIP: tests/test_bind_ws_fuzzer
-# TOTAL: 96
-# PASS:  84
+# TOTAL: 97
+# PASS:  85
 # SKIP:  12
 # XFAIL: 0
 # FAIL:  0


### PR DESCRIPTION
Rebuild zeromq after the libsodium 1.0.18 update.

- add `COMPONENT_REVISION`
- drop the `--with-documentation` and `--without-documentation`, keeping the shorter options.  configure complains the longer options are deprecated.
- add a missing build dependency on `text/xmlto`.  Without it (and asciidoc) the documentation won't be built
- update the test results.  I don't know if the previous results were outdated, but there's one new test appearing.