### PR TITLE
library/perl-5/io-html: rebuild for perl-5.34

### DIFF
--- a/components/perl/IO-HTML/IO-HTML-PERLVER.p5m
+++ b/components/perl/IO-HTML/IO-HTML-PERLVER.p5m
@@ -11,18 +11,27 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/io-html-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="IO::HTML - automatic charset detection based on the HTML5 algorithm"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license IO-HTML.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# force a dependency on the non-PLV version of this module
+depend type=require \
+	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/IO::HTML.3 mode=0444
 file path=usr/perl5/vendor_perl/$(PERLVER)/IO/HTML.pm mode=0444

--- a/components/perl/IO-HTML/Makefile
+++ b/components/perl/IO-HTML/Makefile
@@ -11,28 +11,49 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		IO-HTML
 COMPONENT_VERSION=	1.001
 IPS_COMPONENT_VERSION=	1.1
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		library/perl-5/io-html
+COMPONENT_SUMMARY=	IO::HTML - Open an HTML file with automatic charset detection
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~cjm/IO-HTML/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/IO::HTML
 COMPONENT_ARCHIVE_HASH=	\
     sha256:ea78d2d743794adc028bc9589538eb867174b4e165d7d8b5f63486e6b828e7e0
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/C/CJ/CJM/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/C/CJ/CJM/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/makemaker.mk
-include $(WS_MAKE_RULES)/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-COMPONENT_TEST_TARGETS = test
+include $(WS_MAKE_RULES)/common.mk
 
-build:		$(BUILD_32_and_64)
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-install:	$(INSTALL_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/IO-HTML/manifests/sample-manifest.p5m
+++ b/components/perl/IO-HTML/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +26,11 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/IO::HTML.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/IO::HTML.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/IO::HTML.3
 file path=usr/perl5/vendor_perl/5.22/IO/HTML.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/IO/HTML/.packlist
 file path=usr/perl5/vendor_perl/5.24/IO/HTML.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/IO/HTML/.packlist
+file path=usr/perl5/vendor_perl/5.34/IO/HTML.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/IO/HTML/.packlist

--- a/components/perl/IO-HTML/pkg5
+++ b/components/perl/IO-HTML/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/io-html-522",
         "library/perl-5/io-html-524",
+        "library/perl-5/io-html-534",
         "library/perl-5/io-html"
     ],
     "name": "IO-HTML"

--- a/components/perl/IO-HTML/test/results-all.master
+++ b/components/perl/IO-HTML/test/results-all.master
@@ -1,0 +1,10 @@
+t/00-all_prereqs.t .. ok
+# Testing IO::HTML 1.001
+t/00-load.t ......... ok
+t/10-find.t ......... ok
+t/20-open.t ......... ok
+t/30-outfile.t ...... ok
+All tests successful.
+Files=5, Tests=139
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
No other perl module dependencies, so this can be done in any order in relation to other perl module rebuild PRs.

Standard set of changes and updates:

`Makefile`:
1. `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. add `COMPONENT_REVISION=1`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from their former location in `IO-HTML-PERLVER.p5m`
4. update the URLs for https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, including 5.34
6. drop `COMPONENT_TEST_TARGETS=test` and add `COMPONENT_TEST_MASTER` with a single `results-all.master` and suitable `COMPONENT_TEST_TRANSFORMS`
7. drop `build/install/test`
8. add the updated `REQUIRED_PACKAGES`

`IO-HTML-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `license` `$(COMPONENT_LICENSE)`
5. add a runtime dependency so that each module depends upon its specific version of perl
6. add a runtime dependency upon `library/perl-5/io-html`
