### PR TITLE
library/perl-5/xml-sax-base: rebuild for perl 5.34

### DIFF
--- a/components/perl/xml-sax-base/Makefile
+++ b/components/perl/xml-sax-base/Makefile
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 BUILD_BITS=32_and_64
 BUILD_STYLE=makemaker
@@ -29,23 +30,29 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		XML-SAX-Base
 COMPONENT_VERSION=	1.9
 HUMAN_VERSION=		1.09
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		library/perl-5/xml-sax-base
 COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_SUMMARY=	XML::SAX::Base - Base class for SAX Drivers and Filters
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GR/GRANTM/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~grantm/
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/G/GR/GRANTM/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/XML::SAX::Base
 COMPONENT_LICENSE=	Artistic
 COMPONENT_LICENSE_FILE=	xml-sax-base.license
+
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
 include $(WS_MAKE_RULES)/common.mk
 
 # man pages go in the common area
 COMPONENT_INSTALL_ENV += INSTALLVENDORMAN3DIR=$(USRSHAREMAN3DIR)
 
-COMPONENT_TEST_TARGETS = test
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 COMPONENT_TEST_TRANSFORMS += \
 	'-e "/^PERL_DL_NONLAZY/d" ' \
@@ -54,3 +61,4 @@ COMPONENT_TEST_TRANSFORMS += \
 # Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/xml-sax-base/manifests/sample-manifest.p5m
+++ b/components/perl/xml-sax-base/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,6 +30,10 @@ file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/XML::SAX::Base.3
 file path=usr/perl5/5.24/man/man3/XML::SAX::BuildSAXBase.3
 file path=usr/perl5/5.24/man/man3/XML::SAX::Exception.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/XML::SAX::Base.3
+file path=usr/perl5/5.34/man/man3/XML::SAX::BuildSAXBase.3
+file path=usr/perl5/5.34/man/man3/XML::SAX::Exception.3
 file path=usr/perl5/vendor_perl/5.22/XML/SAX/Base.pm
 file path=usr/perl5/vendor_perl/5.22/XML/SAX/BuildSAXBase.pl
 file path=usr/perl5/vendor_perl/5.22/XML/SAX/Exception.pm
@@ -38,3 +42,7 @@ file path=usr/perl5/vendor_perl/5.24/XML/SAX/Base.pm
 file path=usr/perl5/vendor_perl/5.24/XML/SAX/BuildSAXBase.pl
 file path=usr/perl5/vendor_perl/5.24/XML/SAX/Exception.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/XML/SAX/Base/.packlist
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/Base.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/BuildSAXBase.pl
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/Exception.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/XML/SAX/Base/.packlist

--- a/components/perl/xml-sax-base/pkg5
+++ b/components/perl/xml-sax-base/pkg5
@@ -3,11 +3,14 @@
         "SUNWcs",
         "runtime/perl-522",
         "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/xml-sax-base-522",
         "library/perl-5/xml-sax-base-524",
+        "library/perl-5/xml-sax-base-534",
         "library/perl-5/xml-sax-base"
     ],
     "name": "XML-SAX-Base"

--- a/components/perl/xml-sax-base/xml-sax-base-PERLVER.p5m
+++ b/components/perl/xml-sax-base/xml-sax-base-PERLVER.p5m
@@ -11,10 +11,11 @@
 
 #
 # Copyright 2020 Aurelien Larcher
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="XML::SAX::Base - Base class for SAX Drivers and Filters"
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)


### PR DESCRIPTION
Aurélien touched this component in 2020, so much fewer changes than with other components.

`Makefile`:
1. add `COMPONENT_REVISION=1`
2. add `COMPONENT_SUMMARY` with value from the manifest
3. update the URLs for https and current locations
4. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS` to get 5.34 included in the rebuild
5. drop `COMPONENT_TEST_TARGET`.  Not needed since `makemaker.mk` was fixed years ago
6. run `gmake REQUIRED_PACKAGES`

`xml-sax-base-PERLVER.p5m`:
1. reference `$(COMPONENT_SUMMARY)` from the `Makefile` instead of setting the value here

I left Aurélien's runtime dependencies as-is in the manifest.