### PR TITLE
pdns-recursor: rebuild for updated libsodium

### DIFF
--- a/components/network/pdns-recursor/Makefile
+++ b/components/network/pdns-recursor/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pdns-recursor
 COMPONENT_VERSION=	4.5.5
+COMPONENT_REVISION=	1
 COMPONENT_PROJECT_URL=	https://www.powerdns.com/downloads.html
 COMPONENT_FMRI=		service/network/dns/powerdns-recursor
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)


### PR DESCRIPTION
rebuild pdns-recursor for the libsodium update.

Only change was to add `COMPONENT_REVISION`