### PR TITLE
virtualbox: fix VBoxZoneAccess path

### DIFF
--- a/components/sysutils/virtualbox/Makefile
+++ b/components/sysutils/virtualbox/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         VirtualBox
 COMPONENT_VERSION=      6.1.30
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=      VirtualBox - general-purpose full virtualizer
 COMPONENT_PROJECT_URL=  https://www.virtualbox.org/
 COMPONENT_FMRI=         system/virtualbox

--- a/components/sysutils/virtualbox/patches/22-zoneaccess.patch
+++ b/components/sysutils/virtualbox/patches/22-zoneaccess.patch
@@ -1,0 +1,11 @@
+--- VirtualBox-6.1.30/src/VBox/Installer/solaris/virtualbox-zoneaccess.xml	2021-11-22 16:19:12.000000000 +0000
++++ VirtualBox-6.1.30/src/VBox/Installer/solaris/virtualbox-zoneaccess.xml	2022-01-10 15:01:35.307212119 +0000
+@@ -47,7 +47,7 @@
+     <exec_method
+         type='method'
+         name='start'
+-        exec='/opt/VirtualBox/VBoxZoneAccess'
++        exec='/opt/VirtualBox/amd64/VBoxZoneAccess'
+         timeout_seconds='10' >
+         <method_context>
+             <method_credential user='root' group='root' />


### PR DESCRIPTION
`application/virtualbox/zoneaccess` service fails to start because it executes `/opt/VirtualBox/VBoxZoneAccess` instead of `/opt/VirtualBox/amd64/VBoxZoneAccess`.

From `/var/svc/log/application-virtualbox-zoneaccess:default.log`:
```
[ Jan  9 19:10:42 Enabled. ]
[ Jan  9 19:10:42 Executing start method ("/opt/VirtualBox/VBoxZoneAccess"). ]
/sbin/sh: exec: /opt/VirtualBox/VBoxZoneAccess: not found
[ Jan  9 19:10:43 Method "start" exited with status 127. ]
[ Jan  9 19:10:43 Executing start method ("/opt/VirtualBox/VBoxZoneAccess"). ]
/sbin/sh: exec: /opt/VirtualBox/VBoxZoneAccess: not found
[ Jan  9 19:10:43 Method "start" exited with status 127. ]
[ Jan  9 19:10:43 Executing start method ("/opt/VirtualBox/VBoxZoneAccess"). ]
/sbin/sh: exec: /opt/VirtualBox/VBoxZoneAccess: not found
[ Jan  9 19:10:43 Method "start" exited with status 127. ]
```

With fixed `VBoxZoneAccess` path the service starts fine.