### PR TITLE
redeploy pkg after PR#99 has been merged for pkg5

### DIFF
--- a/components/openindiana/pkg/Makefile
+++ b/components/openindiana/pkg/Makefile
@@ -119,5 +119,6 @@ PACKAGE_NAMES += system/zones/brand/ipkg
 PACKAGE_NAMES += system/zones/brand/kvm
 PACKAGE_NAMES += system/zones/brand/nlipkg
 
+# Manually added dependencies
 REQUIRED_PACKAGES += developer/opensolaris/pkg5
 REQUIRED_PACKAGES += system/zones/internal


### PR DESCRIPTION
Alas the jenkins job failed to include the changes from PR #99 again.
We need to clean the build environment before merging changes to openindiana/pkg5.