### PR TITLE
mate-panel: update to 1.26.0

### DIFF
--- a/components/desktop/mate/mate-panel/Makefile
+++ b/components/desktop/mate/mate-panel/Makefile
@@ -20,18 +20,16 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-panel
-COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	2
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
-COMPONENT_REVISION=		1
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	The Panel of Mate
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:30c5ba0392ec76b110220ee6d10bbdba76af36586592a6b3d604db70602848ea
+COMPONENT_ARCHIVE_HASH= sha256:092e1ed2177b3a13cfb7df19667b06083009210e48294c18c8a68b9b3c47ea64
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE= GPLv2, LGPLv2, FDLv1.1
-COMPONENT_LICENSE_FILE= $(COMPONENT_NAME).license
 COMPONENT_CLASSIFICATION = System/Libraries
 COMPONENT_FMRI = desktop/mate/$(COMPONENT_NAME)
 
@@ -46,9 +44,7 @@ COMPONENT_PREP_ACTION=	cd $(@D)  && NOCONFIGURE=1 ./autogen.sh
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --libexecdir=$(CONFIGURE_LIBDIR.$(BITS))/mate
 CONFIGURE_OPTIONS+= --disable-static
-CONFIGURE_OPTIONS+= --disable-scrollkeeper
 CONFIGURE_OPTIONS+= --localstatedir=/var/lib
-CONFIGURE_OPTIONS+= --with-gtk=2.0
 
 CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 
@@ -57,8 +53,12 @@ COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
 # Build requires
 REQUIRED_PACKAGES += text/itstool
-# Auto-generated dependencies
+
+# were part of the auto-generated for 1.24.x, no longer detected
 REQUIRED_PACKAGES += image/library/librsvg
+REQUIRED_PACKAGES += system/library/libdbus-glib
+
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/atk
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
@@ -70,7 +70,6 @@ REQUIRED_PACKAGES += library/desktop/mate/mate-menus
 REQUIRED_PACKAGES += library/desktop/pango
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += system/library/libdbus-glib
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libice
 REQUIRED_PACKAGES += x11/library/libsm


### PR DESCRIPTION
This is the first package in the 3rd batch of MATE packages ("Group 3").  Packages in this group may require packages from "Group 1" or "Group 2".

Packages in this batch start to have some significant changes from previous versions, so in general more thorough review and testing will be needed with some of these.

Changes of note:
- remove the deprecated `--disable-scrollkeeper` and `--with-gtk=2.0` options.  `configure` just warned about them. 
- `system/library/libdbus-glib` is no longer detected as a required dependency.  I can't tell from the ChangeLog or NEWS if this should be expected or not, so I'm at least a little concerned about it.  I moved it to the manually-specified list of packages so for now the `pkg5` dependencies didn't change, but if it's truly no longer needed (rather than being some breaking change that we would want to fix or revert) it should be dropped from the depencencies.
