### PR TITLE
library/perl-5/mysql-dbi: rebuild for perl 5.34

### DIFF
--- a/components/perl/DBI-MySQL/Makefile
+++ b/components/perl/DBI-MySQL/Makefile
@@ -22,44 +22,57 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= 	DBI-MySQL
 COMPONENT_VERSION=	4.0.41
-COMPONENT_REVISION=	4
-COMPONENT_SUMMARY= 	The DBI MySQL Interface for Perl
+COMPONENT_REVISION=	5
+COMPONENT_SUMMARY= 	MySQL driver for the Perl5 Database Interface (DBI)
+COMPONENT_FMRI=		library/perl-5/mysql-dbi
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL = https://metacpan.org/pod/DBD::mysql
 COMPONENT_SRC=		DBD-mysql-4.041
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
   sha256:4777de11c464b515db9da95c08c225900d0594b65ba3256982dc21f9f9379040
 COMPONENT_ARCHIVE_URL= \
   https://cpan.metacpan.org/authors/id/M/MI/MICHIELB/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://search.cpan.org/dist/DBD-mysql/lib/DBD/mysql.pm
+COMPONENT_LICENSE=	Artistic
+COMPONENT_LICENSE_FILE=	dbi-mysql.license
 
 # Don't depend on host default MySQL
 PATH=$(MYSQL_BINDIR):/usr/sbin:/usr/bin:/usr/perl5/bin
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/makemaker.mk
-include $(WS_MAKE_RULES)/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
+
+include $(WS_MAKE_RULES)/common.mk
 
 LD_OPTIONS += -L$(MYSQL_LIBDIR) -R$(MYSQL_LIBDIR)
 
 # Enable ASLR for this component
 ASLR_MODE = $(ASLR_ENABLE)
 
-build:          $(BUILD_32_and_64)
+#
+# very little can be tested without a database.
+#
+test:		$(NO_TESTS)
 
-install:        $(INSTALL_32_and_64)
-
-test:           $(NO_TESTS)
-
-REQUIRED_PACKAGES += database/mariadb-101/library
+# need the MariaDB client package and perl DBI at build time
+REQUIRED_PACKAGES += database/mariadb-101/client
 REQUIRED_PACKAGES += library/perl-5/database
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += database/mariadb-101/library
 REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/perl/DBI-MySQL/dbi-mysql-PERLVER.p5m
+++ b/components/perl/DBI-MySQL/dbi-mysql-PERLVER.p5m
@@ -11,16 +11,26 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/mysql-dbi-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="The DBI MySQL Interface for Perl"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license dbi-mysql.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this module, don't enable this.
+#depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/Bundle::DBD::mysql.3
 file path=usr/perl5/$(PERLVER)/man/man3/DBD::mysql.3

--- a/components/perl/DBI-MySQL/manifests/sample-manifest.p5m
+++ b/components/perl/DBI-MySQL/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,6 +30,10 @@ file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/Bundle::DBD::mysql.3
 file path=usr/perl5/5.24/man/man3/DBD::mysql.3
 file path=usr/perl5/5.24/man/man3/DBD::mysql::INSTALL.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/Bundle::DBD::mysql.3
+file path=usr/perl5/5.34/man/man3/DBD::mysql.3
+file path=usr/perl5/5.34/man/man3/DBD::mysql::INSTALL.3
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/Bundle/DBD/mysql.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/DBD/mysql.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/DBD/mysql/GetInfo.pm
@@ -42,3 +46,9 @@ file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/DBD/mysql/Get
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/DBD/mysql/INSTALL.pod
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/DBD/mysql/.packlist
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/DBD/mysql/mysql.so
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/Bundle/DBD/mysql.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/mysql.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/mysql/GetInfo.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/mysql/INSTALL.pod
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/DBD/mysql/.packlist
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/DBD/mysql/mysql.so

--- a/components/perl/DBI-MySQL/pkg5
+++ b/components/perl/DBI-MySQL/pkg5
@@ -1,16 +1,20 @@
 {
     "dependencies": [
         "SUNWcs",
+        "database/mariadb-101/client",
         "database/mariadb-101/library",
         "library/perl-5/database",
         "library/zlib",
-        "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
+        "system/library"
     ],
     "fmris": [
         "library/perl-5/mysql-dbi-522",
         "library/perl-5/mysql-dbi-524",
+        "library/perl-5/mysql-dbi-534",
         "library/perl-5/mysql-dbi"
     ],
     "name": "DBI-MySQL"


### PR DESCRIPTION
rebuild dbi-mysql to add perl 5.34 support

Special notes for this package:
1. no test suite, since nearly all of it requires a database
2. I did not modify any of the existing runtime dependencies at the end of the `dbi-mysql-PERLVER.p5m` file.

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 5
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, `COMPONENT_LICENSE_FILE` and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install`.  I kept `test` and added a note about the test suite
7. `gmake REQUIRED_PACKAGES`

`dbi-mysql-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
