### PR TITLE
Update gnome-connection-manager to current GitHub HEAD - d2f66e3 @ 20210420

### DIFF
--- a/components/desktop/gnome2/gnome-connection-manager/Makefile
+++ b/components/desktop/gnome2/gnome-connection-manager/Makefile
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright (c) 2015-2020 Jim Klimov
+# Copyright (c) 2015-2021 Jim Klimov
 #
 
 include ../../../../make-rules/shared-macros.mk
@@ -20,18 +20,33 @@ COMPONENT_NAME_SHORT=	gcm
 # The value below should match the .p5m and .license filenames, in particular:
 COMPONENT_NAME=  		$(COMPONENT_NAME_LONG)
 COMPONENT_VERSION=	1.2.1
+# Currently the latest release is a bit behind the Git HEAD on features
+# Comment away when switching to future "vanilla" release
+COMPONENT_GIT_ORG=	kuthulux
+COMPONENT_GIT_REV=	d2f66e3
+COMPONENT_GIT_DATE=	20210420
 COMPONENT_PROJECT_URL=	http://kuthulu.com/gcm
 
+ifeq (,$(COMPONENT_GIT_REV))
+### How the source dir is named in the archive:
 COMPONENT_SRC=		$(COMPONENT_NAME_LONG)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE_HASH=	\
-    sha256:a78f90fc1b5ea5c3c0f068d51c5db75cfe5b77eff1bed0f910ac9d484b29f3a3
-
 ### How the original sites name the archive:
 COMPONENT_ARCHIVE_ORIG=	v$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_URL=	https://github.com/kuthulux/$(COMPONENT_NAME_LONG)/archive/$(COMPONENT_ARCHIVE_ORIG)
-
+COMPONENT_ARCHIVE_URL=	https://github.com/$(COMPONENT_GIT_ORG)/$(COMPONENT_NAME_LONG)/archive/$(COMPONENT_ARCHIVE_ORIG)
 ### How we name the archive to store on build hosts:
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+else
+### How the source dir is named in the archive:
+COMPONENT_SRC=		$(COMPONENT_GIT_ORG)-$(COMPONENT_NAME_LONG)-$(COMPONENT_GIT_REV)
+### How the original sites name the archive:
+#COMPONENT_ARCHIVE_ORIG=	v$(COMPONENT_VERSION)-$(COMPONENT_GIT_REV).tar.gz
+COMPONENT_ARCHIVE_URL=	https://codeload.github.com/$(COMPONENT_GIT_ORG)/$(COMPONENT_NAME_LONG)/legacy.tar.gz/$(COMPONENT_GIT_REV)
+### How we name the archive to store on build hosts:
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION)-$(COMPONENT_GIT_REV).tar.gz
+endif
+
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:9ab00a8ea22a32e77ad6f225b6da65652c60e097dd125a5e27a07cb5c3dcb659
 
 COMPONENT_SUMMARY=	GCM - an Advanced SSH connections manager for X/Windows
 COMPONENT_FMRI=		terminal/$(COMPONENT_NAME)

--- a/components/desktop/gnome2/gnome-connection-manager/gnome-connection-manager.p5m
+++ b/components/desktop/gnome2/gnome-connection-manager/gnome-connection-manager.p5m
@@ -9,7 +9,7 @@
 #
 
 #
-# Copyright (c) 2015-2020 Jim Klimov
+# Copyright (c) 2015-2021 Jim Klimov
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -63,3 +63,4 @@ file __pycache__/SimpleGladeApp.cpython-$(PYV).pyc path=usr/share/gnome-connecti
 file urlregex.py path=usr/share/gnome-connection-manager/urlregex.py
 file __pycache__/urlregex.cpython-$(PYV).pyc path=usr/share/gnome-connection-manager/__pycache__/urlregex.cpython-$(PYV).pyc
 file ssh.expect path=usr/share/gnome-connection-manager/ssh.expect mode=0555
+file style.css path=usr/share/gnome-connection-manager/style.css

--- a/components/desktop/gnome2/gnome-connection-manager/manifests/sample-manifest.p5m
+++ b/components/desktop/gnome2/gnome-connection-manager/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/desktop/gnome2/gnome-connection-manager/patches/02-mc-doubleclick.patch
+++ b/components/desktop/gnome2/gnome-connection-manager/patches/02-mc-doubleclick.patch
@@ -1,0 +1,27 @@
+Temporary solution for https://github.com/kuthulux/gnome-connection-manager/issues/64
+proposed in PR https://github.com/kuthulux/gnome-connection-manager/pull/72 against
+GCM release 1.2.1 (plus HEAD commits up to 2021-04-20), to process double-clicks
+in Midnight Commander running in GCM terminals better (not perfectly though).
+
+This may get merged or solved differently in future iterations of GCM upstream,
+then this patch file can be removed.
+
+--- gcm-1.2.1-d2f66e3-orig/gnome_connection_manager.py	2021-04-20 16:18:58.000000000 +0200
++++ gcm-1.2.1-current/gnome_connection_manager.py	2021-12-23 18:08:19.018024484 +0000
+@@ -2033,10 +1968,14 @@
+     def on_double_click(self, widget, event, *args):
+         if event.type in [Gdk.EventType._2BUTTON_PRESS, Gdk.EventType._3BUTTON_PRESS] and event.button == 1:
+             if isinstance(widget, Gtk.Notebook):
+-                pos = event.x + widget.get_allocation().x
++                posX = event.x + widget.get_allocation().x
++                posY = event.y + widget.get_allocation().y
+                 size = widget.get_tab_label(widget.get_nth_page(widget.get_n_pages()-1)).get_allocation()
+-                if pos <= size.x + size.width + 8 or event.x >= widget.get_allocation().width - widget.style_get_property("scroll-arrow-hlength"):
++
++                # HACK with (posY > size.height) below as a way to detect we click the label area and not the terminal pane with MC running, see https://github.com/kuthulux/gnome-connection-manager/issues/64 :
++                if posX <= size.x + size.width + 8 or event.x >= widget.get_allocation().width - widget.style_get_property("scroll-arrow-hlength") or posY > size.height:
+                     return True
++                # else fall through to addTab()
+             if isinstance(widget, Gtk.Toolbar) and widget.get_drop_index(event.x,event.y) < widget.get_n_items():
+                 return True
+             self.addTab(widget if isinstance(widget, Gtk.Notebook) else self.nbConsole, 'local')

--- a/components/desktop/gnome2/gnome-connection-manager/pkg5
+++ b/components/desktop/gnome2/gnome-connection-manager/pkg5
@@ -6,6 +6,7 @@
         "library/python/pygobject-3-35",
         "runtime/python-35",
         "shell/expect",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
Not sure when a GCM release would be issued, but some development after 1.2.1 did seemingly fix an issue I had with https://github.com/kuthulux/gnome-connection-manager/issues/5 that made `git log` and `git diff` use unpleasant, and seems to be related to `ksh93` hangs that nobody else could reproduce.

On the downside, that Git HEAD suffers from https://github.com/kuthulux/gnome-connection-manager/issues/64 misinterpreting double-clicks in Midnight Commander... So maybe there would be another PR (hopefully soon - maybe another commit in this one) to take advantage of some solution to that issue too.