### PR TITLE
mate-system-monitor: update to 1.26.0

### DIFF
--- a/components/desktop/mate/mate-system-monitor/Makefile
+++ b/components/desktop/mate/mate-system-monitor/Makefile
@@ -12,6 +12,7 @@
 # Copyright 2016 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
 # Copyright 2020 Marco van Wieringen
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -19,15 +20,14 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-system-monitor
-COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	2
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
-COMPONENT_REVISION=		1
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE system monitor
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= 
+COMPONENT_ARCHIVE_HASH= sha256:83472c3add79e52b2fb3c1bc55f33f968c71a2b90e2b62027ad688c1cecc338f
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		desktop/system-monitor/mate-system-monitor
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
@@ -47,6 +47,8 @@ COMPONENT_PREP_ACTION =        ( cd $(@D) && autoreconf -fi )
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 CONFIGURE_OPTIONS+=	--libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
 CONFIGURE_OPTIONS+=	--disable-static
+# wnck is now optional, but previous versions had it, so enable:
+CONFIGURE_OPTIONS+=	--enable-wnck
 
 CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 


### PR DESCRIPTION
Technically the 6th (and last) package inthe 2nd batch ("Group 2") of MATE updates, like all of the others so far in this batch, the only thing this needs from earlier packages is `mate-common`, so this could be built in any order with anything from "Group 1".

Packages from "Group 2":
- `mate-calc` #7459 
- `mate-desktop` #7460 
- `mate-menus` #7461 
- `marco` #7462 
- `mate-terminal` #7463 
- `mate-system-monitor` #7464 

Of this batch, `marco` is the only one that _might_ require coordination with the later rebuild of its dependency.

As far as `mate-system-monitor`, about the only packaging change was that `libwnck` changed to be an optional dependency.  Since previous versions have required it, I enabled it to keep it as a dependency.

Nothing else changed, even the `sample-manifest` or `pkg5` metadata. 