### PR TITLE
library/perl-5/xml-namespacesupport: rebuild

### DIFF
--- a/components/perl/xml-namespacesupport/Makefile
+++ b/components/perl/xml-namespacesupport/Makefile
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2020, Aurelien Larcher
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 BUILD_BITS=32_and_64
 BUILD_STYLE=makemaker
@@ -30,23 +31,28 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		XML-NamespaceSupport
 COMPONENT_VERSION=	1.12
 HUMAN_VERSION=		1.12
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		library/perl-5/xml-namespacesupport
 COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:47e995859f8dd0413aa3f22d350c4a62da652e854267aa0586ae544ae2bae5ef
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/P/PE/PERIGRIN/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~perigrin/
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/P/PE/PERIGRIN/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/XML::NamespaceSupport
 COMPONENT_LICENSE=	Artistic
 COMPONENT_LICENSE_FILE=	xml-namespacesupport.license
+
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
 include $(WS_MAKE_RULES)/common.mk
 
 # man pages go in the common area
 COMPONENT_INSTALL_ENV += INSTALLVENDORMAN3DIR=$(USRSHAREMAN3DIR)
 
-COMPONENT_TEST_TARGETS = test
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 COMPONENT_TEST_TRANSFORMS += \
 	'-e "/^PERL_DL_NONLAZY/d" ' \
@@ -55,3 +61,4 @@ COMPONENT_TEST_TRANSFORMS += \
 # Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/xml-namespacesupport/manifests/sample-manifest.p5m
+++ b/components/perl/xml-namespacesupport/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +26,11 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/XML::NamespaceSupport.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/XML::NamespaceSupport.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/XML::NamespaceSupport.3
 file path=usr/perl5/vendor_perl/5.22/XML/NamespaceSupport.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/XML/NamespaceSupport/.packlist
 file path=usr/perl5/vendor_perl/5.24/XML/NamespaceSupport.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/XML/NamespaceSupport/.packlist
+file path=usr/perl5/vendor_perl/5.34/XML/NamespaceSupport.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/XML/NamespaceSupport/.packlist

--- a/components/perl/xml-namespacesupport/pkg5
+++ b/components/perl/xml-namespacesupport/pkg5
@@ -3,11 +3,14 @@
         "SUNWcs",
         "runtime/perl-522",
         "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/xml-namespacesupport-522",
         "library/perl-5/xml-namespacesupport-524",
+        "library/perl-5/xml-namespacesupport-534",
         "library/perl-5/xml-namespacesupport"
     ],
     "name": "XML-NamespaceSupport"


### PR DESCRIPTION
This PR requires that PR #7512 be merged first.  It depends upon the additional macros being in place in `makemaker.mk` and `shared-macros.mk` for perl 5.34 support.

Rebuild `library/perl-5/xml-namespacesupport`, adding perl 5.34 support to the existing 5.22 and 5.24.

This component was touched by Aurélien last year, so there was much less to update than with some of the other PRs for perl module rebuilds.

`Makefile`:
1. add `COMPONENT_REVISION = 1`
2. update `COMPONENT_PROJECT_URL` and `COMPONENT_ARCHIVE_URL` to use https and current locations
3. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` before including `common.mk`, to add perl 5.34 to the list of perls this module will be built for.
4. drop `COMPONENT_TEST_TARGET = test`.  It hasn't been needed for years.
5. update `REQUIRED_PACKAGES`

