### PR TITLE
mate-terminal: update to 1.26.0

### DIFF
--- a/components/desktop/mate/mate-terminal/Makefile
+++ b/components/desktop/mate/mate-terminal/Makefile
@@ -11,6 +11,7 @@
 #
 # Copyright 2016 Alexander Pyhalov
 # Copyright 2020 Michal Nowak
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -18,16 +19,16 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-terminal
-COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	1
-COMPONENT_VERSION=      $(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
-COMPONENT_PROJECT_URL=  https://www.mate-desktop.org
-COMPONENT_SUMMARY=      MATE terminal emulator
-COMPONENT_FMRI=			terminal/mate-terminal
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	0
+COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
+COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
+COMPONENT_SUMMARY=	MATE terminal emulator
+COMPONENT_FMRI=		terminal/mate-terminal
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:550d38f223d21ab12d39b00af6cd75f083d3790c38d53051537df2ac6a87be62
+	sha256:7727e714c191c3c55e535e30931974e229ca5128e052b62ce74dcc18f7eaaf22
 COMPONENT_ARCHIVE_URL=  https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3
 COMPONENT_LICENSE_FILE=	COPYING
@@ -49,6 +50,7 @@ COMPONENT_INSTALL_ENV += GCONF_DISABLE_MAKEFILE_SCHEMA_INSTALL=1
 REQUIRED_PACKAGES += library/desktop/mate/mate-common
 REQUIRED_PACKAGES += library/gnome/yelp-tools
 REQUIRED_PACKAGES += text/itstool
+
 # Auto-generated dependencies
 REQUIRED_PACKAGES += gnome/config/dconf
 REQUIRED_PACKAGES += library/desktop/atk

--- a/components/desktop/mate/mate-terminal/pkg5
+++ b/components/desktop/mate/mate-terminal/pkg5
@@ -13,6 +13,7 @@
         "library/gnome/yelp-tools",
         "runtime/perl-522",
         "runtime/perl-524",
+        "shell/ksh93",
         "system/library",
         "text/itstool",
         "x11/library/libice",


### PR DESCRIPTION
Technically the 5th package in the 2nd batch ("Group 2") of MATE packages, but like all the earlier packages in this batch, it only needs `mate-common`, which is already updated, so this could be built in any order with packages from "Group 1".

Nothing really changed from a packaging perspective.