### PR TITLE
install-types: add paprefs to desktop_common

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	45
+COMPONENT_REVISION=	46
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -16,6 +16,7 @@ depend type=require fmri=desktop/compiz/ccsm
 depend type=require fmri=desktop/compiz/plugin/compiz-fusion-extra
 depend type=require fmri=desktop/compiz/plugin/compiz-fusion-main
 depend type=require fmri=desktop/gksu
+depend type=require fmri=desktop/paprefs
 depend type=require fmri=desktop/remote-desktop/tigervnc
 depend type=require fmri=desktop/time-slider
 depend type=require fmri=desktop/window-manager/twm


### PR DESCRIPTION

Add destkop/paprefs to meta-package

NOTE:  I have never updated meta-packages/install-types so hopefully this commit is correct

please double check