### PR TITLE
prepare make-rules for perl 5.34

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -786,17 +786,25 @@ JAVA_HOME = $(JAVA8_HOME)
 # Not necessarily the system's default version, i.e. /usr/bin/perl
 PERL_VERSION =  5.22
 
+# Do *not* add 5.34 to PERL_VERSIONS/PERL_64_ONLY_VERSIONS yet.  We'll
+# enable it system-wide once all existing perl modules have been rebuilt
+# with support for all three current perl versions.
 PERL_VERSIONS = 5.22 5.24
+
+PERL_64_ONLY_VERSIONS = 5.24
 
 PERL.5.22 =	/usr/perl5/5.22/bin/perl
 PERL.5.24 =	/usr/perl5/5.24/bin/perl
+PERL.5.34 =	/usr/perl5/5.34/bin/perl
 
 POD2MAN.5.22 =	/usr/perl5/5.22/bin/pod2man
 POD2MAN.5.24 =	/usr/perl5/5.24/bin/pod2man
+POD2MAN.5.34 =	/usr/perl5/5.34/bin/pod2man
 
 # Location of pod2man, etc
 PERL5BINDIR.5.22 =	/usr/perl5/5.22/bin
 PERL5BINDIR.5.24 =	/usr/perl5/5.24/bin
+PERL5BINDIR.5.34 =	/usr/perl5/5.34/bin
 
 PERL5BINDIR = 	$(PERL5BINDIR.$(PERL_VERSION))
 PERL =		$(PERL.$(PERL_VERSION))


### PR DESCRIPTION
Update `makemaker.mk` and `shared-macros.mk` to prepare for the process of rebuilding existing modules with new support for `perl-534`.

As previously discussed, **these changes do NOT default perl 5.34 for all perl modules**.  The changes only set up the macros needed to add support for 5.34.  To actually start building individual modules to include 5.34, I'll have separate PRs for each module, that override `PERL_VERSIONS` and PERL_64_ONLY_VERSIONS` directly in the module.

The changes to `shared-macros.mk` are pretty straightforward.  They only specify the 5.34 equivalent of 3 macros, plus add a new macro that will be used to specify which perl runtimes are 64 bit.

The changes to `makemaker.mk` are more widespread.  They're based on updates Alexander made to `setup.py.mk` a couple years ago, when python 3.4 and python 3.5 were added.

A lot of the complicated bits with the settings in `makemaker.mk` are because we have one perl (5.22) that's 32-bit only, but the others are 64-bit only.  Once we get to the point where we are comfortable retiring 5.22, a great deal of the code in `makemaker.mk` can be simplified.
 