### PR TITLE
mate-session-manager: update to 1.26.0

### DIFF
--- a/components/desktop/mate/mate-session-manager/Makefile
+++ b/components/desktop/mate/mate-session-manager/Makefile
@@ -13,6 +13,7 @@
 # Copyright 2016 Ken Mays
 # Copyright 2019 Michal Nowak
 # Copyright 2020 Marco van Wieringen
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -20,14 +21,14 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-session-manager
-COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	3
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	The Session manager and session startup stuff
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:90a0aec5b59b6287b4d2c4d452b0b6410f9d12490ca1f890e81ba2801bdab0a2
+COMPONENT_ARCHIVE_HASH= sha256:5915a2f6583c0e5e58afb3abae3f4adbbe6a003c174a5b6e3d204b4e398a1816
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
@@ -40,7 +41,7 @@ include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
-COMPONENT_PREP_ACTION=	cd $(@D) && NOCONFIGURE=1 ./autogen.sh
+#COMPONENT_PREP_ACTION=	cd $(@D) && NOCONFIGURE=1 ./autogen.sh
 
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --libexecdir=$(CONFIGURE_LIBDIR.$(BITS))/mate

--- a/components/desktop/mate/mate-session-manager/manifests/sample-manifest.p5m
+++ b/components/desktop/mate/mate-session-manager/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -118,6 +118,7 @@ file path=usr/share/locale/ks/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/ku/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/ku_IQ/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/ky/LC_MESSAGES/mate-session-manager.mo
+file path=usr/share/locale/la/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/li/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/lo/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/lt/LC_MESSAGES/mate-session-manager.mo

--- a/components/desktop/mate/mate-session-manager/mate-session-manager.p5m
+++ b/components/desktop/mate/mate-session-manager/mate-session-manager.p5m
@@ -124,6 +124,7 @@ file path=usr/share/locale/ks/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/ku/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/ku_IQ/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/ky/LC_MESSAGES/mate-session-manager.mo
+file path=usr/share/locale/la/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/li/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/lo/LC_MESSAGES/mate-session-manager.mo
 file path=usr/share/locale/lt/LC_MESSAGES/mate-session-manager.mo


### PR DESCRIPTION
This is the 7th in a series of MATE-related updates, all part of the 1.26.0 update.

For dependency reasons, I tackled the packages in several "groups".

mate-session-manager is part of "Group 1". The packages in that group can be built in any order.

I used this 1.26.0 version of mate-session-manager with the 1.24.x components from later groups until I had each of those components updated.  I didn't detect any problems mixing mate-session-manager 1.26.0 with the older components.

I see I skipped the configure rebuild for this package;  I don't think that's particularly important, but if you would like it reinstated, I can push a commit with that back in place.