### PR TITLE
caja-extensions: update to 1.26.0

### DIFF
--- a/components/desktop/mate/caja-extensions/Makefile
+++ b/components/desktop/mate/caja-extensions/Makefile
@@ -12,6 +12,7 @@
 # Copyright 2016 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
 # Copyright 2020 Marco van Wieringen
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -19,15 +20,15 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		caja-extensions
-COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	1
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	Set of extensions for Caja, the MATE file manager
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:8533c3e0d3b0984eac284168744ecd12f8d0bdd914b908b4b71a496c95f5538e
+	sha256:f01539530840f8bd32ad119fab346cac214149dec74a69ae65a39442fdd8fc0f
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_CLASSIFICATION=	Desktop (GNOME)/File Managers
 COMPONENT_FMRI=		desktop/mate/caja/caja-extensions
@@ -45,7 +46,10 @@ COMPONENT_PREP_ACTION=  cd $(@D) && NOCONFIGURE=1 ./autogen.sh
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 CONFIGURE_OPTIONS+=	--libexecdir=$(CONFIGURE_LIBDIR$(BITS))/mate
 CONFIGURE_OPTIONS+=	--disable-static
+# if we add gupnp libraries there may be additional functionality or
+# extensions related to sendto
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += desktop/mate/caja
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
 REQUIRED_PACKAGES += library/desktop/gtk3

--- a/components/desktop/mate/caja-extensions/caja-extensions.p5m
+++ b/components/desktop/mate/caja-extensions/caja-extensions.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright 2017 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -40,8 +41,6 @@ file path=usr/lib/$(MACH64)/caja/extensions-2.0/libcaja-share.so
 file path=usr/lib/$(MACH64)/caja/extensions-2.0/libcaja-wallpaper.so
 file path=usr/lib/$(MACH64)/caja/extensions-2.0/libcaja-xattr-tags.so
 file path=usr/lib/$(MACH64)/pkgconfig/caja-sendto.pc
-file path=usr/share/caja-extensions/caja-image-resize.ui
-file path=usr/share/caja-extensions/caja-image-rotate.ui
 file path=usr/share/caja-extensions/share-dialog.ui
 file path=usr/share/caja/extensions/libcaja-gksu.caja-extension
 file path=usr/share/caja/extensions/libcaja-image-converter.caja-extension
@@ -82,6 +81,7 @@ file path=usr/share/locale/es/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_AR/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_CL/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_CO/LC_MESSAGES/caja-extensions.mo
+file path=usr/share/locale/es_ES/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_MX/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/et/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/eu/LC_MESSAGES/caja-extensions.mo
@@ -115,6 +115,7 @@ file path=usr/share/locale/ko/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/ku/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/ku_IQ/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/ky/LC_MESSAGES/caja-extensions.mo
+file path=usr/share/locale/li/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/lt/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/lv/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/mai/LC_MESSAGES/caja-extensions.mo

--- a/components/desktop/mate/caja-extensions/manifests/sample-manifest.p5m
+++ b/components/desktop/mate/caja-extensions/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -37,8 +37,6 @@ file path=usr/lib/$(MACH64)/caja/extensions-2.0/libcaja-share.so
 file path=usr/lib/$(MACH64)/caja/extensions-2.0/libcaja-wallpaper.so
 file path=usr/lib/$(MACH64)/caja/extensions-2.0/libcaja-xattr-tags.so
 file path=usr/lib/$(MACH64)/pkgconfig/caja-sendto.pc
-file path=usr/share/caja-extensions/caja-image-resize.ui
-file path=usr/share/caja-extensions/caja-image-rotate.ui
 file path=usr/share/caja-extensions/share-dialog.ui
 file path=usr/share/caja/extensions/libcaja-gksu.caja-extension
 file path=usr/share/caja/extensions/libcaja-image-converter.caja-extension
@@ -79,6 +77,7 @@ file path=usr/share/locale/es/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_AR/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_CL/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_CO/LC_MESSAGES/caja-extensions.mo
+file path=usr/share/locale/es_ES/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/es_MX/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/et/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/eu/LC_MESSAGES/caja-extensions.mo
@@ -112,6 +111,7 @@ file path=usr/share/locale/ko/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/ku/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/ku_IQ/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/ky/LC_MESSAGES/caja-extensions.mo
+file path=usr/share/locale/li/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/lt/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/lv/LC_MESSAGES/caja-extensions.mo
 file path=usr/share/locale/mai/LC_MESSAGES/caja-extensions.mo

--- a/components/desktop/mate/caja-extensions/pkg5
+++ b/components/desktop/mate/caja-extensions/pkg5
@@ -6,6 +6,7 @@
         "library/desktop/gtk3",
         "library/desktop/mate/mate-desktop",
         "library/glib2",
+        "shell/ksh93",
         "system/library",
         "system/library/libdbus-glib"
     ],


### PR DESCRIPTION
This is the 6th and final package in the 5th batch ("Group 5") of MATE updates.

Group 5:
- `mate-applets` #7470   Needs testing and review
- `mate-control-center` #7471  Also could use testing and review
- `mate-notification-daemon` #7472 
- `mate-utils` #7473 
- `mate-power-manager` #7474  Also could use testing and review
- `caja-extensions` (this PR)

The changes to `caja-extensions` were minor: 
- add a note in the `Makefile` that if we ever package `gupnp`, `caja-extensions` will automatically start building an additional `sendto` uPnP extension, allowing you to use uPnP directly from `caja`.
- a couple of `.ui` files are no longer installed, similar to a couple of earlier MATE packages.
- two additional localizations.
