### PR TITLE
library/perl-5/www-robotrules: rebuild for 5.34

### DIFF
--- a/components/perl/WWW-RobotRules/Makefile
+++ b/components/perl/WWW-RobotRules/Makefile
@@ -22,29 +22,54 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		WWW-RobotRules
 COMPONENT_VERSION=	6.02
 IPS_COMPONENT_VERSION=	6.2
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/www-robotrules
+COMPONENT_SUMMARY=	WWW::RobotRules - database of robots.txt-derived permissions
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/WWW-RobotRules/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/WWW::RobotRules
 COMPONENT_ARCHIVE_HASH=	\
     sha256:46b502e7a288d559429891eeb5d979461dd3ecc6a5c491ead85d165b6e03a51e
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/makemaker.mk
-include $(WS_MAKE_RULES)/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-COMPONENT_TEST_TARGETS = test
+include $(WS_MAKE_RULES)/common.mk
 
-build:		$(BUILD_32_and_64)
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-install:	$(INSTALL_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-test:		$(TEST_32_and_64)
+# to run the test suite, we need the runtime dependency module URI
+REQUIRED_PACKAGES += library/perl-5/uri-522
+REQUIRED_PACKAGES += library/perl-5/uri-524
+REQUIRED_PACKAGES += library/perl-5/uri-534
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/WWW-RobotRules/WWW-RobotRules-PERLVER.p5m
+++ b/components/perl/WWW-RobotRules/WWW-RobotRules-PERLVER.p5m
@@ -11,18 +11,31 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/www-robotrules-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="WWW::RobotRules - database of robots.txt-derived permissions"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license WWW-RobotRules.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# WWW:RobotRules needs URI for the same version of perl
+depend type=require fmri=library/perl-5/uri-$(PLV)
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/WWW::RobotRules.3 mode=0444
 file path=usr/perl5/$(PERLVER)/man/man3/WWW::RobotRules::AnyDBM_File.3 mode=0444

--- a/components/perl/WWW-RobotRules/manifests/sample-manifest.p5m
+++ b/components/perl/WWW-RobotRules/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,15 +22,21 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/perl5/5.16/lib/i86pc-solaris-64int/perllocal.pod
-file path=usr/perl5/5.16/man/man3/WWW::RobotRules.3
-file path=usr/perl5/5.16/man/man3/WWW::RobotRules::AnyDBM_File.3
 file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/WWW::RobotRules.3
 file path=usr/perl5/5.22/man/man3/WWW::RobotRules::AnyDBM_File.3
-file path=usr/perl5/vendor_perl/5.16/WWW/RobotRules.pm
-file path=usr/perl5/vendor_perl/5.16/WWW/RobotRules/AnyDBM_File.pm
-file path=usr/perl5/vendor_perl/5.16/i86pc-solaris-64int/auto/WWW/RobotRules/.packlist
+file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.24/man/man3/WWW::RobotRules.3
+file path=usr/perl5/5.24/man/man3/WWW::RobotRules::AnyDBM_File.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/WWW::RobotRules.3
+file path=usr/perl5/5.34/man/man3/WWW::RobotRules::AnyDBM_File.3
 file path=usr/perl5/vendor_perl/5.22/WWW/RobotRules.pm
 file path=usr/perl5/vendor_perl/5.22/WWW/RobotRules/AnyDBM_File.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/WWW/RobotRules/.packlist
+file path=usr/perl5/vendor_perl/5.24/WWW/RobotRules.pm
+file path=usr/perl5/vendor_perl/5.24/WWW/RobotRules/AnyDBM_File.pm
+file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/WWW/RobotRules/.packlist
+file path=usr/perl5/vendor_perl/5.34/WWW/RobotRules.pm
+file path=usr/perl5/vendor_perl/5.34/WWW/RobotRules/AnyDBM_File.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/WWW/RobotRules/.packlist

--- a/components/perl/WWW-RobotRules/pkg5
+++ b/components/perl/WWW-RobotRules/pkg5
@@ -1,11 +1,19 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/perl-5/uri-522",
+        "library/perl-5/uri-524",
+        "library/perl-5/uri-534",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/www-robotrules-522",
         "library/perl-5/www-robotrules-524",
+        "library/perl-5/www-robotrules-534",
         "library/perl-5/www-robotrules"
     ],
     "name": "WWW-RobotRules"

--- a/components/perl/WWW-RobotRules/test/results-all.master
+++ b/components/perl/WWW-RobotRules/test/results-all.master
@@ -1,0 +1,6 @@
+t/rules-dbm.t .. ok
+t/rules.t ...... ok
+All tests successful.
+Files=2, Tests=63
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild `www-robotrules` to add support for perl 5.34

Of note:
1. add the missing runtime dependency on `library/perl-5/uri-$(PLV)` to the manifest
2. add the `library/perl-5/uri` (non-versioned) to the build dependencies in the `Makefile`

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 2
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and specify `results-all.master`
8. add standard `COMPONENT_TEST_TRANSFORMS`
9. add the `library/perl-5/uri` build dependency so we can run the test suite
10. `gmake REQUIRED_PACKAGES`

`WWW-RobotRules-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the missing runtime dependency on `library/perl-5/uri-${PLV)`
6. add the runtime dependency on the same version of perl
7. add the commented-out stuff for the `non-PLV` version
