### PR TITLE
library/perl-5/encode-locale: rebuild for perl-534

### DIFF
--- a/components/perl/Encode-Locale/Encode-Locale-PERLVER.p5m
+++ b/components/perl/Encode-Locale/Encode-Locale-PERLVER.p5m
@@ -11,18 +11,27 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/encode-locale-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="Encoding::Locale - module to determine what encodings should be used when interfacing to various external interfaces"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license Encode-Locale.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# force a dependency on the non-PLV version of this module
+depend type=require \
+	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/Encode::Locale.3 mode=0444
 file path=usr/perl5/vendor_perl/$(PERLVER)/Encode/Locale.pm mode=0444

--- a/components/perl/Encode-Locale/Makefile
+++ b/components/perl/Encode-Locale/Makefile
@@ -22,29 +22,50 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved. 
 #
-
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Encode-Locale
 COMPONENT_VERSION=	1.05
 IPS_COMPONENT_VERSION=	1.5
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		library/perl-5/encode-locale
+COMPONENT_SUMMARY=	Encode::Locale - Determine the locale encoding
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/Encode-Locale/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/Encode::Locale
 COMPONENT_ARCHIVE_HASH = \
     sha256:176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# with some extra filtering for innocuous differences, we can currently
+# use the same master results for all versions
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"' \
+	'-e "/^Wide character in print at /d"'
 
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/Encode-Locale/manifests/sample-manifest.p5m
+++ b/components/perl/Encode-Locale/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +26,11 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/Encode::Locale.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/Encode::Locale.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/Encode::Locale.3
 file path=usr/perl5/vendor_perl/5.22/Encode/Locale.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/Encode/Locale/.packlist
 file path=usr/perl5/vendor_perl/5.24/Encode/Locale.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Encode/Locale/.packlist
+file path=usr/perl5/vendor_perl/5.34/Encode/Locale.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/Encode/Locale/.packlist

--- a/components/perl/Encode-Locale/pkg5
+++ b/components/perl/Encode-Locale/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/encode-locale-522",
         "library/perl-5/encode-locale-524",
+        "library/perl-5/encode-locale-534",
         "library/perl-5/encode-locale"
     ],
     "name": "Encode-Locale"

--- a/components/perl/Encode-Locale/test/results-all.master
+++ b/components/perl/Encode-Locale/test/results-all.master
@@ -1,0 +1,15 @@
+t/alias.t ...... ok
+# ENCODING_LOCALE is ascii
+t/arg.t ........ ok
+t/env.t ........ ok
+t/tain.t ....... ok
+t/warn_once.t .. ok
+All tests successful.
+
+Test Summary Report
+-------------------
+t/arg.t      (Wstat: 0 Tests: 4 Failed: 0)
+  TODO passed:   1-2
+Files=5, Tests=28
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
Rebuild for all current perl versions, including 5.34

No other perl module dependencies and the PR #7512 has already been merged, so this can be done in any order with the other perl module PRs.

All the standard Makefile and manifest modernizations as other rebuilds:

`Makefile`:
1. add `BUILD_STYLE=makemaker` and `BUILD_BITS=32_and_64` and switch to including just `common.mk`
2. add `COMPONENT_REVISION=1`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE`, using values from the `Encode-Locale-PERLVER.p5m`
4. update URLs with https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` so that we build for 5.34 too
6. drop `COMPONENT_TEST_TARGET=test`
7. add `COMPONENT_TEST_MASTER` using a single `results-all.master` and specify suitable `COMPONENT_TEST_TRANSFORMS`
8. drop `build/install/test`
9. update `REQUIRED_PACKAGES`

`Encode-Locale-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for the `license` `$(COMPONENT_LICENSE)`
5. add a dependency on the version of perl that this module is being built for
6. add a dependency upon the non-PLV `library/perl-5/encode-locale`

