### PR TITLE
library/perl-5/switch: rebuild for perl 5.34

### DIFF
--- a/components/perl/Switch/Makefile
+++ b/components/perl/Switch/Makefile
@@ -11,28 +11,48 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Switch
 COMPONENT_VERSION=	2.17
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/switch
+COMPONENT_SUMMARY=	A switch statement for perl
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/dist/Switch/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/Switch
 COMPONENT_ARCHIVE_HASH=	\
     sha256:31354975140fe6235ac130a109496491ad33dd42f9c62189e23f49f75f936d75
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/C/CH/CHORNY/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/C/CH/CHORNY/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-COMPONENT_TEST_TARGETS = test
+include $(WS_MAKE_RULES)/common.mk
 
-build:		$(BUILD_32_and_64)
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-install:	$(INSTALL_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/Switch/Switch-PERLVER.p5m
+++ b/components/perl/Switch/Switch-PERLVER.p5m
@@ -11,18 +11,27 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/switch-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="A switch statement for Perl"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license Switch.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# force a dependency on the non-PLV version of this module
+depend type=require \
+	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/Switch.3 mode=0444
 file path=usr/perl5/vendor_perl/$(PERLVER)/Switch.pm mode=0444

--- a/components/perl/Switch/manifests/sample-manifest.p5m
+++ b/components/perl/Switch/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +26,11 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/Switch.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/Switch.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/Switch.3
 file path=usr/perl5/vendor_perl/5.22/Switch.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/Switch/.packlist
 file path=usr/perl5/vendor_perl/5.24/Switch.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Switch/.packlist
+file path=usr/perl5/vendor_perl/5.34/Switch.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/Switch/.packlist

--- a/components/perl/Switch/pkg5
+++ b/components/perl/Switch/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/switch-522",
         "library/perl-5/switch-524",
+        "library/perl-5/switch-534",
         "library/perl-5/switch"
     ],
     "name": "Switch"

--- a/components/perl/Switch/test/results-all.master
+++ b/components/perl/Switch/test/results-all.master
@@ -1,0 +1,7 @@
+t/given.t ... ok
+t/nested.t .. ok
+t/switch.t .. ok
+All tests successful.
+Files=3, Tests=590
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
Rebuild for all current perl versions, including perl 5.34

This can be done in any order with the other perl module rebuilds.

Standard updates and modernizations:

`Makefile`:
1. specify `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and switch to including just `common.mk`
2. bump `COMPONENT_REVISION`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, and `COMPONENT_CLASSIFICATION` using values from the manifest
4. update the URLs for https and current locations
5. add `COMPONENT_LICENSE` using the value from the manifest
6. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` so we include 5.34 in the rebuild too
7. drop `COMPONENT_TEST_TARGETS=test` and add `COMPONENT_TEST_MASTER` with a single `results-all.master`
8. specify suitable `COMPONENT_TEST_TRANSFORMS`
9. drop `build/install/test` targets
10. include updated `REQUIRED_PACKAGES`

`Switch-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)`, `$(COMPONENT_SUMMARY)`, `$(COMPONENT_CLASSIFICATION)` and `$(COMPONENT_LICENSE)` from the Makefile instead of specifying here.
2. add runtime dependency on the version of perl for each module rebuild
3. add a runtime dependency on `library/perl-5/switch`

