### PR TITLE
mate-icon-theme: update to 1.26.0

### DIFF
--- a/components/desktop/mate/mate-icon-theme/Makefile
+++ b/components/desktop/mate/mate-icon-theme/Makefile
@@ -12,6 +12,7 @@
 # Copyright 2016 Till Wegmueller
 # Copyright 2016 Ken Mays
 # Copyright 2019 Michal Nowak
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -19,7 +20,7 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-icon-theme
-COMPONENT_MJR_VERSION=	1.24
+COMPONENT_MJR_VERSION=	1.26
 COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	http://www.mate-desktop.org
@@ -27,7 +28,7 @@ COMPONENT_SUMMARY=	Collection of icons for the MATE desktop
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:ca9e5387439fcf7eed53eb33f10a6d3ae51b4d96af525eed6f8cf31d83f95428
+	sha256:41f50436d57f425e54fd9557541be77fb291e03aacd55f7991c042e84a290a5a
 COMPONENT_ARCHIVE_URL=	http://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
@@ -52,9 +53,11 @@ CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
+# build requirements
 REQUIRED_PACKAGES += library/desktop/xdg/icon-naming-utils
 REQUIRED_PACKAGES += text/intltool
 REQUIRED_PACKAGES += text/gnu-gettext
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += library/perl-5/xml-parser
+
 # Auto-generated dependencies

--- a/components/desktop/mate/mate-icon-theme/pkg5
+++ b/components/desktop/mate/mate-icon-theme/pkg5
@@ -4,6 +4,7 @@
         "library/desktop/xdg/icon-naming-utils",
         "library/perl-5/xml-parser",
         "runtime/perl-522",
+        "shell/ksh93",
         "system/library",
         "text/gnu-gettext",
         "text/intltool"


### PR DESCRIPTION
This is the 5th in a series of MATE-related updates, all part of the 1.26.0 update.

For dependency reasons, I tackled the packages in several "groups".

mate-icon-theme is part of "Group 1". The packages in that group can be built in any order.

This package is just static files and none of them changed, so it's safe to update before other package updates or rebuilds.