### PR TITLE
engrampa: update to 1.26.0

### DIFF
--- a/components/desktop/mate/engrampa/Makefile
+++ b/components/desktop/mate/engrampa/Makefile
@@ -12,6 +12,7 @@
 # Copyright 2016 Alexander Pyhalov
 # Copyright 2019 Michal Nowak
 # Copyright 2020 Marco van Wieringen
+# Copyright (c) 2021 Tim Mooney.  All rights reserved
 #
 
 BUILD_BITS=		64
@@ -19,14 +20,14 @@ BUILD_BITS=		64
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		engrampa
-COMPONENT_MJR_VERSION=	1.24
-COMPONENT_MNR_VERSION=	2
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	0
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
 COMPONENT_PROJECT_URL=	https://www.mate-desktop.org
 COMPONENT_SUMMARY=	MATE archive manager
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH=	sha256:ee280d288c974732ec7bc2d1c3e18fa563b33a30f3e4cb3e976ebc71be6c4674
+COMPONENT_ARCHIVE_HASH=	sha256:97cdb2c22c32315a38803d4147dfad9de7309e30ce8f37ac9f600709ad075ee3
 COMPONENT_ARCHIVE_URL=	https://pub.mate-desktop.org/releases/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		desktop/archive-manager/engrampa
 COMPONENT_CLASSIFICATION=	Desktop (GNOME)/File Managers
@@ -45,6 +46,7 @@ CONFIGURE_OPTIONS+=	--disable-static
 
 CONFIGURE_ENV+= PYTHON="$(PYTHON)"
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += desktop/mate/caja
 REQUIRED_PACKAGES += library/desktop/cairo
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
@@ -54,3 +56,5 @@ REQUIRED_PACKAGES += library/desktop/pango
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libice
+REQUIRED_PACKAGES += x11/library/libsm

--- a/components/desktop/mate/engrampa/pkg5
+++ b/components/desktop/mate/engrampa/pkg5
@@ -8,8 +8,11 @@
         "library/desktop/json-glib",
         "library/desktop/pango",
         "library/glib2",
+        "shell/ksh93",
         "system/library",
-        "system/library/math"
+        "system/library/math",
+        "x11/library/libice",
+        "x11/library/libsm"
     ],
     "fmris": [
         "desktop/archive-manager/engrampa"


### PR DESCRIPTION
This is the 2nd (and final) package update in the 6th (and final) batch ("Group 6") of MATE applications.

Group 6 contains:
- `atril` #7476 
- `engrampa` (this PR)

The update to `engrampa` was much easier than many components.  The only changes were newly detected auto-dependencies on `x11/library/libice` and `x11/library/libsm`.

Other MATE-related areas of investigation that I have **not** done:
- I thought I had rebuilt `compiz` on my build box because of the slight changes in `marco`, but it turns out I did not, so `compiz` has been running without a rebuild.  It's possible a rebuild would be useful.
- there are other MATE packages which might be new(ish) that we don't currently package.  I haven't looked at any of them, but I will if anyone thinks a particular package would be useful.  Of the packages I know of:

1. pluma-plugins
2. caja-actions
3. caja-dropbox
4. mate-indicator-applet
5. mate-sensors-applet
6. mate-user-share
7. python-caja

From that list, I'm pretty sure the caja-dropbox requires a closed-source binary blob from Dropbox, and it's probably only available for Linux, so probably not an option for us.

Also, for `mate-indicator-applet`, it seems like several of the freedesktop.org desktop environments are settled on something called "Ayatana indicators" , so if we want `mate-indicator-applet` I suspect we're going to need to investigate the Ayatana components.