### PR TITLE
library/perl-5/pmtools: rebuild for perl 5.34

### DIFF
--- a/components/perl/pmtools/Makefile
+++ b/components/perl/pmtools/Makefile
@@ -21,32 +21,49 @@
 
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pmtools
 COMPONENT_VERSION=	2.0.0
-COMPONENT_PROJECT_URL=	http://search.cpan.org/dist/pmtools/
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		library/perl-5/pmtools
+COMPONENT_SUMMARY=	Perl module tools.
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/pmtools
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:5863fc9434d6a8d7311fd612cf243c29c3573aaba9caa7a8fb54154089d8baf3
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/M/ML/MLFISHER/$(COMPONENT_ARCHIVE)
-COMPONENT_BUGDB=	utility/perl-pmtools
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/M/ML/MLFISHER/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	GPLv1+, Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-# Enable ASLR for this component
-ASLR_MODE = $(ASLR_ENABLE)
+include $(WS_MAKE_RULES)/common.mk
 
-build:		$(BUILD_32_and_64)
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-install:	$(INSTALL_32_and_64)
-
-test:		$(NO_TESTS)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 REQUIRED_PACKAGES += SUNWcs

--- a/components/perl/pmtools/manifests/sample-manifest.p5m
+++ b/components/perl/pmtools/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -128,9 +128,65 @@ file path=usr/perl5/5.24/man/man1/sitepods.1
 file path=usr/perl5/5.24/man/man1/stdpods.1
 file path=usr/perl5/5.24/man/man3/Devel::Loaded.3
 file path=usr/perl5/5.24/man/man3/pmtools.3
+file path=usr/perl5/5.34/bin/basepods
+file path=usr/perl5/5.34/bin/faqpods
+file path=usr/perl5/5.34/bin/modpods
+file path=usr/perl5/5.34/bin/pfcat
+file path=usr/perl5/5.34/bin/plxload
+file path=usr/perl5/5.34/bin/pmall
+file path=usr/perl5/5.34/bin/pman
+file path=usr/perl5/5.34/bin/pmcat
+file path=usr/perl5/5.34/bin/pmcheck
+file path=usr/perl5/5.34/bin/pmdesc
+file path=usr/perl5/5.34/bin/pmeth
+file path=usr/perl5/5.34/bin/pmexp
+file path=usr/perl5/5.34/bin/pmfunc
+file path=usr/perl5/5.34/bin/pminclude
+file path=usr/perl5/5.34/bin/pminst
+file path=usr/perl5/5.34/bin/pmload
+file path=usr/perl5/5.34/bin/pmls
+file path=usr/perl5/5.34/bin/pmpath
+file path=usr/perl5/5.34/bin/pmvers
+file path=usr/perl5/5.34/bin/podgrep
+file path=usr/perl5/5.34/bin/podpath
+file path=usr/perl5/5.34/bin/pods
+file path=usr/perl5/5.34/bin/podtoc
+file path=usr/perl5/5.34/bin/sitepods
+file path=usr/perl5/5.34/bin/stdpods
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man1/basepods.1
+file path=usr/perl5/5.34/man/man1/faqpods.1
+file path=usr/perl5/5.34/man/man1/modpods.1
+file path=usr/perl5/5.34/man/man1/pfcat.1
+file path=usr/perl5/5.34/man/man1/plxload.1
+file path=usr/perl5/5.34/man/man1/pmall.1
+file path=usr/perl5/5.34/man/man1/pman.1
+file path=usr/perl5/5.34/man/man1/pmcat.1
+file path=usr/perl5/5.34/man/man1/pmcheck.1
+file path=usr/perl5/5.34/man/man1/pmdesc.1
+file path=usr/perl5/5.34/man/man1/pmeth.1
+file path=usr/perl5/5.34/man/man1/pmexp.1
+file path=usr/perl5/5.34/man/man1/pmfunc.1
+file path=usr/perl5/5.34/man/man1/pminclude.1
+file path=usr/perl5/5.34/man/man1/pminst.1
+file path=usr/perl5/5.34/man/man1/pmload.1
+file path=usr/perl5/5.34/man/man1/pmls.1
+file path=usr/perl5/5.34/man/man1/pmpath.1
+file path=usr/perl5/5.34/man/man1/pmvers.1
+file path=usr/perl5/5.34/man/man1/podgrep.1
+file path=usr/perl5/5.34/man/man1/podpath.1
+file path=usr/perl5/5.34/man/man1/pods.1
+file path=usr/perl5/5.34/man/man1/podtoc.1
+file path=usr/perl5/5.34/man/man1/sitepods.1
+file path=usr/perl5/5.34/man/man1/stdpods.1
+file path=usr/perl5/5.34/man/man3/Devel::Loaded.3
+file path=usr/perl5/5.34/man/man3/pmtools.3
 file path=usr/perl5/vendor_perl/5.22/Devel/Loaded.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/pmtools/.packlist
 file path=usr/perl5/vendor_perl/5.22/pmtools.pm
 file path=usr/perl5/vendor_perl/5.24/Devel/Loaded.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/pmtools/.packlist
 file path=usr/perl5/vendor_perl/5.24/pmtools.pm
+file path=usr/perl5/vendor_perl/5.34/Devel/Loaded.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/pmtools/.packlist
+file path=usr/perl5/vendor_perl/5.34/pmtools.pm

--- a/components/perl/pmtools/pkg5
+++ b/components/perl/pmtools/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/pmtools-522",
         "library/perl-5/pmtools-524",
+        "library/perl-5/pmtools-534",
         "library/perl-5/pmtools"
     ],
     "name": "pmtools"

--- a/components/perl/pmtools/pmtools-PERLVER.p5m
+++ b/components/perl/pmtools/pmtools-PERLVER.p5m
@@ -19,22 +19,30 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
-set name=pkg.fmri value=pkg:/library/perl-5/pmtools-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.description \
     value="Perl module tools is a suite of small tools that help manage and inspect perl modules, perl Plain Old Documentation files, and perl programs."
-set name=pkg.summary value="Perl module tools."
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=com.oracle.info.description value="the Perl module tools"
-set name=info.classification \
-    value=org.opensolaris.category.2008:Development/Perl
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
-set name=org.opensolaris.arc-caseid value=PSARC/2009/121
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license pmtools.license license="GPLv2, Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether having this package require
+# the non-PLV version of this module, don't enable this.
+#depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/bin/basepods
 file path=usr/perl5/$(PERLVER)/bin/faqpods

--- a/components/perl/pmtools/pmtools.license
+++ b/components/perl/pmtools/pmtools.license
@@ -1,399 +1,379 @@
-GNU GENERAL PUBLIC LICENSE
+This software is copyright (c) 2014 by Mark Leighton Fisher.
 
-Version 2, June 1991
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
 
-Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+Terms of the Perl programming language system itself
 
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+a) the GNU General Public License as published by the Free
+   Software Foundation; either version 1, or (at your option) any
+   later version, or
+b) the "Artistic License"
 
-Preamble
+--- The GNU General Public License, Version 1, February 1989 ---
 
-The licenses for most software are designed to take away your freedom
-to share and change it. By contrast, the GNU General Public License is
-intended to guarantee your freedom to share and change free software--to
-make sure the software is free for all its users. This General Public
-License applies to most of the Free Software Foundation's software and
-to any other program whose authors commit to using it. (Some other Free
-Software Foundation software is covered by the GNU Lesser General Public
-License instead.) You can apply it to your programs, too.
+This software is Copyright (c) 2014 by Mark Leighton Fisher.
 
-When we speak of free software, we are referring to freedom, not
-price. Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it in
-new free programs; and that you know you can do these things.
+This is free software, licensed under:
 
-To protect your rights, we need to make restrictions that forbid anyone
-to deny you these rights or to ask you to surrender the rights. These
-restrictions translate to certain responsibilities for you if you
+  The GNU General Public License, Version 1, February 1989
+
+                    GNU GENERAL PUBLIC LICENSE
+                     Version 1, February 1989
+
+ Copyright (C) 1989 Free Software Foundation, Inc.
+ 51 Franklin St, Suite 500, Boston, MA  02110-1335  USA
+
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The license agreements of most software companies try to keep users
+at the mercy of those companies.  By contrast, our General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  The
+General Public License applies to the Free Software Foundation's
+software and to any other program whose authors commit to using it.
+You can use it for your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Specifically, the General Public License is designed to make
+sure that you have the freedom to give away or sell copies of free
+software, that you receive source code or can get it if you want it,
+that you can change the software or use pieces of it in new free
+programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
 distribute copies of the software, or if you modify it.
 
-For example, if you distribute copies of such a program, whether gratis or
-for a fee, you must give the recipients all the rights that you have. You
-must make sure that they, too, receive or can get the source code. And
-you must show them these terms so they know their rights.
+  For example, if you distribute copies of a such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must tell them their rights.
 
-We protect your rights with two steps: (1) copyright the software, and
+  We protect your rights with two steps: (1) copyright the software, and
 (2) offer you this license which gives you legal permission to copy,
 distribute and/or modify the software.
 
-Also, for each author's protection and ours, we want to make certain
+  Also, for each author's protection and ours, we want to make certain
 that everyone understands that there is no warranty for this free
-software. If the software is modified by someone else and passed on,
-we want its recipients to know that what they have is not the original,
-so that any problems introduced by others will not reflect on the original
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
 authors' reputations.
 
-Finally, any free program is threatened constantly by software
-patents. We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary. To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
-
-The precise terms and conditions for copying, distribution and
+  The precise terms and conditions for copying, distribution and
 modification follow.
-TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License. The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language. (Hereinafter, translation is included without limitation in
-the term "modification".) Each licensee is addressed as "you".
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope. The act of running
-the Program is not restricted, and the output from the Program is covered
-only if its contents constitute a work based on the Program (independent
-of having been made by running the Program). Whether that is true depends
-on what the Program does.
+  0. This License Agreement applies to any program or other work which
+contains a notice placed by the copyright holder saying it may be
+distributed under the terms of this General Public License.  The
+"Program", below, refers to any such program or work, and a "work based
+on the Program" means either the Program or any work containing the
+Program or a portion of it, either verbatim or with modifications.  Each
+licensee is addressed as "you".
 
-1. You may copy and distribute verbatim copies of the Program's source
-code as you receive it, in any medium, provided that you conspicuously
-and appropriately publish on each copy an appropriate copyright notice
-and disclaimer of warranty; keep intact all the notices that refer to
-this License and to the absence of any warranty; and give any other
-recipients of the Program a copy of this License along with the Program.
+  1. You may copy and distribute verbatim copies of the Program's source
+code as you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and
+disclaimer of warranty; keep intact all the notices that refer to this
+General Public License and to the absence of any warranty; and give any
+other recipients of the Program a copy of this General Public License
+along with the Program.  You may charge a fee for the physical act of
+transferring a copy.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+  2. You may modify your copy or copies of the Program or any portion of
+it, and copy and distribute such modifications under the terms of Paragraph
+1 above, provided that you also do the following:
 
-2. You may modify your copy or copies of the Program or any portion of
-it, thus forming a work based on the Program, and copy and distribute
-such modifications or work under the terms of Section 1 above, provided
-that you also meet all of these conditions:
+    a) cause the modified files to carry prominent notices stating that
+    you changed the files and the date of any change; and
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any part
-    thereof, to be licensed as a whole at no charge to all third parties
-    under the terms of this License.
+    b) cause the whole of any work that you distribute or publish, that
+    in whole or in part contains the Program or any part thereof, either
+    with or without modifications, to be licensed at no charge to all
+    third parties under the terms of this General Public License (except
+    that you may choose to grant warranty protection to some or all
+    third parties, at your option).
+
     c) If the modified program normally reads commands interactively when
-    run, you must cause it, when started running for such interactive
-    use in the most ordinary way, to print or display an announcement
-    including an appropriate copyright notice and a notice that there
-    is no warranty (or else, saying that you provide a warranty) and
-    that users may redistribute the program under these conditions, and
-    telling the user how to view a copy of this License. (Exception: if
-    the Program itself is interactive but does not normally print such
-    an announcement, your work based on the Program is not required to
-    print an announcement.)
+    run, you must cause it, when started running for such interactive use
+    in the simplest and most usual way, to print or display an
+    announcement including an appropriate copyright notice and a notice
+    that there is no warranty (or else, saying that you provide a
+    warranty) and that users may redistribute the program under these
+    conditions, and telling the user how to view a copy of this General
+    Public License.
 
-These requirements apply to the modified work as a whole. If identifiable
-sections of that work are not derived from the Program, and can be
-reasonably considered independent and separate works in themselves,
-then this License, and its terms, do not apply to those sections when
-you distribute them as separate works. But when you distribute the same
-sections as part of a whole which is a work based on the Program, the
-distribution of the whole must be on the terms of this License, whose
-permissions for other licensees extend to the entire whole, and thus to
-each and every part regardless of who wrote it.
+    d) You may charge a fee for the physical act of transferring a
+    copy, and you may at your option offer warranty protection in
+    exchange for a fee.
 
-Thus, it is not the intent of this section to claim rights or contest your
-rights to work written entirely by you; rather, the intent is to exercise
-the right to control the distribution of derivative or collective works
-based on the Program.
+Mere aggregation of another independent work with the Program (or its
+derivative) on a volume of a storage or distribution medium does not bring
+the other work under the scope of these terms.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of a
-storage or distribution medium does not bring the other work under the
-scope of this License.
+  3. You may copy and distribute the Program (or a portion or derivative of
+it, under Paragraph 2) in object code or executable form under the terms of
+Paragraphs 1 and 2 above provided that you also do one of the following:
 
-3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+    a) accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of
+    Paragraphs 1 and 2 above; or,
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections 1
-    and 2 above on a medium customarily used for software interchange; or,
-    b) Accompany it with a written offer, valid for at least three years,
-    to give any third party, for a charge no more than your cost of
-    physically performing source distribution, a complete machine-readable
-    copy of the corresponding source code, to be distributed under the
-    terms of Sections 1 and 2 above on a medium customarily used for
-    software interchange; or,
-    c) Accompany it with the information you received as to the offer to
-    distribute corresponding source code. (This alternative is allowed
-    only for noncommercial distribution and only if you received the
-    program in object code or executable form with such an offer, in
-    accord with Subsection b above.)
+    b) accompany it with a written offer, valid for at least three
+    years, to give any third party free (except for a nominal charge
+    for the cost of distribution) a complete machine-readable copy of the
+    corresponding source code, to be distributed under the terms of
+    Paragraphs 1 and 2 above; or,
 
-The source code for a work means the preferred form of the work for making
-modifications to it. For an executable work, complete source code means
-all the source code for all modules it contains, plus any associated
-interface definition files, plus the scripts used to control compilation
-and installation of the executable. However, as a special exception,
-the source code distributed need not include anything that is normally
-distributed (in either source or binary form) with the major components
-(compiler, kernel, and so on) of the operating system on which the
-executable runs, unless that component itself accompanies the executable.
+    c) accompany it with the information you received as to where the
+    corresponding source code may be obtained.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form alone.)
 
-If distribution of executable or object code is made by offering access
-to copy from a designated place, then offering equivalent access to
-copy the source code from the same place counts as distribution of the
-source code, even though third parties are not compelled to copy the
-source along with the object code.
+Source code for a work means the preferred form of the work for making
+modifications to it.  For an executable file, complete source code means
+all the source code for all modules it contains; but, as a special
+exception, it need not include source code for modules which are standard
+libraries that accompany the operating system on which the executable
+file runs, or for standard header files or definitions files that
+accompany that operating system.
 
-4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License. Any attempt otherwise
-to copy, modify, sublicense or distribute the Program is void, and will
-automatically terminate your rights under this License. However, parties
-who have received copies, or rights, from you under this License will
-not have their licenses terminated so long as such parties remain in
-full compliance.
+  4. You may not copy, modify, sublicense, distribute or transfer the
+Program except as expressly provided under this General Public License.
+Any attempt otherwise to copy, modify, sublicense, distribute or transfer
+the Program is void, and will automatically terminate your rights to use
+the Program under this License.  However, parties who have received
+copies, or rights to use copies, from you under this General Public
+License will not have their licenses terminated so long as such parties
+remain in full compliance.
 
-5. You are not required to accept this License, since you have not signed
-it. However, nothing else grants you permission to modify or distribute
-the Program or its derivative works. These actions are prohibited
-by law if you do not accept this License. Therefore, by modifying or
-distributing the Program (or any work based on the Program), you indicate
-your acceptance of this License to do so, and all its terms and conditions
-for copying, distributing or modifying the Program or works based on it.
+  5. By copying, distributing or modifying the Program (or any work based
+on the Program) you indicate your acceptance of this license to do so,
+and all its terms and conditions.
 
-6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions. You may not impose any further restrictions
-on the recipients' exercise of the rights granted herein. You are not
-responsible for enforcing compliance by third parties to this License.
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the original
+licensor to copy, distribute or modify the Program subject to these
+terms and conditions.  You may not impose any further restrictions on the
+recipients' exercise of the rights granted herein.
 
-7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License. If you cannot distribute
-so as to satisfy simultaneously your obligations under this License
-and any other pertinent obligations, then as a consequence you may not
-distribute the Program at all. For example, if a patent license would
-not permit royalty-free redistribution of the Program by all those who
-receive copies directly or indirectly through you, then the only way you
-could satisfy both it and this License would be to refrain entirely from
-distribution of the Program.
+  7. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
 
-If any portion of this section is held invalid or unenforceable under any
-particular circumstance, the balance of the section is intended to apply
-and the section as a whole is intended to apply in other circumstances.
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of the license which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+the license, you may choose any version ever published by the Free Software
+Foundation.
 
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any such
-claims; this section has the sole purpose of protecting the integrity of
-the free software distribution system, which is implemented by public
-license practices. Many people have made generous contributions to the
-wide range of software distributed through that system in reliance on
-consistent application of that system; it is up to the author/donor to
-decide if he or she is willing to distribute software through any other
-system and a licensee cannot impose that choice.
-
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
-
-8. If the distribution and/or use of the Program is restricted in certain
-countries either by patents or by copyrighted interfaces, the original
-copyright holder who places the Program under this License may add an
-explicit geographical distribution limitation excluding those countries,
-so that distribution is permitted only in or among countries not thus
-excluded. In such case, this License incorporates the limitation as if
-written in the body of this License.
-
-9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time. Such new versions will
-be similar in spirit to the present version, but may differ in detail
-to address new problems or concerns.
-
-Each version is given a distinguishing version number. If the Program
-specifies a version number of this License which applies to it and
-"any later version", you have the option of following the terms and
-conditions either of that version or of any later version published by
-the Free Software Foundation. If the Program does not specify a version
-number of this License, you may choose any version ever published by
-the Free Software Foundation.
-
-10. If you wish to incorporate parts of the Program into other free
+  8. If you wish to incorporate parts of the Program into other free
 programs whose distribution conditions are different, write to the author
-to ask for permission. For software which is copyrighted by the Free
+to ask for permission.  For software which is copyrighted by the Free
 Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this. Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software
-and of promoting the sharing and reuse of software generally.
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
 
-NO WARRANTY
+                            NO WARRANTY
 
-11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN
+  9. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
 OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
 PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
 OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK
-AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
 PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
 REPAIR OR CORRECTION.
 
-12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
-WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
-AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU
-FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
-DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING
-BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR
-LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM
-TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY
-HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-END OF TERMS AND CONDITIONS
+  10. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
 
-======================================================================
+                     END OF TERMS AND CONDITIONS
+
+        Appendix: How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to humanity, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these
+terms.
+
+  To do so, attach the following notices to the program.  It is safest to
+attach them to the start of each source file to most effectively convey
+the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) 19yy  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 1, or (at your option)
+    any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA  02110-1301 USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) 19xx name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the
+appropriate parts of the General Public License.  Of course, the
+commands you use may be called something other than `show w' and `show
+c'; they could even be mouse-clicks or menu items--whatever suits your
+program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  program `Gnomovision' (a program to direct compilers to make passes
+  at assemblers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+
+--- The Artistic License 1.0 ---
+
+This software is Copyright (c) 2014 by Mark Leighton Fisher.
+
+This is free software, licensed under:
+
+  The Artistic License 1.0
 
 The Artistic License
-August 15, 1997
+
 Preamble
 
-The intent of this document is to state the conditions under which a
-Package may be copied, such that the Copyright Holder maintains some
-semblance of artistic control over the development of the package,
-while giving the users of the package the right to use and distribute
-the Package in a more-or-less customary fashion, plus the right to make
-reasonable modifications.
-Definitions
+The intent of this document is to state the conditions under which a Package
+may be copied, such that the Copyright Holder maintains some semblance of
+artistic control over the development of the package, while giving the users of
+the package the right to use and distribute the Package in a more-or-less
+customary fashion, plus the right to make reasonable modifications.
 
-    "Package" refers to the collection of files distributed by the
-    Copyright Holder, and derivatives of that collection of files created
-    through textual modification.
+Definitions:
 
-    "Standard Version" refers to such a Package if it has not been
-    modified, or has been modified in accordance with the wishes of the
-    Copyright Holder as specified below.
+  - "Package" refers to the collection of files distributed by the Copyright
+    Holder, and derivatives of that collection of files created through
+    textual modification. 
+  - "Standard Version" refers to such a Package if it has not been modified,
+    or has been modified in accordance with the wishes of the Copyright
+    Holder. 
+  - "Copyright Holder" is whoever is named in the copyright or copyrights for
+    the package. 
+  - "You" is you, if you're thinking about copying or distributing this Package.
+  - "Reasonable copying fee" is whatever you can justify on the basis of media
+    cost, duplication charges, time of people involved, and so on. (You will
+    not be required to justify it to the Copyright Holder, but only to the
+    computing community at large as a market that must bear the fee.) 
+  - "Freely Available" means that no fee is charged for the item itself, though
+    there may be fees involved in handling the item. It also means that
+    recipients of the item may redistribute it under the same conditions they
+    received it. 
 
-    "Copyright Holder" is whoever is named in the copyright or copyrights
-    for the package.
+1. You may make and give away verbatim copies of the source form of the
+Standard Version of this Package without restriction, provided that you
+duplicate all of the original copyright notices and associated disclaimers.
 
-    "You" is you, if you're thinking about copying or distributing
-    this Package.
+2. You may apply bug fixes, portability fixes and other modifications derived
+from the Public Domain or from the Copyright Holder. A Package modified in such
+a way shall still be considered the Standard Version.
 
-    "Reasonable copying fee" is whatever you can justify on the basis
-    of media cost, duplication charges, time of people involved, and so
-    on. (You will not be required to justify it to the Copyright Holder,
-    but only to the computing community at large as a market that must
-    bear the fee.)
+3. You may otherwise modify your copy of this Package in any way, provided that
+you insert a prominent notice in each changed file stating how and when you
+changed that file, and provided that you do at least ONE of the following:
 
-    "Freely Available" means that no fee is charged for the item itself,
-    though there may be fees involved in handling the item. It also
-    means that recipients of the item may redistribute it under the same
-    conditions they received it.
+  a) place your modifications in the Public Domain or otherwise make them
+     Freely Available, such as by posting said modifications to Usenet or an
+     equivalent medium, or placing the modifications on a major archive site
+     such as ftp.uu.net, or by allowing the Copyright Holder to include your
+     modifications in the Standard Version of the Package.
 
-   1. You may make and give away verbatim copies of the source form of the
-   Standard Version of this Package without restriction, provided that
-   you duplicate all of the original copyright notices and associated
-   disclaimers.
+  b) use the modified Package only within your corporation or organization.
 
-   2. You may apply bug fixes, portability fixes and other modifications
-   derived from the Public Domain or from the Copyright Holder. A Package
-   modified in such a way shall still be considered the Standard Version.
+  c) rename any non-standard executables so the names do not conflict with
+     standard executables, which must also be provided, and provide a separate
+     manual page for each non-standard executable that clearly documents how it
+     differs from the Standard Version.
 
-   3. You may otherwise modify your copy of this Package in any way,
-   provided that you insert a prominent notice in each changed file
-   stating how and when you changed that file, and provided that you do
-   at least ONE of the following:
+  d) make other distribution arrangements with the Copyright Holder.
 
-         1. place your modifications in the Public Domain or otherwise
-         make them Freely Available, such as by posting said modifications
-         to Usenet or an equivalent medium, or placing the modifications
-         on a major archive site such as uunet.uu.net, or by allowing the
-         Copyright Holder to include your modifications in the Standard
-         Version of the Package.
-         2. use the modified Package only within your corporation or
-         organization.
-         3. rename any non-standard executables so the names do not
-         conflict with standard executables, which must also be provided,
-         and provide a separate manual page for each non-standard
-         executable that clearly documents how it differs from the
-         Standard Version.
-         4. make other distribution arrangements with the Copyright
-         Holder.
+4. You may distribute the programs of this Package in object code or executable
+form, provided that you do at least ONE of the following:
 
-   4. You may distribute the programs of this Package in object code or
-   executable form, provided that you do at least ONE of the following:
+  a) distribute a Standard Version of the executables and library files,
+     together with instructions (in the manual page or equivalent) on where to
+     get the Standard Version.
 
-         1. distribute a Standard Version of the executables and library
-         files, together with instructions (in the manual page or
-         equivalent) on where to get the Standard Version.
-         2. accompany the distribution with the machine-readable source
-         of the Package with your modifications.
-         3. give non-standard executables non-standard names, and clearly
-         document the differences in manual pages (or equivalent),
-         together with instructions on where to get the Standard Version.
-         4. make other distribution arrangements with the Copyright
-         Holder.
+  b) accompany the distribution with the machine-readable source of the Package
+     with your modifications.
 
-   5. You may charge a reasonable copying fee for any distribution of
-   this Package. You may charge any fee you choose for support of this
-   Package. You may not charge a fee for this Package itself. However,
-   you may distribute this Package in aggregate with other (possibly
-   commercial) programs as part of a larger (possibly commercial)
-   software distribution provided that you do not advertise this Package
-   as a product of your own. You may embed this Package's interpreter
-   within an executable of yours (by linking); this shall be construed
-   as a mere form of aggregation, provided that the complete Standard
-   Version of the interpreter is so embedded.
+  c) accompany any non-standard executables with their corresponding Standard
+     Version executables, giving the non-standard executables non-standard
+     names, and clearly documenting the differences in manual pages (or
+     equivalent), together with instructions on where to get the Standard
+     Version.
 
-   6. The scripts and library files supplied as input to or produced as
-   output from the programs of this Package do not automatically fall
-   under the copyright of this Package, but belong to whomever generated
-   them, and may be sold commercially, and may be aggregated with this
-   Package. If such scripts or library files are aggregated with this
-   Package via the so-called "undump" or "unexec" methods of producing
-   a binary executable image, then distribution of such an image shall
-   neither be construed as a distribution of this Package nor shall it
-   fall under the restrictions of Paragraphs 3 and 4, provided that you
-   do not represent such an executable image as a Standard Version of
-   this Package.
+  d) make other distribution arrangements with the Copyright Holder.
 
-   7. C subroutines (or comparably compiled subroutines in other
-   languages) supplied by you and linked into this Package in order to
-   emulate subroutines and variables of the language defined by this
-   Package shall not be considered part of this Package, but are the
-   equivalent of input as in Paragraph 6, provided these subroutines do
-   not change the language in any way that would cause it to fail the
-   regression tests for the language.
+5. You may charge a reasonable copying fee for any distribution of this
+Package.  You may charge any fee you choose for support of this Package. You
+may not charge a fee for this Package itself. However, you may distribute this
+Package in aggregate with other (possibly commercial) programs as part of a
+larger (possibly commercial) software distribution provided that you do not
+advertise this Package as a product of your own.
 
-   8. Aggregation of this Package with a commercial distribution is always
-   permitted provided that the use of this Package is embedded; that
-   is, when no overt attempt is made to make this Package's interfaces
-   visible to the end user of the commercial distribution. Such use
-   shall not be construed as a distribution of this Package.
+6. The scripts and library files supplied as input to or produced as output
+from the programs of this Package do not automatically fall under the copyright
+of this Package, but belong to whomever generated them, and may be sold
+commercially, and may be aggregated with this Package.
 
-   9. The name of the Copyright Holder may not be used to endorse or
-   promote products derived from this software without specific prior
-   written permission.
+7. C or perl subroutines supplied by you and linked into this Package shall not
+be considered part of this Package.
 
-  10. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
-  WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
-  MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+8. The name of the Copyright Holder may not be used to endorse or promote
+products derived from this software without specific prior written permission.
+
+9. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 
 The End
-
 

--- a/components/perl/pmtools/test/results-all.master
+++ b/components/perl/pmtools/test/results-all.master
@@ -1,0 +1,27 @@
+t/basepods.t ..... ok
+t/faqpods.t ...... ok
+t/lib/pmtools.t .. ok
+t/modpods.t ...... ok
+t/pfcat.t ........ ok
+t/plxload.t ...... ok
+t/pmall.t ........ ok
+t/pman.t ......... ok
+t/pmcat.t ........ ok
+t/pmcheck.t ...... ok
+t/pmdesc.t ....... ok
+t/pmeth.t ........ ok
+t/pmexp.t ........ ok
+t/pmfunc.t ....... ok
+t/pmload.t ....... ok
+t/pmls.t ......... ok
+t/pmpath.t ....... ok
+t/pmvers.t ....... ok
+t/podgrep.t ...... ok
+t/pods.t ......... ok
+t/podtoc.t ....... ok
+t/sitepods.t ..... ok
+t/stdpods.t ...... ok
+All tests successful.
+Files=23, Tests=49
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild, including perl 5.34

One change from recent perl module rebuilds is that I added this **commented out** to the manifest:

```
# Until there is consensus on whether having this package require
# the non-PLV version of this module, don't enable this.
#depend type=require \
#  fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
```

If a decision is made, either way, about that particular dependency, it will be easy to either enable or completely remove.

The standard changes:

`Makefile`:
1. added `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64` and switched to include `common.mk`
2. add `COMPONENT_REVISION=1`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` from the manifest.  Note: Corrected the license, it's `GPLv1 or Artistic`, not `GPLv2 or Artistic`
4. updated the URLs for https and current locations
5. dropped `COMPONENT_BUGDB` (not used by OI)
6. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` before including `common.mk`, to get 5.34 included
7. **Remove** the `ASLR_MODE`.  That must be copy-paste from another module, because this module doesn't have any compiled code.
8. drop `build/install/test`
9. add `COMPONENT_TEST_MASTER` and specify a single `results-all.master`
10. include suitable `COMPONENT_TEST_TRANSFORMS`
11. update `REQUIRED_PACKAGES`

`pmtools-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)`, `$(COMPONENT_SUMMARY)`, `$(COMPONENT_CLASSIFICATION)`, and `$(COMPONENT_LICENSE)` from the `Makefile`
2. drop `org.opensolaris.arc-caseid`, it's not used by OI
3. add the dependency on the perl runtime that matches this module, using the syntax that causes it to also be detected by `REQUIRED_PACKAGES`.
4. as mentioned above, add commented out code for the `non-PLV` module dependency.  I'm personally in favor of getting rid of this dependency, but until there's a decision, make it clear it's been thought about.

`pmtools.license`:
1. Replace with the correct license file.  The previous file was for GPLv2, which is not what this module is licensed as.