### PR TITLE
library/perl-5/parse-yapp: rebuild for perl 5.34

### DIFF
--- a/components/perl/Parse-Yapp/Makefile
+++ b/components/perl/Parse-Yapp/Makefile
@@ -10,31 +10,49 @@
 
 #
 # Copyright 2020 Rouven Weiler
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         Parse-Yapp
 COMPONENT_VERSION=      1.21
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		library/perl-5/parse-yapp
+COMPONENT_SUMMARY=	Perl extension for generating and using LALR parsers
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_PROJECT_URL=  https://metacpan.org/pod/Parse::Yapp
 COMPONENT_ARCHIVE_HASH= \
   sha256:3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5
 COMPONENT_ARCHIVE_URL= \
   https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=  https://metacpan.org/release/Parse-Yapp/source/lib/Parse/Yapp.pm
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-COMPONENT_TEST_TARGETS = test
+include $(WS_MAKE_RULES)/common.mk
 
-build:          $(BUILD_32_and_64)
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-install:        $(INSTALL_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-test:           $(TEST_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/Parse-Yapp/Parse-Yapp-PERLVER.p5m
+++ b/components/perl/Parse-Yapp/Parse-Yapp-PERLVER.p5m
@@ -11,19 +11,29 @@
 
 #
 # Copyright 2020 Rouven Weiler
+# Copyright (c) 2022 Tim Mooney.  All rights reserved
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/parse-yapp-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="Perl extension for generating and using LALR parsers"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license Parse-Yapp.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 link path=usr/bin/yapp target=../perl5/$(PERLVER)/bin/yapp \
     mediator=perl mediator-version=$(PERLVER)
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# force a dependency on the non-PLV version of this module
+depend type=require \
+	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
 
 file path=usr/perl5/$(PERLVER)/bin/yapp
 file path=usr/perl5/$(PERLVER)/man/man1/yapp.1

--- a/components/perl/Parse-Yapp/manifests/sample-manifest.p5m
+++ b/components/perl/Parse-Yapp/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,6 +30,10 @@ file path=usr/perl5/5.24/bin/yapp
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man1/yapp.1
 file path=usr/perl5/5.24/man/man3/Parse::Yapp.3
+file path=usr/perl5/5.34/bin/yapp
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man1/yapp.1
+file path=usr/perl5/5.34/man/man3/Parse::Yapp.3
 file path=usr/perl5/vendor_perl/5.22/Parse/Yapp.pm
 file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Driver.pm
 file path=usr/perl5/vendor_perl/5.22/Parse/Yapp/Grammar.pm
@@ -46,3 +50,11 @@ file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Options.pm
 file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Output.pm
 file path=usr/perl5/vendor_perl/5.24/Parse/Yapp/Parse.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Parse/Yapp/.packlist
+file path=usr/perl5/vendor_perl/5.34/Parse/Yapp.pm
+file path=usr/perl5/vendor_perl/5.34/Parse/Yapp/Driver.pm
+file path=usr/perl5/vendor_perl/5.34/Parse/Yapp/Grammar.pm
+file path=usr/perl5/vendor_perl/5.34/Parse/Yapp/Lalr.pm
+file path=usr/perl5/vendor_perl/5.34/Parse/Yapp/Options.pm
+file path=usr/perl5/vendor_perl/5.34/Parse/Yapp/Output.pm
+file path=usr/perl5/vendor_perl/5.34/Parse/Yapp/Parse.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/Parse/Yapp/.packlist

--- a/components/perl/Parse-Yapp/pkg5
+++ b/components/perl/Parse-Yapp/pkg5
@@ -3,11 +3,14 @@
         "SUNWcs",
         "runtime/perl-522",
         "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/parse-yapp-522",
         "library/perl-5/parse-yapp-524",
+        "library/perl-5/parse-yapp-534",
         "library/perl-5/parse-yapp"
     ],
     "name": "Parse-Yapp"

--- a/components/perl/Parse-Yapp/test/results-all.master
+++ b/components/perl/Parse-Yapp/test/results-all.master
@@ -1,0 +1,7 @@
+t/base.t .... ok
+t/calc.t .... ok
+t/stress.t .. ok
+All tests successful.
+Files=3, Tests=33
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
Rebuild `library/perl-5/parse-yapp` for all perl versions, including 5.34.

No other perl module dependencies and you've already committed PR #7512 , so this can be merged in any order related to the other perl modules.

Modernization changes similar to my last several perl module rebuild merge requests:

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and switch to the `common.mk` include
2. add `COMPONENT_REVISION=1`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, and `COMPONENT_CLASSIFICATION` based on values from the `parse-yapp-PERLVER.p5m`
4. update `COMPONENT_PROJECT_URL` and `COMPONENT_ARCHIVE_URL` for https and current locations
5. specify `COMPONENT_LICENSE` here instead of directly in the manifest
6. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, overriding the current default and including 5.34
7. drop `COMPONENT_TEST_TARGETS` (not needed since `makemaker.mk` was fixed long ago)
8. specify `COMPONENT_TEST_MASTER` to use one `results-all.master` for all 3 versions.
9. add suitable `COMPONENT_TEST_TRANSFORMS`
10. drop `build/install/test`
11. include updated `REQUIRED_PACKAGES`

`parse-yapp-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for the `license` `$(COMPONENT_LICENSE_FILE)` and `$(COMPONENT_LICENSE)`
5. add a runtime dependency on the version of perl that matches each module rebuild
6. add a runtime dependency so that non-perl-specific `library/perl-5/parse-yapp` is also installed.

