### PR TITLE
remmina: rebuild for libsodium update

### DIFF
--- a/components/desktop/remmina/Makefile
+++ b/components/desktop/remmina/Makefile
@@ -19,6 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		remmina
 COMPONENT_VERSION=	1.4.8
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Remmina remote desktop client
 COMPONENT_PROJECT_URL=	https://www.freerdp.com
 COMPONENT_FMRI=		desktop/remote-desktop/remmina

--- a/components/desktop/remmina/pkg5
+++ b/components/desktop/remmina/pkg5
@@ -14,6 +14,7 @@
         "library/print/cups-libs",
         "library/security/libsodium",
         "library/security/openssl",
+        "shell/ksh93",
         "system/library",
         "system/library/security/libgcrypt",
         "x11/library/libx11"


### PR DESCRIPTION
rebuild remmina for libsodium 1.0.18 update

I wanted to update remmina and switch it to OpenSSL 1.1.x, but to keep things simple I just did a rebuild.

- add `COMPONENT_REVISION`
- publish target picked up new dependency `shell/ksh93`

