### PR TITLE
Make illumos-closed usable for illumos-gate build

### DIFF
--- a/components/openindiana/illumos-closed/Makefile
+++ b/components/openindiana/illumos-closed/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		illumos-closed
 COMPONENT_VERSION=	5.11
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	illumos-closed - illumos closed binaries
 COMPONENT_PROJECT_URL=	https://www.openindiana.org/
 COMPONENT_FMRI=		developer/illumos-closed
@@ -45,6 +45,19 @@ include $(WS_MAKE_RULES)/prep.mk
 include $(WS_MAKE_RULES)/ips.mk
 
 CLEAN_PATHS += $(BUILD_DIR)
+
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386/etc/init.d/llc2
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386/kernel/strmod/$(MACH64)/sdpib
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386/kernel/strmod/sdpib
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.46
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.46
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386/usr/xpg4/bin/alias
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386-nd/etc/init.d/llc2
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/sdpib
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386-nd/kernel/drv/sdpib
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.46
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.46
+PKG_HARDLINKS +=	opt/onbld/closed/root_i386-nd/usr/xpg4/bin/alias
 
 $(BUILD_32):
 	$(MKDIR) $(BUILD_DIR_32)

--- a/components/openindiana/illumos-closed/illumos-closed.p5m
+++ b/components/openindiana/illumos-closed/illumos-closed.p5m
@@ -22,1270 +22,3931 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=opt/onbld/closed/.* -> set pkg.depend.bypass-generate .*>
+<transform file mode=0[67] -> default pkg.linted true>
+# files should be readable by everyone
+<transform file -> edit mode "00$" "44">
 
 file path=opt/onbld/closed/BINARYLICENSE.txt
 file path=opt/onbld/closed/README.ON-BINARIES.i386
 file path=opt/onbld/closed/THIRDPARTYLICENSE.ON-BINARIES
 file path=opt/onbld/closed/on-closed-bins-nd.i386.tar.bz2
 file path=opt/onbld/closed/on-closed-bins.i386.tar.bz2
-file path=opt/onbld/closed/root_i386-nd/etc/init.d/llc2
-file path=opt/onbld/closed/root_i386-nd/etc/llc2/llc2_start.default
+dir  path=opt/onbld/closed/root_i386-nd/etc
+dir  path=opt/onbld/closed/root_i386-nd/etc/certs
+dir  path=opt/onbld/closed/root_i386-nd/etc/crypto
+dir  path=opt/onbld/closed/root_i386-nd/etc/crypto/certs
+dir  path=opt/onbld/closed/root_i386-nd/etc/init.d
+file path=opt/onbld/closed/root_i386-nd/etc/init.d/llc2 mode=0744
+dir  path=opt/onbld/closed/root_i386-nd/etc/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/llc2/default
+file path=opt/onbld/closed/root_i386-nd/etc/llc2/llc2_start.default mode=0744
+dir  path=opt/onbld/closed/root_i386-nd/etc/rc0.d
 hardlink path=opt/onbld/closed/root_i386-nd/etc/rc0.d/K52llc2 \
     target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/rc1.d
 hardlink path=opt/onbld/closed/root_i386-nd/etc/rc1.d/K52llc2 \
     target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/rc2.d
 hardlink path=opt/onbld/closed/root_i386-nd/etc/rc2.d/S40llc2 \
     target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/rcS.d
 hardlink path=opt/onbld/closed/root_i386-nd/etc/rcS.d/K52llc2 \
     target=../init.d/llc2
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.example
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.multi
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.single
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.multi
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.single
-file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/mibiisa.reg
-file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/snmpd.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/acpi_toshiba
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/adpu320
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/atiatom
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bcm_sata
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnxe
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/cpqary3
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/glm
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/intel_nhmex
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/iprb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/ixgb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/lsimega
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/marvell88sx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcn
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcser
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/sdpib
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/usbser_edge
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/acpi_toshiba
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/atiatom
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bcm_sata
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/iprb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/ixgb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/marvell88sx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcn
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcser
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/nfs
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/nfs
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmmod
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmops
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmmod
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmops
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc
+dir  path=opt/onbld/closed/root_i386-nd/etc/security
+dir  path=opt/onbld/closed/root_i386-nd/etc/security/tsol
+file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings \
+    mode=0400
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.example \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.multi \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.single \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.multi \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.single \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/etc/snmp
+dir  path=opt/onbld/closed/root_i386-nd/etc/snmp/conf
+file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/mibiisa.reg mode=0644
+file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/snmpd.conf mode=0600
+dir  path=opt/onbld/closed/root_i386-nd/kernel
+dir  path=opt/onbld/closed/root_i386-nd/kernel/drv
+dir  path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/acpi_toshiba \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/atiatom mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnx mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnxe mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/glm mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/intel_nhmex \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/iprb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/ixgb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/lsimega mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/marvell88sx \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/mpt mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcn mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcser mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/sdpib mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/usbser_edge \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/acpi_toshiba mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/atiatom mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/iprb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/ixgb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/marvell88sx mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcn mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcser mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge.conf mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/kernel/kmdb
+dir  path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/mpt mode=0555
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/nfs mode=0555
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/mpt mode=0555
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/nfs mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmmod mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmops mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmmod mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmops mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc \
+    mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/kernel/strmod
+dir  path=opt/onbld/closed/root_i386-nd/kernel/strmod/$(MACH64)
 hardlink path=opt/onbld/closed/root_i386-nd/kernel/strmod/$(MACH64)/sdpib \
     target=../../drv/$(MACH64)/sdpib
 hardlink path=opt/onbld/closed/root_i386-nd/kernel/strmod/sdpib \
     target=../drv/sdpib
-file path=opt/onbld/closed/root_i386-nd/lib/$(MACH64)/libc_i18n.a
-file path=opt/onbld/closed/root_i386-nd/lib/crypto/kcfd
-file path=opt/onbld/closed/root_i386-nd/lib/libc_i18n.a
-file path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network/ipsec/ike.xml
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip
-hardlink \
+dir  path=opt/onbld/closed/root_i386-nd/lib
+dir  path=opt/onbld/closed/root_i386-nd/lib/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/lib/$(MACH64)/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/lib/crypto
+file path=opt/onbld/closed/root_i386-nd/lib/crypto/kcfd mode=0555
+file path=opt/onbld/closed/root_i386-nd/lib/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc/manifest
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network/ipsec
+file path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network/ipsec/ike.xml \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/licenses
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal
+file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd
+file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2
+file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4 \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/platform
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)
+file \
     path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.46 \
-    target=cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.47
+    mode=0755
 hardlink \
+    path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.47 \
+    target=cpu_ms.GenuineIntel.6.46
+file \
     path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.46 \
-    target=cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386-nd/usr/bin/iconv
-file path=opt/onbld/closed/root_i386-nd/usr/bin/kbdcomp
-file path=opt/onbld/closed/root_i386-nd/usr/bin/localedef
-file path=opt/onbld/closed/root_i386-nd/usr/bin/od
-file path=opt/onbld/closed/root_i386-nd/usr/bin/pax
-file path=opt/onbld/closed/root_i386-nd/usr/bin/printf
-file path=opt/onbld/closed/root_i386-nd/usr/bin/sed
-file path=opt/onbld/closed/root_i386-nd/usr/bin/tail
-file path=opt/onbld/closed/root_i386-nd/usr/bin/tr
-file path=opt/onbld/closed/root_i386-nd/usr/has/bin/patch
-file path=opt/onbld/closed/root_i386-nd/usr/include/sys/lc_core.h
-file path=opt/onbld/closed/root_i386-nd/usr/include/sys/localedef.h
-file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/$(MACH64)/llc2
-file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2
-file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2.conf
+    mode=0755
+hardlink \
+    path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.47 \
+    target=cpu_ms.GenuineIntel.6.46
+dir  path=opt/onbld/closed/root_i386-nd/usr
+dir  path=opt/onbld/closed/root_i386-nd/usr/bin
+file path=opt/onbld/closed/root_i386-nd/usr/bin/iconv mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/kbdcomp mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/localedef mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/od mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/pax mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/printf mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/tail mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/has
+dir  path=opt/onbld/closed/root_i386-nd/usr/has/bin
+file path=opt/onbld/closed/root_i386-nd/usr/has/bin/patch mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/include
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/1394
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/agp
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/audio
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/av
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/contract
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/crypto
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/dcam
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/dktp
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fc4
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm/cpu
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm/fs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm/io
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/hotplug
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/hotplug/pci
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/adapters
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/adapters/hermon
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/adapters/tavor
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/ibd
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/rdma
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_ofs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_ucma
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_umad
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_uverbs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/ibnex
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/ibtl
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/ibtl/impl
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/mgt
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/mgt/ibmf
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/iscsit
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/iso
+file path=opt/onbld/closed/root_i386-nd/usr/include/sys/lc_core.h mode=0644
+file path=opt/onbld/closed/root_i386-nd/usr/include/sys/localedef.h mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/lvm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/pcmcia
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/rsm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/sata
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/adapters
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/conf
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/generic
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/impl
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/targets
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/sysevent
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/tsol
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/audio
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/hid
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/hwarc
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/mass_storage
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/printer
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/ugen
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/usbcdc
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/usbinput
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/usbinput/usbwcm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/video
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/video/usbvc
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/hubd
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/uwb
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/uwb/uwba
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/drv
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/$(MACH64)/llc2 mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2 mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2.conf mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/strmod
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/strmod/$(MACH64)
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)
 link path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/libike.so \
     target=libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/llib-like.ln
+file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/libike.so.1 mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify
 link path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/ses-LSILOGIC.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/ses-SUN.so
+file path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/ses-SUN.so \
+    mode=0755
 link \
     path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/sgen-LSILOGIC.so \
     target=ses-SUN.so
 link path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/sgen-SUN.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646da.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646de.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646en.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646es.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646fr.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646it.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646sv.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646da.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646de.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646en.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646es.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646fr.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646it.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646sv.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/iconv_data
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH32)/in.iked
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH64)/in.iked
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certdb
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certlocal
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certrldb
-file path=opt/onbld/closed/root_i386-nd/usr/lib/labeld
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/iconv
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646da.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646de.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646en.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646es.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646fr.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646it.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646sv.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646da.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646de.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646en.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646es.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646fr.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646it.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646sv.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/iconv_data mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/inet
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH32)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH32)/in.iked mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH64)/in.iked mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certdb mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certlocal mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certrldb mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/labeld mode=0555
 link path=opt/onbld/closed/root_i386-nd/usr/lib/libike.so target=libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_autoconfig
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_config
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop2
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop3
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop4
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_stats
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tcap
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tparser
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like.ln
-file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/locale_description
+file path=opt/onbld/closed/root_i386-nd/usr/lib/libike.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/llc2
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_autoconfig mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_config mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop2 mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop3 mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop4 mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_stats mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tcap mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tparser mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like mode=0644
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_COLLATE
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_CTYPE
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_MESSAGES
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_MONETARY
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_NUMERIC
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_TIME
+file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/locale_description \
+    mode=0444
 link path=opt/onbld/closed/root_i386-nd/usr/lib/locale/POSIX target=./C
-file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/generic_eucbc.x
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/single_byte.x
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/charmap.src
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/extension.src
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/localedef.src
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/mpt.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/nfs.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/mpt.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/nfs.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/nfs/lockd
-file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/$(MACH64)/mpt.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/mpt.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/snmp/mibiisa
-file path=opt/onbld/closed/root_i386-nd/usr/sbin/chk_encodings
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/alias target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/bg target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/cd target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/command target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fc target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fg target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/getopts target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/hash target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/jobs target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/kill target=ulimit
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/more
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/od
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/read target=ulimit
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sed
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sh
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tail
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/test target=ulimit
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tr
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/type target=ulimit
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/umask target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/unalias target=ulimit
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/wait target=ulimit
-file path=opt/onbld/closed/root_i386-nd/usr/xpg6/bin/tr
-file path=opt/onbld/closed/root_i386-nd/var/snmp/mib/sun.mib
-hardlink path=opt/onbld/closed/root_i386/etc/init.d/llc2 target=../rc1.d/K52llc2
-file path=opt/onbld/closed/root_i386/etc/llc2/llc2_start.default
-hardlink path=opt/onbld/closed/root_i386/etc/rc0.d/K52llc2 \
-    target=../rc1.d/K52llc2
-file path=opt/onbld/closed/root_i386/etc/rc1.d/K52llc2
-hardlink path=opt/onbld/closed/root_i386/etc/rc2.d/S40llc2 \
-    target=../rc1.d/K52llc2
-hardlink path=opt/onbld/closed/root_i386/etc/rcS.d/K52llc2 \
-    target=../rc1.d/K52llc2
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.example
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.multi
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.single
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.multi
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.single
-file path=opt/onbld/closed/root_i386/etc/snmp/conf/mibiisa.reg
-file path=opt/onbld/closed/root_i386/etc/snmp/conf/snmpd.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/acpi_toshiba
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/adpu320
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/atiatom
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bcm_sata
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnx
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnxe
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/cpqary3
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/glm
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/intel_nhmex
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/iprb
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/ixgb
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/lsimega
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/marvell88sx
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcn
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcser
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/LC_CTYPE
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/generic_eucbc.x \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/single_byte.x \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/charmap.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/extension.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/localedef.src \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/mdb
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/mpt.so \
+    mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/nfs.so \
+    mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/mpt.so mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/nfs.so mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/nfs
+file path=opt/onbld/closed/root_i386-nd/usr/lib/nfs/lockd mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/$(MACH64)/mpt.so.1 \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/mpt.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/snmp
+file path=opt/onbld/closed/root_i386-nd/usr/lib/snmp/mibiisa mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/usr/platform
+dir  path=opt/onbld/closed/root_i386-nd/usr/platform/i86pc
+dir  path=opt/onbld/closed/root_i386-nd/usr/platform/i86pc/lib
+dir  path=opt/onbld/closed/root_i386-nd/usr/sbin
+file path=opt/onbld/closed/root_i386-nd/usr/sbin/chk_encodings mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg4
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/alias mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/bg target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/cd target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/command target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fc target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fg target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/getopts target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/hash target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/jobs target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/kill target=alias
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/more mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/od mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/read target=alias
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sh mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tail mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/test target=alias
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tr mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/type target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/ulimit target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/umask target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/unalias target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/wait target=alias
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg6
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg6/bin
+file path=opt/onbld/closed/root_i386-nd/usr/xpg6/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/var
+dir  path=opt/onbld/closed/root_i386-nd/var/snmp
+dir  path=opt/onbld/closed/root_i386-nd/var/snmp/mib
+file path=opt/onbld/closed/root_i386-nd/var/snmp/mib/sun.mib mode=0644
+dir  path=opt/onbld/closed/root_i386/etc
+dir  path=opt/onbld/closed/root_i386/etc/certs
+dir  path=opt/onbld/closed/root_i386/etc/crypto
+dir  path=opt/onbld/closed/root_i386/etc/crypto/certs
+dir  path=opt/onbld/closed/root_i386/etc/init.d
+file path=opt/onbld/closed/root_i386/etc/init.d/llc2 mode=0744
+dir  path=opt/onbld/closed/root_i386/etc/llc2
+dir  path=opt/onbld/closed/root_i386/etc/llc2/default
+file path=opt/onbld/closed/root_i386/etc/llc2/llc2_start.default mode=0744
+dir  path=opt/onbld/closed/root_i386/etc/rc0.d
+hardlink path=opt/onbld/closed/root_i386/etc/rc0.d/K52llc2 target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386/etc/rc1.d
+hardlink path=opt/onbld/closed/root_i386/etc/rc1.d/K52llc2 target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386/etc/rc2.d
+hardlink path=opt/onbld/closed/root_i386/etc/rc2.d/S40llc2 target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386/etc/rcS.d
+hardlink path=opt/onbld/closed/root_i386/etc/rcS.d/K52llc2 target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386/etc/security
+dir  path=opt/onbld/closed/root_i386/etc/security/tsol
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings mode=0400
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.example \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.multi \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.single \
+    mode=0444
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.multi \
+    mode=0444
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.single \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/etc/snmp
+dir  path=opt/onbld/closed/root_i386/etc/snmp/conf
+file path=opt/onbld/closed/root_i386/etc/snmp/conf/mibiisa.reg mode=0644
+file path=opt/onbld/closed/root_i386/etc/snmp/conf/snmpd.conf mode=0600
+dir  path=opt/onbld/closed/root_i386/kernel
+dir  path=opt/onbld/closed/root_i386/kernel/drv
+dir  path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/acpi_toshiba mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/atiatom mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnxe mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/glm mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/intel_nhmex mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/iprb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/ixgb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/lsimega mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/marvell88sx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/mpt mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcn mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcser mode=0755
 hardlink path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/sdpib \
     target=../../strmod/$(MACH64)/sdpib
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/usbser_edge
-file path=opt/onbld/closed/root_i386/kernel/drv/acpi_toshiba
-file path=opt/onbld/closed/root_i386/kernel/drv/adpu320
-file path=opt/onbld/closed/root_i386/kernel/drv/adpu320.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/atiatom
-file path=opt/onbld/closed/root_i386/kernel/drv/bcm_sata
-file path=opt/onbld/closed/root_i386/kernel/drv/bnx
-file path=opt/onbld/closed/root_i386/kernel/drv/bnx.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/bnxe
-file path=opt/onbld/closed/root_i386/kernel/drv/bnxe.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3
-file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/glm
-file path=opt/onbld/closed/root_i386/kernel/drv/glm.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex
-file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/iprb
-file path=opt/onbld/closed/root_i386/kernel/drv/ixgb
-file path=opt/onbld/closed/root_i386/kernel/drv/lsimega
-file path=opt/onbld/closed/root_i386/kernel/drv/lsimega.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/marvell88sx
-file path=opt/onbld/closed/root_i386/kernel/drv/mpt
-file path=opt/onbld/closed/root_i386/kernel/drv/mpt.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/pcn
-file path=opt/onbld/closed/root_i386/kernel/drv/pcser
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/usbser_edge mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/acpi_toshiba mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/adpu320.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/atiatom mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bnx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bnx.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/bnxe mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bnxe.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/glm mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/glm.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/iprb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/ixgb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/lsimega mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/lsimega.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/marvell88sx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/mpt mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/mpt.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/pcn mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/pcser mode=0755
 hardlink path=opt/onbld/closed/root_i386/kernel/drv/sdpib target=../strmod/sdpib
-file path=opt/onbld/closed/root_i386/kernel/drv/sdpib.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge
-file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge.conf
-file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/nfs
-file path=opt/onbld/closed/root_i386/kernel/kmdb/mpt
-file path=opt/onbld/closed/root_i386/kernel/kmdb/nfs
-file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmmod
-file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmops
-file path=opt/onbld/closed/root_i386/kernel/misc/klmmod
-file path=opt/onbld/closed/root_i386/kernel/misc/klmops
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc
-file path=opt/onbld/closed/root_i386/kernel/strmod/$(MACH64)/sdpib
-file path=opt/onbld/closed/root_i386/kernel/strmod/sdpib
-file path=opt/onbld/closed/root_i386/lib/$(MACH64)/libc_i18n.a
-file path=opt/onbld/closed/root_i386/lib/crypto/kcfd
-file path=opt/onbld/closed/root_i386/lib/libc_i18n.a
-file path=opt/onbld/closed/root_i386/lib/svc/manifest/network/ipsec/ike.xml
-file path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip
-hardlink \
+file path=opt/onbld/closed/root_i386/kernel/drv/sdpib.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge.conf mode=0644
+dir  path=opt/onbld/closed/root_i386/kernel/kmdb
+dir  path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/mpt mode=0555
+file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/nfs mode=0555
+file path=opt/onbld/closed/root_i386/kernel/kmdb/mpt mode=0555
+file path=opt/onbld/closed/root_i386/kernel/kmdb/nfs mode=0555
+dir  path=opt/onbld/closed/root_i386/kernel/misc
+dir  path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmmod mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmops mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/klmmod mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/klmops mode=0755
+dir  path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci
+dir  path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi \
+    mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc \
+    mode=0755
+dir  path=opt/onbld/closed/root_i386/kernel/strmod
+dir  path=opt/onbld/closed/root_i386/kernel/strmod/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/strmod/$(MACH64)/sdpib mode=0755
+file path=opt/onbld/closed/root_i386/kernel/strmod/sdpib mode=0755
+dir  path=opt/onbld/closed/root_i386/lib
+dir  path=opt/onbld/closed/root_i386/lib/$(MACH64)
+file path=opt/onbld/closed/root_i386/lib/$(MACH64)/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386/lib/crypto
+file path=opt/onbld/closed/root_i386/lib/crypto/kcfd mode=0555
+file path=opt/onbld/closed/root_i386/lib/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386/lib/svc
+dir  path=opt/onbld/closed/root_i386/lib/svc/manifest
+dir  path=opt/onbld/closed/root_i386/lib/svc/manifest/network
+dir  path=opt/onbld/closed/root_i386/lib/svc/manifest/network/ipsec
+file path=opt/onbld/closed/root_i386/lib/svc/manifest/network/ipsec/ike.xml \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/licenses
+dir  path=opt/onbld/closed/root_i386/licenses/usr
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE mode=0644
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2
+file path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl
+file path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/grub
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97
+file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip \
+    mode=0644
+file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4 \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/platform
+dir  path=opt/onbld/closed/root_i386/platform/i86pc
+dir  path=opt/onbld/closed/root_i386/platform/i86pc/kernel
+dir  path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu
+dir  path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)
+file \
     path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.46 \
-    target=cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.47
+    mode=0755
 hardlink \
+    path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.47 \
+    target=cpu_ms.GenuineIntel.6.46
+file \
     path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.46 \
-    target=cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386/usr/bin/iconv
-file path=opt/onbld/closed/root_i386/usr/bin/kbdcomp
-file path=opt/onbld/closed/root_i386/usr/bin/localedef
-file path=opt/onbld/closed/root_i386/usr/bin/od
-file path=opt/onbld/closed/root_i386/usr/bin/pax
-file path=opt/onbld/closed/root_i386/usr/bin/printf
-file path=opt/onbld/closed/root_i386/usr/bin/sed
-file path=opt/onbld/closed/root_i386/usr/bin/tail
-file path=opt/onbld/closed/root_i386/usr/bin/tr
-file path=opt/onbld/closed/root_i386/usr/has/bin/patch
-file path=opt/onbld/closed/root_i386/usr/include/sys/lc_core.h
-file path=opt/onbld/closed/root_i386/usr/include/sys/localedef.h
-file path=opt/onbld/closed/root_i386/usr/kernel/drv/$(MACH64)/llc2
-file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2
-file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2.conf
+    mode=0755
+hardlink \
+    path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.47 \
+    target=cpu_ms.GenuineIntel.6.46
+dir  path=opt/onbld/closed/root_i386/usr
+dir  path=opt/onbld/closed/root_i386/usr/bin
+file path=opt/onbld/closed/root_i386/usr/bin/iconv mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/kbdcomp mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/localedef mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/od mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/pax mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/printf mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/tail mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/has
+dir  path=opt/onbld/closed/root_i386/usr/has/bin
+file path=opt/onbld/closed/root_i386/usr/has/bin/patch mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/include
+dir  path=opt/onbld/closed/root_i386/usr/include/sys
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/1394
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/agp
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/audio
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/av
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/contract
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/crypto
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/dcam
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/dktp
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fc4
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm/cpu
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm/fs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm/io
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/hotplug
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/hotplug/pci
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/adapters
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/adapters/hermon
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/adapters/tavor
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/ibd
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/rdma
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_ofs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_ucma
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_umad
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_uverbs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/ibnex
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/ibtl
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/ibtl/impl
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/mgt
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/mgt/ibmf
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/iscsit
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/iso
+file path=opt/onbld/closed/root_i386/usr/include/sys/lc_core.h mode=0644
+file path=opt/onbld/closed/root_i386/usr/include/sys/localedef.h mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/lvm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/pcmcia
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/rsm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/sata
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/adapters
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/conf
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/generic
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/impl
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/targets
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/sysevent
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/tsol
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/audio
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/hid
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/hwarc
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/mass_storage
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/printer
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/ugen
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/usbcdc
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/usbinput
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/usbinput/usbwcm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/video
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/video/usbvc
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/hubd
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/uwb
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/uwb/uwba
+dir  path=opt/onbld/closed/root_i386/usr/kernel
+dir  path=opt/onbld/closed/root_i386/usr/kernel/drv
+dir  path=opt/onbld/closed/root_i386/usr/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/kernel/drv/$(MACH64)/llc2 mode=0755
+file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2 mode=0755
+file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2.conf mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/kernel/strmod
+dir  path=opt/onbld/closed/root_i386/usr/kernel/strmod/$(MACH64)
+dir  path=opt/onbld/closed/root_i386/usr/lib
+dir  path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)
 link path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/libike.so \
     target=libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/llib-like.ln
+file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/libike.so.1 mode=0755
+file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/lib/fwflash
+dir  path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify
 link path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/ses-LSILOGIC.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/ses-SUN.so
+file path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/ses-SUN.so mode=0755
 link path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/sgen-LSILOGIC.so \
     target=ses-SUN.so
 link path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/sgen-SUN.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646da.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646de.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646en.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646es.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646fr.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646it.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646sv.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646da.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646de.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646en.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646es.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646fr.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646it.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646sv.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/iconv_data
-file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH32)/in.iked
-file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH64)/in.iked
-file path=opt/onbld/closed/root_i386/usr/lib/inet/certdb
-file path=opt/onbld/closed/root_i386/usr/lib/inet/certlocal
-file path=opt/onbld/closed/root_i386/usr/lib/inet/certrldb
-file path=opt/onbld/closed/root_i386/usr/lib/labeld
+dir  path=opt/onbld/closed/root_i386/usr/lib/iconv
+dir  path=opt/onbld/closed/root_i386/usr/lib/iconv/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646da.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646de.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646en.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646es.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646fr.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646it.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646sv.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646da.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646de.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646en.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646es.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646fr.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646it.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646sv.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/iconv_data mode=0444
+dir  path=opt/onbld/closed/root_i386/usr/lib/inet
+dir  path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH32)
+file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH32)/in.iked mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH64)/in.iked mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/inet/certdb mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/inet/certlocal mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/inet/certrldb mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/labeld mode=0555
 link path=opt/onbld/closed/root_i386/usr/lib/libike.so target=libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_autoconfig
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_config
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop2
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop3
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop4
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_stats
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tcap
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tparser
-file path=opt/onbld/closed/root_i386/usr/lib/llib-like
-file path=opt/onbld/closed/root_i386/usr/lib/llib-like.ln
-file path=opt/onbld/closed/root_i386/usr/lib/locale/C/locale_description
+file path=opt/onbld/closed/root_i386/usr/lib/libike.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386/usr/lib/llc2
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_autoconfig mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_config mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop2 mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop3 mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop4 mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_stats mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tcap mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tparser mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llib-like mode=0644
+file path=opt/onbld/closed/root_i386/usr/lib/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_COLLATE
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_CTYPE
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_MESSAGES
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_MONETARY
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_NUMERIC
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_TIME
+file path=opt/onbld/closed/root_i386/usr/lib/locale/C/locale_description \
+    mode=0444
 link path=opt/onbld/closed/root_i386/usr/lib/locale/POSIX target=./C
-file path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/generic_eucbc.x
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/single_byte.x
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/charmap.src
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/extension.src
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/localedef.src
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/mpt.so
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/nfs.so
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/mpt.so
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/nfs.so
-file path=opt/onbld/closed/root_i386/usr/lib/nfs/lockd
-file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/$(MACH64)/mpt.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/mpt.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/snmp/mibiisa
-file path=opt/onbld/closed/root_i386/usr/sbin/chk_encodings
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/alias target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/bg target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/cd target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/command target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fc target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fg target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/getopts target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/hash target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/jobs target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/kill target=ulimit
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/more
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/od
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/read target=ulimit
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sed
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sh
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tail
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/test target=ulimit
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tr
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/type target=ulimit
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/umask target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/unalias target=ulimit
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/wait target=ulimit
-file path=opt/onbld/closed/root_i386/usr/xpg6/bin/tr
-file path=opt/onbld/closed/root_i386/var/snmp/mib/sun.mib
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/LC_CTYPE
+file path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/generic_eucbc.x \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/single_byte.x \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef/src
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/charmap.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/extension.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/localedef.src \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/usr/lib/mdb
+dir  path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm
+dir  path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/mpt.so mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/nfs.so mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/mpt.so mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/nfs.so mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/nfs
+file path=opt/onbld/closed/root_i386/usr/lib/nfs/lockd mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/raidcfg
+dir  path=opt/onbld/closed/root_i386/usr/lib/raidcfg/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/$(MACH64)/mpt.so.1 \
+    mode=0755
+file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/mpt.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386/usr/lib/snmp
+file path=opt/onbld/closed/root_i386/usr/lib/snmp/mibiisa mode=0755
+dir  path=opt/onbld/closed/root_i386/usr/platform
+dir  path=opt/onbld/closed/root_i386/usr/platform/i86pc
+dir  path=opt/onbld/closed/root_i386/usr/platform/i86pc/lib
+dir  path=opt/onbld/closed/root_i386/usr/sbin
+file path=opt/onbld/closed/root_i386/usr/sbin/chk_encodings mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/xpg4
+dir  path=opt/onbld/closed/root_i386/usr/xpg4/bin
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/alias mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/bg target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/cd target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/command target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fc target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fg target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/getopts target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/hash target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/jobs target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/kill target=alias
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/more mode=0555
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/od mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/read target=alias
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sh mode=0555
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tail mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/test target=alias
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tr mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/type target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/ulimit target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/umask target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/unalias target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/wait target=alias
+dir  path=opt/onbld/closed/root_i386/usr/xpg6
+dir  path=opt/onbld/closed/root_i386/usr/xpg6/bin
+file path=opt/onbld/closed/root_i386/usr/xpg6/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386/var
+dir  path=opt/onbld/closed/root_i386/var/snmp
+dir  path=opt/onbld/closed/root_i386/var/snmp/mib
+file path=opt/onbld/closed/root_i386/var/snmp/mib/sun.mib mode=0644

--- a/components/openindiana/illumos-closed/manifests/sample-manifest.p5m
+++ b/components/openindiana/illumos-closed/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,1261 +27,3922 @@ file path=opt/onbld/closed/README.ON-BINARIES.i386
 file path=opt/onbld/closed/THIRDPARTYLICENSE.ON-BINARIES
 file path=opt/onbld/closed/on-closed-bins-nd.i386.tar.bz2
 file path=opt/onbld/closed/on-closed-bins.i386.tar.bz2
-hardlink path=opt/onbld/closed/root_i386-nd/etc/init.d/llc2 \
-    target=../rc1.d/K52llc2
-file path=opt/onbld/closed/root_i386-nd/etc/llc2/llc2_start.default
+dir  path=opt/onbld/closed/root_i386-nd/etc
+dir  path=opt/onbld/closed/root_i386-nd/etc/certs
+dir  path=opt/onbld/closed/root_i386-nd/etc/crypto
+dir  path=opt/onbld/closed/root_i386-nd/etc/crypto/certs
+dir  path=opt/onbld/closed/root_i386-nd/etc/init.d
+file path=opt/onbld/closed/root_i386-nd/etc/init.d/llc2 mode=0744
+dir  path=opt/onbld/closed/root_i386-nd/etc/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/llc2/default
+file path=opt/onbld/closed/root_i386-nd/etc/llc2/llc2_start.default mode=0744
+dir  path=opt/onbld/closed/root_i386-nd/etc/rc0.d
 hardlink path=opt/onbld/closed/root_i386-nd/etc/rc0.d/K52llc2 \
-    target=../rc1.d/K52llc2
-file path=opt/onbld/closed/root_i386-nd/etc/rc1.d/K52llc2
+    target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/rc1.d
+hardlink path=opt/onbld/closed/root_i386-nd/etc/rc1.d/K52llc2 \
+    target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/rc2.d
 hardlink path=opt/onbld/closed/root_i386-nd/etc/rc2.d/S40llc2 \
-    target=../rc1.d/K52llc2
+    target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/rcS.d
 hardlink path=opt/onbld/closed/root_i386-nd/etc/rcS.d/K52llc2 \
-    target=../rc1.d/K52llc2
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.example
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.multi
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.single
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.multi
-file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.single
-file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/mibiisa.reg
-file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/snmpd.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/acpi_toshiba
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/adpu320
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/atiatom
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bcm_sata
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnxe
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/cpqary3
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/glm
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/intel_nhmex
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/iprb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/ixgb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/lsimega
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/marvell88sx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcn
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcser
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/sdpib
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/usbser_edge
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/acpi_toshiba
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/atiatom
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bcm_sata
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/iprb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/ixgb
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/marvell88sx
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcn
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcser
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge.conf
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/nfs
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/mpt
-file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/nfs
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmmod
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmops
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmmod
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmops
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc
+    target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386-nd/etc/security
+dir  path=opt/onbld/closed/root_i386-nd/etc/security/tsol
+file path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings \
+    mode=0400
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.example \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.multi \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.gfi.single \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.multi \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/etc/security/tsol/label_encodings.single \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/etc/snmp
+dir  path=opt/onbld/closed/root_i386-nd/etc/snmp/conf
+file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/mibiisa.reg mode=0644
+file path=opt/onbld/closed/root_i386-nd/etc/snmp/conf/snmpd.conf mode=0600
+dir  path=opt/onbld/closed/root_i386-nd/kernel
+dir  path=opt/onbld/closed/root_i386-nd/kernel/drv
+dir  path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/acpi_toshiba \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/atiatom mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnx mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/bnxe mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/glm mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/intel_nhmex \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/iprb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/ixgb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/lsimega mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/marvell88sx \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/mpt mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcn mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcser mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/sdpib mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/usbser_edge \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/acpi_toshiba mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/adpu320.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/atiatom mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnx.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/bnxe.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/cpqary3.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/glm.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/intel_nhmex.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/iprb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/ixgb mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/lsimega.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/marvell88sx mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcn mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcser mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib.conf mode=0644
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge.conf mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/kernel/kmdb
+dir  path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/mpt mode=0555
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/$(MACH64)/nfs mode=0555
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/mpt mode=0555
+file path=opt/onbld/closed/root_i386-nd/kernel/kmdb/nfs mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmmod mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/$(MACH64)/klmops mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmmod mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/misc/klmops mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci
+dir  path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386-nd/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc \
+    mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/kernel/strmod
+dir  path=opt/onbld/closed/root_i386-nd/kernel/strmod/$(MACH64)
 hardlink path=opt/onbld/closed/root_i386-nd/kernel/strmod/$(MACH64)/sdpib \
     target=../../drv/$(MACH64)/sdpib
 hardlink path=opt/onbld/closed/root_i386-nd/kernel/strmod/sdpib \
     target=../drv/sdpib
-file path=opt/onbld/closed/root_i386-nd/lib/$(MACH64)/libc_i18n.a
-file path=opt/onbld/closed/root_i386-nd/lib/crypto/kcfd
-file path=opt/onbld/closed/root_i386-nd/lib/libc_i18n.a
-file path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network/ipsec/ike.xml
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip
-hardlink \
+dir  path=opt/onbld/closed/root_i386-nd/lib
+dir  path=opt/onbld/closed/root_i386-nd/lib/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/lib/$(MACH64)/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/lib/crypto
+file path=opt/onbld/closed/root_i386-nd/lib/crypto/kcfd mode=0555
+file path=opt/onbld/closed/root_i386-nd/lib/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc/manifest
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network
+dir  path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network/ipsec
+file path=opt/onbld/closed/root_i386-nd/lib/svc/manifest/network/ipsec/ike.xml \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/licenses
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal
+file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hal/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd
+file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ndmpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/powertop/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2
+file path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/bzip2/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/common/openssl/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/grub/grub-0.97/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/librstp/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4 \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/arn/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ath/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386-nd/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/platform
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu
+dir  path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)
+file \
     path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.46 \
-    target=cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.46
+    mode=0755
+hardlink \
+    path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.47 \
+    target=cpu_ms.GenuineIntel.6.46
+file \
+    path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.46 \
+    mode=0755
 hardlink \
     path=opt/onbld/closed/root_i386-nd/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.47 \
     target=cpu_ms.GenuineIntel.6.46
-file path=opt/onbld/closed/root_i386-nd/usr/bin/iconv
-file path=opt/onbld/closed/root_i386-nd/usr/bin/kbdcomp
-file path=opt/onbld/closed/root_i386-nd/usr/bin/localedef
-file path=opt/onbld/closed/root_i386-nd/usr/bin/od
-file path=opt/onbld/closed/root_i386-nd/usr/bin/pax
-file path=opt/onbld/closed/root_i386-nd/usr/bin/printf
-file path=opt/onbld/closed/root_i386-nd/usr/bin/sed
-file path=opt/onbld/closed/root_i386-nd/usr/bin/tail
-file path=opt/onbld/closed/root_i386-nd/usr/bin/tr
-file path=opt/onbld/closed/root_i386-nd/usr/has/bin/patch
-file path=opt/onbld/closed/root_i386-nd/usr/include/sys/lc_core.h
-file path=opt/onbld/closed/root_i386-nd/usr/include/sys/localedef.h
-file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/$(MACH64)/llc2
-file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2
-file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2.conf
+dir  path=opt/onbld/closed/root_i386-nd/usr
+dir  path=opt/onbld/closed/root_i386-nd/usr/bin
+file path=opt/onbld/closed/root_i386-nd/usr/bin/iconv mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/kbdcomp mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/localedef mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/od mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/pax mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/printf mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/tail mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/has
+dir  path=opt/onbld/closed/root_i386-nd/usr/has/bin
+file path=opt/onbld/closed/root_i386-nd/usr/has/bin/patch mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/include
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/1394
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/agp
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/audio
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/av
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/contract
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/crypto
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/dcam
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/dktp
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fc4
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm/cpu
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm/fs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fm/io
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/fs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/hotplug
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/hotplug/pci
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/adapters
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/adapters/hermon
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/adapters/tavor
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/ibd
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/rdma
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_ofs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_ucma
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_umad
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/clients/of/sol_uverbs
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/ibnex
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/ibtl
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/ibtl/impl
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/mgt
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/ib/mgt/ibmf
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/iscsit
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/iso
+file path=opt/onbld/closed/root_i386-nd/usr/include/sys/lc_core.h mode=0644
+file path=opt/onbld/closed/root_i386-nd/usr/include/sys/localedef.h mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/lvm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/pcmcia
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/rsm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/sata
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/adapters
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/conf
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/generic
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/impl
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/scsi/targets
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/sysevent
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/tsol
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/audio
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/hid
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/hwarc
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/mass_storage
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/printer
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/ugen
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/usbcdc
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/usbinput
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/usbinput/usbwcm
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/video
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/clients/video/usbvc
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/usb/hubd
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/uwb
+dir  path=opt/onbld/closed/root_i386-nd/usr/include/sys/uwb/uwba
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/drv
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/$(MACH64)/llc2 mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2 mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/kernel/drv/llc2.conf mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/strmod
+dir  path=opt/onbld/closed/root_i386-nd/usr/kernel/strmod/$(MACH64)
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)
 link path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/libike.so \
     target=libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/llib-like.ln
+file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/libike.so.1 mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/lib/$(MACH64)/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify
 link path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/ses-LSILOGIC.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/ses-SUN.so
+file path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/ses-SUN.so \
+    mode=0755
 link \
     path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/sgen-LSILOGIC.so \
     target=ses-SUN.so
 link path=opt/onbld/closed/root_i386-nd/usr/lib/fwflash/verify/sgen-SUN.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646da.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646de.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646en.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646es.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646fr.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646it.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646sv.8859.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646da.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646de.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646en.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646es.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646fr.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646it.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646sv.t
-file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/iconv_data
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH32)/in.iked
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH64)/in.iked
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certdb
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certlocal
-file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certrldb
-file path=opt/onbld/closed/root_i386-nd/usr/lib/labeld
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/iconv
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646da.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646de.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646en.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646es.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646fr.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646it.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/646sv.8859.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646da.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646de.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646en.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646es.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646fr.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646it.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/8859.646sv.t mode=0444
+file path=opt/onbld/closed/root_i386-nd/usr/lib/iconv/iconv_data mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/inet
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH32)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH32)/in.iked mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/$(MACH64)/in.iked mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certdb mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certlocal mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/inet/certrldb mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/labeld mode=0555
 link path=opt/onbld/closed/root_i386-nd/usr/lib/libike.so target=libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/libike.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_autoconfig
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_config
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop2
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop3
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop4
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_stats
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tcap
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tparser
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like
-file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like.ln
-file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/locale_description
+file path=opt/onbld/closed/root_i386-nd/usr/lib/libike.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/llc2
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_autoconfig mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_config mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop2 mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop3 mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_loop4 mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_stats mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tcap mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llc2/llc2_tparser mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like mode=0644
+file path=opt/onbld/closed/root_i386-nd/usr/lib/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_COLLATE
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_CTYPE
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_MESSAGES
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_MONETARY
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_NUMERIC
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/LC_TIME
+file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/C/locale_description \
+    mode=0444
 link path=opt/onbld/closed/root_i386-nd/usr/lib/locale/POSIX target=./C
-file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/generic_eucbc.x
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/single_byte.x
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/charmap.src
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/extension.src
-file path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/localedef.src
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/mpt.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/nfs.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/mpt.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/nfs.so
-file path=opt/onbld/closed/root_i386-nd/usr/lib/nfs/lockd
-file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/$(MACH64)/mpt.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/mpt.so.1
-file path=opt/onbld/closed/root_i386-nd/usr/lib/snmp/mibiisa
-file path=opt/onbld/closed/root_i386-nd/usr/sbin/chk_encodings
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/alias target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/bg target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/cd target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/command target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fc target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fg target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/getopts target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/hash target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/jobs target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/kill target=unalias
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/more
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/od
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/read target=unalias
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sed
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sh
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tail
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/test target=unalias
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tr
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/type target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/ulimit target=unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/umask target=unalias
-file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/unalias
-hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/wait target=unalias
-file path=opt/onbld/closed/root_i386-nd/usr/xpg6/bin/tr
-file path=opt/onbld/closed/root_i386-nd/var/snmp/mib/sun.mib
-file path=opt/onbld/closed/root_i386/etc/init.d/llc2
-file path=opt/onbld/closed/root_i386/etc/llc2/llc2_start.default
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/LC_CTYPE
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/locale/iso_8859_1/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/generic_eucbc.x \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/extensions/single_byte.x \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/charmap.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/extension.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386-nd/usr/lib/localedef/src/iso_8859_1/localedef.src \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/mdb
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/mpt.so \
+    mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/$(MACH64)/nfs.so \
+    mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/mpt.so mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/lib/mdb/kvm/nfs.so mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/nfs
+file path=opt/onbld/closed/root_i386-nd/usr/lib/nfs/lockd mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/$(MACH64)
+file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/$(MACH64)/mpt.so.1 \
+    mode=0755
+file path=opt/onbld/closed/root_i386-nd/usr/lib/raidcfg/mpt.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/usr/lib/snmp
+file path=opt/onbld/closed/root_i386-nd/usr/lib/snmp/mibiisa mode=0755
+dir  path=opt/onbld/closed/root_i386-nd/usr/platform
+dir  path=opt/onbld/closed/root_i386-nd/usr/platform/i86pc
+dir  path=opt/onbld/closed/root_i386-nd/usr/platform/i86pc/lib
+dir  path=opt/onbld/closed/root_i386-nd/usr/sbin
+file path=opt/onbld/closed/root_i386-nd/usr/sbin/chk_encodings mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg4
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/alias mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/bg target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/cd target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/command target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fc target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/fg target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/getopts target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/hash target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/jobs target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/kill target=alias
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/more mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/od mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/read target=alias
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/sh mode=0555
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tail mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/test target=alias
+file path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/tr mode=0555
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/type target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/ulimit target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/umask target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/unalias target=alias
+hardlink path=opt/onbld/closed/root_i386-nd/usr/xpg4/bin/wait target=alias
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg6
+dir  path=opt/onbld/closed/root_i386-nd/usr/xpg6/bin
+file path=opt/onbld/closed/root_i386-nd/usr/xpg6/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386-nd/var
+dir  path=opt/onbld/closed/root_i386-nd/var/snmp
+dir  path=opt/onbld/closed/root_i386-nd/var/snmp/mib
+file path=opt/onbld/closed/root_i386-nd/var/snmp/mib/sun.mib mode=0644
+dir  path=opt/onbld/closed/root_i386/etc
+dir  path=opt/onbld/closed/root_i386/etc/certs
+dir  path=opt/onbld/closed/root_i386/etc/crypto
+dir  path=opt/onbld/closed/root_i386/etc/crypto/certs
+dir  path=opt/onbld/closed/root_i386/etc/init.d
+file path=opt/onbld/closed/root_i386/etc/init.d/llc2 mode=0744
+dir  path=opt/onbld/closed/root_i386/etc/llc2
+dir  path=opt/onbld/closed/root_i386/etc/llc2/default
+file path=opt/onbld/closed/root_i386/etc/llc2/llc2_start.default mode=0744
+dir  path=opt/onbld/closed/root_i386/etc/rc0.d
 hardlink path=opt/onbld/closed/root_i386/etc/rc0.d/K52llc2 target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386/etc/rc1.d
 hardlink path=opt/onbld/closed/root_i386/etc/rc1.d/K52llc2 target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386/etc/rc2.d
 hardlink path=opt/onbld/closed/root_i386/etc/rc2.d/S40llc2 target=../init.d/llc2
+dir  path=opt/onbld/closed/root_i386/etc/rcS.d
 hardlink path=opt/onbld/closed/root_i386/etc/rcS.d/K52llc2 target=../init.d/llc2
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.example
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.multi
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.single
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.multi
-file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.single
-file path=opt/onbld/closed/root_i386/etc/snmp/conf/mibiisa.reg
-file path=opt/onbld/closed/root_i386/etc/snmp/conf/snmpd.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/acpi_toshiba
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/adpu320
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/atiatom
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bcm_sata
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnx
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnxe
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/cpqary3
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/glm
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/intel_nhmex
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/iprb
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/ixgb
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/lsimega
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/marvell88sx
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcn
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcser
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/sdpib
-file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/usbser_edge
-file path=opt/onbld/closed/root_i386/kernel/drv/acpi_toshiba
-file path=opt/onbld/closed/root_i386/kernel/drv/adpu320
-file path=opt/onbld/closed/root_i386/kernel/drv/adpu320.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/atiatom
-file path=opt/onbld/closed/root_i386/kernel/drv/bcm_sata
-file path=opt/onbld/closed/root_i386/kernel/drv/bnx
-file path=opt/onbld/closed/root_i386/kernel/drv/bnx.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/bnxe
-file path=opt/onbld/closed/root_i386/kernel/drv/bnxe.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3
-file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/glm
-file path=opt/onbld/closed/root_i386/kernel/drv/glm.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex
-file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/iprb
-file path=opt/onbld/closed/root_i386/kernel/drv/ixgb
-file path=opt/onbld/closed/root_i386/kernel/drv/lsimega
-file path=opt/onbld/closed/root_i386/kernel/drv/lsimega.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/marvell88sx
-file path=opt/onbld/closed/root_i386/kernel/drv/mpt
-file path=opt/onbld/closed/root_i386/kernel/drv/mpt.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/pcn
-file path=opt/onbld/closed/root_i386/kernel/drv/pcser
-file path=opt/onbld/closed/root_i386/kernel/drv/sdpib
-file path=opt/onbld/closed/root_i386/kernel/drv/sdpib.conf
-file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge
-file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge.conf
-file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/mpt
-file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/nfs
-file path=opt/onbld/closed/root_i386/kernel/kmdb/mpt
-file path=opt/onbld/closed/root_i386/kernel/kmdb/nfs
-file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmmod
-file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmops
-file path=opt/onbld/closed/root_i386/kernel/misc/klmmod
-file path=opt/onbld/closed/root_i386/kernel/misc/klmops
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi
-file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc
-hardlink path=opt/onbld/closed/root_i386/kernel/strmod/$(MACH64)/sdpib \
-    target=../../drv/$(MACH64)/sdpib
-hardlink path=opt/onbld/closed/root_i386/kernel/strmod/sdpib target=../drv/sdpib
-file path=opt/onbld/closed/root_i386/lib/$(MACH64)/libc_i18n.a
-file path=opt/onbld/closed/root_i386/lib/crypto/kcfd
-file path=opt/onbld/closed/root_i386/lib/libc_i18n.a
-file path=opt/onbld/closed/root_i386/lib/svc/manifest/network/ipsec/ike.xml
-file path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE
-file path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip
-file path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.46
+dir  path=opt/onbld/closed/root_i386/etc/security
+dir  path=opt/onbld/closed/root_i386/etc/security/tsol
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings mode=0400
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.example \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.multi \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.gfi.single \
+    mode=0444
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.multi \
+    mode=0444
+file path=opt/onbld/closed/root_i386/etc/security/tsol/label_encodings.single \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/etc/snmp
+dir  path=opt/onbld/closed/root_i386/etc/snmp/conf
+file path=opt/onbld/closed/root_i386/etc/snmp/conf/mibiisa.reg mode=0644
+file path=opt/onbld/closed/root_i386/etc/snmp/conf/snmpd.conf mode=0600
+dir  path=opt/onbld/closed/root_i386/kernel
+dir  path=opt/onbld/closed/root_i386/kernel/drv
+dir  path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/acpi_toshiba mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/atiatom mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/bnxe mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/glm mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/intel_nhmex mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/iprb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/ixgb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/lsimega mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/marvell88sx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/mpt mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcn mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/pcser mode=0755
+hardlink path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/sdpib \
+    target=../../strmod/$(MACH64)/sdpib
+file path=opt/onbld/closed/root_i386/kernel/drv/$(MACH64)/usbser_edge mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/acpi_toshiba mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/adpu320 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/adpu320.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/atiatom mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bcm_sata mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bnx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bnx.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/bnxe mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/bnxe.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3 mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/cpqary3.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/glm mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/glm.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/intel_nhmex.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/iprb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/ixgb mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/lsimega mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/lsimega.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/marvell88sx mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/mpt mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/mpt.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/pcn mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/pcser mode=0755
+hardlink path=opt/onbld/closed/root_i386/kernel/drv/sdpib target=../strmod/sdpib
+file path=opt/onbld/closed/root_i386/kernel/drv/sdpib.conf mode=0644
+file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge mode=0755
+file path=opt/onbld/closed/root_i386/kernel/drv/usbser_edge.conf mode=0644
+dir  path=opt/onbld/closed/root_i386/kernel/kmdb
+dir  path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/mpt mode=0555
+file path=opt/onbld/closed/root_i386/kernel/kmdb/$(MACH64)/nfs mode=0555
+file path=opt/onbld/closed/root_i386/kernel/kmdb/mpt mode=0555
+file path=opt/onbld/closed/root_i386/kernel/kmdb/nfs mode=0555
+dir  path=opt/onbld/closed/root_i386/kernel/misc
+dir  path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmmod mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/$(MACH64)/klmops mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/klmmod mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/klmops mode=0755
+dir  path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci
+dir  path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_asym_lsi \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/$(MACH64)/scsi_vhci_f_sym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_emc \
+    mode=0755
+file \
+    path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_asym_lsi \
+    mode=0755
+file path=opt/onbld/closed/root_i386/kernel/misc/scsi_vhci/scsi_vhci_f_sym_emc \
+    mode=0755
+dir  path=opt/onbld/closed/root_i386/kernel/strmod
+dir  path=opt/onbld/closed/root_i386/kernel/strmod/$(MACH64)
+file path=opt/onbld/closed/root_i386/kernel/strmod/$(MACH64)/sdpib mode=0755
+file path=opt/onbld/closed/root_i386/kernel/strmod/sdpib mode=0755
+dir  path=opt/onbld/closed/root_i386/lib
+dir  path=opt/onbld/closed/root_i386/lib/$(MACH64)
+file path=opt/onbld/closed/root_i386/lib/$(MACH64)/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386/lib/crypto
+file path=opt/onbld/closed/root_i386/lib/crypto/kcfd mode=0555
+file path=opt/onbld/closed/root_i386/lib/libc_i18n.a mode=0755
+dir  path=opt/onbld/closed/root_i386/lib/svc
+dir  path=opt/onbld/closed/root_i386/lib/svc/manifest
+dir  path=opt/onbld/closed/root_i386/lib/svc/manifest/network
+dir  path=opt/onbld/closed/root_i386/lib/svc/manifest/network/ipsec
+file path=opt/onbld/closed/root_i386/lib/svc/manifest/network/ipsec/ike.xml \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/licenses
+dir  path=opt/onbld/closed/root_i386/licenses/usr
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io
+dir  path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/closed/uts/intel/io/iprb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/acpihpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/agents/snmp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/backup/dump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/bnu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checkeq/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/checknr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/THIRDPARTYLICENSE.kcmd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/sbin/ifparse/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rcp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/THIRDPARTYLICENSE.rsh.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/ftp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/nc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.minconnect.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppd/plugins/THIRDPARTYLICENSE.passwd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/pppdump/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/rdist/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.bin/telnet/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.dhcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/in.mpathd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/mdnsd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.lib/wpad/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.arp.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.comsat.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.rlogind.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/THIRDPARTYLICENSE.route.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/ifconfig/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.ftpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.rdisc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.bsd.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/in.routed/THIRDPARTYLICENSE.freebsd.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cmd-inet/usr.sbin/traceroute/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/compress/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/cron/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/csh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eeprom/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/eqn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/udfs/fsck/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/fs.d/ufs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE mode=0644
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hal/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/hwdata/THIRDPARTYLICENSE.pciids.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ipf/tools/IPFILTER.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lastcomm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ldap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lms/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/look/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/lp/cmd/lptest/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/instant.src/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/nsgmls.src/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/man/src/util/solbookv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mdb/common/libstand/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/mt/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ndmpd/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ntfsprogs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/parted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/perl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/powertop/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/refer/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/script/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/sendmail/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/soelim/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ssh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/stat/vmstat/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tbl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tcpd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/terminfo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/tip/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/ul/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/units/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vgrind/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi
+file path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/vi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/which/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/cmd/xstr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2
+file path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/bzip2/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/THIRDPARTYLICENSE.cryptogams.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.gladman.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/aes/$(MACH64)/THIRDPARTYLICENSE.openssl.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/ecc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/crypto/md5/$(MACH64)/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/mpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl
+file path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/common/openssl/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/grub
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97
+file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/AUTHORS.descrip \
+    mode=0644
+file path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/grub/grub-0.97/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/gss_mechs/mech_krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/hbaapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libast/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libbsdmalloc/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/$(MACH64)/gen/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libc/port/fp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libcmd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdll/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libdns_sd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libgss/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libima/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libinetutil/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libkmsagent/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap4/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libldap5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libmp/common/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libntfs/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libparted/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpkg/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libpp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libresolv2/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/librstp/common/COPYING.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsasl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libshell/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.apple.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.boris_popov.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4 \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.bsd4.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsmbfs/smb/THIRDPARTYLICENSE.microsoft.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libsum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libtecla/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/libwrap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/mpapi/libmpapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pam_modules/authtok_check/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/passwdutil/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/include/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/pkcs11/pkcs11_tpm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/print/libhttp-core/common/LICENSE.txt.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/sasl_plugins/gssapi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/lib/smhba/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/ctf/dwarf/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/tools/onbld/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/basename/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/echo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/from/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/groups/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ln/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/ls/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/sum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/test/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/tset/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/users/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whereis/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucbcmd/whoami/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libcurses/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libtermcap/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/ucblib/libucb/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/gssapi/mechs/krb5/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/ip/THIRDPARTYLICENSE.rts.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/inet/tcp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/THIRDPARTYLICENSE.etheraddr.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/aac/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/afe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/arn/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ath/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/atu/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/audio/drv/audiosolo/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/bpf/BPF.LICENCE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/chxge/com/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/drm/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/e1000g/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/elxl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/emlxs/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/fibre-channel/fca/qlc/FIRMWARELICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/of/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rds/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ib/clients/rdsv3/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ipw/fw-ipw2100/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5000/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwh/fw-iw/fw_5150/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwi/fw-ipw2200/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwk/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/iwp/fw-iw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ixgbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mega_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mr_sas/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mwl/mwl_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/mxfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/myri10ge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ntxn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcan/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/pcwl/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ppp/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ral/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rum/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/rwn/fw-rt2860/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/scsi/adapters/pmcs/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/sfe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/uath/uath_fw/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/ural/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/urtw/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/usb/clients/hwa1480_fw/i1480/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/wpi/fw-wpi/LICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/yge/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/io/zyd/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.agpgart.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.icu.descrip \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/common/zmod/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/i86pc/io/fipe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/acpica/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amd8111s/THIRDPARTYLICENSE.amd8111s.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/amr/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/io/heci/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE \
+    mode=0644
+file \
+    path=opt/onbld/closed/root_i386/licenses/usr/src/uts/intel/pcbe/THIRDPARTYLICENSE.descrip \
+    mode=0644
+dir  path=opt/onbld/closed/root_i386/platform
+dir  path=opt/onbld/closed/root_i386/platform/i86pc
+dir  path=opt/onbld/closed/root_i386/platform/i86pc/kernel
+dir  path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu
+dir  path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.46 \
+    mode=0755
 hardlink \
     path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/$(MACH64)/cpu_ms.GenuineIntel.6.47 \
     target=cpu_ms.GenuineIntel.6.46
-hardlink \
+file \
     path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.46 \
-    target=cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.47
-file path=opt/onbld/closed/root_i386/usr/bin/iconv
-file path=opt/onbld/closed/root_i386/usr/bin/kbdcomp
-file path=opt/onbld/closed/root_i386/usr/bin/localedef
-file path=opt/onbld/closed/root_i386/usr/bin/od
-file path=opt/onbld/closed/root_i386/usr/bin/pax
-file path=opt/onbld/closed/root_i386/usr/bin/printf
-file path=opt/onbld/closed/root_i386/usr/bin/sed
-file path=opt/onbld/closed/root_i386/usr/bin/tail
-file path=opt/onbld/closed/root_i386/usr/bin/tr
-file path=opt/onbld/closed/root_i386/usr/has/bin/patch
-file path=opt/onbld/closed/root_i386/usr/include/sys/lc_core.h
-file path=opt/onbld/closed/root_i386/usr/include/sys/localedef.h
-file path=opt/onbld/closed/root_i386/usr/kernel/drv/$(MACH64)/llc2
-file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2
-file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2.conf
+    mode=0755
+hardlink \
+    path=opt/onbld/closed/root_i386/platform/i86pc/kernel/cpu/cpu_ms.GenuineIntel.6.47 \
+    target=cpu_ms.GenuineIntel.6.46
+dir  path=opt/onbld/closed/root_i386/usr
+dir  path=opt/onbld/closed/root_i386/usr/bin
+file path=opt/onbld/closed/root_i386/usr/bin/iconv mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/kbdcomp mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/localedef mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/od mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/pax mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/printf mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/tail mode=0555
+file path=opt/onbld/closed/root_i386/usr/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/has
+dir  path=opt/onbld/closed/root_i386/usr/has/bin
+file path=opt/onbld/closed/root_i386/usr/has/bin/patch mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/include
+dir  path=opt/onbld/closed/root_i386/usr/include/sys
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/1394
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/agp
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/audio
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/av
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/contract
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/crypto
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/dcam
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/dktp
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fc4
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm/cpu
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm/fs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fm/io
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/fs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/hotplug
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/hotplug/pci
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/adapters
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/adapters/hermon
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/adapters/tavor
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/ibd
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/rdma
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_ofs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_ucma
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_umad
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/clients/of/sol_uverbs
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/ibnex
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/ibtl
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/ibtl/impl
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/mgt
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/ib/mgt/ibmf
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/iscsit
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/iso
+file path=opt/onbld/closed/root_i386/usr/include/sys/lc_core.h mode=0644
+file path=opt/onbld/closed/root_i386/usr/include/sys/localedef.h mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/lvm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/pcmcia
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/rsm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/sata
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/adapters
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/conf
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/generic
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/impl
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/scsi/targets
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/sysevent
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/tsol
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/audio
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/hid
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/hwarc
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/mass_storage
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/printer
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/ugen
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/usbcdc
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/usbinput
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/usbinput/usbwcm
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/video
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/clients/video/usbvc
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/usb/hubd
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/uwb
+dir  path=opt/onbld/closed/root_i386/usr/include/sys/uwb/uwba
+dir  path=opt/onbld/closed/root_i386/usr/kernel
+dir  path=opt/onbld/closed/root_i386/usr/kernel/drv
+dir  path=opt/onbld/closed/root_i386/usr/kernel/drv/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/kernel/drv/$(MACH64)/llc2 mode=0755
+file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2 mode=0755
+file path=opt/onbld/closed/root_i386/usr/kernel/drv/llc2.conf mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/kernel/strmod
+dir  path=opt/onbld/closed/root_i386/usr/kernel/strmod/$(MACH64)
+dir  path=opt/onbld/closed/root_i386/usr/lib
+dir  path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)
 link path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/libike.so \
     target=libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/llib-like.ln
+file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/libike.so.1 mode=0755
+file path=opt/onbld/closed/root_i386/usr/lib/$(MACH64)/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/lib/fwflash
+dir  path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify
 link path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/ses-LSILOGIC.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/ses-SUN.so
+file path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/ses-SUN.so mode=0755
 link path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/sgen-LSILOGIC.so \
     target=ses-SUN.so
 link path=opt/onbld/closed/root_i386/usr/lib/fwflash/verify/sgen-SUN.so \
     target=ses-SUN.so
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646da.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646de.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646en.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646es.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646fr.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646it.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/646sv.8859.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646da.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646de.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646en.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646es.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646fr.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646it.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646sv.t
-file path=opt/onbld/closed/root_i386/usr/lib/iconv/iconv_data
-file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH32)/in.iked
-file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH64)/in.iked
-file path=opt/onbld/closed/root_i386/usr/lib/inet/certdb
-file path=opt/onbld/closed/root_i386/usr/lib/inet/certlocal
-file path=opt/onbld/closed/root_i386/usr/lib/inet/certrldb
-file path=opt/onbld/closed/root_i386/usr/lib/labeld
+dir  path=opt/onbld/closed/root_i386/usr/lib/iconv
+dir  path=opt/onbld/closed/root_i386/usr/lib/iconv/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646da.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646de.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646en.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646es.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646fr.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646it.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/646sv.8859.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646da.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646de.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646en.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646es.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646fr.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646it.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/8859.646sv.t mode=0444
+file path=opt/onbld/closed/root_i386/usr/lib/iconv/iconv_data mode=0444
+dir  path=opt/onbld/closed/root_i386/usr/lib/inet
+dir  path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH32)
+file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH32)/in.iked mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/inet/$(MACH64)/in.iked mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/inet/certdb mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/inet/certlocal mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/inet/certrldb mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/labeld mode=0555
 link path=opt/onbld/closed/root_i386/usr/lib/libike.so target=libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/libike.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_autoconfig
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_config
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop2
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop3
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop4
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_stats
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tcap
-file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tparser
-file path=opt/onbld/closed/root_i386/usr/lib/llib-like
-file path=opt/onbld/closed/root_i386/usr/lib/llib-like.ln
-file path=opt/onbld/closed/root_i386/usr/lib/locale/C/locale_description
+file path=opt/onbld/closed/root_i386/usr/lib/libike.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386/usr/lib/llc2
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_autoconfig mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_config mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop2 mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop3 mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_loop4 mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_stats mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tcap mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llc2/llc2_tparser mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/llib-like mode=0644
+file path=opt/onbld/closed/root_i386/usr/lib/llib-like.ln mode=0644
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_COLLATE
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_CTYPE
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_MESSAGES
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_MONETARY
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_NUMERIC
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/C/LC_TIME
+file path=opt/onbld/closed/root_i386/usr/lib/locale/C/locale_description \
+    mode=0444
 link path=opt/onbld/closed/root_i386/usr/lib/locale/POSIX target=./C
-file path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/iso_8859_1.so.3
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/generic_eucbc.x
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/single_byte.x
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/charmap.src
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/extension.src
-file path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/localedef.src
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/mpt.so
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/nfs.so
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/mpt.so
-file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/nfs.so
-file path=opt/onbld/closed/root_i386/usr/lib/nfs/lockd
-file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/$(MACH64)/mpt.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/mpt.so.1
-file path=opt/onbld/closed/root_i386/usr/lib/snmp/mibiisa
-file path=opt/onbld/closed/root_i386/usr/sbin/chk_encodings
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/alias target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/bg target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/cd target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/command target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fc target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fg target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/getopts target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/hash target=jobs
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/kill target=jobs
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/more
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/od
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/read target=jobs
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sed
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sh
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tail
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/test target=jobs
-file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tr
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/type target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/ulimit target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/umask target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/unalias target=jobs
-hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/wait target=jobs
-file path=opt/onbld/closed/root_i386/usr/xpg6/bin/tr
-file path=opt/onbld/closed/root_i386/var/snmp/mib/sun.mib
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/$(MACH64)
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/$(MACH64)/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/LC_CTYPE
+file path=opt/onbld/closed/root_i386/usr/lib/locale/iso_8859_1/iso_8859_1.so.3 \
+    mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/generic_eucbc.x \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/extensions/single_byte.x \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef/src
+dir  path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/charmap.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/extension.src \
+    mode=0444
+file \
+    path=opt/onbld/closed/root_i386/usr/lib/localedef/src/iso_8859_1/localedef.src \
+    mode=0444
+dir  path=opt/onbld/closed/root_i386/usr/lib/mdb
+dir  path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm
+dir  path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/mpt.so mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/$(MACH64)/nfs.so mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/mpt.so mode=0555
+file path=opt/onbld/closed/root_i386/usr/lib/mdb/kvm/nfs.so mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/nfs
+file path=opt/onbld/closed/root_i386/usr/lib/nfs/lockd mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/lib/raidcfg
+dir  path=opt/onbld/closed/root_i386/usr/lib/raidcfg/$(MACH64)
+file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/$(MACH64)/mpt.so.1 \
+    mode=0755
+file path=opt/onbld/closed/root_i386/usr/lib/raidcfg/mpt.so.1 mode=0755
+dir  path=opt/onbld/closed/root_i386/usr/lib/snmp
+file path=opt/onbld/closed/root_i386/usr/lib/snmp/mibiisa mode=0755
+dir  path=opt/onbld/closed/root_i386/usr/platform
+dir  path=opt/onbld/closed/root_i386/usr/platform/i86pc
+dir  path=opt/onbld/closed/root_i386/usr/platform/i86pc/lib
+dir  path=opt/onbld/closed/root_i386/usr/sbin
+file path=opt/onbld/closed/root_i386/usr/sbin/chk_encodings mode=0555
+dir  path=opt/onbld/closed/root_i386/usr/xpg4
+dir  path=opt/onbld/closed/root_i386/usr/xpg4/bin
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/alias mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/bg target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/cd target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/command target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fc target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/fg target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/getopts target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/hash target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/jobs target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/kill target=alias
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/more mode=0555
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/od mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/read target=alias
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sed mode=0555
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/sh mode=0555
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tail mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/test target=alias
+file path=opt/onbld/closed/root_i386/usr/xpg4/bin/tr mode=0555
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/type target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/ulimit target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/umask target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/unalias target=alias
+hardlink path=opt/onbld/closed/root_i386/usr/xpg4/bin/wait target=alias
+dir  path=opt/onbld/closed/root_i386/usr/xpg6
+dir  path=opt/onbld/closed/root_i386/usr/xpg6/bin
+file path=opt/onbld/closed/root_i386/usr/xpg6/bin/tr mode=0555
+dir  path=opt/onbld/closed/root_i386/var
+dir  path=opt/onbld/closed/root_i386/var/snmp
+dir  path=opt/onbld/closed/root_i386/var/snmp/mib
+file path=opt/onbld/closed/root_i386/var/snmp/mib/sun.mib mode=0644

--- a/components/openindiana/illumos-closed/pkg5
+++ b/components/openindiana/illumos-closed/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [

--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -302,7 +302,7 @@ $(GENERATED).p5m:	install
 	[ ! -d $(SAMPLE_MANIFEST_DIR) ] && $(MKDIR) $(SAMPLE_MANIFEST_DIR) || true
 	$(PKGSEND) generate $(PKG_HARDLINKS:%=--target %) $(PROTO_DIR) | \
 	$(PKGMOGRIFY) $(PKG_OPTIONS) /dev/fd/0 $(GENERATE_TRANSFORMS) | \
-		sed -e '/^$$/d' -e '/^#.*$$/d' -e '/^dir .*$$/d' \
+		sed -e '/^$$/d' -e '/^#.*$$/d' \
 		-e '/\.la$$/d' -e '/\.pyo$$/d' -e '/usr\/lib\/python[23]\..*\.pyc$$/d' \
 		-e '/usr\/lib\/python3\..*\/__pycache__\/.*/d'  | \
 		$(PKGFMT) | \

--- a/transforms/generate-cleanup
+++ b/transforms/generate-cleanup
@@ -36,7 +36,9 @@
 <transform dir file link hardlink license -> delete pkg.size .*>
 <transform dir file link hardlink license -> delete owner .*>
 <transform dir file link hardlink license -> delete group .*>
-<transform dir file link hardlink license -> delete mode .*>
+<transform dir link hardlink license -> delete mode .*>
+# preserve mode for illumos-closed files
+<transform file path=(?!opt/onbld/closed/root_i386) -> delete mode .*>
 
 #<transform set name=pkg.fmri -> edit value "@[^ \t\n\r\f\v]*" "@$!(IPS_COMPONENT_VERSION),$!(BUILD_VERSION)">
 
@@ -109,5 +111,6 @@
 <transform dir file link hardlink -> \
 	edit target "\$!\((.*)\)" "$(\1)">
 
-<transform dir path=mangled -> drop>
-<transform dir file link hardlink path=mangled/(.*) -> drop>
+<transform file link hardlink path=mangled/(.*) -> drop>
+# drop all dirs except for illumos-closed
+<transform dir path=(?!(opt/onbld/closed/root_i386(-nd)?/)) -> drop>


### PR DESCRIPTION
If you try to build the illumos-gate with:
* the `illumos-closed` package intalled (usually installed),
* `ON_CLOSED_BINS` set to `/opt/onbld/closed` (this is default),
* missing `/opt/onbld/closed/on-closed-bins{,-nd}.i386.tar.bz2` files (this is **non-default**),

the gate build fails because:

1. some (many) files in the `illumos-closed` package have different permissions (mode) than expected by the illumos-gate,
2. there are some empty directories missing from the `illumos-closed` package.

This PR aims to solve both problems and allows to build the illumos-gate even without closed bins tarballs available in `/opt/onbld/closed`.