### PR TITLE
atril: update to 1.26.0

### DIFF
--- a/components/desktop/mate/atril/Makefile
+++ b/components/desktop/mate/atril/Makefile
@@ -12,6 +12,7 @@
 # Copyright 2016 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
 # Copyright 2020 Marco van Wieringen
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -19,14 +20,14 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		atril
-COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	1
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE PDF document viewer
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:b48372a89813f31d2635de02d9e92ba38e794daddf625f06d80c3793248bde1a
+COMPONENT_ARCHIVE_HASH= sha256:715e766eaede3fa5d8ca300fa3319fb2b63055dfdc6e971d8750c2aec624e45f
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		desktop/pdf-viewer/atril
 COMPONENT_CLASSIFICATION=	Applications/Office
@@ -39,22 +40,38 @@ include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
+# gobject-introspection
+COMPONENT_BUILD_ENV += CC="$(CC)"
+COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
+COMPONENT_BUILD_ENV += GI_SCANNER_DISABLE_CACHE=""
+
 COMPONENT_PREP_ACTION=  cd $(@D) && NOCONFIGURE=1 ./autogen.sh
 
 CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 CONFIGURE_OPTIONS+=	--libexecdir=$(CONFIGURE_LIBDIR.$(BITS))/mate
 CONFIGURE_OPTIONS+=	--disable-static
-# Atril's support for epub seems broken
+CONFIGURE_OPTIONS+=	--enable-introspection
+# tested atril 1.26.0 with epub support and it's still poor.  It
+# uses webkitgtk2 for the epubs and can open some, but fails on
+# others.  Worse, Atril spawns webkitgtk2 processes for non-epub
+# documents too.  Leave epub disabled until that improves, maybe
+# with an updated webkitgtk?
 CONFIGURE_OPTIONS+=	--disable-epub
 
 CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 
+# test suite requires a python module called 'dogtail'
+# for testing GUI applications which we don't currently package.
+
 # Build dependencies
 REQUIRED_PACKAGES += library/desktop/mate/mate-common
 
+# formerly part of auto-generated, no longer included
+#REQUIRED_PACKAGES += desktop/mate/caja/caja-extensions
+#REQUIRED_PACKAGES += x11/library/libx11
+
 # Auto-generated dependencies
 REQUIRED_PACKAGES += desktop/mate/caja
-REQUIRED_PACKAGES += desktop/mate/caja/caja-extensions
 REQUIRED_PACKAGES += image/djvulibre
 REQUIRED_PACKAGES += image/library/libtiff
 REQUIRED_PACKAGES += library/desktop/atk
@@ -73,4 +90,3 @@ REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libice
 REQUIRED_PACKAGES += x11/library/libsm
-REQUIRED_PACKAGES += x11/library/libx11

--- a/components/desktop/mate/atril/atril.p5m
+++ b/components/desktop/mate/atril/atril.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright 2017 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -88,6 +89,8 @@ file path=usr/lib/$(MACH64)/atril/3/backends/pdfdocument.atril-backend
 file path=usr/lib/$(MACH64)/atril/3/backends/psdocument.atril-backend
 file path=usr/lib/$(MACH64)/atril/3/backends/tiffdocument.atril-backend
 file path=usr/lib/$(MACH64)/caja/extensions-2.0/libatril-properties-page.so
+file path=usr/lib/$(MACH64)/girepository-1.0/AtrilDocument-1.5.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/AtrilView-1.5.0.typelib
 link path=usr/lib/$(MACH64)/libatrildocument.so target=libatrildocument.so.3.0.0
 link path=usr/lib/$(MACH64)/libatrildocument.so.3 \
     target=libatrildocument.so.3.0.0
@@ -141,10 +144,60 @@ file path=usr/share/atril/icons/hicolor/scalable/actions/object-rotate-right.svg
 file path=usr/share/atril/icons/hicolor/scalable/mimetypes/x-office-presentation.svg
 file path=usr/share/caja/extensions/libatril-properties-page.caja-extension
 file path=usr/share/dbus-1/services/org.mate.atril.Daemon.service
+file path=usr/share/gir-1.0/AtrilDocument-1.5.0.gir
+file path=usr/share/gir-1.0/AtrilView-1.5.0.gir
 file path=usr/share/glib-2.0/schemas/org.mate.Atril.gschema.xml
-file path=usr/share/help/C/atril/figures/atril_start_window.png
-file path=usr/share/help/C/atril/index.docbook
+file path=usr/share/help/C/atril/annotation-properties.page
+file path=usr/share/help/C/atril/annotations-delete.page
+file path=usr/share/help/C/atril/annotations-disabled.page
+file path=usr/share/help/C/atril/annotations-navigate.page
+file path=usr/share/help/C/atril/annotations-save.page
+file path=usr/share/help/C/atril/annotations.page
+file path=usr/share/help/C/atril/bookmarks.page
+file path=usr/share/help/C/atril/bug-filing.page
+file path=usr/share/help/C/atril/commandline.page
+file path=usr/share/help/C/atril/convertPostScript.page
+file path=usr/share/help/C/atril/convertSVG.page
+file path=usr/share/help/C/atril/convertpdf.page
+file path=usr/share/help/C/atril/default-settings.page
+file path=usr/share/help/C/atril/develop.page
+file path=usr/share/help/C/atril/documentation.page
+file path=usr/share/help/C/atril/duplex-npages.page
+file path=usr/share/help/C/atril/editing.page
+file path=usr/share/help/C/atril/figures/atril-trail.png
+file path=usr/share/help/C/atril/figures/atril.png
+file path=usr/share/help/C/atril/finding.page
+file path=usr/share/help/C/atril/formats.page
+file path=usr/share/help/C/atril/forms-saving.page
+file path=usr/share/help/C/atril/forms.page
+file path=usr/share/help/C/atril/index.page
+file path=usr/share/help/C/atril/introduction.page
+file path=usr/share/help/C/atril/invert-colors.page
+file path=usr/share/help/C/atril/legal-unported.xml
 file path=usr/share/help/C/atril/legal.xml
+file path=usr/share/help/C/atril/license.page
+file path=usr/share/help/C/atril/movingaround.page
+file path=usr/share/help/C/atril/noprint.page
+file path=usr/share/help/C/atril/openerror.page
+file path=usr/share/help/C/atril/opening.page
+file path=usr/share/help/C/atril/password.page
+file path=usr/share/help/C/atril/presentations.page
+file path=usr/share/help/C/atril/print-2sided.page
+file path=usr/share/help/C/atril/print-booklet.page
+file path=usr/share/help/C/atril/print-differentsize.page
+file path=usr/share/help/C/atril/print-pagescaling.page
+file path=usr/share/help/C/atril/printing.page
+file path=usr/share/help/C/atril/reload.page
+file path=usr/share/help/C/atril/shortcuts.page
+file path=usr/share/help/C/atril/singlesided-npages.page
+file path=usr/share/help/C/atril/synctex-beamer.page
+file path=usr/share/help/C/atril/synctex-compile.page
+file path=usr/share/help/C/atril/synctex-editors.page
+file path=usr/share/help/C/atril/synctex-search.page
+file path=usr/share/help/C/atril/synctex-support.page
+file path=usr/share/help/C/atril/synctex.page
+file path=usr/share/help/C/atril/textselection.page
+file path=usr/share/help/C/atril/translate.page
 file path=usr/share/icons/hicolor/16x16/apps/atril.png
 file path=usr/share/icons/hicolor/22x22/apps/atril.png
 file path=usr/share/icons/hicolor/24x24/apps/atril.png
@@ -220,6 +273,7 @@ file path=usr/share/locale/it/LC_MESSAGES/atril.mo
 file path=usr/share/locale/ja/LC_MESSAGES/atril.mo
 file path=usr/share/locale/jv/LC_MESSAGES/atril.mo
 file path=usr/share/locale/ka/LC_MESSAGES/atril.mo
+file path=usr/share/locale/kab/LC_MESSAGES/atril.mo
 file path=usr/share/locale/kk/LC_MESSAGES/atril.mo
 file path=usr/share/locale/kn/LC_MESSAGES/atril.mo
 file path=usr/share/locale/ko/LC_MESSAGES/atril.mo

--- a/components/desktop/mate/atril/manifests/sample-manifest.p5m
+++ b/components/desktop/mate/atril/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -85,6 +85,8 @@ file path=usr/lib/$(MACH64)/atril/3/backends/pdfdocument.atril-backend
 file path=usr/lib/$(MACH64)/atril/3/backends/psdocument.atril-backend
 file path=usr/lib/$(MACH64)/atril/3/backends/tiffdocument.atril-backend
 file path=usr/lib/$(MACH64)/caja/extensions-2.0/libatril-properties-page.so
+file path=usr/lib/$(MACH64)/girepository-1.0/AtrilDocument-1.5.0.typelib
+file path=usr/lib/$(MACH64)/girepository-1.0/AtrilView-1.5.0.typelib
 link path=usr/lib/$(MACH64)/libatrildocument.so target=libatrildocument.so.3.0.0
 link path=usr/lib/$(MACH64)/libatrildocument.so.3 \
     target=libatrildocument.so.3.0.0
@@ -138,10 +140,60 @@ file path=usr/share/atril/icons/hicolor/scalable/actions/object-rotate-right.svg
 file path=usr/share/atril/icons/hicolor/scalable/mimetypes/x-office-presentation.svg
 file path=usr/share/caja/extensions/libatril-properties-page.caja-extension
 file path=usr/share/dbus-1/services/org.mate.atril.Daemon.service
+file path=usr/share/gir-1.0/AtrilDocument-1.5.0.gir
+file path=usr/share/gir-1.0/AtrilView-1.5.0.gir
 file path=usr/share/glib-2.0/schemas/org.mate.Atril.gschema.xml
-file path=usr/share/help/C/atril/figures/atril_start_window.png
-file path=usr/share/help/C/atril/index.docbook
+file path=usr/share/help/C/atril/annotation-properties.page
+file path=usr/share/help/C/atril/annotations-delete.page
+file path=usr/share/help/C/atril/annotations-disabled.page
+file path=usr/share/help/C/atril/annotations-navigate.page
+file path=usr/share/help/C/atril/annotations-save.page
+file path=usr/share/help/C/atril/annotations.page
+file path=usr/share/help/C/atril/bookmarks.page
+file path=usr/share/help/C/atril/bug-filing.page
+file path=usr/share/help/C/atril/commandline.page
+file path=usr/share/help/C/atril/convertPostScript.page
+file path=usr/share/help/C/atril/convertSVG.page
+file path=usr/share/help/C/atril/convertpdf.page
+file path=usr/share/help/C/atril/default-settings.page
+file path=usr/share/help/C/atril/develop.page
+file path=usr/share/help/C/atril/documentation.page
+file path=usr/share/help/C/atril/duplex-npages.page
+file path=usr/share/help/C/atril/editing.page
+file path=usr/share/help/C/atril/figures/atril-trail.png
+file path=usr/share/help/C/atril/figures/atril.png
+file path=usr/share/help/C/atril/finding.page
+file path=usr/share/help/C/atril/formats.page
+file path=usr/share/help/C/atril/forms-saving.page
+file path=usr/share/help/C/atril/forms.page
+file path=usr/share/help/C/atril/index.page
+file path=usr/share/help/C/atril/introduction.page
+file path=usr/share/help/C/atril/invert-colors.page
+file path=usr/share/help/C/atril/legal-unported.xml
 file path=usr/share/help/C/atril/legal.xml
+file path=usr/share/help/C/atril/license.page
+file path=usr/share/help/C/atril/movingaround.page
+file path=usr/share/help/C/atril/noprint.page
+file path=usr/share/help/C/atril/openerror.page
+file path=usr/share/help/C/atril/opening.page
+file path=usr/share/help/C/atril/password.page
+file path=usr/share/help/C/atril/presentations.page
+file path=usr/share/help/C/atril/print-2sided.page
+file path=usr/share/help/C/atril/print-booklet.page
+file path=usr/share/help/C/atril/print-differentsize.page
+file path=usr/share/help/C/atril/print-pagescaling.page
+file path=usr/share/help/C/atril/printing.page
+file path=usr/share/help/C/atril/reload.page
+file path=usr/share/help/C/atril/shortcuts.page
+file path=usr/share/help/C/atril/singlesided-npages.page
+file path=usr/share/help/C/atril/synctex-beamer.page
+file path=usr/share/help/C/atril/synctex-compile.page
+file path=usr/share/help/C/atril/synctex-editors.page
+file path=usr/share/help/C/atril/synctex-search.page
+file path=usr/share/help/C/atril/synctex-support.page
+file path=usr/share/help/C/atril/synctex.page
+file path=usr/share/help/C/atril/textselection.page
+file path=usr/share/help/C/atril/translate.page
 file path=usr/share/icons/hicolor/16x16/apps/atril.png
 file path=usr/share/icons/hicolor/22x22/apps/atril.png
 file path=usr/share/icons/hicolor/24x24/apps/atril.png
@@ -217,6 +269,7 @@ file path=usr/share/locale/it/LC_MESSAGES/atril.mo
 file path=usr/share/locale/ja/LC_MESSAGES/atril.mo
 file path=usr/share/locale/jv/LC_MESSAGES/atril.mo
 file path=usr/share/locale/ka/LC_MESSAGES/atril.mo
+file path=usr/share/locale/kab/LC_MESSAGES/atril.mo
 file path=usr/share/locale/kk/LC_MESSAGES/atril.mo
 file path=usr/share/locale/kn/LC_MESSAGES/atril.mo
 file path=usr/share/locale/ko/LC_MESSAGES/atril.mo

--- a/components/desktop/mate/atril/pkg5
+++ b/components/desktop/mate/atril/pkg5
@@ -2,7 +2,6 @@
     "dependencies": [
         "SUNWcs",
         "desktop/mate/caja",
-        "desktop/mate/caja/caja-extensions",
         "image/djvulibre",
         "image/library/libtiff",
         "library/desktop/atk",
@@ -18,11 +17,11 @@
         "library/libsynctex",
         "library/libxml2",
         "library/zlib",
+        "shell/ksh93",
         "system/library",
         "system/library/math",
         "x11/library/libice",
-        "x11/library/libsm",
-        "x11/library/libx11"
+        "x11/library/libsm"
     ],
     "fmris": [
         "desktop/pdf-viewer/atril"


### PR DESCRIPTION
This is the first (of just 2) packages in the 6th and final batch ("Group 6") of MATE package updates.

Overall `atril` was easier to update than many of the components that have significant local customizations.

Changes of note:
- I noticed that atril supported (for 64 bit builds, which it is) g-object-introspection but the Makefile was missing the necessary settings, so I added them.
- with the `configure` environment set up for `g-object-introspection`, some additional introspection-related files were installed.
- I tested whether Aurélien's comment in the Makefile about epub files was still true, and it is.  Atril requires `webkitgtk2` for epub support and with that enabled, the behavior is very poor.  I updated the comment and left `epub` disabled.
- I added a note that this is a testsuite of sorts, but it requires a python module (`dogtail`) that we don't currently ship.  If we ever add that, we could at least manually run the test suite.
- `desktop/mate/caja/caja-extensions` were formerly in the auto-generated dependencies, but `gmake REQUIRED_PACKAGES` no longer includes that.  I made a note but didn't manually force the dependency.
- strangely, `x11/library/libx11` is also no longer part of the auto-generated dependencies.  `libice` and `libsm` are still detected, but not `libx11`, which seems weird.
- some additional help files and one new localization file are installed.
