### PR TITLE
Fix Missing attribute 'info.classification' warning in entire.

### DIFF
--- a/components/meta-packages/entire-incorporation/entire-2015.0.3.0.p5m
+++ b/components/meta-packages/entire-incorporation/entire-2015.0.3.0.p5m
@@ -10,12 +10,13 @@
 #
 
 #
-# Copyright 2014 Andrzej Szeszo.  All rights reserved.
+# Copyright 2021 Klaus Ziegler.  All rights reserved.
 #
 
 set name=pkg.fmri value=pkg:/entire@0.5.11,$(PKG_SOLARIS_VERSION)-2015.0.3.0
 set name=pkg.description value="incorporation to lock all system packages to same build"
 set name=pkg.summary value="incorporation to lock all system packages to same build"
+set name=info.classification value="org.opensolaris.category.2008:Meta Packages/Group Packages"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 depend type=require fmri=consolidation/userland/userland-incorporation facet.require.consolidation/userland/userland-incorporation=true

--- a/components/meta-packages/entire-incorporation/entire.p5m
+++ b/components/meta-packages/entire-incorporation/entire.p5m
@@ -10,12 +10,13 @@
 #
 
 #
-# Copyright 2014 Andrzej Szeszo.  All rights reserved.
+# Copyright 2021 Klaus Ziegler.  All rights reserved.
 #
 
 set name=pkg.fmri value=pkg:/entire@0.5.11,$(BUILD_VERSION)
 set name=pkg.description value="incorporation to lock all system packages to same build (empty package)"
 set name=pkg.summary value="incorporation to lock all system packages to same build (empty package)"
+set name=info.classification value="org.opensolaris.category.2008:Meta Packages/Group Packages"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 depend type=require fmri=consolidation/userland/userland-incorporation facet.require.consolidation/userland/userland-incorporation=true


### PR DESCRIPTION
WARNING opensolaris.manifest001.1 Missing attribute 'info.classification' in pkg:/entire@0.5.11,5.11-2015.0.3.0/pkg:/entire@0.5.11,5.11-2021.0.0.0
