### PR TITLE
libjpeg9-ijg : version 9.4.0 of libjpeg

### DIFF
--- a/components/library/libjpeg9-ijg/Makefile
+++ b/components/library/libjpeg9-ijg/Makefile
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+# Copyright 2021 David Stes
+#
+
+BUILD_BITS=32_and_64
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		libjpeg9-ijg
+COMPONENT_VERSION=	9.4.0
+LIBJPEG_API_VERSION= 9d
+COMPONENT_FMRI= 	image/library/libjpeg9-ijg
+COMPONENT_PROJECT_URL=	http://www.ijg.org/
+COMPONENT_SUMMARY=	libjpeg - Independent JPEG Group library version 9d
+COMPONENT_SRC=		jpeg-$(LIBJPEG_API_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+ sha256:6c434a3be59f8f62425b2e3c077e785c9ce30ee5874ea1c270e843f273ba71ee
+COMPONENT_ARCHIVE_URL=	http://www.ijg.org/files/jpegsrc.v$(LIBJPEG_API_VERSION).tar.gz
+COMPONENT_LICENSE=	IJG,GPLv2.0
+COMPONENT_CLASSIFICATION=System/Multimedia Libraries
+
+include $(WS_MAKE_RULES)/common.mk
+
+CONFIGURE_DEFAULT_DIRS=no
+
+CONFIGURE_OPTIONS+= --enable-shared
+CONFIGURE_OPTIONS+= --disable-static
+CONFIGURE_OPTIONS+= --mandir=$(CONFIGURE_MANDIR)
+CONFIGURE_OPTIONS+= --includedir=$(CONFIGURE_INCLUDEDIR)/$(COMPONENT_NAME)
+CONFIGURE_OPTIONS.32+= --bindir=$(USRLIBDIR)/$(COMPONENT_NAME)/bin
+CONFIGURE_OPTIONS.32+= --libdir=$(USRLIBDIR)/$(COMPONENT_NAME)/lib
+CONFIGURE_OPTIONS.64+= --bindir=$(USRLIBDIR)/$(COMPONENT_NAME)/bin/$(MACH64)
+CONFIGURE_OPTIONS.64+= --libdir=$(USRLIBDIR)/$(COMPONENT_NAME)/lib/$(MACH64)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/library/libjpeg9-ijg/libjpeg9-ijg.license
+++ b/components/library/libjpeg9-ijg/libjpeg9-ijg.license
@@ -1,0 +1,59 @@
+The Independent JPEG Group's JPEG software
+==========================================
+
+LEGAL ISSUES
+============
+
+In plain English:
+
+1. We don't promise that this software works.  (But if you find any bugs,
+   please let us know!)
+2. You can use this software for whatever you want.  You don't have to pay us.
+3. You may not pretend that you wrote this software.  If you use it in a
+   program, you must acknowledge somewhere in your documentation that
+   you've used the IJG code.
+
+In legalese:
+
+The authors make NO WARRANTY or representation, either express or implied,
+with respect to this software, its quality, accuracy, merchantability, or
+fitness for a particular purpose.  This software is provided "AS IS", and you,
+its user, assume the entire risk as to its quality and accuracy.
+
+This software is copyright (C) 1991-2020, Thomas G. Lane, Guido Vollbeding.
+All Rights Reserved except as specified below.
+
+Permission is hereby granted to use, copy, modify, and distribute this
+software (or portions thereof) for any purpose, without fee, subject to these
+conditions:
+(1) If any part of the source code for this software is distributed, then this
+README file must be included, with this copyright and no-warranty notice
+unaltered; and any additions, deletions, or changes to the original files
+must be clearly indicated in accompanying documentation.
+(2) If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the work of
+the Independent JPEG Group".
+(3) Permission for use of this software is granted only if the user accepts
+full responsibility for any undesirable consequences; the authors accept
+NO LIABILITY for damages of any kind.
+
+These conditions apply to any software derived from or based on the IJG code,
+not just to the unmodified library.  If you use our work, you ought to
+acknowledge us.
+
+Permission is NOT granted for the use of any IJG author's name or company name
+in advertising or publicity relating to this software or products derived from
+it.  This software may be referred to only as "the Independent JPEG Group's
+software".
+
+We specifically permit and encourage the use of this software as the basis of
+commercial products, provided that all warranty or liability claims are
+assumed by the product vendor.
+
+
+The Unix configuration script "configure" was produced with GNU Autoconf.
+It is copyright by the Free Software Foundation but is freely distributable.
+The same holds for its supporting scripts (config.guess, config.sub,
+ltmain.sh).  Another support script, install-sh, is copyright by X Consortium
+but is also freely distributable.
+

--- a/components/library/libjpeg9-ijg/libjpeg9-ijg.p5m
+++ b/components/library/libjpeg9-ijg/libjpeg9-ijg.p5m
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Aurelien Larcher
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+
+file path=usr/include/$(COMPONENT_NAME)/jconfig.h
+file path=usr/include/$(COMPONENT_NAME)/jerror.h
+file path=usr/include/$(COMPONENT_NAME)/jmorecfg.h
+file path=usr/include/$(COMPONENT_NAME)/jpeglib.h
+
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/cjpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/djpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/jpegtran
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/rdjpgcom
+file path=usr/lib/$(COMPONENT_NAME)/bin/$(MACH64)/wrjpgcom
+file path=usr/lib/$(COMPONENT_NAME)/bin/cjpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/djpeg
+file path=usr/lib/$(COMPONENT_NAME)/bin/jpegtran
+file path=usr/lib/$(COMPONENT_NAME)/bin/rdjpgcom
+file path=usr/lib/$(COMPONENT_NAME)/bin/wrjpgcom
+link path=usr/lib/$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so target=libjpeg.so.9.4.0
+link path=usr/lib/$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.9 target=libjpeg.so.9.4.0
+file path=usr/lib/$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.9.4.0
+link path=usr/lib/$(COMPONENT_NAME)/lib/libjpeg.so target=libjpeg.so.9.4.0
+link path=usr/lib/$(COMPONENT_NAME)/lib/libjpeg.so.9 target=libjpeg.so.9.4.0
+file path=usr/lib/$(COMPONENT_NAME)/lib/libjpeg.so.9.4.0
+

--- a/components/library/libjpeg9-ijg/manifests/sample-manifest.p5m
+++ b/components/library/libjpeg9-ijg/manifests/sample-manifest.p5m
@@ -1,0 +1,52 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/libjpeg9-ijg/jconfig.h
+file path=usr/include/libjpeg9-ijg/jerror.h
+file path=usr/include/libjpeg9-ijg/jmorecfg.h
+file path=usr/include/libjpeg9-ijg/jpeglib.h
+file path=usr/lib/libjpeg9-ijg/bin/$(MACH64)/cjpeg
+file path=usr/lib/libjpeg9-ijg/bin/$(MACH64)/djpeg
+file path=usr/lib/libjpeg9-ijg/bin/$(MACH64)/jpegtran
+file path=usr/lib/libjpeg9-ijg/bin/$(MACH64)/rdjpgcom
+file path=usr/lib/libjpeg9-ijg/bin/$(MACH64)/wrjpgcom
+file path=usr/lib/libjpeg9-ijg/bin/cjpeg
+file path=usr/lib/libjpeg9-ijg/bin/djpeg
+file path=usr/lib/libjpeg9-ijg/bin/jpegtran
+file path=usr/lib/libjpeg9-ijg/bin/rdjpgcom
+file path=usr/lib/libjpeg9-ijg/bin/wrjpgcom
+link path=usr/lib/libjpeg9-ijg/lib/$(MACH64)/libjpeg.so target=libjpeg.so.9.4.0
+link path=usr/lib/libjpeg9-ijg/lib/$(MACH64)/libjpeg.so.9 \
+    target=libjpeg.so.9.4.0
+file path=usr/lib/libjpeg9-ijg/lib/$(MACH64)/libjpeg.so.9.4.0
+file path=usr/lib/libjpeg9-ijg/lib/$(MACH64)/pkgconfig/libjpeg.pc
+link path=usr/lib/libjpeg9-ijg/lib/libjpeg.so target=libjpeg.so.9.4.0
+link path=usr/lib/libjpeg9-ijg/lib/libjpeg.so.9 target=libjpeg.so.9.4.0
+file path=usr/lib/libjpeg9-ijg/lib/libjpeg.so.9.4.0
+file path=usr/lib/libjpeg9-ijg/lib/pkgconfig/libjpeg.pc
+file path=usr/share/man/man1/cjpeg.1
+file path=usr/share/man/man1/djpeg.1
+file path=usr/share/man/man1/jpegtran.1
+file path=usr/share/man/man1/rdjpgcom.1
+file path=usr/share/man/man1/wrjpgcom.1

--- a/components/library/libjpeg9-ijg/pkg5
+++ b/components/library/libjpeg9-ijg/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "image/library/libjpeg9-ijg"
+    ],
+    "name": "libjpeg9-ijg"
+}


### PR DESCRIPTION

This version does not work with Squeak but still it may be useful ...

Attempt can be made to check whether Squeak can be made compatible with libjpeg 9.4.0