### PR TITLE
Fix building of top 64 bit only binary.

### DIFF
--- a/components/sysutils/top/Makefile
+++ b/components/sysutils/top/Makefile
@@ -28,7 +28,6 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		top
 COMPONENT_VERSION=	3.8beta1
-COMPONENT_REVISION=	6
 COMPONENT_PROJECT_URL=	https://sourceforge.net/projects/unixtop/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -45,10 +44,7 @@ include $(WS_MAKE_RULES)/common.mk
 # viewpathing support in the build is broken in the 'install' target
 COMPONENT_PRE_CONFIGURE_ACTION = ($(CLONEY) $(SOURCE_DIR) $(@D))
 
-# top build process is producing both 32-bit and 64-bit in one Makefile target.
-# It will receive LDFLAGS and cause 64-bit object files linked with 32-bit argument.
-# Till top fixes that mess, unseting LDFLAGS is the hacky workaround.
-LDFLAGS=
+CONFIGURE_OPTIONS += --disable-dualarch
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/sysutils/top/manifests/sample-manifest.p5m
+++ b/components/sysutils/top/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,7 +22,5 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH)/top
-file path=usr/bin/$(MACH64)/top
 file path=usr/bin/top
 file path=usr/share/man/man1/top.1

--- a/components/sysutils/top/top.p5m
+++ b/components/sysutils/top/top.p5m
@@ -33,5 +33,5 @@ set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license top.license license="BSD, Apachev2.0"
-file usr/bin/$(MACH64)/top path=usr/bin/top
+file usr/bin/top
 file path=usr/share/man/man1/top.1


### PR DESCRIPTION
enable configure option --disable-dualarch which disables building 32 and 64 bit executabels