### PR TITLE
library/perl-5/http-date: rebuild for perl 5.34

### DIFF
--- a/components/perl/HTTP-Date/HTTP-Date-PERLVER.p5m
+++ b/components/perl/HTTP-Date/HTTP-Date-PERLVER.p5m
@@ -11,16 +11,26 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/http-date-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="HTTP::Date - date conversion routines"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license HTTP-Date.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on having this package require
+# the non-PLV version of this module, don't enable this.
+#depend type=require \
+#  fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/HTTP::Date.3 mode=0444
 file path=usr/perl5/vendor_perl/$(PERLVER)/HTTP/Date.pm mode=0444

--- a/components/perl/HTTP-Date/Makefile
+++ b/components/perl/HTTP-Date/Makefile
@@ -22,30 +22,48 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
-
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		HTTP-Date
 COMPONENT_VERSION=	6.02
 IPS_COMPONENT_VERSION=	6.2
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/http-date
+COMPONENT_SUMMARY=	HTTP::Date - date conversion routines
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/HTTP-Date/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/HTTP::Date
 COMPONENT_ARCHIVE_HASH=	\
     sha256:e8b9941da0f9f0c9c01068401a5e81341f0e3707d1c754f8e11f42a7e629e333
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/O/OA/OALDERS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/makemaker.mk
-include $(WS_MAKE_RULES)/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/HTTP-Date/manifests/sample-manifest.p5m
+++ b/components/perl/HTTP-Date/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +26,11 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/HTTP::Date.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/HTTP::Date.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/HTTP::Date.3
 file path=usr/perl5/vendor_perl/5.22/HTTP/Date.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/HTTP/Date/.packlist
 file path=usr/perl5/vendor_perl/5.24/HTTP/Date.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/HTTP/Date/.packlist
+file path=usr/perl5/vendor_perl/5.34/HTTP/Date.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/HTTP/Date/.packlist

--- a/components/perl/HTTP-Date/pkg5
+++ b/components/perl/HTTP-Date/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/http-date-522",
         "library/perl-5/http-date-524",
+        "library/perl-5/http-date-534",
         "library/perl-5/http-date"
     ],
     "name": "HTTP-Date"

--- a/components/perl/HTTP-Date/test/results-all.master
+++ b/components/perl/HTTP-Date/test/results-all.master
@@ -1,0 +1,5 @@
+t/date.t .. ok
+All tests successful.
+Files=1, Tests=136
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild library/perl-5/http-date for perl 5.34

All the same changes as in other recent perl module rebuild.

`Makefile`:
1. `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs for https and current locations
5. override `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` to include 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` with a single `results-all.master` and suitable `COMPONENT_TEST_TRANSFORMS`
8. run `gmake REQUIRED_PACKAGES`

`HTTP-Date-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the perl dependency using the syntax that `REQUIRED_PACKAGES` understands
6. add the **commented out** dependency for the `non-PLV` module.
