### PR TITLE
relocate gmp.h into /usr/include from /usr/include/gmp.

### DIFF
--- a/components/library/gmp/Makefile
+++ b/components/library/gmp/Makefile
@@ -59,7 +59,7 @@ LDFLAGS += $(LD_Z_REDLOCSYM) $(LD_Z_RESCAN_NOW)
 MPN32_i386 = x86/pentium x86 generic
 MPN64_i386 = x86_64/pentium4 x86_64 generic
 MPN32_sparc = sparc32/v9 sparc32 generic
-MPN64_sparc = sparc64 generic
+MPN64_sparc = sparc64/ultrasparc34 sparc64/ultrasparc1234 sparc64 generic
 MPN_32 = $(MPN32_$(MACH))
 MPN_64 = $(MPN64_$(MACH))
 GM4 = /usr/bin/gm4
@@ -85,7 +85,6 @@ CONFIGURE_ENV += SED="$(GSED)"
 CONFIGURE_ENV += ABI="$(BITS)"
 CONFIGURE_ENV += "MPN_PATH=$(MPN_$(BITS))"
 
-CONFIGURE_OPTIONS += --includedir=/usr/include/gmp
 CONFIGURE_OPTIONS += --localstatedir=/var
 CONFIGURE_OPTIONS += --enable-shared
 CONFIGURE_OPTIONS += --disable-static
@@ -126,8 +125,6 @@ COMPONENT_POST_INSTALL_ACTION = \
       $(GSED) -e "s/MACH64/$(MACH64)/g" \
 					$(COMPONENT_DIR)/Solaris/libgmpxx-64.pc > \
 							$(COMPONENT_DIR)/libgmpxx.pc ; \
-      $(MV) $(PROTOUSRINCLUDEDIR)/gmp.h $(PROTOUSRINCLUDEDIR)/gmp/ ; \
-      $(MV) $(PROTOUSRINCLUDEDIR)/mp.h $(PROTOUSRINCLUDEDIR)/gmp/ ; \
       $(INSTALL) -m 0644 $(COMPONENT_DIR)/Solaris/libgmp.pc \
 					$(PROTOPKGCONFIGDIR) ; \
       $(INSTALL) -m 0644 $(COMPONENT_DIR)/Solaris/libgmpxx.pc \

--- a/components/library/gmp/gmp.p5m
+++ b/components/library/gmp/gmp.p5m
@@ -22,8 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/include/gmp/gmp.h
-file path=usr/include/gmp/gmpxx.h
+file path=usr/include/gmp.h
+file path=usr/include/gmpxx.h
 link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.4.1
 link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.4.1
 file path=usr/lib/$(MACH64)/libgmp.so.10.4.1

--- a/components/library/gmp/manifests/sample-manifest.p5m
+++ b/components/library/gmp/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,8 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/include/gmp/gmp.h
-file path=usr/include/gmp/gmpxx.h
+file path=usr/include/gmp.h
+file path=usr/include/gmpxx.h
 link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.4.1
 link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.4.1
 file path=usr/lib/$(MACH64)/libgmp.so.10.4.1

--- a/components/library/gnutls-3/Makefile
+++ b/components/library/gnutls-3/Makefile
@@ -43,7 +43,6 @@ COMPONENT_LICENSE=	GPLv3, LGPLv2.1, FDLv1.3
 
 include $(WS_MAKE_RULES)/common.mk
 
-CFLAGS += -I$(USRINCDIR)/gmp
 CFLAGS += -I$(USRINCDIR)/idn2
 
 MCS = mcs

--- a/components/library/guile/Makefile
+++ b/components/library/guile/Makefile
@@ -50,13 +50,22 @@ include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_ENV+= CPP="$(GCC_ROOT)/bin/gcc -E"
 
-CONFIGURE_OPTIONS +=	CPPFLAGS="-I/usr/include/gmp -D__USE_LEGACY_PROTOTYPES__"
+CONFIGURE_OPTIONS +=	CPPFLAGS="-D__USE_LEGACY_PROTOTYPES__"
 CONFIGURE_OPTIONS +=	LIBS="-lsocket -lnsl"
 CONFIGURE_OPTIONS +=	--disable-static 
 CONFIGURE_OPTIONS +=	--disable-error-on-warning
+ifeq ($(strip $(MACH)),i386)
 CONFIGURE_OPTIONS +=	ac_cv_type_complex_double=no
+endif
 
 CONFIGURE_ENV.64 += LT_SYS_LIBRARY_PATH="/lib/$(MACH64):/usr/lib/$(MACH64)"
+
+# bug at: https://bugs.gentoo.org/676468
+ifeq ($(strip $(MACH)),sparc)
+COMPONENT_POST_UNPACK_ACTION= \
+	( cd $(COMPONENT_SRC)/prebuilt/32-bit-big-endian ; \
+		find . -name \*.go -exec rm {} \; )
+endif
 
 # It is imperative the timestamps of .scm and .go files be preserved, and .go
 # file be newer than its source, or nothing works

--- a/components/library/mpfr/Makefile
+++ b/components/library/mpfr/Makefile
@@ -51,11 +51,10 @@ LDFLAGS += $(LD_Z_REDLOCSYM) $(LD_Z_RESCAN_NOW)
 MPN32_i386 = x86/pentium x86 generic
 MPN64_i386 = x86_64/pentium4 x86_64 generic
 MPN32_sparc = sparc32/v9 sparc32 generic
-MPN64_sparc = sparc64 generic
+MPN64_sparc = sparc64/ultrasparc34 sparc64/ultrasparc1234 sparc64 generic
 MPN32 = $(MPN32_$(MACH))
 MPN64 = $(MPN64_$(MACH))
 
-GMPINCDIR = /usr/include/gmp
 GMPLIBDIR_32 = /usr/lib
 GMPLIBDIR_64 = /usr/lib/$(MACH64)
 MPFRMULHIGH = 2048
@@ -75,13 +74,9 @@ CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --disable-libtool-lock
 CONFIGURE_OPTIONS += --enable-thread-safe
 CONFIGURE_OPTIONS += --enable-tests-timeout=0
-CONFIGURE_OPTIONS += --with-gmp-include=$(GMPINCDIR)
 CONFIGURE_OPTIONS += --with-gmp-lib=$(GMPLIBDIR_$(BITS))
 CONFIGURE_OPTIONS += --with-mulhigh-size=$(MPFRMULHIGH)
 CONFIGURE_OPTIONS += --with-pic
-
-COMPONENT_POST_INSTALL_ACTION = \
-      ( $(GSED) -i -e "s^\#include <gmp.h>^\#include <gmp/gmp.h>^g" $(PROTOUSRDIR)/include/mpfr/mpfr.h ; )
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/gmp

--- a/components/library/nettle/Makefile
+++ b/components/library/nettle/Makefile
@@ -38,8 +38,6 @@ PATH=$(PATH.gnu)
 
 COMPONENT_PREP_ACTION = ( cd $(@D) && autoreconf -f -i )
 
-CPPFLAGS += -I/usr/include/gmp
-
 CONFIGURE_OPTIONS += --disable-assembler
 
 CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"

--- a/components/sysutils/coreutils/Makefile
+++ b/components/sysutils/coreutils/Makefile
@@ -59,7 +59,6 @@ COMPONENT_PREP_ACTION = (cd $(@D) ; autoreconf -f -i)
 
 CONFIGURE_PREFIX	 =	$(GNUDIR)
 CONFIGURE_BINDIR.64	 =	$(GNUBIN)
-CONFIGURE_OPTIONS	+=	CPPFLAGS=" -I$(USRINCDIR)/gmp"
 CONFIGURE_OPTIONS	+=	--libdir=$(USRLIBDIR.$(BITS))
 # Put libstdbuf in the library directory
 CONFIGURE_OPTIONS	+=	--libexecdir=$(USRLIBDIR.$(BITS))

--- a/components/web/aria2/Makefile
+++ b/components/web/aria2/Makefile
@@ -27,7 +27,6 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           aria2
 COMPONENT_VERSION=        1.36.0
-COMPONENT_REVISION=       1
 COMPONENT_FMRI=           web/aria2
 COMPONENT_PROJECT_URL=    https://aria2.github.io/
 COMPONENT_CLASSIFICATION= Applications/Internet
@@ -41,8 +40,6 @@ COMPONENT_LICENSE=	GPLv3
 include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
-
-CXXFLAGS += -I/usr/include/gmp
 
 LDFLAGS += -lsocket -lnsl
 


### PR DESCRIPTION
Many opensource packages expect gmp.h to be located in /usr/include rather then /usr/include/gmp.
These packages depend on library/gmp:
desktop/remote-desktop/rdesktop
developer/gnu-cobol
editor/gnu-emacs/gnu-emacs-gtk
editor/gnu-emacs/gnu-emacs-no-x11
editor/gnu-emacs/gnu-emacs-x11
file/gnu-coreutils
library/gnutls-3
library/guile
library/mpc
library/mpfr
library/nettle
text/gawk
web/aria2
All of them don't need a recompile because of this change, however emacs would benefit from a recompile,
because gmp has been enabled in the Makefile but was never detected during configure/build time. All
the depending packages have already been re-packaged on SPARC without any problems.