### PR TITLE
mate-power-manager: update to 1.26.0

### DIFF
--- a/components/desktop/mate/mate-power-manager/Makefile
+++ b/components/desktop/mate/mate-power-manager/Makefile
@@ -12,6 +12,7 @@
 # Copyright (c) 2018 Alexander Pyhalov
 # Copyright (c) 2019 Michal Nowak
 # Copyright (c) 2020 Marco van Wieringen
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -19,14 +20,14 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mate-power-manager
-COMPONENT_MJR_VERSION=  1.24
-COMPONENT_MNR_VERSION=  3
+COMPONENT_MJR_VERSION=  1.26
+COMPONENT_MNR_VERSION=  0
 COMPONENT_VERSION=      $(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=  https://www.mate-desktop.org
 COMPONENT_SUMMARY=      MATE Power Manager utilities for desktop users
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:861e6ddf9e29f7a9bc8424092b8266c05871302bd04cfb252e83c211e3cdace6
+COMPONENT_ARCHIVE_HASH= sha256:26b603ccf077366414a41e91ca6aa4c4c227a8e9fb6925a8ec5ca147c4e67b79
 COMPONENT_ARCHIVE_URL=  https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		desktop/mate/mate-power-manager
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
@@ -44,7 +45,7 @@ COMPONENT_PREP_ACTION =        ( cd $(@D) && autoreconf -fi )
 CONFIGURE_OPTIONS+=	--libexecdir=/usr/lib/mate
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 # Needs library/gnome/gnome-keyring >= 3.0.0
-CONFIGURE_OPTIONS+=	--without-keyring
+#CONFIGURE_OPTIONS+=	--without-keyring
 
 CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 CONFIGURE_ENV+= PERL="$(PERL)"
@@ -58,6 +59,7 @@ REQUIRED_PACKAGES += library/desktop/pango
 REQUIRED_PACKAGES += library/desktop/xdg/libcanberra
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += library/libnotify
+REQUIRED_PACKAGES += library/libsecret
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/libdbus
 REQUIRED_PACKAGES += system/library/libdbus-glib

--- a/components/desktop/mate/mate-power-manager/patches/05-correct-policy.patch
+++ b/components/desktop/mate/mate-power-manager/patches/05-correct-policy.patch
@@ -1,3 +1,7 @@
+Note: tiny modification (in place) at 1.26.0 to get the 
+      gpm_manager_correct_policy(manager, &policy);
+      to apply after minor nearby changes.
+
 We want to have 'hibernate/sleep' policy by default, when it's supported, but if suspend/hibernate is
 not supported, we avoid doing anything excepting critical actions.
 So we correct policy: set it to "Do nothing" when shutdown/hibernate/sleep is not supported and 
@@ -40,7 +44,7 @@ diff -ur mate-power-manager-1.18.1-1/src/gpm-manager.c mate-power-manager-1.18.1
 +
 +		old_policy = *policy;
 +		*policy = GPM_ACTION_POLICY_NOTHING;
-+		egg_debug ("corrected policy: set policy to %i (as %i is not supported or allowed)", *policy, old_policy);
++		g_debug ("corrected policy: set policy to %i (as %i is not supported or allowed)", *policy, old_policy);
 +        }
 +}
 +
@@ -50,12 +54,12 @@ diff -ur mate-power-manager-1.18.1-1/src/gpm-manager.c mate-power-manager-1.18.1
 @@ -680,6 +703,8 @@
  
  	policy = g_settings_get_enum (manager->priv->settings, policy_key);
- 	egg_debug ("action: %s set to %i (%s)", policy_key, policy, reason);
+ 	g_debug ("action: %s set to %i (%s)", policy_key, policy, reason);
 +      
 +        gpm_manager_correct_policy(manager, &policy);
  
  	if (policy == GPM_ACTION_POLICY_NOTHING) {
- 		egg_debug ("doing nothing, reason: %s", reason);
+ 		g_debug ("doing nothing, reason: %s", reason);
 @@ -728,6 +753,8 @@
  	else
  		policy = g_settings_get_enum (manager->priv->settings, GPM_SETTINGS_ACTION_SLEEP_TYPE_BATT);

--- a/components/desktop/mate/mate-power-manager/patches/06-screensaver.patch
+++ b/components/desktop/mate/mate-power-manager/patches/06-screensaver.patch
@@ -1,3 +1,6 @@
+Note: minor modification to this patch in-place at 1.26.0, changing
+instances of egg_debug to g_debug.
+
 Run screensaver on suspend/hibernate
 
 diff -ur mate-power-manager-1.18.1/data/org.mate.power-manager.gschema.xml.in mate-power-manager-new/data/org.mate.power-manager.gschema.xml.in
@@ -85,7 +88,7 @@ diff -ur mate-power-manager-1.18.1/src/gpm-screensaver.c mate-power-manager-new/
 +      command = g_strdup ("/usr/bin/xdg-screensaver lock");   
 +      screen = gdk_screen_get_default ();
 +
-+      egg_debug ("Doing xdg-screensaver lock");
++      g_debug ("Doing xdg-screensaver lock");
 +      if (!gpm_screensaver_gdk_spawn_command_line_on_screen (screen, command, &error)) {
 +              g_warning ("Cannot lock screen: %s", error->message);
 +              g_error_free (error);
@@ -95,7 +98,7 @@ diff -ur mate-power-manager-1.18.1/src/gpm-screensaver.c mate-power-manager-new/
 +      /* TODO: Make sure screen locking takes effect until both point 
 +       * and keyboard are grabbed successfully.
 +       */
-+      egg_debug ("Screen locking is sucessful!, sleepcount = %d", sleepcount);
++      g_debug ("Screen locking is sucessful!, sleepcount = %d", sleepcount);
 +#else
  
  	g_return_val_if_fail (GPM_IS_SCREENSAVER (screensaver), FALSE);

--- a/components/desktop/mate/mate-power-manager/pkg5
+++ b/components/desktop/mate/mate-power-manager/pkg5
@@ -9,6 +9,8 @@
         "library/desktop/xdg/libcanberra",
         "library/glib2",
         "library/libnotify",
+        "library/libsecret",
+        "shell/ksh93",
         "system/library",
         "system/library/libdbus",
         "system/library/libdbus-glib",


### PR DESCRIPTION
This is the 5th package in the 5th batch ("Group 5") of MATE package updates.

Changes of note:
- I needed to adjust a couple of our local patches to get everything to apply.  The changes were mainly pretty easy, and I'm not as concerned about these patches as I am about some of the earlier and more extensive patches I've mentioned in other PRs.  In several cases it was just a change from the older `egg_debug` to `g_debug`, with no other source changes.
- the `Makefile` has previously passed `--without-keyring` with a comment about needing gnome-keyring >= 3.0.0, but we've been shipping that for a while, so I removed the `--without-keyring` option, allowing configure to find what we have.  This **didn't** result in a dependency on `gnome-keyring`, but `gmake REQUIRED_PACKAGES` did add `library/libsecret`