### PR TITLE
add macro ADDITIONAL_PATCHES to prep-patch.mk

### DIFF
--- a/make-rules/prep-patch.mk
+++ b/make-rules/prep-patch.mk
@@ -39,7 +39,7 @@ GPATCH_FLAGS =	--strip=$(PATCH_LEVEL) $(GPATCH_BACKUP)
 # PATCH_DIR can be overridden to move patches to a different location
 # PATCH_PATTERN can be overridden to adjust the patch naming scheme that the
 #     build recognizes.
-# EXTRA_PATCHES{version} can be defined in the component Makefile to include
+# ADDITIONAL_PATCHES can be defined in the component Makefile to include
 #     additional patches.
 #
 
@@ -65,6 +65,10 @@ PATCHES$(1) = $(filter %.patch,$(PATCHES))
 else
 PATCH_PATTERN$(1) ?=	%.patch$(1)
 PATCHES$(1) = $(filter %.patch$(1),$(PATCHES))
+endif
+
+ifneq ($(strip $(ADDITIONAL_PATCHES$(1))),)
+PATCHES$(1) += $(ADDITIONAL_PATCHES$(1))
 endif
 
 ifneq ($$(PATCHES$(1)),)


### PR DESCRIPTION
This is needed to be able to add $MACH specific patches to component Makefiles e.g. different mapfiles