### PR TITLE
Add CPU tunning flags to gcc for SPARC.

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1142,8 +1142,8 @@ CFLAGS.studio +=	$(studio_OPT) $(studio_XBITS) $(studio_XREGS) \
 #
 
 # Control the GCC optimization level.
-gcc_OPT.sparc.32 =	-O3
-gcc_OPT.sparc.64 =	-O3
+gcc_OPT.sparc.32 =	-O3 -mcpu=ultrasparc -mvis
+gcc_OPT.sparc.64 =	-O3 -mcpu=ultrasparc -mvis
 gcc_OPT.i386.32 =	-O3
 gcc_OPT.i386.64 =	-O3
 gcc_OPT =		$(gcc_OPT.$(MACH).$(BITS))


### PR DESCRIPTION
These add-on gcc flags have been used on SPARC for about 6 months now and didn't caused any trouble.
After all non UltraSPARC systems are EOL since 16 years now, so it's time to enble something like that.