### PR TITLE
libmatekbd: update to 1.26.0

### DIFF
--- a/components/desktop/mate/libmatekbd/Makefile
+++ b/components/desktop/mate/libmatekbd/Makefile
@@ -12,22 +12,23 @@
 # Copyright 2016 Till Wegmueller
 # Copyright 2016 Ken Mays
 # Copyright 2020 Michal Nowak
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
-BUILD_BITS=		32_and_64
+BUILD_BITS=		64_and_32
 
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmatekbd
-COMPONENT_MJR_VERSION=  1.24
-COMPONENT_MNR_VERSION=  1
+COMPONENT_MJR_VERSION=  1.26
+COMPONENT_MNR_VERSION=  0
 COMPONENT_VERSION=      $(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE keyboard shared library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:a87f6369e3f35428bc8fccafca1103004b2e2f5cb3d8d122019704baa7ebac9e
+	sha256:220ee8cab0cbc5f42ca6b621bcd009b0b736507945a2aedbffe2235fa1d811ad
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
@@ -51,6 +52,7 @@ CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
 REQUIRED_PACKAGES += library/desktop/gtk3

--- a/components/desktop/mate/libmatekbd/pkg5
+++ b/components/desktop/mate/libmatekbd/pkg5
@@ -7,6 +7,7 @@
         "library/desktop/libxklavier",
         "library/desktop/pango",
         "library/glib2",
+        "shell/ksh93",
         "system/library",
         "system/library/math",
         "x11/library/libx11"


### PR DESCRIPTION
The first in a series of MATE-related updates, all part of the 1.26.0 update.

I was going to open a meta-PR to track all of the individual PRs, but I couldn't find an easy way to do that.

For dependency reasons, I tackled the packages in several "groups".

libmatekbd is part of "Group 1".  The packages in that group can be built in any order.

Very little changed in libmatekbd or the other 2 libmate* libraries.  You should be able to apply this without needing to rush to later package updates.