### PR TITLE
cleanup EXTRA_PATCHES from components Makefile

### DIFF
--- a/components/developer/gcc49/Makefile
+++ b/components/developer/gcc49/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gcc
 COMPONENT_VERSION= 4.9.4
-COMPONENT_REVISION= 7
+COMPONENT_REVISION= 8
 MPFR_NAME= mpfr
 MPFR_VERSION=3.1.3
 MPC_NAME=mpc
@@ -36,7 +36,7 @@ COMPONENT_SIG_URL= $(COMPONENT_ARCHIVE_URL).sig
 COMPONENT_PROJECT_URL = http://gcc.gnu.org/
 PATCH_EACH_ARCHIVE=1
 PATCHDIR_PATCHES = $(shell find $(PATCH_DIR) $(PARFAIT_PATCH_DIR) -type f -name '$(PATCH_PATTERN)' \
-                                2>/dev/null | sort) $(EXTRA_PATCHES)
+                                2>/dev/null | sort)
 
 COMPONENT_SRC_1=    $(MPFR_NAME)-$(MPFR_VERSION)
 COMPONENT_ARCHIVE_1=    $(COMPONENT_SRC_1).tar.bz2

--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -66,7 +66,7 @@ download:: $(SOURCE_DIR)/.downloaded
 PATCH_DIR ?=    patches
 PATCH_PATTERN ?=        *.patch
 PATCHES =       $(shell find $(PATCH_DIR) $(PARFAIT_PATCH_DIR) -type f -name '$(PATCH_PATTERN)' \
-                                2>/dev/null | sort) $(EXTRA_PATCHES)
+                                2>/dev/null | sort)
 
 $(SOURCE_DIR)/.patched:	$(SOURCE_DIR)/.downloaded $(PATCHES)
 	$(MKDIR) $(@D)

--- a/make-rules/gcc-component.mk
+++ b/make-rules/gcc-component.mk
@@ -43,7 +43,7 @@ COMPONENT_ARCHIVE_URL ?= \
 
 PATCH_EACH_ARCHIVE=1
 PATCHDIR_PATCHES = $(shell find $(PATCH_DIR) -type f -name '$(PATCH_PATTERN)' \
-                                2>/dev/null | sort) $(EXTRA_PATCHES)
+                                2>/dev/null | sort)
 
 MPFR_NAME= mpfr
 ifeq ($(strip $(MPFR_VERSION)),)


### PR DESCRIPTION
This is a followup change to PR #7412 to delete stale EXTRA_PATCHES from components Makefiles, it has been replaced by ADDITIONAL_PATCHES.