### PR TITLE
Upgrade of pycairo to 1.20.1 with python 3.7 and 3.9

### DIFF
--- a/components/python/pycairo-12/Makefile
+++ b/components/python/pycairo-12/Makefile
@@ -1,0 +1,70 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 Gary Mills
+# Copyright 2017 Alexander Pyhalov
+#
+
+BUILD_BITS=		64
+BUILD_STYLE=		setup.py
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		pycairo
+# This version supports python 3.6+
+COMPONENT_VERSION=	1.20.1
+COMPONENT_SUMMARY=	Python bindings for Cairo
+COMPONENT_PROJECT_URL=	http://www.cairographics.org
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+    sha256:34f0a86ee5d98f3fca1f09dd3960d43ea9937b2df44f5270d2eb94f529677150
+COMPONENT_ARCHIVE_URL=	https://github.com/pygobject/$(COMPONENT_NAME)/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_FMRI=			library/python/pycairo
+COMPONENT_CLASSIFICATION=	Development/Python
+
+PYTHON_VERSIONS=	3.7 3.9
+PYTHON_DATA=		$(USRDIR)
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Rename some files to make way for symlinks
+COMPONENT_POST_INSTALL_ACTION += \
+	(cd $(PROTOUSRINCDIR)/pycairo; $(MV) py3cairo.h py3cairo.h-$(PYTHON_VERSION)) ;
+COMPONENT_POST_INSTALL_ACTION += \
+	(cd $(PROTOUSRLIBDIR)/pkgconfig; $(MV) py3cairo.pc py3cairo.pc-$(PYTHON_VERSION)) ;
+
+# Tests require packages: pytest py pluggy benchmark
+COMPONENT_TEST_DIR=	$(COMPONENT_SRC)
+COMPONENT_TEST_CMD=	$(PYTHON)
+COMPONENT_TEST_ARGS=	setup.py test
+
+# Typical test results:
+#=========================== short test summary info ==========================
+#FAILED tests/test_hypothesis.py::test_fspaths - TypeError: randoms() got an u...
+#FAILED tests/test_typing.py::test_typing - AssertionError: assert {'ANTIALIAS...
+#=================== 2 failed, 270 passed, 3 skipped in 3.19s =================
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += runtime/python-37
+REQUIRED_PACKAGES += runtime/python-39
+REQUIRED_PACKAGES += system/library

--- a/components/python/pycairo-12/manifests/generic-manifest.p5m
+++ b/components/python/pycairo-12/manifests/generic-manifest.p5m
@@ -1,0 +1,29 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2021 <contributor>
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+file path=usr/include/pycairo/py3cairo.h-$(PYVER)
+file path=usr/lib/pkgconfig/py3cairo.pc-$(PYVER)
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.pyi
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/_cairo.cpython-37m.so
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/include/py3cairo.h
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/_cairo.cpython-39.so

--- a/components/python/pycairo-12/manifests/sample-manifest.p5m
+++ b/components/python/pycairo-12/manifests/sample-manifest.p5m
@@ -1,0 +1,46 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/pycairo/py3cairo.h-3.7
+file path=usr/include/pycairo/py3cairo.h-3.9
+file path=usr/lib/pkgconfig/py3cairo.pc-3.7
+file path=usr/lib/pkgconfig/py3cairo.pc-3.9
+file path=usr/lib/python3.7/vendor-packages/cairo/__init__.py
+file path=usr/lib/python3.7/vendor-packages/cairo/__init__.pyi
+file path=usr/lib/python3.7/vendor-packages/cairo/_cairo.cpython-37m.so
+file path=usr/lib/python3.7/vendor-packages/cairo/include/py3cairo.h
+file path=usr/lib/python3.7/vendor-packages/cairo/py.typed
+file path=usr/lib/python3.7/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.7.egg-info/PKG-INFO
+file path=usr/lib/python3.7/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.7.egg-info/SOURCES.txt
+file path=usr/lib/python3.7/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.7.egg-info/dependency_links.txt
+file path=usr/lib/python3.7/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.7.egg-info/top_level.txt
+file path=usr/lib/python3.9/vendor-packages/cairo/__init__.py
+file path=usr/lib/python3.9/vendor-packages/cairo/__init__.pyi
+file path=usr/lib/python3.9/vendor-packages/cairo/_cairo.cpython-39.so
+file path=usr/lib/python3.9/vendor-packages/cairo/include/py3cairo.h
+file path=usr/lib/python3.9/vendor-packages/cairo/py.typed
+file path=usr/lib/python3.9/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/pycairo-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt

--- a/components/python/pycairo-12/pkg5
+++ b/components/python/pycairo-12/pkg5
@@ -2,12 +2,15 @@
     "dependencies": [
         "SUNWcs",
         "library/desktop/cairo",
-        "runtime/python-35",
+        "runtime/python-37",
+        "runtime/python-39",
         "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "library/python/pycairo-35"
+        "library/python/pycairo-37",
+        "library/python/pycairo-39",
+        "library/python/pycairo"
     ],
     "name": "pycairo"
 }

--- a/components/python/pycairo-12/pycairo-12-GENFRAG.p5m
+++ b/components/python/pycairo-12/pycairo-12-GENFRAG.p5m
@@ -20,13 +20,17 @@
 #
 
 #
+# Copyright 2021 Gary Mills
 # Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
 #
 
-file path=usr/include/pycairo/py3cairo.h
-file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc
-license COPYING license=GPLv3
-license COPYING.LESSER license=LGPLv3
+license COPYING-MPL-1.1 license="MPL v1.1"
+license COPYING-LGPL-2.1 license="LGPL v2.1"
+
 # Manually added since python2 version is built separately in ../py2cairo
-depend type=conditional fmri=library/python/pycairo-27 \
+depend type=conditional fmri=$(COMPONENT_FMRI)-27 \
     predicate=runtime/python-27
+
+# Manually added since python3 version is built separately in ../pycairo
+depend type=conditional fmri=$(COMPONENT_FMRI)-35 \
+    predicate=runtime/python-35

--- a/components/python/pycairo-12/pycairo-12-PYVER.p5m
+++ b/components/python/pycairo-12/pycairo-12-PYVER.p5m
@@ -20,11 +20,12 @@
 #
 
 #
+# Copyright 2021 Gary Mills
 # Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
 #
 
 set name=pkg.fmri \
-    value=pkg:/library/python/pycairo-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+    value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary \
     value="Python bindings for the Cairo graphics library"
 set name=com.oracle.info.description \
@@ -36,13 +37,26 @@ set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.arc-caseid value=PSARC/2014/371
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-file path=usr/lib/python$(PYVER)/vendor-packages/cairo/64/_cairo.so
-file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.py
-file path=usr/lib/python$(PYVER)/vendor-packages/cairo/_cairo.so
+link path=usr/include/pycairo/py3cairo.h target=py3cairo.h-$(PYVER) \
+	mediator=python3 mediator-version=$(PYVER)
+link path=usr/lib/pkgconfig/py3cairo.pc target=py3cairo.pc-$(PYVER) \
+	mediator=python3 mediator-version=$(PYVER)
 
-license COPYING license=GPLv3
-license COPYING.LESSER license=LGPLv3
+file path=usr/include/pycairo/py3cairo.h-$(PYVER)
+file path=usr/lib/pkgconfig/py3cairo.pc-$(PYVER)
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.pyi
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/_cairo.so
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/include/py3cairo.h
+file path=usr/lib/python$(PYVER)/vendor-packages/cairo/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/pycairo-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+
+license COPYING-MPL-1.1 license="MPL v1.1"
+license COPYING-LGPL-2.1 license="LGPL v2.1"
 
 # force a dependency on the unversioned package
 depend type=require \
-    fmri=library/python/pycairo@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+    fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/python/pycairo/Makefile
+++ b/components/python/pycairo/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2021 Gary Mills
 # Copyright 2017 Alexander Pyhalov
 #
 BUILD_BITS=64
@@ -17,8 +18,9 @@ BUILD_STYLE=waf
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pycairo
+# This version supports only python 3.5
 COMPONENT_VERSION=	1.10.0
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_PROJECT_URL=	http://www.cairographics.org
 COMPONENT_SUMMARY=	Python bindings for Cairo
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -66,6 +68,11 @@ COMPONENT_POST_INSTALL_ACTION += \
             $(PYTHON) -m compileall $(PROTO_DIR)/usr/lib/python3.5/vendor-packages/cairo ; \
 	fi ;
 
+# Rename some files to make way for symlinks
+COMPONENT_POST_INSTALL_ACTION += \
+	(cd $(PROTOUSRINCDIR)/pycairo; $(MV) py3cairo.h py3cairo.h-3.5) ;
+COMPONENT_POST_INSTALL_ACTION += \
+	(cd $(PROTOUSRLIBDIR.64)/pkgconfig; $(MV) py3cairo.pc py3cairo.pc-3.5) ;
 
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += runtime/python-35

--- a/components/python/pycairo/manifests/sample-manifest.p5m
+++ b/components/python/pycairo/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,7 +22,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/include/pycairo/py3cairo.h
-file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc
+file path=usr/include/pycairo/py3cairo.h-3.5
+file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc-3.5
 file path=usr/lib/python3.5/vendor-packages/cairo/__init__.py
 file path=usr/lib/python3.5/vendor-packages/cairo/_cairo.cpython-35m.so

--- a/components/python/pycairo/pycairo-35.p5m
+++ b/components/python/pycairo/pycairo-35.p5m
@@ -1,0 +1,62 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2021 Gary Mills
+# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+#
+
+# This file intentionally hardcodes Python 3.5 instead of using the PYVER
+# subsititutions to avoid triggering the auto-generation of a generic
+# library/python/pycairo in this component, since that's being done in
+# ../pycairo-12 instead to cover the other python 3.x versions correctly.
+
+set name=pkg.fmri \
+    value=pkg:/library/python/pycairo-35@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary \
+    value="Python bindings for the Cairo graphics library"
+set name=com.oracle.info.description \
+    value="Python bindings for Cairo"
+set name=info.classification \
+    value=org.opensolaris.category.2008:Development/Python
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.arc-caseid value=PSARC/2014/371
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+link path=usr/include/pycairo/py3cairo.h target=py3cairo.h-3.5 \
+	mediator=python3 mediator-version=3.5
+link path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc target=py3cairo.pc-3.5 \
+	mediator=python3 mediator-version=3.5
+
+file path=usr/include/pycairo/py3cairo.h-3.5
+file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc-3.5
+
+file path=usr/lib/python3.5/vendor-packages/cairo/__init__.py
+# Now 64-bit SO file
+file path=usr/lib/python3.5/vendor-packages/cairo/_cairo.so
+
+license COPYING license=GPLv3
+license COPYING.LESSER license=LGPLv3
+
+# force a dependency on the unversioned package
+depend type=require \
+    fmri=library/python/pycairo


### PR DESCRIPTION
Pycairo is a set of Python bindings for the Cairo library.  This PR introduces version 1.20.1 of pycairo, the latest version, which supports python 3.6+ .  For OI, this means python 3.7 and 3.9 support.  This version does not support python 3.5 or 2.7 .  For this reason, the new version has to reside in a new component directory: python/pycairo-12 .  It supplies the packages pycairo-37, pycairo-39, and pycairo.

There are two existing component directories: python/pycairo and python/py2cairo.  The python/pycairo directory supplies the package pycairo-35, and is changed slightly.  The python/py2cairo directory supplies the package pycairo-27 .  It is unchanged.  Both of these directories can be removed when the corresponding python versions are obsoleted.

In the new component directory, Makefile downloads the new version of pycairo, and builds it, using the setup.py build style.  The file pycairo-12-GENFRAG.p5m contains conditional dependencies, using them and other statements to populate the pycairo package.  The file pycairo-12-PYVER.p5m contains mediated symlinks, using the python3 mediator.  It populates the packages pycairo-37 and pycairo-39 .

In the existing python/pycairo component directory, Makefile is changed to increment COMPONENT_REVISION.  The file pycairo-PYVER.p5m has been renamed to pycairo-35.p5m .  It also contains mediated symlinks, using the python3 mediator.  As before, it populates one package, the pycairo-35 package.  The file pycairo-GENFRAG.p5m has been deleted, as its function is replaced by the new pycairo package.

The build, install, and publish steps were all successful.  The built-in tests, for the new component, resulted in 2 failed tests, and 270 passed tests.  Note that this target does a complete rebuild and install of the product, in a temporary directory.

I also did a successful "pkg install" of all of the packages.  I was unable to do an external test, as I was unable to find any top-level package that depended on the pycairo packages.
