### PR TITLE
library/perl-5/sqlite-dbi: rebuild for perl 5.34

### DIFF
--- a/components/perl/DBI-SQLite/Makefile
+++ b/components/perl/DBI-SQLite/Makefile
@@ -10,34 +10,65 @@
 
 #
 # Copyright 2015 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
+# copyright 2022 (c) Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= 	DBI-SQLite
 COMPONENT_VERSION=	1.52
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY= 	The DBI SQLite Interface for Perl
+COMPONENT_FMRI=		library/perl-5/sqlite-dbi
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL = https://metacpan.org/pod/DBD::SQLite
 COMPONENT_SRC=		DBD-SQLite-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
   sha256:a6da099e9b953262afafea18335930bede1f195fdead45bd3f00e690b158354e
 COMPONENT_ARCHIVE_URL= \
-  http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://search.cpan.org/dist/DBD-SQLite/lib/DBD/SQLite.pm
+  http://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
+COMPONENT_LICENSE_FILE=	dbi-sqlite.license
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-build:          $(BUILD_32_and_64)
+# Enable ASLR for this component
+ASLR_MODE = $(ASLR_ENABLE)
 
-install:        $(INSTALL_32_and_64)
+include $(WS_MAKE_RULES)/common.mk
 
-test:           $(NO_TESTS)
+#
+# need different results per version because 5.24+ has threading while
+# 5.22 does not.
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-$(PERL_VERSION).master
 
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+# also remove a couple of version numbers to reduce spurious test diffs
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"' \
+	'-e "s/DBI::VERSION=.*/DBI::VERSION=removed for test uniformity/"' \
+	'-e "s/sqlite_version=.*/sqlite_version=removed for test uniformity/"'
+
+# database/sqlite-3 is not required, either at build time or runtime.
+# DBD::SQLite includes its own copy of the source and builds SQLite into
+# its own shared object.
+
+# build and runtime dependency on perl's DBI module
 REQUIRED_PACKAGES += library/perl-5/database
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/perl/DBI-SQLite/dbi-sqlite-PERLVER.p5m
+++ b/components/perl/DBI-SQLite/dbi-sqlite-PERLVER.p5m
@@ -11,16 +11,29 @@
 
 #
 # Copyright 2015 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
+# Copyright 2022 (c) Tim Mooney.  All rights reserved
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/sqlite-dbi-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="The DBI SQLite Interface for Perl"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license dbi-sqlite.license license='Artistic'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether having this package require
+# the non-PLV version of this  module, don\t enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
+# DBD::SQLite needs DBI for the same version of perl
+depend fmri=library/perl-5/database-$(PLV) type=require
 
 file path=usr/perl5/$(PERLVER)/man/man3/DBD::SQLite.3
 file path=usr/perl5/$(PERLVER)/man/man3/DBD::SQLite::Constants.3

--- a/components/perl/DBI-SQLite/manifests/sample-manifest.p5m
+++ b/components/perl/DBI-SQLite/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,6 +38,14 @@ file path=usr/perl5/5.24/man/man3/DBD::SQLite::Fulltext_search.3
 file path=usr/perl5/5.24/man/man3/DBD::SQLite::VirtualTable.3
 file path=usr/perl5/5.24/man/man3/DBD::SQLite::VirtualTable::FileContent.3
 file path=usr/perl5/5.24/man/man3/DBD::SQLite::VirtualTable::PerlData.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/DBD::SQLite.3
+file path=usr/perl5/5.34/man/man3/DBD::SQLite::Constants.3
+file path=usr/perl5/5.34/man/man3/DBD::SQLite::Cookbook.3
+file path=usr/perl5/5.34/man/man3/DBD::SQLite::Fulltext_search.3
+file path=usr/perl5/5.34/man/man3/DBD::SQLite::VirtualTable.3
+file path=usr/perl5/5.34/man/man3/DBD::SQLite::VirtualTable::FileContent.3
+file path=usr/perl5/5.34/man/man3/DBD::SQLite::VirtualTable::PerlData.3
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/DBD/SQLite.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/DBD/SQLite/Constants.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/DBD/SQLite/Cookbook.pod
@@ -62,3 +70,15 @@ file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/DBD/SQLi
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/share/dist/DBD-SQLite/sqlite3.c
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/share/dist/DBD-SQLite/sqlite3.h
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/share/dist/DBD-SQLite/sqlite3ext.h
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/SQLite.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/SQLite/Constants.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/SQLite/Cookbook.pod
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/SQLite/Fulltext_search.pod
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/SQLite/VirtualTable.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/SQLite/VirtualTable/FileContent.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/SQLite/VirtualTable/PerlData.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/DBD/SQLite/.packlist
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/DBD/SQLite/SQLite.so
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/share/dist/DBD-SQLite/sqlite3.c
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/share/dist/DBD-SQLite/sqlite3.h
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/share/dist/DBD-SQLite/sqlite3ext.h

--- a/components/perl/DBI-SQLite/pkg5
+++ b/components/perl/DBI-SQLite/pkg5
@@ -2,13 +2,16 @@
     "dependencies": [
         "SUNWcs",
         "library/perl-5/database",
-        "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
+        "system/library"
     ],
     "fmris": [
         "library/perl-5/sqlite-dbi-522",
         "library/perl-5/sqlite-dbi-524",
+        "library/perl-5/sqlite-dbi-534",
         "library/perl-5/sqlite-dbi"
     ],
     "name": "DBI-SQLite"

--- a/components/perl/DBI-SQLite/test/results-5.22.master
+++ b/components/perl/DBI-SQLite/test/results-5.22.master
@@ -1,0 +1,134 @@
+# $DBI::VERSION=removed for test uniformity
+# Compile Options:
+#   ENABLE_COLUMN_METADATA
+#   ENABLE_FTS3
+#   ENABLE_FTS3_PARENTHESIS
+#   ENABLE_FTS4
+#   ENABLE_FTS5
+#   ENABLE_JSON1
+#   ENABLE_RTREE
+#   ENABLE_STAT4
+#   SYSTEM_MALLOC
+#   THREADSAFE=0
+t/01_compile.t ........................................ ok
+# sqlite_version=removed for test uniformity
+t/02_logon.t .......................................... ok
+t/03_create_table.t ................................... ok
+t/04_insert.t ......................................... ok
+t/05_select.t ......................................... ok
+t/06_tran.t ........................................... ok
+t/07_error.t .......................................... ok
+t/08_busy.t ........................................... ok
+t/09_create_function.t ................................ ok
+t/10_create_aggregate.t ............................... ok
+t/12_unicode.t ........................................ ok
+t/13_create_collation.t ............................... ok
+t/14_progress_handler.t ............................... ok
+t/15_ak_dbd.t ......................................... ok
+t/16_column_info.t .................................... ok
+t/17_createdrop.t ..................................... ok
+t/18_insertfetch.t .................................... ok
+t/19_bindparam.t ...................................... ok
+t/20_blobs.t .......................................... ok
+t/21_blobtext.t ....................................... ok
+t/22_listfields.t ..................................... ok
+t/23_nulls.t .......................................... ok
+t/24_numrows.t ........................................ ok
+t/25_chopblanks.t ..................................... ok
+t/26_commit.t ......................................... ok
+t/27_metadata.t ....................................... ok
+t/28_schemachange.t ................................... ok
+t/30_auto_rollback.t .................................. ok
+t/31_bind_weird_number_param.t ........................ ok
+t/32_inactive_error.t ................................. ok
+t/33_non_latin_path.t ................................. ok
+t/34_online_backup.t .................................. ok
+t/35_table_info.t ..................................... ok
+t/36_hooks.t .......................................... ok
+t/37_regexp.t ......................................... ok
+t/38_empty_statement.t ................................ ok
+t/39_foreign_keys.t ................................... ok
+t/40_multiple_statements.t ............................ ok
+t/41_placeholders.t ................................... ok
+t/42_primary_key_info.t ............................... ok
+t/43_fts3.t ........................................... skipped: FTS3 tokenizer is disabled for this DBD::SQLite
+t/44_rtree.t .......................................... ok
+t/45_savepoints.t ..................................... ok
+t/46_mod_perl.t ....................................... skipped: requires APR::Table
+t/47_execute.t ........................................ ok
+t/48_bind_param_is_sticky.t ........................... ok
+t/49_trace_and_profile.t .............................. ok
+t/50_foreign_key_info.t ............................... ok
+t/51_table_column_metadata.t .......................... ok
+t/52_db_filename.t .................................... ok
+t/53_status.t ......................................... ok
+t/54_literal_txn.t .................................... ok
+t/55_statistics_info.t ................................ ok
+t/56_open_flags.t ..................................... ok
+t/57_uri_filename.t ................................... ok
+t/58_see_if_its_a_number_and_explicit_binding.t ....... ok
+t/59_extended_result_codes.t .......................... skipped: this test is for Win32 only
+t/60_readonly.t ....................................... ok
+t/61_strlike.t ........................................ ok
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30B9) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30F3) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30B9) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30F3) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+t/62_regexp_multibyte_char_class.t .................... ok
+t/cookbook_variance.t ................................. ok
+t/rt_106151_outermost_savepoint.t ..................... ok
+t/rt_106950_extra_warnings_with_savepoints.t .......... ok
+t/rt_115465_column_info_with_spaces.t ................. ok
+t/rt_15186_prepcached.t ............................... ok
+t/rt_21406_auto_finish.t .............................. ok
+t/rt_25371_asymmetric_unicode.t ....................... ok
+t/rt_25460_numeric_aggregate.t ........................ ok
+t/rt_25924_user_defined_func_unicode.t ................ ok
+t/rt_26775_distinct.t ................................. ok
+t/rt_27553_prepared_cache_and_analyze.t ............... ok
+t/rt_29058_group_by.t ................................. ok
+t/rt_29629_sqlite_where_length.t ...................... ok
+t/rt_31324_full_names.t ............................... ok
+t/rt_32889_prepare_cached_reexecute.t ................. ok
+t/rt_36836_duplicate_key.t ............................ ok
+t/rt_36838_unique_and_bus_error.t ..................... ok
+t/rt_40594_nullable.t ................................. ok
+t/rt_48393_debug_panic_with_commit.t .................. skipped: set $ENV{TEST_DBD_SQLITE_WITH_DEBUGGER} to enable this test
+t/rt_50503_fts3.t ..................................... ok
+t/rt_52573_manual_exclusive_lock.t .................... ok
+t/rt_53235_icu_compatibility.t ........................ skipped: requires SQLite ICU plugin to be enabled
+t/rt_62370_diconnected_handles_operation.t ............ ok
+t/rt_64177_ping_wipes_out_the_errstr.t ................ ok
+t/rt_67581_bind_params_mismatch.t ..................... ok
+t/rt_71311_bind_col_and_unicode.t ..................... ok
+t/rt_73159_fts_tokenizer_segfault.t ................... ok
+t/rt_73787_exponential_buffer_overflow.t .............. ok
+t/rt_76395_int_overflow.t ............................. ok
+t/rt_77724_primary_key_with_a_whitespace.t ............ ok
+t/rt_78833_utf8_flag_for_column_names.t ............... ok
+t/rt_81536_multi_column_primary_key_info.t ............ ok
+t/rt_88228_sqlite_3_8_0_crash.t ....................... ok
+t/rt_96050_db_filename_for_a_closed_database.t ........ ok
+t/rt_96877_unicode_statements.t ....................... ok
+t/rt_96878_fts_contentless_table.t .................... ok
+t/rt_97598_crash_on_disconnect_with_virtual_tables.t .. ok
+t/virtual_table/00_base.t ............................. ok
+t/virtual_table/01_destroy.t .......................... ok
+t/virtual_table/02_find_function.t .................... ok
+t/virtual_table/10_filecontent.t ...................... ok
+t/virtual_table/11_filecontent_fulltext.t ............. ok
+t/virtual_table/20_perldata.t ......................... ok
+t/virtual_table/21_perldata_charinfo.t ................ ok
+t/virtual_table/rt_99748.t ............................ ok
+All tests successful.
+Files=105, Tests=3548
+Result: PASS
+make[1]: Leaving directory '$(@D)'

--- a/components/perl/DBI-SQLite/test/results-5.24.master
+++ b/components/perl/DBI-SQLite/test/results-5.24.master
@@ -1,0 +1,134 @@
+# $DBI::VERSION=removed for test uniformity
+# Compile Options:
+#   ENABLE_COLUMN_METADATA
+#   ENABLE_FTS3
+#   ENABLE_FTS3_PARENTHESIS
+#   ENABLE_FTS4
+#   ENABLE_FTS5
+#   ENABLE_JSON1
+#   ENABLE_RTREE
+#   ENABLE_STAT4
+#   SYSTEM_MALLOC
+#   THREADSAFE=1
+t/01_compile.t ........................................ ok
+# sqlite_version=removed for test uniformity
+t/02_logon.t .......................................... ok
+t/03_create_table.t ................................... ok
+t/04_insert.t ......................................... ok
+t/05_select.t ......................................... ok
+t/06_tran.t ........................................... ok
+t/07_error.t .......................................... ok
+t/08_busy.t ........................................... ok
+t/09_create_function.t ................................ ok
+t/10_create_aggregate.t ............................... ok
+t/12_unicode.t ........................................ ok
+t/13_create_collation.t ............................... ok
+t/14_progress_handler.t ............................... ok
+t/15_ak_dbd.t ......................................... ok
+t/16_column_info.t .................................... ok
+t/17_createdrop.t ..................................... ok
+t/18_insertfetch.t .................................... ok
+t/19_bindparam.t ...................................... ok
+t/20_blobs.t .......................................... ok
+t/21_blobtext.t ....................................... ok
+t/22_listfields.t ..................................... ok
+t/23_nulls.t .......................................... ok
+t/24_numrows.t ........................................ ok
+t/25_chopblanks.t ..................................... ok
+t/26_commit.t ......................................... ok
+t/27_metadata.t ....................................... ok
+t/28_schemachange.t ................................... ok
+t/30_auto_rollback.t .................................. ok
+t/31_bind_weird_number_param.t ........................ ok
+t/32_inactive_error.t ................................. ok
+t/33_non_latin_path.t ................................. ok
+t/34_online_backup.t .................................. ok
+t/35_table_info.t ..................................... ok
+t/36_hooks.t .......................................... ok
+t/37_regexp.t ......................................... ok
+t/38_empty_statement.t ................................ ok
+t/39_foreign_keys.t ................................... ok
+t/40_multiple_statements.t ............................ ok
+t/41_placeholders.t ................................... ok
+t/42_primary_key_info.t ............................... ok
+t/43_fts3.t ........................................... skipped: FTS3 tokenizer is disabled for this DBD::SQLite
+t/44_rtree.t .......................................... ok
+t/45_savepoints.t ..................................... ok
+t/46_mod_perl.t ....................................... skipped: requires APR::Table
+t/47_execute.t ........................................ ok
+t/48_bind_param_is_sticky.t ........................... ok
+t/49_trace_and_profile.t .............................. ok
+t/50_foreign_key_info.t ............................... ok
+t/51_table_column_metadata.t .......................... ok
+t/52_db_filename.t .................................... ok
+t/53_status.t ......................................... ok
+t/54_literal_txn.t .................................... ok
+t/55_statistics_info.t ................................ ok
+t/56_open_flags.t ..................................... ok
+t/57_uri_filename.t ................................... ok
+t/58_see_if_its_a_number_and_explicit_binding.t ....... ok
+t/59_extended_result_codes.t .......................... skipped: this test is for Win32 only
+t/60_readonly.t ....................................... ok
+t/61_strlike.t ........................................ ok
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30B9) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30F3) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30B9) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30F3) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+t/62_regexp_multibyte_char_class.t .................... ok
+t/cookbook_variance.t ................................. ok
+t/rt_106151_outermost_savepoint.t ..................... ok
+t/rt_106950_extra_warnings_with_savepoints.t .......... ok
+t/rt_115465_column_info_with_spaces.t ................. ok
+t/rt_15186_prepcached.t ............................... ok
+t/rt_21406_auto_finish.t .............................. ok
+t/rt_25371_asymmetric_unicode.t ....................... ok
+t/rt_25460_numeric_aggregate.t ........................ ok
+t/rt_25924_user_defined_func_unicode.t ................ ok
+t/rt_26775_distinct.t ................................. ok
+t/rt_27553_prepared_cache_and_analyze.t ............... ok
+t/rt_29058_group_by.t ................................. ok
+t/rt_29629_sqlite_where_length.t ...................... ok
+t/rt_31324_full_names.t ............................... ok
+t/rt_32889_prepare_cached_reexecute.t ................. ok
+t/rt_36836_duplicate_key.t ............................ ok
+t/rt_36838_unique_and_bus_error.t ..................... ok
+t/rt_40594_nullable.t ................................. ok
+t/rt_48393_debug_panic_with_commit.t .................. skipped: set $ENV{TEST_DBD_SQLITE_WITH_DEBUGGER} to enable this test
+t/rt_50503_fts3.t ..................................... ok
+t/rt_52573_manual_exclusive_lock.t .................... ok
+t/rt_53235_icu_compatibility.t ........................ skipped: requires SQLite ICU plugin to be enabled
+t/rt_62370_diconnected_handles_operation.t ............ ok
+t/rt_64177_ping_wipes_out_the_errstr.t ................ ok
+t/rt_67581_bind_params_mismatch.t ..................... ok
+t/rt_71311_bind_col_and_unicode.t ..................... ok
+t/rt_73159_fts_tokenizer_segfault.t ................... ok
+t/rt_73787_exponential_buffer_overflow.t .............. ok
+t/rt_76395_int_overflow.t ............................. ok
+t/rt_77724_primary_key_with_a_whitespace.t ............ ok
+t/rt_78833_utf8_flag_for_column_names.t ............... ok
+t/rt_81536_multi_column_primary_key_info.t ............ ok
+t/rt_88228_sqlite_3_8_0_crash.t ....................... ok
+t/rt_96050_db_filename_for_a_closed_database.t ........ ok
+t/rt_96877_unicode_statements.t ....................... ok
+t/rt_96878_fts_contentless_table.t .................... ok
+t/rt_97598_crash_on_disconnect_with_virtual_tables.t .. ok
+t/virtual_table/00_base.t ............................. ok
+t/virtual_table/01_destroy.t .......................... ok
+t/virtual_table/02_find_function.t .................... ok
+t/virtual_table/10_filecontent.t ...................... ok
+t/virtual_table/11_filecontent_fulltext.t ............. ok
+t/virtual_table/20_perldata.t ......................... ok
+t/virtual_table/21_perldata_charinfo.t ................ ok
+t/virtual_table/rt_99748.t ............................ ok
+All tests successful.
+Files=105, Tests=3548
+Result: PASS
+make[1]: Leaving directory '$(@D)'

--- a/components/perl/DBI-SQLite/test/results-5.34.master
+++ b/components/perl/DBI-SQLite/test/results-5.34.master
@@ -1,0 +1,134 @@
+# $DBI::VERSION=removed for test uniformity
+# Compile Options:
+#   ENABLE_COLUMN_METADATA
+#   ENABLE_FTS3
+#   ENABLE_FTS3_PARENTHESIS
+#   ENABLE_FTS4
+#   ENABLE_FTS5
+#   ENABLE_JSON1
+#   ENABLE_RTREE
+#   ENABLE_STAT4
+#   SYSTEM_MALLOC
+#   THREADSAFE=1
+t/01_compile.t ........................................ ok
+# sqlite_version=removed for test uniformity
+t/02_logon.t .......................................... ok
+t/03_create_table.t ................................... ok
+t/04_insert.t ......................................... ok
+t/05_select.t ......................................... ok
+t/06_tran.t ........................................... ok
+t/07_error.t .......................................... ok
+t/08_busy.t ........................................... ok
+t/09_create_function.t ................................ ok
+t/10_create_aggregate.t ............................... ok
+t/12_unicode.t ........................................ ok
+t/13_create_collation.t ............................... ok
+t/14_progress_handler.t ............................... ok
+t/15_ak_dbd.t ......................................... ok
+t/16_column_info.t .................................... ok
+t/17_createdrop.t ..................................... ok
+t/18_insertfetch.t .................................... ok
+t/19_bindparam.t ...................................... ok
+t/20_blobs.t .......................................... ok
+t/21_blobtext.t ....................................... ok
+t/22_listfields.t ..................................... ok
+t/23_nulls.t .......................................... ok
+t/24_numrows.t ........................................ ok
+t/25_chopblanks.t ..................................... ok
+t/26_commit.t ......................................... ok
+t/27_metadata.t ....................................... ok
+t/28_schemachange.t ................................... ok
+t/30_auto_rollback.t .................................. ok
+t/31_bind_weird_number_param.t ........................ ok
+t/32_inactive_error.t ................................. ok
+t/33_non_latin_path.t ................................. ok
+t/34_online_backup.t .................................. ok
+t/35_table_info.t ..................................... ok
+t/36_hooks.t .......................................... ok
+t/37_regexp.t ......................................... ok
+t/38_empty_statement.t ................................ ok
+t/39_foreign_keys.t ................................... ok
+t/40_multiple_statements.t ............................ ok
+t/41_placeholders.t ................................... ok
+t/42_primary_key_info.t ............................... ok
+t/43_fts3.t ........................................... skipped: FTS3 tokenizer is disabled for this DBD::SQLite
+t/44_rtree.t .......................................... ok
+t/45_savepoints.t ..................................... ok
+t/46_mod_perl.t ....................................... skipped: requires APR::Table
+t/47_execute.t ........................................ ok
+t/48_bind_param_is_sticky.t ........................... ok
+t/49_trace_and_profile.t .............................. ok
+t/50_foreign_key_info.t ............................... ok
+t/51_table_column_metadata.t .......................... ok
+t/52_db_filename.t .................................... ok
+t/53_status.t ......................................... ok
+t/54_literal_txn.t .................................... ok
+t/55_statistics_info.t ................................ ok
+t/56_open_flags.t ..................................... ok
+t/57_uri_filename.t ................................... ok
+t/58_see_if_its_a_number_and_explicit_binding.t ....... ok
+t/59_extended_result_codes.t .......................... skipped: this test is for Win32 only
+t/60_readonly.t ....................................... ok
+t/61_strlike.t ........................................ ok
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30B9) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30F3) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30B9) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C6) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30F3) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+Wide character (U+30C8) in pattern match (m//) at $(@D)/blib/lib/DBD/SQLite.pm line 187.
+t/62_regexp_multibyte_char_class.t .................... ok
+t/cookbook_variance.t ................................. ok
+t/rt_106151_outermost_savepoint.t ..................... ok
+t/rt_106950_extra_warnings_with_savepoints.t .......... ok
+t/rt_115465_column_info_with_spaces.t ................. ok
+t/rt_15186_prepcached.t ............................... ok
+t/rt_21406_auto_finish.t .............................. ok
+t/rt_25371_asymmetric_unicode.t ....................... ok
+t/rt_25460_numeric_aggregate.t ........................ ok
+t/rt_25924_user_defined_func_unicode.t ................ ok
+t/rt_26775_distinct.t ................................. ok
+t/rt_27553_prepared_cache_and_analyze.t ............... ok
+t/rt_29058_group_by.t ................................. ok
+t/rt_29629_sqlite_where_length.t ...................... ok
+t/rt_31324_full_names.t ............................... ok
+t/rt_32889_prepare_cached_reexecute.t ................. ok
+t/rt_36836_duplicate_key.t ............................ ok
+t/rt_36838_unique_and_bus_error.t ..................... ok
+t/rt_40594_nullable.t ................................. ok
+t/rt_48393_debug_panic_with_commit.t .................. skipped: set $ENV{TEST_DBD_SQLITE_WITH_DEBUGGER} to enable this test
+t/rt_50503_fts3.t ..................................... ok
+t/rt_52573_manual_exclusive_lock.t .................... ok
+t/rt_53235_icu_compatibility.t ........................ skipped: requires SQLite ICU plugin to be enabled
+t/rt_62370_diconnected_handles_operation.t ............ ok
+t/rt_64177_ping_wipes_out_the_errstr.t ................ ok
+t/rt_67581_bind_params_mismatch.t ..................... ok
+t/rt_71311_bind_col_and_unicode.t ..................... ok
+t/rt_73159_fts_tokenizer_segfault.t ................... ok
+t/rt_73787_exponential_buffer_overflow.t .............. ok
+t/rt_76395_int_overflow.t ............................. ok
+t/rt_77724_primary_key_with_a_whitespace.t ............ ok
+t/rt_78833_utf8_flag_for_column_names.t ............... ok
+t/rt_81536_multi_column_primary_key_info.t ............ ok
+t/rt_88228_sqlite_3_8_0_crash.t ....................... ok
+t/rt_96050_db_filename_for_a_closed_database.t ........ ok
+t/rt_96877_unicode_statements.t ....................... ok
+t/rt_96878_fts_contentless_table.t .................... ok
+t/rt_97598_crash_on_disconnect_with_virtual_tables.t .. ok
+t/virtual_table/00_base.t ............................. ok
+t/virtual_table/01_destroy.t .......................... ok
+t/virtual_table/02_find_function.t .................... ok
+t/virtual_table/10_filecontent.t ...................... ok
+t/virtual_table/11_filecontent_fulltext.t ............. ok
+t/virtual_table/20_perldata.t ......................... ok
+t/virtual_table/21_perldata_charinfo.t ................ ok
+t/virtual_table/rt_99748.t ............................ ok
+All tests successful.
+Files=105, Tests=3548
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild sqlite-dbi, including support for perl 5.34.

Two changes of note:
1. since this does have a compiled component (SQLite.so), I added the Makefile config for `ASLR_MODE`
2. this module requires library/perl-5/database for the same version of perl, so I added a runtime dependency in `dbi-sqlite-PERLVER.p5m`.

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 3
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, `COMPONENT_LICENSE`, and `COMPONENT_LICENSE_FILE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. add `ASLR_MODE = $(ASLR_ENABLE)` since this module does have compiled components
7. drop `build/install/test`
8. add `COMPONENT_TEST_MASTER` and specify version-specific results files, since there are (minor) differences between versions because of threading
9. add `COMPONENT_TEST_TRANSFORMS`, including a couple of special transforms to avoid spurious diffs because of versions printed as part of the test output
10. add `REQUIRED_PACKAGES += library/perl-5/database`, so that all versions of DBI are present at build time
11. `gmake REQUIRED_PACKAGES` and include

`dbi-sqlite-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. ditto for `$(COMPONENT_LICENSE_FILE)`, which is needed since the license file name doesn't match the `COMPONENT_NAME`
6. add the dependency on the same version of perl, using the syntax that `REQUIRED_PACKAGES` can handle
7. add the commented out block related to the `non-PLV` module.
8. add a runtime dependency on `library/perl-5/database-$(PLV)`, so that DBI is also installed for the same version of perl.