### PR TITLE
move gmp.h to /usr/include and change MPN64_sparc variables for UltraSPARC support

### DIFF
--- a/components/library/gmp/Makefile
+++ b/components/library/gmp/Makefile
@@ -59,7 +59,7 @@ LDFLAGS += $(LD_Z_REDLOCSYM) $(LD_Z_RESCAN_NOW)
 MPN32_i386 = x86/pentium x86 generic
 MPN64_i386 = x86_64/pentium4 x86_64 generic
 MPN32_sparc = sparc32/v9 sparc32 generic
-MPN64_sparc = sparc64 generic
+MPN64_sparc = sparc64/ultrasparc34 sparc64/ultrasparc1234 sparc64 generic
 MPN_32 = $(MPN32_$(MACH))
 MPN_64 = $(MPN64_$(MACH))
 GM4 = /usr/bin/gm4
@@ -85,7 +85,6 @@ CONFIGURE_ENV += SED="$(GSED)"
 CONFIGURE_ENV += ABI="$(BITS)"
 CONFIGURE_ENV += "MPN_PATH=$(MPN_$(BITS))"
 
-CONFIGURE_OPTIONS += --includedir=/usr/include/gmp
 CONFIGURE_OPTIONS += --localstatedir=/var
 CONFIGURE_OPTIONS += --enable-shared
 CONFIGURE_OPTIONS += --disable-static
@@ -103,7 +102,7 @@ PROTOUSRINCLUDEDIR = $(PROTOUSRDIR)/include
 PROTOPKGCONFIGDIR = $(PROTOUSRLIBDIR)/pkgconfig
 PROTOPKGCONFIGDIR64 = $(PROTOUSRLIBDIR64)/pkgconfig
 
-GMP_SOVERSION=4.5.2
+GMP_SOVERSION=4.6.1
 
 GCCLIBDIR  =$(GCC_ROOT)/lib
 GCCLIBDIR64=$(GCC_ROOT)/lib/$(MACH64)
@@ -126,8 +125,6 @@ COMPONENT_POST_INSTALL_ACTION = \
       $(GSED) -e "s/MACH64/$(MACH64)/g" \
 					$(COMPONENT_DIR)/Solaris/libgmpxx-64.pc > \
 							$(COMPONENT_DIR)/libgmpxx.pc ; \
-      $(MV) $(PROTOUSRINCLUDEDIR)/gmp.h $(PROTOUSRINCLUDEDIR)/gmp/ ; \
-      $(MV) $(PROTOUSRINCLUDEDIR)/mp.h $(PROTOUSRINCLUDEDIR)/gmp/ ; \
       $(INSTALL) -m 0644 $(COMPONENT_DIR)/Solaris/libgmp.pc \
 					$(PROTOPKGCONFIGDIR) ; \
       $(INSTALL) -m 0644 $(COMPONENT_DIR)/Solaris/libgmpxx.pc \

--- a/components/library/gmp/Solaris/libgmp-64.pc
+++ b/components/library/gmp/Solaris/libgmp-64.pc
@@ -1,7 +1,7 @@
 prefix=/usr
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib/MACH64
-includedir=${prefix}/include/gmp
+includedir=${prefix}/include
 
 Name: libgmp
 Description: The GNU Multiple Precision Bignum Library

--- a/components/library/gmp/Solaris/libgmp.pc
+++ b/components/library/gmp/Solaris/libgmp.pc
@@ -1,7 +1,7 @@
 prefix=/usr
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
-includedir=${prefix}/include/gmp
+includedir=${prefix}/include
 
 Name: libgmp
 Description: The GNU Multiple Precision Bignum Library

--- a/components/library/gmp/Solaris/libgmpxx-64.pc
+++ b/components/library/gmp/Solaris/libgmpxx-64.pc
@@ -1,7 +1,7 @@
 prefix=/usr
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib/MACH64
-includedir=${prefix}/include/gmp
+includedir=${prefix}/include
 
 Name: libgmpxx
 Description: The GNU Multiple Precision Bignum Library

--- a/components/library/gmp/Solaris/libgmpxx.pc
+++ b/components/library/gmp/Solaris/libgmpxx.pc
@@ -1,7 +1,7 @@
 prefix=/usr
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
-includedir=${prefix}/include/gmp
+includedir=${prefix}/include
 
 Name: libgmpxx
 Description: The GNU Multiple Precision Bignum Library

--- a/components/library/gmp/gmp.p5m
+++ b/components/library/gmp/gmp.p5m
@@ -22,8 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/include/gmp/gmp.h
-file path=usr/include/gmp/gmpxx.h
+file path=usr/include/gmp.h
+file path=usr/include/gmpxx.h
 link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.4.1
 link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.4.1
 file path=usr/lib/$(MACH64)/libgmp.so.10.4.1

--- a/components/library/gmp/manifests/sample-manifest.p5m
+++ b/components/library/gmp/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,8 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/include/gmp/gmp.h
-file path=usr/include/gmp/gmpxx.h
+file path=usr/include/gmp.h
+file path=usr/include/gmpxx.h
 link path=usr/lib/$(MACH64)/libgmp.so target=libgmp.so.10.4.1
 link path=usr/lib/$(MACH64)/libgmp.so.10 target=libgmp.so.10.4.1
 file path=usr/lib/$(MACH64)/libgmp.so.10.4.1


### PR DESCRIPTION
This is to follow the coding standards of Oracle Solaris 11.4, solaris-userland has switched re-locating gmp.h to /usr/include about 4 years ago now. A simple re-compile of emacs, php and other software will benefit from
this. Dependent other software packages will be changed in separate PR(s), this is the second follow up PR to #7382
