### PR TITLE
library/perl-5/lwp-mediatypes: perl-5.34 rebuild

### DIFF
--- a/components/perl/LWP-MediaTypes/LWP-MediaTypes-PERLVER.p5m
+++ b/components/perl/LWP-MediaTypes/LWP-MediaTypes-PERLVER.p5m
@@ -11,18 +11,28 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/lwp-mediatypes-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="LWP::MediaTypes - guess media type for a file or a URL"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license LWP-MediaTypes.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# force a dependency on the non-PLV version of this module
+depend type=require \
+	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
 
 file path=usr/perl5/$(PERLVER)/man/man3/LWP::MediaTypes.3 mode=0444
 file path=usr/perl5/vendor_perl/$(PERLVER)/LWP/MediaTypes.pm mode=0444

--- a/components/perl/LWP-MediaTypes/Makefile
+++ b/components/perl/LWP-MediaTypes/Makefile
@@ -11,30 +11,48 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
-
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		LWP-MediaTypes
 COMPONENT_VERSION=	6.02
 IPS_COMPONENT_VERSION=	6.2
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/lwp-mediatypes
+COMPONENT_SUMMARY=	LWP::MediaTypes - guess media type for a file or a URL
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/LWP-MediaTypes/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/LWP::MediaTypes
 COMPONENT_ARCHIVE_HASH=	\
     sha256:18790b0cc5f0a51468495c3847b16738f785a2d460403595001e0b932e5db676
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/O/OA/OALDERS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/LWP-MediaTypes/manifests/sample-manifest.p5m
+++ b/components/perl/LWP-MediaTypes/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,9 +26,14 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/LWP::MediaTypes.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/LWP::MediaTypes.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/LWP::MediaTypes.3
 file path=usr/perl5/vendor_perl/5.22/LWP/MediaTypes.pm
 file path=usr/perl5/vendor_perl/5.22/LWP/media.types
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/LWP/MediaTypes/.packlist
 file path=usr/perl5/vendor_perl/5.24/LWP/MediaTypes.pm
 file path=usr/perl5/vendor_perl/5.24/LWP/media.types
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/LWP/MediaTypes/.packlist
+file path=usr/perl5/vendor_perl/5.34/LWP/MediaTypes.pm
+file path=usr/perl5/vendor_perl/5.34/LWP/media.types
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/LWP/MediaTypes/.packlist

--- a/components/perl/LWP-MediaTypes/pkg5
+++ b/components/perl/LWP-MediaTypes/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/lwp-mediatypes-522",
         "library/perl-5/lwp-mediatypes-524",
+        "library/perl-5/lwp-mediatypes-534",
         "library/perl-5/lwp-mediatypes"
     ],
     "name": "LWP-MediaTypes"

--- a/components/perl/LWP-MediaTypes/test/results-all.master
+++ b/components/perl/LWP-MediaTypes/test/results-all.master
@@ -1,0 +1,5 @@
+t/mediatypes.t .. ok
+All tests successful.
+Files=1, Tests=39
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild lwp-mediatypes for all perl versions, including 5.34

No dependency on other perl modules and PR #7512 has already been merged, so this can be done in any order relative to the other module rebuilds.

All the same updates and modernizations as other recent perl module rebuilds

`Makefile`:
1. `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` based upon values from the manifest
4. update the URLs for https and current locations/maintainer
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` so this includes 5.34 in the rebuild
6. drop `COMPONENT_TEST_TARGETS=test` and add `COMPONENT_TEST_MASTER` with one `results-all.master` and suitable `COMPONENT_TEST_TRANSFORMS`
7. drop `build/install/test`
8. update `REQUIRED_PACKAGES`

`LWP-MediaTypes-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)`, now specified in the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add a runtime dependency on the perl runtime used for each rebuild of this module
6. add a dependency upon `library/perl-5/lwp-mediatypes`

