### PR TITLE
tig: update to 2.5.5

### DIFF
--- a/components/developer/tig/Makefile
+++ b/components/developer/tig/Makefile
@@ -11,7 +11,7 @@
 #
 # Copyright 2018 Harry Liebel
 # Copyright 2019 Michal Nowak
-# Copyright 2021 Nona Hansel
+# Copyright 2021, 2022 Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -19,7 +19,7 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		tig
-COMPONENT_VERSION=	2.5.4
+COMPONENT_VERSION=	2.5.5
 COMPONENT_FMRI=		developer/versioning/tig
 COMPONENT_PROJECT_URL=	https://jonas.github.io/$(COMPONENT_NAME)
 COMPONENT_SUMMARY=	Text-mode interface for git
@@ -27,7 +27,7 @@ COMPONENT_DESCRIPTION=	Tig is an ncurses-based text-mode interface for git. It f
 COMPONENT_CLASSIFICATION= Development/Source Code Management
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:c48284d30287a6365f8a4750eb0b122e78689a1aef8ce1d2961b6843ac246aa7
+COMPONENT_ARCHIVE_HASH= sha256:24ba2c8beae889e6002ea7ced0e29851dee57c27fde8480fb9c64d5eb8765313
 COMPONENT_ARCHIVE_URL=	https://github.com/jonas/$(COMPONENT_NAME)/releases/download/$(COMPONENT_SRC)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE_FILE=	COPYING
 COMPONENT_LICENSE=	GPLv2


### PR DESCRIPTION
Sample-manifest didn't change. It builds, installs and publishes fine. Three tests didn't passed but this is the case even for current version.
When installed locally, it works.