### PR TITLE
perl-archive-zip: rebuild for perl-534

### DIFF
--- a/components/perl/Archive-Zip/Archive-Zip-PERLVER.p5m
+++ b/components/perl/Archive-Zip/Archive-Zip-PERLVER.p5m
@@ -11,18 +11,24 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2021 Tim Mooney.  All rights reserved. 
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/archive-zip-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="Provide an interface to ZIP archive files"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license Archive-Zip.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# Until there is consensus on whether having this package require
+# the non-PLV version of this module, don't enable this.
+#depend type=require \
+#  fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/bin/crc32 mode=0555
 file path=usr/perl5/$(PERLVER)/man/man3/Archive::Zip.3

--- a/components/perl/Archive-Zip/Makefile
+++ b/components/perl/Archive-Zip/Makefile
@@ -11,31 +11,49 @@
 
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2021 Tim Mooney.  All rights reserved.
 #
+
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=		Archive-Zip
-COMPONENT_VERSION=	1.37
-COMPONENT_REVISION=	1
-COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/dist/Archive-Zip/
-COMPONENT_ARCHIVE_HASH=	\
-    sha256:ba789436dc82db02a7f3d2e9d120d0221edc83d8c7ec72519648ae64bbc4ce05
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/P/PH/PHRED/$(COMPONENT_ARCHIVE)
+COMPONENT_NAME=         Archive-Zip
+COMPONENT_VERSION=      1.37
+COMPONENT_REVISION=     2
+COMPONENT_FMRI=         library/perl-5/archive-zip
+COMPONENT_SUMMARY=	Provide an interface to ZIP archive files
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_PROJECT_URL=  https://metacpan.org/pod/Archive::Zip
+COMPONENT_ARCHIVE_HASH= \
+	sha256:ba789436dc82db02a7f3d2e9d120d0221edc83d8c7ec72519648ae64bbc4ce05
+COMPONENT_ARCHIVE_URL=  https://cpan.metacpan.org/authors/id/P/PH/PHRED/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-COMPONENT_TEST_TARGETS = test
+include $(WS_MAKE_RULES)/common.mk
 
-build:		$(BUILD_32_and_64)
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-install:	$(INSTALL_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-test:		$(TEST_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/Archive-Zip/manifests/sample-manifest.p5m
+++ b/components/perl/Archive-Zip/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2021 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -34,6 +34,12 @@ file path=usr/perl5/5.24/man/man3/Archive::Zip.3
 file path=usr/perl5/5.24/man/man3/Archive::Zip::FAQ.3
 file path=usr/perl5/5.24/man/man3/Archive::Zip::MemberRead.3
 file path=usr/perl5/5.24/man/man3/Archive::Zip::Tree.3
+file path=usr/perl5/5.34/bin/crc32
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/Archive::Zip.3
+file path=usr/perl5/5.34/man/man3/Archive::Zip::FAQ.3
+file path=usr/perl5/5.34/man/man3/Archive::Zip::MemberRead.3
+file path=usr/perl5/5.34/man/man3/Archive::Zip::Tree.3
 file path=usr/perl5/vendor_perl/5.22/Archive/Zip.pm
 file path=usr/perl5/vendor_perl/5.22/Archive/Zip/Archive.pm
 file path=usr/perl5/vendor_perl/5.22/Archive/Zip/BufferedFileHandle.pm
@@ -62,3 +68,17 @@ file path=usr/perl5/vendor_perl/5.24/Archive/Zip/StringMember.pm
 file path=usr/perl5/vendor_perl/5.24/Archive/Zip/Tree.pm
 file path=usr/perl5/vendor_perl/5.24/Archive/Zip/ZipFileMember.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Archive/Zip/.packlist
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/Archive.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/BufferedFileHandle.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/DirectoryMember.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/FAQ.pod
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/FileMember.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/Member.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/MemberRead.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/MockFileHandle.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/NewFileMember.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/StringMember.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/Tree.pm
+file path=usr/perl5/vendor_perl/5.34/Archive/Zip/ZipFileMember.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/Archive/Zip/.packlist

--- a/components/perl/Archive-Zip/pkg5
+++ b/components/perl/Archive-Zip/pkg5
@@ -3,11 +3,14 @@
         "SUNWcs",
         "runtime/perl-522",
         "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/archive-zip-522",
         "library/perl-5/archive-zip-524",
+        "library/perl-5/archive-zip-534",
         "library/perl-5/archive-zip"
     ],
     "name": "Archive-Zip"

--- a/components/perl/Archive-Zip/test/results-all.master
+++ b/components/perl/Archive-Zip/test/results-all.master
@@ -1,0 +1,20 @@
+t/01_compile.t ................ ok
+t/02_main.t ................... ok
+t/03_ex.t ..................... ok
+t/04_readmember.t ............. ok
+t/05_tree.t ................... ok
+t/06_update.t ................. ok
+t/07_filenames_of_0.t ......... ok
+t/08_readmember_record_sep.t .. ok
+t/09_output_record_sep.t ...... ok
+t/10_chmod.t .................. ok
+t/11_explorer.t ............... ok
+t/12_bug_47223.t .............. skipped: Only required on Win32.
+t/13_bug_46303.t .............. ok
+t/14_leading_separator.t ...... ok
+t/15_decrypt.t ................ ok
+t/16_decrypt.t ................ ok
+All tests successful.
+Files=16, Tests=246
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild `library/perl-5/archive-zip` for 5.34

Another case where I added the **commented out** `non-PLV` dependency in the manifest:
```
# Until there is consensus on whether having this package require
# the non-PLV version of this module, don't enable this.
#depend type=require \
#  fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
```

`Makefile`:
1. add `BUILD_STYILE=makemaker`, `BUILD_BITS=32_and_64` and switch to including `common.mk`
2. bump `COMPONENT_REVISION`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` to `Makefile`, with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and a single `results-all.master`
8. add suitable `COMPONENT_TEST_TRANSFORMS`
9. re-run `gmake REQUIRED_PACKAGES`

`Archive-Zip-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from Makefile
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the commented out dependency I've already mentioned
6. No forced runtime dependency on the main perl package was needed, probably because of the script installed in the `bin` directory.

