### PR TITLE
library/perl-5/authen-pam: rebuild for perl 5.34

### DIFF
--- a/components/perl/authen_pam/Makefile
+++ b/components/perl/authen_pam/Makefile
@@ -19,24 +19,38 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		Authen-PAM
 COMPONENT_VERSION=	16
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
+COMPONENT_FMRI=		library/perl-5/authen-pam
+COMPONENT_SUMMARY=	Authen::PAM - Perl interface to PAM library
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/Authen::PAM
 COMPONENT_SRC=		$(COMPONENT_NAME)-0.16
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:0e949bd9a2a9df0f829971030fe9169cbaf6cec78b92faf22f547ff6c6155c9b
 COMPONENT_ARCHIVE_URL=	\
-    http://search.cpan.org/CPAN/authors/id/N/NI/NIKIP/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~nikip/Authen-PAM-0.16/
+    https://cpan.metacpan.org/authors/id/N/NI/NIKIP/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
+COMPONENT_LICENSE_FILE=	authen-pam.license
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/ips.mk
-include $(WS_TOP)/make-rules/makemaker.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
+
+# the tests all pass, but can't all be run non-interactively
+TEST_TARGET=$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
 
 # Enable ASLR for this component
 ASLR_MODE = $(ASLR_ENABLE)
@@ -44,19 +58,10 @@ ASLR_MODE = $(ASLR_ENABLE)
 # man pages go in the common area
 COMPONENT_INSTALL_ENV += INSTALLVENDORMAN3DIR=$(USRSHAREMAN3DIR)
 
-COMPONENT_PREP_ACTION =        ( cd $(@D) && \
-                                        autoconf )
+COMPONENT_PREP_ACTION = ( cd $(@D) && autoconf )
 
-
-COMPONENT_TEST_TARGETS = test
-
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/perl/authen_pam/authen-pam-PERLVER.p5m
+++ b/components/perl/authen_pam/authen-pam-PERLVER.p5m
@@ -10,23 +10,31 @@
 
 #
 # Copyright 2013, Alexander Pyhalov
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
 
-set name=pkg.fmri value=pkg:/library/perl-5/authen-pam-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary \
-    value="Authen-PAM PERL module"
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=pkg.description value="Authen-PAM PERL module"
 set name=com.oracle.info.description value="Authen-PAM PERL module"
-set name=info.classification \
-    value="org.opensolaris.category.2008:Development/Perl"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license authen-pam.license license='Artistic'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/Authen::PAM.3
 file path=usr/perl5/$(PERLVER)/man/man3/Authen::PAM::FAQ.3

--- a/components/perl/authen_pam/manifests/sample-manifest.p5m
+++ b/components/perl/authen_pam/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,6 +28,9 @@ file path=usr/perl5/5.22/man/man3/Authen::PAM::FAQ.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/Authen::PAM.3
 file path=usr/perl5/5.24/man/man3/Authen::PAM::FAQ.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/Authen::PAM.3
+file path=usr/perl5/5.34/man/man3/Authen::PAM::FAQ.3
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/Authen/PAM.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/Authen/PAM/FAQ.pod
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/Authen/PAM/.packlist
@@ -36,3 +39,7 @@ file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/Authen/PAM.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/Authen/PAM/FAQ.pod
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Authen/PAM/.packlist
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/Authen/PAM/PAM.so
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/Authen/PAM.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/Authen/PAM/FAQ.pod
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/Authen/PAM/.packlist
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/Authen/PAM/PAM.so

--- a/components/perl/authen_pam/patches/02-Makefile.PL.patch
+++ b/components/perl/authen_pam/patches/02-Makefile.PL.patch
@@ -1,0 +1,20 @@
+
+perl 5.26 dropped '.' from the module search path (@INC), so to allow
+5.34 to find build-time code in ., add '.' to the end of the path
+in INC.
+
+diff -ur Authen-PAM-0.16.orig/Makefile.PL Authen-PAM-0.16/Makefile.PL
+--- Authen-PAM-0.16.orig/Makefile.PL	2005-06-06 08:29:12.000000000 +0000
++++ Authen-PAM-0.16/Makefile.PL	2022-01-13 23:45:25.221646510 +0000
+@@ -1,6 +1,11 @@
+ use ExtUtils::MakeMaker;
+ use Config;
+ 
++# allow perl 5.26 and later to find code relative to .
++BEGIN {
++	push @INC, '.';
++}
++
+ sub configure {
+     $ENV{'CC'} # If a compiler is not specified on the command line then
+       or $ENV{'CC'} = $Config{'cc'}; # use the one with which perl was built

--- a/components/perl/authen_pam/pkg5
+++ b/components/perl/authen_pam/pkg5
@@ -3,13 +3,14 @@
         "SUNWcs",
         "runtime/perl-522",
         "runtime/perl-524",
-        "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "runtime/perl-534",
+        "shell/ksh93",
+        "system/library"
     ],
     "fmris": [
         "library/perl-5/authen-pam-522",
         "library/perl-5/authen-pam-524",
+        "library/perl-5/authen-pam-534",
         "library/perl-5/authen-pam"
     ],
     "name": "Authen-PAM"


### PR DESCRIPTION
rebuild `authen-pam` to add support for perl 5.34

Of note:
1. the 5.34 build requires a new patch that's almost identical to one for net-ssleay.  The perl `Makefile.PL` is trying to reference code relative to `.` and that behavior changed at perl 5.26,   The fix is to add `.` back to `@INC`.  The patch is safe for all 3 versions of perl, but it's only required for 5.34
2. since the test suite is interactive I disabled it, this time using `TEST_TARGET=$(NO_TESTS)` before including `common.mk`.  That seems to work better than trying `test: $(NO_TESTS)`.  Everything seems to pass if you run the test suite interactively.

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 5
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, `COMPONENT_LICENSE_FILE` and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. add `TEST_TARGET=$(NO_TESTS)` before `common.mk` to (successfully) disable the test suite
8. drop `build/install`
7. reformat the `COMPONENT_PREP_ACTION` slightly to fit on one line
8. `gmake REQUIRED_PACKAGES`

`authen_pam-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. I left the description and `com.oracle.info.description` untouched in the manifest
6. add the runtime dependency on the same version of perl
7. add the commented-out stuff for the `non-PLV` version
