### PR TITLE
library/perl-5/html-tagset: rebuild for perl 5.34

### DIFF
--- a/components/perl/HTML-Tagset/HTML-Tagset-PERLVER.p5m
+++ b/components/perl/HTML-Tagset/HTML-Tagset-PERLVER.p5m
@@ -11,18 +11,28 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/html-tagset-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="HTML::Target - data tables useful in dealing with HTML"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license HTML-Tagset.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+#depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/HTML::Tagset.3 mode=0444
 file path=usr/perl5/vendor_perl/$(PERLVER)/HTML/Tagset.pm mode=0444

--- a/components/perl/HTML-Tagset/Makefile
+++ b/components/perl/HTML-Tagset/Makefile
@@ -22,29 +22,48 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		HTML-Tagset
 COMPONENT_VERSION=	3.20
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/html-tagset
+COMPONENT_SUMMARY=	HTML::Tagset - data tables useful in parsing HTML
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~petdance/HTML-Tagset/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/HTML::Tagset
 COMPONENT_ARCHIVE_HASH=	\
     sha256:adb17dac9e36cd011f5243881c9739417fd102fce760f8de4e9be4c7131108e2
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/P/PE/PETDANCE/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# delete any lines up through test_harness
+# delete timings
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/HTML-Tagset/manifests/sample-manifest.p5m
+++ b/components/perl/HTML-Tagset/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +26,11 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/HTML::Tagset.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/HTML::Tagset.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/HTML::Tagset.3
 file path=usr/perl5/vendor_perl/5.22/HTML/Tagset.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/HTML/Tagset/.packlist
 file path=usr/perl5/vendor_perl/5.24/HTML/Tagset.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/HTML/Tagset/.packlist
+file path=usr/perl5/vendor_perl/5.34/HTML/Tagset.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/HTML/Tagset/.packlist

--- a/components/perl/HTML-Tagset/pkg5
+++ b/components/perl/HTML-Tagset/pkg5
@@ -1,11 +1,16 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/html-tagset-522",
         "library/perl-5/html-tagset-524",
+        "library/perl-5/html-tagset-534",
         "library/perl-5/html-tagset"
     ],
     "name": "HTML-Tagset"

--- a/components/perl/HTML-Tagset/test/results-all.master
+++ b/components/perl/HTML-Tagset/test/results-all.master
@@ -1,0 +1,7 @@
+t/00_about_verbose.t .. ok
+t/01_old_junk.t ....... ok
+t/pod.t ............... skipped: Test::Pod 1.14 required for testing POD
+All tests successful.
+Files=3, Tests=3
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild html-tagset with support for perl 5.34.

Nothing out of the ordinary for this one.

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 2
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and specify `results-all.master`
8. add standard `COMPONENT_TEST_TRANSFORMS`
9. `gmake REQUIRED_PACKAGES`

`HTML-Tagset-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
