### PR TITLE
pari/gp: gp 2.13.3 initial version

### DIFF
--- a/components/scientific/pari/Makefile
+++ b/components/scientific/pari/Makefile
@@ -1,0 +1,71 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 David Stes
+#
+
+
+#
+# Package Makefile for the "Pari/GP" Computer Algebra System
+# See  https://pari.math.u-bordeaux.fr
+#
+
+BUILD_BITS=64
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		pari
+COMPONENT_VERSION=	2.13.3
+COMPONENT_SUMMARY=	The PARI Computer Algebra System
+COMPONENT_PROJECT_URL=	https://pari.math.u-bordeaux.fr
+COMPONENT_FMRI=		library/math/pari
+COMPONENT_CLASSIFICATION=	Development/Other Languages
+
+COMPONENT_SRC=		pari-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	sha256:ccba7f1606c6854f1443637bb57ad0958d41c7f4753f8ae8459f1d64c267a1ca
+COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/pub/pari/unix/$(COMPONENT_ARCHIVE)
+
+COMPONENT_LICENSE=     	GPLv2
+COMPONENT_LICENSE_FILE=	COPYING
+
+TEST_TARGET= $(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
+
+PATH=$(PATH.gnu)
+
+# Configure complains when built outside of source tree
+COMPONENT_PRE_CONFIGURE_ACTION= ($(CLONEY) $(SOURCE_DIR) $(@D))
+
+# PARI/gp Configure is not autoconf 
+CONFIGURE_SCRIPT= 	$(SOURCE_DIR)/Configure
+
+# reset all options because Configure does not understand --sbindir= only --dir
+CONFIGURE_OPTIONS=     --prefix=$(CONFIGURE_PREFIX)
+
+# PARI/gp installs its 64bit library in /usr/lib
+CONFIGURE_OPTIONS+=	--libdir=$(USRLIBDIR64)
+
+# PARI/gp says GMP on OpenIndiana is too old
+CONFIGURE_OPTIONS+=	--without-gmp
+
+CONFIGURE_ENV+= 	CFLAGS="$(CFLAGS)"
+
+# all does not work because documentation requires Tex typesetting
+COMPONENT_BUILD_TARGET = gp
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/readline
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/scientific/pari/manifests/sample-manifest.p5m
+++ b/components/scientific/pari/manifests/sample-manifest.p5m
@@ -1,0 +1,94 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/bin/gp target=gp-2.13
+file path=usr/bin/gp-2.13
+file path=usr/bin/gphelp
+file path=usr/bin/tex2mail
+link path=usr/include/pari/genpari.h target=pari.h
+file path=usr/include/pari/mpinl.h
+file path=usr/include/pari/pari.h
+file path=usr/include/pari/paricast.h
+file path=usr/include/pari/paricfg.h
+file path=usr/include/pari/paricom.h
+file path=usr/include/pari/paridecl.h
+file path=usr/include/pari/parierr.h
+file path=usr/include/pari/parigen.h
+file path=usr/include/pari/pariinl.h
+file path=usr/include/pari/parimt.h
+file path=usr/include/pari/parinf.h
+file path=usr/include/pari/pariold.h
+file path=usr/include/pari/paripriv.h
+file path=usr/include/pari/paristio.h
+file path=usr/include/pari/parisys.h
+file path=usr/include/pari/paritune.h
+link path=usr/lib/$(MACH64)/libpari.so target=libpari.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libpari.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libpari.so.7 target=libpari.so.$(COMPONENT_VERSION)
+file path=usr/lib/pari/pari.cfg
+file path=usr/share/man/man1/gp-2.13.1
+link path=usr/share/man/man1/gp.1 target=gp-2.13.1
+file path=usr/share/man/man1/gphelp.1
+link path=usr/share/man/man1/pari.1 target=gp.1
+file path=usr/share/man/man1/tex2mail.1
+file path=usr/share/pari/PARI/822.pm
+file path=usr/share/pari/doc/appa.tex
+file path=usr/share/pari/doc/appb.tex
+file path=usr/share/pari/doc/appd.tex
+file path=usr/share/pari/doc/develop.tex
+file path=usr/share/pari/doc/paricfg.tex
+file path=usr/share/pari/doc/parimacro.tex
+file path=usr/share/pari/doc/pdfmacs.tex
+file path=usr/share/pari/doc/refcard.tex
+file path=usr/share/pari/doc/translations
+file path=usr/share/pari/doc/tutorial-mf.tex
+file path=usr/share/pari/doc/tutorial.tex
+file path=usr/share/pari/doc/users.tex
+file path=usr/share/pari/doc/usersch1.tex
+file path=usr/share/pari/doc/usersch2.tex
+file path=usr/share/pari/doc/usersch3.tex
+file path=usr/share/pari/doc/usersch4.tex
+file path=usr/share/pari/doc/usersch5.tex
+file path=usr/share/pari/doc/usersch6.tex
+file path=usr/share/pari/doc/usersch7.tex
+file path=usr/share/pari/doc/usersch8.tex
+file path=usr/share/pari/examples/EXPLAIN
+file path=usr/share/pari/examples/Inputrc
+file path=usr/share/pari/examples/Makefile
+file path=usr/share/pari/examples/bench.gp
+file path=usr/share/pari/examples/cl.gp
+file path=usr/share/pari/examples/classno.gp
+file path=usr/share/pari/examples/contfrac.gp
+file path=usr/share/pari/examples/extgcd.c
+file path=usr/share/pari/examples/lucas.gp
+file path=usr/share/pari/examples/rho.gp
+file path=usr/share/pari/examples/squfof.gp
+file path=usr/share/pari/examples/taylor.gp
+file path=usr/share/pari/misc/README
+file path=usr/share/pari/misc/color.dft
+file path=usr/share/pari/misc/gpalias
+file path=usr/share/pari/misc/gpflog
+file path=usr/share/pari/misc/gprc.dft
+file path=usr/share/pari/misc/xgp
+file path=usr/share/pari/pari.desc

--- a/components/scientific/pari/pari.p5m
+++ b/components/scientific/pari/pari.p5m
@@ -1,0 +1,94 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 David Stes
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/bin/gp target=gp-2.13
+file path=usr/bin/gp-2.13
+file path=usr/bin/gphelp
+file path=usr/bin/tex2mail
+link path=usr/include/pari/genpari.h target=pari.h
+file path=usr/include/pari/mpinl.h
+file path=usr/include/pari/pari.h
+file path=usr/include/pari/paricast.h
+file path=usr/include/pari/paricfg.h
+file path=usr/include/pari/paricom.h
+file path=usr/include/pari/paridecl.h
+file path=usr/include/pari/parierr.h
+file path=usr/include/pari/parigen.h
+file path=usr/include/pari/pariinl.h
+file path=usr/include/pari/parimt.h
+file path=usr/include/pari/parinf.h
+file path=usr/include/pari/pariold.h
+file path=usr/include/pari/paripriv.h
+file path=usr/include/pari/paristio.h
+file path=usr/include/pari/parisys.h
+file path=usr/include/pari/paritune.h
+link path=usr/lib/$(MACH64)/libpari.so target=libpari.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libpari.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libpari.so.7 target=libpari.so.$(COMPONENT_VERSION)
+file path=usr/lib/pari/pari.cfg
+file path=usr/share/man/man1/gp-2.13.1
+link path=usr/share/man/man1/gp.1 target=gp-2.13.1
+file path=usr/share/man/man1/gphelp.1
+link path=usr/share/man/man1/pari.1 target=gp.1
+file path=usr/share/man/man1/tex2mail.1
+file path=usr/share/pari/PARI/822.pm
+file path=usr/share/pari/doc/appa.tex
+file path=usr/share/pari/doc/appb.tex
+file path=usr/share/pari/doc/appd.tex
+file path=usr/share/pari/doc/develop.tex
+file path=usr/share/pari/doc/paricfg.tex
+file path=usr/share/pari/doc/parimacro.tex
+file path=usr/share/pari/doc/pdfmacs.tex
+file path=usr/share/pari/doc/refcard.tex
+file path=usr/share/pari/doc/translations
+file path=usr/share/pari/doc/tutorial-mf.tex
+file path=usr/share/pari/doc/tutorial.tex
+file path=usr/share/pari/doc/users.tex
+file path=usr/share/pari/doc/usersch1.tex
+file path=usr/share/pari/doc/usersch2.tex
+file path=usr/share/pari/doc/usersch3.tex
+file path=usr/share/pari/doc/usersch4.tex
+file path=usr/share/pari/doc/usersch5.tex
+file path=usr/share/pari/doc/usersch6.tex
+file path=usr/share/pari/doc/usersch7.tex
+file path=usr/share/pari/doc/usersch8.tex
+file path=usr/share/pari/examples/EXPLAIN
+file path=usr/share/pari/examples/Inputrc
+file path=usr/share/pari/examples/Makefile
+file path=usr/share/pari/examples/bench.gp
+file path=usr/share/pari/examples/cl.gp
+file path=usr/share/pari/examples/classno.gp
+file path=usr/share/pari/examples/contfrac.gp
+file path=usr/share/pari/examples/extgcd.c
+file path=usr/share/pari/examples/lucas.gp
+file path=usr/share/pari/examples/rho.gp
+file path=usr/share/pari/examples/squfof.gp
+file path=usr/share/pari/examples/taylor.gp
+file path=usr/share/pari/misc/README
+file path=usr/share/pari/misc/color.dft
+file path=usr/share/pari/misc/gpalias
+file path=usr/share/pari/misc/gpflog
+file path=usr/share/pari/misc/gprc.dft
+file path=usr/share/pari/misc/xgp
+file path=usr/share/pari/pari.desc

--- a/components/scientific/pari/pkg5
+++ b/components/scientific/pari/pkg5
@@ -1,0 +1,15 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "library/readline",
+        "runtime/perl-524",
+        "shell/ksh93",
+        "system/library",
+        "system/library/math",
+        "x11/library/libx11"
+    ],
+    "fmris": [
+        "library/math/pari"
+    ],
+    "name": "pari"
+}


### PR DESCRIPTION
PARI/GP is a system for computer algebra

It is also a C library that can be used in C programs

By default it now uses GNU MP multiprecision airthmetic but originally PARI kernel is basically a multiple precision airhtmetic library which I have enabled because (1) their configure says the OpenIndiana libgmp is too old and (2) in my opinion their implementatoin in their kernel is of great interest.

The current GP copyright says GPLv2  and copyright 2000-2021 but I think PARI is much older, presumably the original author Henri Cohen had PARI already at the end of 1980's.

I like using PARI and would be highly motivated to be the maintainer of this package.   If it can be added, please do so and I'll also check later with the PARI team but I cannot imagine problems from their part.

Documentation is on their website.