### PR TITLE
update bcrypt & add python-3.7 and 3.9 versions

### DIFF
--- a/components/python/bcrypt-legacy/Makefile
+++ b/components/python/bcrypt-legacy/Makefile
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 Alexander Pyhalov
+#
+
+# Component uses ABI3 naming.
+PYTHON3_SOABI= abi3
+BUILD_BITS= 64_and_32
+BUILD_STYLE= setup.py
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		bcrypt
+COMPONENT_VERSION=	3.1.7
+COMPONENT_SUMMARY=	Modern password hashing for your software and your servers
+COMPONENT_PROJECT_URL=	https://github.com/pyca/bcrypt/
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42
+COMPONENT_ARCHIVE_URL=	$(call pypi_url)
+COMPONENT_FMRI=	library/python/bcrypt
+COMPONENT_CLASSIFICATION=	Development/Python
+COMPONENT_LICENSE=	Apache-2.0
+COMPONENT_LICENSE_FILE=	LICENSE
+
+PYTHON_VERSIONS=	2.7 3.5
+
+# We don't support tests for legacy python modules
+TEST_TARGET=	$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/python-27
+REQUIRED_PACKAGES += runtime/python-35
+REQUIRED_PACKAGES += system/library

--- a/components/python/bcrypt-legacy/bcrypt-PYVER.p5m
+++ b/components/python/bcrypt-legacy/bcrypt-PYVER.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2018 Alexander Pyhalov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/not-zip-safe
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/requires.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/64/_bcrypt.so
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/__about__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/_bcrypt.so

--- a/components/python/bcrypt-legacy/history
+++ b/components/python/bcrypt-legacy/history
@@ -1,0 +1,1 @@
+library/python/bcrypt-34@3.1.5,5.11-2020.0.1.1

--- a/components/python/bcrypt-legacy/manifests/generic-manifest.p5m
+++ b/components/python/bcrypt-legacy/manifests/generic-manifest.p5m
@@ -1,0 +1,28 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2021 <contributor>
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/not-zip-safe
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/requires.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/64/_bcrypt.so
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/__about__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/_bcrypt.so
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/_bcrypt.abi3.so

--- a/components/python/bcrypt-legacy/manifests/sample-manifest.p5m
+++ b/components/python/bcrypt-legacy/manifests/sample-manifest.p5m
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2021 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/PKG-INFO
+file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/SOURCES.txt
+file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/dependency_links.txt
+file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/not-zip-safe
+file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/requires.txt
+file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/top_level.txt
+file path=usr/lib/python2.7/vendor-packages/bcrypt/64/_bcrypt.so
+file path=usr/lib/python2.7/vendor-packages/bcrypt/__about__.py
+file path=usr/lib/python2.7/vendor-packages/bcrypt/__init__.py
+file path=usr/lib/python2.7/vendor-packages/bcrypt/_bcrypt.so
+file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/PKG-INFO
+file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/SOURCES.txt
+file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/dependency_links.txt
+file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/not-zip-safe
+file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/requires.txt
+file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
+file path=usr/lib/python3.5/vendor-packages/bcrypt/__about__.py
+file path=usr/lib/python3.5/vendor-packages/bcrypt/__init__.py
+file path=usr/lib/python3.5/vendor-packages/bcrypt/_bcrypt.abi3.so

--- a/components/python/bcrypt-legacy/pkg5
+++ b/components/python/bcrypt-legacy/pkg5
@@ -1,0 +1,15 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "runtime/python-27",
+        "runtime/python-35",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "library/python/bcrypt-27",
+        "library/python/bcrypt-35",
+        "library/python/bcrypt"
+    ],
+    "name": "bcrypt"
+}

--- a/components/python/bcrypt/Makefile
+++ b/components/python/bcrypt/Makefile
@@ -10,53 +10,58 @@
 
 #
 # Copyright 2018 Alexander Pyhalov
+# Copyright 2021 Andreas Wacknitz
 #
 
 # Component uses ABI3 naming.
-PYTHON3_SOABI=abi3
-
+PYTHON3_SOABI= abi3
+BUILD_BITS= 64
+BUILD_STYLE= setup.py
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		bcrypt
-COMPONENT_VERSION=	3.1.5
-COMPONENT_REVISION=	1
-COMPONENT_SUMMARY=	'Modern password hashing for your software and your servers'
+COMPONENT_VERSION=	3.2.0
+COMPONENT_SUMMARY=	Modern password hashing for your software and your servers
 COMPONENT_PROJECT_URL=	https://github.com/pyca/bcrypt/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	\
-    sha256:136243dc44e5bab9b61206bd46fff3018bd80980b1a1dfbab64a22ff5745957f
+COMPONENT_ARCHIVE_HASH= sha256:5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29
 COMPONENT_ARCHIVE_URL=	$(call pypi_url)
 COMPONENT_FMRI=	library/python/bcrypt
 COMPONENT_CLASSIFICATION=	Development/Python
 COMPONENT_LICENSE=	Apache-2.0
 COMPONENT_LICENSE_FILE=	LICENSE
 
-PYTHON_VERSIONS=	2.7 3.5
+PYTHON_VERSIONS=	3.7 3.9
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
-TEST_PYTHONPATH = $(PROTO_DIR)/usr/lib/python$(PYTHON_VERSION)/vendor-packages
+TEST_PYTHONPATH= $(PROTO_DIR)/usr/lib/python$(PYTHON_VERSION)/vendor-packages
 
-COMPONENT_TEST_ENV = PYTHONPATH=$(TEST_PYTHONPATH)
-COMPONENT_TEST_DIR =    $(COMPONENT_SRC)/tests
-COMPONENT_TEST_CMD =    $(PYTHON) /usr/bin/py.test-$(PYTHON_VERSION)
-COMPONENT_TEST_ARGS =   test_bcrypt.py
-
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:           $(TEST_32_and_64)
+COMPONENT_TEST_ENV=	PYTHONPATH=$(TEST_PYTHONPATH)
+COMPONENT_TEST_DIR=	$(COMPONENT_SRC)/tests
+COMPONENT_TEST_CMD=	$(PYTHON) /usr/bin/py.test-$(PYTHON_VERSION)
+COMPONENT_TEST_ARGS=	test_bcrypt.py
 
 # Test dependencies
-REQUIRED_PACKAGES += library/python/pytest-27
-REQUIRED_PACKAGES += library/python/pytest-35
+REQUIRED_PACKAGES += library/python/flaky-37
+REQUIRED_PACKAGES += library/python/flaky-39
+REQUIRED_PACKAGES += library/python/hypothesis-37
+REQUIRED_PACKAGES += library/python/hypothesis-39
+REQUIRED_PACKAGES += library/python/py-37
+REQUIRED_PACKAGES += library/python/py-39
+REQUIRED_PACKAGES += library/python/pyparsing-37
+REQUIRED_PACKAGES += library/python/pyparsing-39
+REQUIRED_PACKAGES += library/python/pytest-37
+REQUIRED_PACKAGES += library/python/pytest-39
+REQUIRED_PACKAGES += library/python/pytest-benchmark-37
+REQUIRED_PACKAGES += library/python/pytest-benchmark-39
+REQUIRED_PACKAGES += library/python/pytest-reporter-37
+REQUIRED_PACKAGES += library/python/pytest-reporter-39
+REQUIRED_PACKAGES += library/python/sortedcontainers-37
+REQUIRED_PACKAGES += library/python/sortedcontainers-39
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += runtime/python-27
-REQUIRED_PACKAGES += runtime/python-35
+REQUIRED_PACKAGES += runtime/python-37
+REQUIRED_PACKAGES += runtime/python-39
 REQUIRED_PACKAGES += system/library

--- a/components/python/bcrypt/history
+++ b/components/python/bcrypt/history
@@ -1,1 +1,0 @@
-library/python/bcrypt-34@3.1.5,5.11-2020.0.1.1

--- a/components/python/bcrypt/manifests/generic-manifest.p5m
+++ b/components/python/bcrypt/manifests/generic-manifest.p5m
@@ -7,24 +7,14 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-#
-# Copyright 2018 Alexander Pyhalov
-# Copyright 2021 Andreas Wacknitz
-#
-
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(COMPONENT_VERSION),$(BUILD_VERSION)
+# Copyright 2021 <contributor>
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
-
-# force a dependency on the Python $(PYVER) runtime
-depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
-    pkg.debug.depend.path=usr/bin
-
 file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
 file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
 file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
@@ -33,5 +23,5 @@ file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$
 file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
 file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/__about__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/__init__.py
-file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/_bcrypt.so
+file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/_bcrypt.abi3.so
 file path=usr/lib/python$(PYVER)/vendor-packages/bcrypt/py.typed

--- a/components/python/bcrypt/manifests/sample-manifest.p5m
+++ b/components/python/bcrypt/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,32 +22,23 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/PKG-INFO
-file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/SOURCES.txt
-file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/dependency_links.txt
-file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/not-zip-safe
-file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/requires.txt
-file path=usr/lib/python2.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py2.7.egg-info/top_level.txt
-file path=usr/lib/python2.7/vendor-packages/bcrypt/64/_bcrypt.so
-file path=usr/lib/python2.7/vendor-packages/bcrypt/__about__.py
-file path=usr/lib/python2.7/vendor-packages/bcrypt/__init__.py
-file path=usr/lib/python2.7/vendor-packages/bcrypt/_bcrypt.so
-file path=usr/lib/python3.4/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.4.egg-info/PKG-INFO
-file path=usr/lib/python3.4/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.4.egg-info/SOURCES.txt
-file path=usr/lib/python3.4/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.4.egg-info/dependency_links.txt
-file path=usr/lib/python3.4/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.4.egg-info/not-zip-safe
-file path=usr/lib/python3.4/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.4.egg-info/requires.txt
-file path=usr/lib/python3.4/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.4.egg-info/top_level.txt
-file path=usr/lib/python3.4/vendor-packages/bcrypt/64/_bcrypt.abi3.so
-file path=usr/lib/python3.4/vendor-packages/bcrypt/__about__.py
-file path=usr/lib/python3.4/vendor-packages/bcrypt/__init__.py
-file path=usr/lib/python3.4/vendor-packages/bcrypt/_bcrypt.abi3.so
-file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/PKG-INFO
-file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/SOURCES.txt
-file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/dependency_links.txt
-file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/not-zip-safe
-file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/requires.txt
-file path=usr/lib/python3.5/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
-file path=usr/lib/python3.5/vendor-packages/bcrypt/__about__.py
-file path=usr/lib/python3.5/vendor-packages/bcrypt/__init__.py
-file path=usr/lib/python3.5/vendor-packages/bcrypt/_bcrypt.abi3.so
+file path=usr/lib/python3.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.7.egg-info/PKG-INFO
+file path=usr/lib/python3.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.7.egg-info/SOURCES.txt
+file path=usr/lib/python3.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.7.egg-info/dependency_links.txt
+file path=usr/lib/python3.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.7.egg-info/not-zip-safe
+file path=usr/lib/python3.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.7.egg-info/requires.txt
+file path=usr/lib/python3.7/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.7.egg-info/top_level.txt
+file path=usr/lib/python3.7/vendor-packages/bcrypt/__about__.py
+file path=usr/lib/python3.7/vendor-packages/bcrypt/__init__.py
+file path=usr/lib/python3.7/vendor-packages/bcrypt/_bcrypt.abi3.so
+file path=usr/lib/python3.7/vendor-packages/bcrypt/py.typed
+file path=usr/lib/python3.9/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
+file path=usr/lib/python3.9/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
+file path=usr/lib/python3.9/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
+file path=usr/lib/python3.9/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.9.egg-info/not-zip-safe
+file path=usr/lib/python3.9/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.9.egg-info/requires.txt
+file path=usr/lib/python3.9/vendor-packages/bcrypt-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
+file path=usr/lib/python3.9/vendor-packages/bcrypt/__about__.py
+file path=usr/lib/python3.9/vendor-packages/bcrypt/__init__.py
+file path=usr/lib/python3.9/vendor-packages/bcrypt/_bcrypt.abi3.so
+file path=usr/lib/python3.9/vendor-packages/bcrypt/py.typed

--- a/components/python/bcrypt/pkg5
+++ b/components/python/bcrypt/pkg5
@@ -1,15 +1,30 @@
 {
     "dependencies": [
         "SUNWcs",
-        "library/python/pytest-27",
-        "library/python/pytest-35",
-        "runtime/python-27",
-        "runtime/python-35",
+        "library/python/flaky-37",
+        "library/python/flaky-39",
+        "library/python/hypothesis-37",
+        "library/python/hypothesis-39",
+        "library/python/py-37",
+        "library/python/py-39",
+        "library/python/pyparsing-37",
+        "library/python/pyparsing-39",
+        "library/python/pytest-37",
+        "library/python/pytest-39",
+        "library/python/pytest-benchmark-37",
+        "library/python/pytest-benchmark-39",
+        "library/python/pytest-reporter-37",
+        "library/python/pytest-reporter-39",
+        "library/python/sortedcontainers-37",
+        "library/python/sortedcontainers-39",
+        "runtime/python-37",
+        "runtime/python-39",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "library/python/bcrypt-27",
-        "library/python/bcrypt-35",
+        "library/python/bcrypt-37",
+        "library/python/bcrypt-39",
         "library/python/bcrypt"
     ],
     "name": "bcrypt"


### PR DESCRIPTION
Latest bcrypt needs python >= 3.6 so for python-2.7 and 3.5 we stay at bcrypt-3.1.7