### PR TITLE
perl-uri: rebuild for perl 5.34

### DIFF
--- a/components/perl/URI/Makefile
+++ b/components/perl/URI/Makefile
@@ -22,29 +22,51 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2016 Alexander Pyhalov
+# Copyright (c) 2021 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		URI
 COMPONENT_VERSION=	1.71
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/uri
+COMPONENT_SUMMARY=	URI manipulation utilities
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/URI/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/URI
 COMPONENT_ARCHIVE_HASH=	\
     sha256:9c8eca0d7f39e74bbc14706293e653b699238eeb1a7690cc9c136fb8c2644115
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/O/OA/OALDERS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/makemaker.mk
-include $(WS_MAKE_RULES)/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
+
+include $(WS_MAKE_RULES)/common.mk
+
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
+
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
 
-COMPONENT_TEST_TARGETS = test
+# not autodetected, but required to build
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies

--- a/components/perl/URI/URI-PERLVER.p5m
+++ b/components/perl/URI/URI-PERLVER.p5m
@@ -11,16 +11,25 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2021 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/uri-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="URI manipulation utilities"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license URI.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# make this module depend upon the perl version it was built for.
+depend fmri=runtime/perl-$(PLV) type=require
+
+# force a dependency on the non-PLV version of this module
+depend type=require \
+    fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
 
 file path=usr/perl5/$(PERLVER)/man/man3/URI.3 mode=0444
 file path=usr/perl5/$(PERLVER)/man/man3/URI::Escape.3 mode=0444

--- a/components/perl/URI/manifests/sample-manifest.p5m
+++ b/components/perl/URI/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -46,6 +46,18 @@ file path=usr/perl5/5.24/man/man3/URI::_punycode.3
 file path=usr/perl5/5.24/man/man3/URI::data.3
 file path=usr/perl5/5.24/man/man3/URI::file.3
 file path=usr/perl5/5.24/man/man3/URI::ldap.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/URI.3
+file path=usr/perl5/5.34/man/man3/URI::Escape.3
+file path=usr/perl5/5.34/man/man3/URI::Heuristic.3
+file path=usr/perl5/5.34/man/man3/URI::QueryParam.3
+file path=usr/perl5/5.34/man/man3/URI::Split.3
+file path=usr/perl5/5.34/man/man3/URI::URL.3
+file path=usr/perl5/5.34/man/man3/URI::WithBase.3
+file path=usr/perl5/5.34/man/man3/URI::_punycode.3
+file path=usr/perl5/5.34/man/man3/URI::data.3
+file path=usr/perl5/5.34/man/man3/URI::file.3
+file path=usr/perl5/5.34/man/man3/URI::ldap.3
 file path=usr/perl5/vendor_perl/5.22/URI.pm
 file path=usr/perl5/vendor_perl/5.22/URI/Escape.pm
 file path=usr/perl5/vendor_perl/5.22/URI/Heuristic.pm
@@ -154,3 +166,57 @@ file path=usr/perl5/vendor_perl/5.24/URI/urn.pm
 file path=usr/perl5/vendor_perl/5.24/URI/urn/isbn.pm
 file path=usr/perl5/vendor_perl/5.24/URI/urn/oid.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/URI/.packlist
+file path=usr/perl5/vendor_perl/5.34/URI.pm
+file path=usr/perl5/vendor_perl/5.34/URI/Escape.pm
+file path=usr/perl5/vendor_perl/5.34/URI/Heuristic.pm
+file path=usr/perl5/vendor_perl/5.34/URI/IRI.pm
+file path=usr/perl5/vendor_perl/5.34/URI/QueryParam.pm
+file path=usr/perl5/vendor_perl/5.34/URI/Split.pm
+file path=usr/perl5/vendor_perl/5.34/URI/URL.pm
+file path=usr/perl5/vendor_perl/5.34/URI/WithBase.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_foreign.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_generic.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_idna.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_ldap.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_login.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_punycode.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_query.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_segment.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_server.pm
+file path=usr/perl5/vendor_perl/5.34/URI/_userpass.pm
+file path=usr/perl5/vendor_perl/5.34/URI/data.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file/Base.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file/FAT.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file/Mac.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file/OS2.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file/QNX.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file/Unix.pm
+file path=usr/perl5/vendor_perl/5.34/URI/file/Win32.pm
+file path=usr/perl5/vendor_perl/5.34/URI/ftp.pm
+file path=usr/perl5/vendor_perl/5.34/URI/gopher.pm
+file path=usr/perl5/vendor_perl/5.34/URI/http.pm
+file path=usr/perl5/vendor_perl/5.34/URI/https.pm
+file path=usr/perl5/vendor_perl/5.34/URI/ldap.pm
+file path=usr/perl5/vendor_perl/5.34/URI/ldapi.pm
+file path=usr/perl5/vendor_perl/5.34/URI/ldaps.pm
+file path=usr/perl5/vendor_perl/5.34/URI/mailto.pm
+file path=usr/perl5/vendor_perl/5.34/URI/mms.pm
+file path=usr/perl5/vendor_perl/5.34/URI/news.pm
+file path=usr/perl5/vendor_perl/5.34/URI/nntp.pm
+file path=usr/perl5/vendor_perl/5.34/URI/pop.pm
+file path=usr/perl5/vendor_perl/5.34/URI/rlogin.pm
+file path=usr/perl5/vendor_perl/5.34/URI/rsync.pm
+file path=usr/perl5/vendor_perl/5.34/URI/rtsp.pm
+file path=usr/perl5/vendor_perl/5.34/URI/rtspu.pm
+file path=usr/perl5/vendor_perl/5.34/URI/sftp.pm
+file path=usr/perl5/vendor_perl/5.34/URI/sip.pm
+file path=usr/perl5/vendor_perl/5.34/URI/sips.pm
+file path=usr/perl5/vendor_perl/5.34/URI/snews.pm
+file path=usr/perl5/vendor_perl/5.34/URI/ssh.pm
+file path=usr/perl5/vendor_perl/5.34/URI/telnet.pm
+file path=usr/perl5/vendor_perl/5.34/URI/tn3270.pm
+file path=usr/perl5/vendor_perl/5.34/URI/urn.pm
+file path=usr/perl5/vendor_perl/5.34/URI/urn/isbn.pm
+file path=usr/perl5/vendor_perl/5.34/URI/urn/oid.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/URI/.packlist

--- a/components/perl/URI/pkg5
+++ b/components/perl/URI/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/uri-522",
         "library/perl-5/uri-524",
+        "library/perl-5/uri-534",
         "library/perl-5/uri"
     ],
     "name": "URI"

--- a/components/perl/URI/test/results-all.master
+++ b/components/perl/URI/test/results-all.master
@@ -1,0 +1,47 @@
+t/abs.t ................... ok
+t/clone.t ................. ok
+t/cwd.t ................... ok
+t/data.t .................. ok
+t/distmanifest.t .......... skipped: these tests are for authors only!
+t/escape-char.t ........... ok
+t/escape.t ................ ok
+t/file.t .................. ok
+t/ftp.t ................... ok
+t/generic.t ............... ok
+t/gopher.t ................ ok
+t/heuristic.t ............. ok
+t/http.t .................. ok
+t/idna.t .................. ok
+t/iri.t ................... ok
+t/ldap.t .................. ok
+t/mailto.t ................ ok
+t/mix.t ................... ok
+t/mms.t ................... ok
+t/news.t .................. ok
+t/num_eq.t ................ ok
+t/old-absconf.t ........... ok
+t/old-base.t .............. ok
+t/old-file.t .............. ok
+t/old-relbase.t ........... ok
+t/path-segments.t ......... ok
+t/pop.t ................... ok
+t/punycode.t .............. ok
+t/query-param.t ........... ok
+t/query.t ................. ok
+t/rel.t ................... ok
+t/rfc2732.t ............... ok
+t/roy-test.t .............. ok
+t/rsync.t ................. ok
+t/rtsp.t .................. ok
+t/scheme-exceptions.t ..... ok
+t/sip.t ................... ok
+t/sort-hash-query-form.t .. ok
+t/split.t ................. ok
+t/storable.t .............. ok
+t/urn-isbn.t .............. skipped: Needs the Business::ISBN module installed
+t/urn-oid.t ............... ok
+t/utf8.t .................. ok
+All tests successful.
+Files=43, Tests=624
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
This PR requires that PR #7512 be committed first. It relies on updated macros being in place in `makemaker.mk` and `shared-macros.mk`. It doesn't depend upon any other perl modules already having been rebuilt, though.

Rebuild the existing URI module, adding perl 5.34 to the existing 5.22 and 5.24 builds.

`Makefile`:
1. add `BUILD_STYLE=makemaker` and `BUILD_BITS=32_and_64`
2. bump `COMPONENT_REVISION`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with settings copied from `URI-PERLVER.p5m`
4. update `COMPONENT_PROJECT_URL` and `COMPONENT_ARCHIVE_URL` to use https and current locations
5. override `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` to include 5.34
6. switch to using `include $(WS_MAKE_RULES)/common.mk`
7. drop `COMPONENT_TEST_TARGET`.  Hasn't been needed since `makemaker.mk` was fixed a couple years ago
8. specify one master test result for all builds via `COMPONENT_TEST_MASTER` and add suitable `COMPONENT_TEST_TRANSFORMS`
9. drop `build/install/test`.   These are correctly set by `makemaker.mk`
10. update `REQUIRED_PACKAGES`

`URI-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` setting from the `Makefile`
2. reference `$(COMPONENT_SUMMARY)` from the `Makefile`
3. reference `$(COMPONENT_CLASSIFCATION)` from the `Makefile`
4. update the `license` attribute to reference `$(COMPONENT_LICENSE_FILE)` and `$(COMPONENT_LICENSE)`
5. add depends for the specific perl runtime and for the non-versioned `library/perl-5/uri`