### PR TITLE
library/perl-5/net-http: rebuild for perl 5.34

### DIFF
--- a/components/perl/Net-HTTP/Makefile
+++ b/components/perl/Net-HTTP/Makefile
@@ -22,28 +22,52 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Net-HTTP
 COMPONENT_VERSION=	6.12
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		library/perl-5/net-http
+COMPONENT_SUMMARY=	Net::HTTP - Low-level HTTP connection (client)
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/Net-HTTP/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/Net::HTTP
 COMPONENT_ARCHIVE_HASH=	\
     sha256:8565aff76b3d09084642f3a83c654fb4ced8220e8e19d35c78b661519b4c1be6
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/O/OA/OALDERS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/makemaker.mk
-include $(WS_MAKE_RULES)/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
+# Net::HTTP requires URI at runtime, so make certain it's installed
+# at build time for the test suite
+REQUIRED_PACKAGES += library/perl-5/uri
 
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/Net-HTTP/Net-HTTP-PERLVER.p5m
+++ b/components/perl/Net-HTTP/Net-HTTP-PERLVER.p5m
@@ -11,16 +11,29 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/net-http-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="Net::HTTP - Low-level HTTP connection (client)"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license Net-HTTP.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether having this package require
+# the non-PLV version of this  module, don't enable this.
+#depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
+# Net::HTTP requires URI
+depend type=require fmri=library/perl-5/uri-$(PLV)
 
 file path=usr/perl5/$(PERLVER)/man/man3/Net::HTTP.3
 file path=usr/perl5/$(PERLVER)/man/man3/Net::HTTP::Methods.3

--- a/components/perl/Net-HTTP/manifests/sample-manifest.p5m
+++ b/components/perl/Net-HTTP/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -32,6 +32,11 @@ file path=usr/perl5/5.24/man/man3/Net::HTTP.3
 file path=usr/perl5/5.24/man/man3/Net::HTTP::Methods.3
 file path=usr/perl5/5.24/man/man3/Net::HTTP::NB.3
 file path=usr/perl5/5.24/man/man3/Net::HTTPS.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/Net::HTTP.3
+file path=usr/perl5/5.34/man/man3/Net::HTTP::Methods.3
+file path=usr/perl5/5.34/man/man3/Net::HTTP::NB.3
+file path=usr/perl5/5.34/man/man3/Net::HTTPS.3
 file path=usr/perl5/vendor_perl/5.22/Net/HTTP.pm
 file path=usr/perl5/vendor_perl/5.22/Net/HTTP/Methods.pm
 file path=usr/perl5/vendor_perl/5.22/Net/HTTP/NB.pm
@@ -42,3 +47,8 @@ file path=usr/perl5/vendor_perl/5.24/Net/HTTP/Methods.pm
 file path=usr/perl5/vendor_perl/5.24/Net/HTTP/NB.pm
 file path=usr/perl5/vendor_perl/5.24/Net/HTTPS.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Net/HTTP/.packlist
+file path=usr/perl5/vendor_perl/5.34/Net/HTTP.pm
+file path=usr/perl5/vendor_perl/5.34/Net/HTTP/Methods.pm
+file path=usr/perl5/vendor_perl/5.34/Net/HTTP/NB.pm
+file path=usr/perl5/vendor_perl/5.34/Net/HTTPS.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/Net/HTTP/.packlist

--- a/components/perl/Net-HTTP/pkg5
+++ b/components/perl/Net-HTTP/pkg5
@@ -1,11 +1,17 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/perl-5/uri",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/net-http-522",
         "library/perl-5/net-http-524",
+        "library/perl-5/net-http-534",
         "library/perl-5/net-http"
     ],
     "name": "Net-HTTP"

--- a/components/perl/Net-HTTP/test/results-all.master
+++ b/components/perl/Net-HTTP/test/results-all.master
@@ -1,0 +1,9 @@
+t/http-nb.t ..... ok
+t/http.t ........ ok
+t/live-https.t .. skipped: Live tests disabled; pass --live-tests to Makefile.PL to enable
+t/live.t ........ skipped: Live tests disabled; pass --live-tests to Makefile.PL to enable
+t/rt-112313.t ... skipped: Live tests disabled; pass --live-tests to Makefile.PL to enable
+All tests successful.
+Files=5, Tests=51
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild net-http adding support for perl 5.34

Only thing "unique" to this package is that I added the missing dependency on `library/perl-5/uri` for the same version of perl.  Since it's needed to run the tests, it also got added to the `Makefile`.

Otherwise, all the same standard changes as recent modules.

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. add `COMPONENT_REVISION=1`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and specify one `results-all.master`
8. add standard `COMPONENT_TEST_TRANSFORMS`
9. add `REQUIRED_PACKAGES += library/perl-5/uri`, needed to run the tests
10. run `gmake REQUIRED_PACKAGES`

`Net-HTTP-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the runtime dependency on the same version of perl this module is built for, using the syntax that `REQUIRED_PACKAGES` recognizes
6. add the `non-PLV` stuff, commented out.
7. specific to this package, add the runtime dependency on `library/perl-5/uri-$(PLV)`
