### PR TITLE
pycairo, pygobject: fix pkgconfig install path

### DIFF
--- a/components/python/pycairo-12/Makefile
+++ b/components/python/pycairo-12/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		pycairo
 # This version supports python 3.6+
 COMPONENT_VERSION=	1.20.1
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Python bindings for Cairo
 COMPONENT_PROJECT_URL=	http://www.cairographics.org
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -50,7 +51,7 @@ include $(WS_MAKE_RULES)/common.mk
 COMPONENT_POST_INSTALL_ACTION += \
 	(cd $(PROTOUSRINCDIR)/pycairo; $(MV) py3cairo.h py3cairo.h-$(PYTHON_VERSION)) ;
 COMPONENT_POST_INSTALL_ACTION += \
-	(cd $(PROTOUSRLIBDIR)/pkgconfig; $(MV) py3cairo.pc py3cairo.pc-$(PYTHON_VERSION)) ;
+	(cd $(PROTOUSRLIBDIR)/pkgconfig; $(MKDIR) ../$(MACH64)/pkgconfig; $(MV) py3cairo.pc ../$(MACH64)/pkgconfig/py3cairo.pc-$(PYTHON_VERSION)) ;
 
 # Tests require packages: pytest py pluggy benchmark
 COMPONENT_TEST_DIR=	$(COMPONENT_SRC)

--- a/components/python/pycairo-12/manifests/generic-manifest.p5m
+++ b/components/python/pycairo-12/manifests/generic-manifest.p5m
@@ -7,7 +7,7 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2021 <contributor>
+# Copyright 2022 <contributor>
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
@@ -16,7 +16,7 @@ set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/include/pycairo/py3cairo.h-$(PYVER)
-file path=usr/lib/pkgconfig/py3cairo.pc-$(PYVER)
+file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc-$(PYVER)
 file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.pyi
 file path=usr/lib/python$(PYVER)/vendor-packages/cairo/_cairo.cpython-37m.so

--- a/components/python/pycairo-12/manifests/sample-manifest.p5m
+++ b/components/python/pycairo-12/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2021 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,8 +24,8 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/pycairo/py3cairo.h-3.7
 file path=usr/include/pycairo/py3cairo.h-3.9
-file path=usr/lib/pkgconfig/py3cairo.pc-3.7
-file path=usr/lib/pkgconfig/py3cairo.pc-3.9
+file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc-3.7
+file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc-3.9
 file path=usr/lib/python3.7/vendor-packages/cairo/__init__.py
 file path=usr/lib/python3.7/vendor-packages/cairo/__init__.pyi
 file path=usr/lib/python3.7/vendor-packages/cairo/_cairo.cpython-37m.so

--- a/components/python/pycairo-12/pycairo-12-PYVER.p5m
+++ b/components/python/pycairo-12/pycairo-12-PYVER.p5m
@@ -39,11 +39,11 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 link path=usr/include/pycairo/py3cairo.h target=py3cairo.h-$(PYVER) \
 	mediator=python3 mediator-version=$(PYVER)
-link path=usr/lib/pkgconfig/py3cairo.pc target=py3cairo.pc-$(PYVER) \
+link path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc target=py3cairo.pc-$(PYVER) \
 	mediator=python3 mediator-version=$(PYVER)
 
 file path=usr/include/pycairo/py3cairo.h-$(PYVER)
-file path=usr/lib/pkgconfig/py3cairo.pc-$(PYVER)
+file path=usr/lib/$(MACH64)/pkgconfig/py3cairo.pc-$(PYVER)
 file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/cairo/__init__.pyi
 file path=usr/lib/python$(PYVER)/vendor-packages/cairo/_cairo.so

--- a/components/python/pygobject-3/Makefile
+++ b/components/python/pygobject-3/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		pygobject
 # This version only supports python 3.7 - 3.9 inclusive
 COMPONENT_VERSION=	3.42.0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Python bindings for GObject
 COMPONENT_PROJECT_URL=	http://www.gnome.org
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -54,7 +55,7 @@ include $(WS_MAKE_RULES)/common.mk
 COMPONENT_POST_INSTALL_ACTION += \
 	(cd $(PROTOUSRINCDIR)/pygobject-3.0; $(MV) pygobject.h pygobject.h-$(PYTHON_VERSION)) ;
 COMPONENT_POST_INSTALL_ACTION += \
-	(cd $(PROTOUSRLIBDIR)/pkgconfig; $(MV) pygobject-3.0.pc pygobject-3.0.pc-$(PYTHON_VERSION)) ;
+	(cd $(PROTOUSRLIBDIR)/pkgconfig; $(MKDIR) ../$(MACH64)/pkgconfig; $(MV) pygobject-3.0.pc ../$(MACH64)/pkgconfig/pygobject-3.0.pc-$(PYTHON_VERSION)) ;
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/cairo

--- a/components/python/pygobject-3/manifests/generic-manifest.p5m
+++ b/components/python/pygobject-3/manifests/generic-manifest.p5m
@@ -7,7 +7,7 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2021 <contributor>
+# Copyright 2022 <contributor>
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
@@ -16,7 +16,7 @@ set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/include/pygobject-3.0/pygobject.h-$(PYVER)
-file path=usr/lib/pkgconfig/pygobject-3.0.pc-$(PYVER)
+file path=usr/lib/$(MACH64)/pkgconfig/pygobject-3.0.pc-$(PYVER)
 file path=usr/lib/python$(PYVER)/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
 file path=usr/lib/python$(PYVER)/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
 file path=usr/lib/python$(PYVER)/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt

--- a/components/python/pygobject-3/manifests/sample-manifest.p5m
+++ b/components/python/pygobject-3/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2021 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,8 +24,8 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/pygobject-3.0/pygobject.h-3.7
 file path=usr/include/pygobject-3.0/pygobject.h-3.9
-file path=usr/lib/pkgconfig/pygobject-3.0.pc-3.7
-file path=usr/lib/pkgconfig/pygobject-3.0.pc-3.9
+file path=usr/lib/$(MACH64)/pkgconfig/pygobject-3.0.pc-3.7
+file path=usr/lib/$(MACH64)/pkgconfig/pygobject-3.0.pc-3.9
 file path=usr/lib/python3.7/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py3.7.egg-info/PKG-INFO
 file path=usr/lib/python3.7/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py3.7.egg-info/SOURCES.txt
 file path=usr/lib/python3.7/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py3.7.egg-info/dependency_links.txt

--- a/components/python/pygobject-3/pygobject-3-PYVER.p5m
+++ b/components/python/pygobject-3/pygobject-3-PYVER.p5m
@@ -28,11 +28,11 @@ depend type=require fmri=library/desktop/gtk3
 
 link path=usr/include/pygobject-3.0/pygobject.h target=pygobject.h-$(PYVER) \
 	mediator=python3 mediator-version=$(PYVER)
-link path=usr/lib/pkgconfig/pygobject-3.0.pc target=pygobject-3.0.pc-$(PYVER) \
+link path=usr/lib/$(MACH64)/pkgconfig/pygobject-3.0.pc target=pygobject-3.0.pc-$(PYVER) \
 	mediator=python3 mediator-version=$(PYVER)
 
 file path=usr/include/pygobject-3.0/pygobject.h-$(PYVER)
-file path=usr/lib/pkgconfig/pygobject-3.0.pc-$(PYVER)
+file path=usr/lib/$(MACH64)/pkgconfig/pygobject-3.0.pc-$(PYVER)
 file path=usr/lib/python$(PYVER)/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
 file path=usr/lib/python$(PYVER)/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
 file path=usr/lib/python$(PYVER)/vendor-packages/PyGObject-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt


### PR DESCRIPTION
During update of meld I ran into a problem with installed dependencies pygobject-3 and pycairo-39 - meld wasn't able to see them even though they were installed. When I ran `pkg contents library/python/pygobject-3-39` and `pkg contents library/python/pycairo-39` I saw that they were installed in `/usr/lib/pkgconfig/` which is the spot to install 32-bit packaged.

This PR should install them into `/usr/lib/amd64/pkgconfig/` as 64-bit package. When I installed both packages with the change, meld was able to find them and build itself.