### PR TITLE
library/perl-5/http-message: rebuild for perl 5.34

### DIFF
--- a/components/perl/HTTP-Message/HTTP-Message-PERLVER.p5m
+++ b/components/perl/HTTP-Message/HTTP-Message-PERLVER.p5m
@@ -11,23 +11,34 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/http-message-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="HTML::Message - classes useful for representing the messages passed in HTTP style communication"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license HTTP-Message.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
 
+depend fmri=library/perl-5/encode-locale-$(PLV) type=require
 depend fmri=library/perl-5/lwp-mediatypes-$(PLV) type=require
 depend fmri=library/perl-5/io-html-$(PLV) type=require
 depend fmri=library/perl-5/uri-$(PLV) type=require
 depend fmri=library/perl-5/http-date-$(PLV) type=require
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/HTTP::Config.3 mode=0444
 file path=usr/perl5/$(PERLVER)/man/man3/HTTP::Headers.3 mode=0444

--- a/components/perl/HTTP-Message/Makefile
+++ b/components/perl/HTTP-Message/Makefile
@@ -22,29 +22,66 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		HTTP-Message
 COMPONENT_VERSION=	6.11
 IPS_COMPONENT_VERSION=	6.11
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		library/perl-5/http-message
+COMPONENT_SUMMARY=	HTML::Message - classes useful for representing the messages passed in HTTP style communication
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/HTTP-Message/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/HTTP::Message
 COMPONENT_ARCHIVE_HASH=	\
     sha256:e7b368077ae6a188d99920411d8f52a8e5acfb39574d4f5c24f46fd22533d81b
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/E/ET/ETHER/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
+# all of these runtime dependencies are needed to run the test suite
+REQUIRED_PACKAGES += library/perl-5/encode-locale-522
+REQUIRED_PACKAGES += library/perl-5/encode-locale-524
+REQUIRED_PACKAGES += library/perl-5/encode-locale-534
+REQUIRED_PACKAGES += library/perl-5/http-date-522
+REQUIRED_PACKAGES += library/perl-5/http-date-524
+REQUIRED_PACKAGES += library/perl-5/http-date-534
+REQUIRED_PACKAGES += library/perl-5/io-html-522
+REQUIRED_PACKAGES += library/perl-5/io-html-524
+REQUIRED_PACKAGES += library/perl-5/io-html-534
+REQUIRED_PACKAGES += library/perl-5/lwp-mediatypes-522
+REQUIRED_PACKAGES += library/perl-5/lwp-mediatypes-524
+REQUIRED_PACKAGES += library/perl-5/lwp-mediatypes-534
+REQUIRED_PACKAGES += library/perl-5/uri-522
+REQUIRED_PACKAGES += library/perl-5/uri-524
+REQUIRED_PACKAGES += library/perl-5/uri-534
 
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/HTTP-Message/manifests/sample-manifest.p5m
+++ b/components/perl/HTTP-Message/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -40,6 +40,15 @@ file path=usr/perl5/5.24/man/man3/HTTP::Request.3
 file path=usr/perl5/5.24/man/man3/HTTP::Request::Common.3
 file path=usr/perl5/5.24/man/man3/HTTP::Response.3
 file path=usr/perl5/5.24/man/man3/HTTP::Status.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/HTTP::Config.3
+file path=usr/perl5/5.34/man/man3/HTTP::Headers.3
+file path=usr/perl5/5.34/man/man3/HTTP::Headers::Util.3
+file path=usr/perl5/5.34/man/man3/HTTP::Message.3
+file path=usr/perl5/5.34/man/man3/HTTP::Request.3
+file path=usr/perl5/5.34/man/man3/HTTP::Request::Common.3
+file path=usr/perl5/5.34/man/man3/HTTP::Response.3
+file path=usr/perl5/5.34/man/man3/HTTP::Status.3
 file path=usr/perl5/vendor_perl/5.22/HTTP/Config.pm
 file path=usr/perl5/vendor_perl/5.22/HTTP/Headers.pm
 file path=usr/perl5/vendor_perl/5.22/HTTP/Headers/Auth.pm
@@ -62,3 +71,14 @@ file path=usr/perl5/vendor_perl/5.24/HTTP/Request/Common.pm
 file path=usr/perl5/vendor_perl/5.24/HTTP/Response.pm
 file path=usr/perl5/vendor_perl/5.24/HTTP/Status.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/HTTP/Message/.packlist
+file path=usr/perl5/vendor_perl/5.34/HTTP/Config.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Headers.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Headers/Auth.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Headers/ETag.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Headers/Util.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Message.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Request.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Request/Common.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Response.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Status.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/HTTP/Message/.packlist

--- a/components/perl/HTTP-Message/pkg5
+++ b/components/perl/HTTP-Message/pkg5
@@ -1,11 +1,31 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/perl-5/encode-locale-522",
+        "library/perl-5/encode-locale-524",
+        "library/perl-5/encode-locale-534",
+        "library/perl-5/http-date-522",
+        "library/perl-5/http-date-524",
+        "library/perl-5/http-date-534",
+        "library/perl-5/io-html-522",
+        "library/perl-5/io-html-524",
+        "library/perl-5/io-html-534",
+        "library/perl-5/lwp-mediatypes-522",
+        "library/perl-5/lwp-mediatypes-524",
+        "library/perl-5/lwp-mediatypes-534",
+        "library/perl-5/uri-522",
+        "library/perl-5/uri-524",
+        "library/perl-5/uri-534",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/http-message-522",
         "library/perl-5/http-message-524",
+        "library/perl-5/http-message-534",
         "library/perl-5/http-message"
     ],
     "name": "HTTP-Message"

--- a/components/perl/HTTP-Message/test/results-all.master
+++ b/components/perl/HTTP-Message/test/results-all.master
@@ -1,0 +1,21 @@
+t/common-req.t .............. ok
+t/distmanifest.t ............ skipped: these tests are for authors only!
+t/headers-auth.t ............ ok
+t/headers-etag.t ............ ok
+t/headers-util.t ............ ok
+t/headers.t ................. ok
+t/http-config.t ............. ok
+t/message-charset.t ......... ok
+t/message-decode-xml.t ...... ok
+t/message-old.t ............. ok
+t/message-parts.t ........... ok
+t/message.t ................. ok
+t/request.t ................. ok
+t/request_type_with_data.t .. ok
+t/response.t ................ ok
+t/status-old.t .............. ok
+t/status.t .................. ok
+All tests successful.
+Files=17, Tests=563
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild `http-message` to add support for perl 5.34

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. add `COMPONENT_REVISION=1`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and specify `results-all.master`
8. add standard `COMPONENT_TEST_TRANSFORMS`
9. add all of runtime dependencies as build dependencies, using the versioned package names rather than the meta-packages
9. `gmake REQUIRED_PACKAGES`

`HTML-Messagea-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
7. add a missing runtime dependency on `library/perl-5/encode-locale-$(PLV)`

