### PR TITLE
squeak:  patch to use pkg:/image/library/libjpeg6-ijg

### DIFF
--- a/components/runtime/smalltalk/squeak/Makefile
+++ b/components/runtime/smalltalk/squeak/Makefile
@@ -42,6 +42,12 @@
 
 BUILD_BITS=32_and_64
 
+# the goal is to use libjpeg8-turbo but that links, but does not display
+# working jpeg images; needs to be fixed upstream by the Squeak team
+# currently use libjpeg6-ijg which is better than using the copy of
+# those libjpeg files in the squeak source tree
+JPEG_IMPLEM=libjpeg6-ijg
+
 include ../../../../make-rules/shared-macros.mk
 
 # the version is the same as the VMMaker Smalltalk sources
@@ -49,7 +55,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.19.9
-COMPONENT_REVISION=	5
+COMPONENT_REVISION=	6
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -86,16 +92,32 @@ PATH=$(PATH.gnu)
 # lfcompile - large file compilation environment for 32-bit applications
 
 gcc_OPT=	-O
-gcc_OPT+=	-D_LARGEFILE_SOURCE
-gcc_OPT+=	-D_FILE_OFFSET_BITS=64
+
+CPPFLAGS +=     $(CPP_LARGEFILES)
+
+# build against libjpeg6 (see Illumos feature request #7391 for libjpeg8-turbo)
+# use --link-shared-lib to avoid the Squeak copy of libjpeg
+CPPFLAGS +=	$(JPEG_CPPFLAGS)
+LDFLAGS  +=     $(JPEG_LDFLAGS)
+
+SOURCE_JPEG = $(SOURCE_DIR)/platforms/Cross/plugins/JPEGReadWriter2Plugin
 
 # squeak configure looks for .svn or svnversion file, but
 # prep-svn.mk did a svn export and created an unversioned copy of the sources
 COMPONENT_PRE_CONFIGURE_ACTION = \
-( echo $(SVN_REV) > $(SOURCE_DIR)/platforms/unix/svnversion )
+( echo $(SVN_REV) > $(SOURCE_DIR)/platforms/unix/svnversion; \
+  find $(SOURCE_JPEG) \
+     \! -name JPEGReadWriter2Plugin.h \
+     \! -name sqJPEGReadWriter2Plugin.c \
+     \! -name Error.c \
+     \! -name jinclude.h \
+     \! -name jmemdatasrc.c \
+     \! -name jmemdatadst.c \
+  -exec rm {} \;)
 
 CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/cmake/configure
 CONFIGURE_OPTIONS +=	--src=$(SOURCE_DIR)/src
+CONFIGURE_OPTIONS +=    --link-shared-lib
 
 # in the 64bit case the vm is called squeakvm64 (not squeakvm)
 # the plugin directory under usr/lib/squeak has a _64bit suffix
@@ -130,6 +152,8 @@ REQUIRED_PACKAGES += x11/library/mesa
 REQUIRED_PACKAGES += system/library/dbus
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += image/library/libjpeg6
+REQUIRED_PACKAGES += image/library/libjpeg6-ijg
 REQUIRED_PACKAGES += library/audio/gstreamer
 REQUIRED_PACKAGES += library/audio/pulseaudio
 REQUIRED_PACKAGES += library/desktop/cairo
@@ -145,3 +169,4 @@ REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libx11
 REQUIRED_PACKAGES += x11/library/libxext
 REQUIRED_PACKAGES += x11/library/libxrender
+

--- a/components/runtime/smalltalk/squeak/patches/05-jmemdatasrc.patch
+++ b/components/runtime/smalltalk/squeak/patches/05-jmemdatasrc.patch
@@ -1,0 +1,18 @@
+--- squeak-3814/platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatasrc.c	Fri Oct  5 02:00:00 2018
++++ p0/squeak-3814/platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatasrc.c	Sat Dec 25 17:36:07 2021
+@@ -151,7 +151,6 @@
+   /* no work necessary here */
+ }
+ 
+-#if !defined(USE_LIBRARY_SHARED)
+ /*
+  * Prepare for input from a stdio stream.
+  * The caller must have already opened the stream, and is responsible
+@@ -189,7 +188,6 @@
+   src->pub.bytes_in_buffer = 0; /* forces fill_input_buffer on first read */
+   src->pub.next_input_byte = NULL; /* until buffer loaded */
+ }
+-#endif
+ 
+ /* This function allows data to be moved if necessary */
+ GLOBAL(int) jpeg_mem_src_newLocationOfData (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize) {

--- a/components/runtime/smalltalk/squeak/patches/06-jmemdatadst.patch
+++ b/components/runtime/smalltalk/squeak/patches/06-jmemdatadst.patch
@@ -1,0 +1,16 @@
+--- squeak-3814/platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatadst.c	Fri Oct  5 02:00:00 2018
++++ p0/squeak-3814/platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatadst.c	Sat Dec 25 17:40:27 2021
+@@ -115,7 +115,6 @@
+   }
+ }
+ 
+-#if !defined(USE_LIBRARY_SHARED)
+ /*
+  * Prepare for output to a stdio stream.
+  * The caller must have already opened the stream, and is responsible
+@@ -145,5 +144,4 @@
+   dest->pSpaceUsed = pDestinationSize;
+   *(dest->pSpaceUsed) = 0;
+ }
+-#endif
+ 

--- a/components/runtime/smalltalk/squeak/pkg5
+++ b/components/runtime/smalltalk/squeak/pkg5
@@ -1,6 +1,8 @@
 {
     "dependencies": [
         "SUNWcs",
+        "image/library/libjpeg6",
+        "image/library/libjpeg6-ijg",
         "library/audio/gstreamer",
         "library/audio/pulseaudio",
         "library/desktop/cairo",


### PR DESCRIPTION

The Squeak source code contains a (builtin) plugin for reading JPEG

Unfortunately this is done by a copy of the libjpeg6-ijg library copied into the source code of Squeak

There is work going on to link against system provide libjpeg libraries for Debian/Ubuntu.

For OpenIndiana we can succesfully do the same thing using the image/library/libjpeg6-ijg    
it does not work with libjpeg8-turbo

This is being escalated to the Squeak developer(s).

The current patches change the dependencies so that squeak now depend on OpenIndiana provided libjpeg instead of using a builtin libjpeg (statically linked into the Squeakvm)
