### PR TITLE
pynacl: rebuild for libsodium update

### DIFF
--- a/components/python/pynacl/Makefile
+++ b/components/python/pynacl/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		PyNaCl
 COMPONENT_VERSION=	1.3.0
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	'Python binding to libsodium'
 COMPONENT_PROJECT_URL=	https://github.com/pyca/pynacl/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/python/pynacl/pkg5
+++ b/components/python/pynacl/pkg5
@@ -6,6 +6,7 @@
         "library/security/libsodium",
         "runtime/python-27",
         "runtime/python-35",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
rebuild pynacl for libsodium 1.0.18 update

- bump `COMPONENT_REVISION`
- publish target picked up a new dependency `shell/ksh93`