### PR TITLE
database/mariadb-103 fix cflags escape & fix for newer CMake

### DIFF
--- a/components/database/mariadb-103/Makefile
+++ b/components/database/mariadb-103/Makefile
@@ -12,6 +12,7 @@
 # Copyright 2011-2013, EveryCity Ltd. All rights reserved.
 # Copyright 2016-2017, Wiselabs Software Ltda - http://www.wiselabs.com.br . All rights reserved.
 # Copyright 2019, Michal Nowak
+# Copyright 2022, erwinlem
 #
 
 BUILD_BITS= 32_and_64
@@ -47,7 +48,7 @@ CMAKE_PLUGINDIR.32 =	lib/$(MACH32)/plugin
 
 CMAKE_OPTIONS+= -DCMAKE_C_COMPILER=$(CC)
 CMAKE_OPTIONS+= -DCMAKE_CXX_COMPILER=$(CXX)
-CMAKE_OPTIONS+= -DCMAKE_C_FLAGS=$(CFLAGS)
+CMAKE_OPTIONS+= -DCMAKE_C_FLAGS="$(CFLAGS)"
 
 CMAKE_OPTIONS+= -DINSTALL_LAYOUT=SVR4
 CMAKE_OPTIONS+= -DCMAKE_INSTALL_PREFIX=$(CONFIGURE_PREFIX)

--- a/components/database/mariadb-103/patches/10-ConnectorName.cmake.patch
+++ b/components/database/mariadb-103/patches/10-ConnectorName.cmake.patch
@@ -1,0 +1,11 @@
+--- mariadb-10.3.24/libmariadb/cmake/ConnectorName.cmake.bak	Fri Jan  7 13:28:10 2022
++++ mariadb-10.3.24/libmariadb/cmake/ConnectorName.cmake	Fri Jan  7 13:29:05 2022
+@@ -22,7 +22,7 @@
+     SET(MACHINE_NAME "x64")
+   ELSE()
+     SET(MACHINE_NAME "32")
+-  END()
++  ENDIF()
+ ENDIF()
+ 
+ SET(product_name "mysql-connector-c-${CPACK_PACKAGE_VERSION}-${PLATFORM_NAME}${CONCAT_SIGN}${MACHINE_NAME}")


### PR DESCRIPTION
Support multiple cflags arguments.
If closes with endif in cmake. (see https://github.com/mariadb-corporation/mariadb-connector-c/commit/242cab8c)