### PR TITLE
library/perl-5/postgres-dbi: rebuild for perl 5.34

### DIFF
--- a/components/perl/DBI-PostgreSQL/Makefile
+++ b/components/perl/DBI-PostgreSQL/Makefile
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
 BUILD_STYLE=makemaker
@@ -30,30 +31,44 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= 	DBI-PostgreSQL
 COMPONENT_VERSION=	3.10.0
-COMPONENT_REVISION=	3
-COMPONENT_SUMMARY= 	The DBI PostgreSQL Interface for Perl
+COMPONENT_REVISION=	4
+COMPONENT_SUMMARY= 	PostgreSQL database driver for the DBI module
+COMPONENT_FMRI=		library/perl-5/postgres-dbi
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/DBD::Pg
 COMPONENT_SRC=		DBD-Pg-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
   sha256:e103268a63e2828e3d43659bdba5f743446cbbe047a766f843112eedae105f80
 COMPONENT_ARCHIVE_URL= \
-  http://search.cpan.org/CPAN/authors/id/T/TU/TURNSTEP/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://search.cpan.org/dist/DBD-Pg/Pg.pm
+  https://cpan.metacpan.org/authors/id/T/TU/TURNSTEP/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE_FILE=	dbi-postgresql.license
+COMPONENT_LICENSE=	Artistic
 
 # Don't depend on host default pg_config
 PATH=$(PG_BINDIR):/usr/sbin:/usr/bin:/usr/perl5/bin
 
 TEST_TARGET=$(NO_TESTS)
+
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
+
 include $(WS_MAKE_RULES)/common.mk
+
+# Enable ASLR for this component
+ASLR_MODE = $(ASLR_ENABLE)
 
 LD_OPTIONS += -L$(PG_LIBDIR) -R$(PG_LIBDIR)
 
 # Build dependencies
 REQUIRED_PACKAGES += $(PG_DEVELOPER_PKG)
 REQUIRED_PACKAGES += library/perl-5/database
+
 # Auto-generated dependencies
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(PG_LIBRARY_PKG)
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 REQUIRED_PACKAGES += system/library
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/perl/DBI-PostgreSQL/dbi-postgresql-PERLVER.p5m
+++ b/components/perl/DBI-PostgreSQL/dbi-postgresql-PERLVER.p5m
@@ -11,16 +11,31 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/postgres-dbi-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="The DBI PostgreSQL Interface for Perl"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license dbi-postgresql.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this module, don't enable this.
+#depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
+# DBD::Pg should have a dependency on DBI built for the same version of
+# perl, but the general dependency on 'library/perl-5/database@1.623'
+# below covers that.
+# depend fmri=library/perl-5/database-$(PLV) type=require
 
 file path=usr/perl5/$(PERLVER)/man/man3/Bundle::DBD::Pg.3
 file path=usr/perl5/$(PERLVER)/man/man3/DBD::Pg.3

--- a/components/perl/DBI-PostgreSQL/manifests/sample-manifest.p5m
+++ b/components/perl/DBI-PostgreSQL/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,6 +28,9 @@ file path=usr/perl5/5.22/man/man3/DBD::Pg.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/Bundle::DBD::Pg.3
 file path=usr/perl5/5.24/man/man3/DBD::Pg.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/Bundle::DBD::Pg.3
+file path=usr/perl5/5.34/man/man3/DBD::Pg.3
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/Bundle/DBD/Pg.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/DBD/Pg.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/DBD/Pg/.packlist
@@ -36,3 +39,7 @@ file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/Bundle/DBD/Pg
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/DBD/Pg.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/DBD/Pg/.packlist
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/DBD/Pg/Pg.so
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/Bundle/DBD/Pg.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/DBD/Pg.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/DBD/Pg/.packlist
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/DBD/Pg/Pg.so

--- a/components/perl/DBI-PostgreSQL/pkg5
+++ b/components/perl/DBI-PostgreSQL/pkg5
@@ -4,14 +4,16 @@
         "database/postgres-96/developer",
         "database/postgres-96/library",
         "library/perl-5/database",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
         "shell/ksh93",
-        "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "system/library"
     ],
     "fmris": [
         "library/perl-5/postgres-dbi-522",
         "library/perl-5/postgres-dbi-524",
+        "library/perl-5/postgres-dbi-534",
         "library/perl-5/postgres-dbi"
     ],
     "name": "DBI-PostgreSQL"


### PR DESCRIPTION
rebuild `postgres-dbi` to add support for perl 5.34

Of note:
1. no testsuite for this since it requires a database
2. since it builds a binary, I added `ASLR_MODE = $(ASLR_ENABLE)`
3. I did not touch the existing runtime dependencies at the end of the manifest

`Makefile`:
1. this must have been touched recently, because I did not need to add any of `BUILD_STYLE`, `BUILD_BITS`, or include `common.mk`
2. bump `COMPONENT_REVISION` to 4
3. add `COMPONENT_FMRI`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest.  `COMPONENT_SUMMARY` was already present but I updated the text to match the module summary.
4. update the URLs to use https and current locations.
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. add `ASLR_MODE = $(ASLR_ENABLE)`
7. `gmake REQUIRED_PACKAGES`

`HTML-Tagset-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)` and `$(COMPONENT_LICENSE_FILE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
7. I did not touch the runtime dependencies at the end of the file.

