### PR TITLE
library/perl-5/http-cookies: rebuild for perl 5.34

### DIFF
--- a/components/perl/HTTP-Cookies/HTTP-Cookies-PERLVER.p5m
+++ b/components/perl/HTTP-Cookies/HTTP-Cookies-PERLVER.p5m
@@ -11,18 +11,33 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/http-cookies-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="HTTP::Cookies - HTTP cookie jars"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license HTTP-Cookies.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
+
+# requires HTTP::Date and HTTP::Headers (from HTTP::Message) for the
+# same version of perl
+depend type=require fmri=library/perl-5/http-date-$(PLV)
+depend type=require fmri=library/perl-5/http-message-$(PLV)
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/HTTP::Cookies.3 mode=0444
 file path=usr/perl5/$(PERLVER)/man/man3/HTTP::Cookies::Microsoft.3 mode=0444

--- a/components/perl/HTTP-Cookies/Makefile
+++ b/components/perl/HTTP-Cookies/Makefile
@@ -22,30 +22,58 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		HTTP-Cookies
 COMPONENT_VERSION=	6.01
-COMPONENT_REVISION=	1
 IPS_COMPONENT_VERSION=	6.1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/http-cookies
+COMPONENT_SUMMARY=	HTTP::Cookies - HTTP cookie jars
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/HTTP-Cookies/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/HTTP::Cookies
 COMPONENT_ARCHIVE_HASH=	\
     sha256:f5d3ade383ce6389d80cb0d0356b643af80435bb036afd8edce335215ec5eb20
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
+# runtime requires HTTP::Date and HTTP::Headers (part of HTTP::Message),
+# so we need them for the test suite
+REQUIRED_PACKAGES += library/perl-5/http-message-522
+REQUIRED_PACKAGES += library/perl-5/http-message-524
+REQUIRED_PACKAGES += library/perl-5/http-message-534
+REQUIRED_PACKAGES += library/perl-5/http-date-522
+REQUIRED_PACKAGES += library/perl-5/http-date-524
+REQUIRED_PACKAGES += library/perl-5/http-date-534
 
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/HTTP-Cookies/manifests/sample-manifest.p5m
+++ b/components/perl/HTTP-Cookies/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,6 +30,10 @@ file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/HTTP::Cookies.3
 file path=usr/perl5/5.24/man/man3/HTTP::Cookies::Microsoft.3
 file path=usr/perl5/5.24/man/man3/HTTP::Cookies::Netscape.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/HTTP::Cookies.3
+file path=usr/perl5/5.34/man/man3/HTTP::Cookies::Microsoft.3
+file path=usr/perl5/5.34/man/man3/HTTP::Cookies::Netscape.3
 file path=usr/perl5/vendor_perl/5.22/HTTP/Cookies.pm
 file path=usr/perl5/vendor_perl/5.22/HTTP/Cookies/Microsoft.pm
 file path=usr/perl5/vendor_perl/5.22/HTTP/Cookies/Netscape.pm
@@ -38,3 +42,7 @@ file path=usr/perl5/vendor_perl/5.24/HTTP/Cookies.pm
 file path=usr/perl5/vendor_perl/5.24/HTTP/Cookies/Microsoft.pm
 file path=usr/perl5/vendor_perl/5.24/HTTP/Cookies/Netscape.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/HTTP/Cookies/.packlist
+file path=usr/perl5/vendor_perl/5.34/HTTP/Cookies.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Cookies/Microsoft.pm
+file path=usr/perl5/vendor_perl/5.34/HTTP/Cookies/Netscape.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/HTTP/Cookies/.packlist

--- a/components/perl/HTTP-Cookies/pkg5
+++ b/components/perl/HTTP-Cookies/pkg5
@@ -1,11 +1,22 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/perl-5/http-date-522",
+        "library/perl-5/http-date-524",
+        "library/perl-5/http-date-534",
+        "library/perl-5/http-message-522",
+        "library/perl-5/http-message-524",
+        "library/perl-5/http-message-534",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/http-cookies-522",
         "library/perl-5/http-cookies-524",
+        "library/perl-5/http-cookies-534",
         "library/perl-5/http-cookies"
     ],
     "name": "HTTP-Cookies"

--- a/components/perl/HTTP-Cookies/test/results-all.master
+++ b/components/perl/HTTP-Cookies/test/results-all.master
@@ -1,0 +1,5 @@
+t/cookies.t .. ok
+All tests successful.
+Files=1, Tests=66
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild `http-cookies` to add perl 5.34 support

You've already merged the `http-date` and `http-message` PRs, which are module dependencies for this module, so the prereqs are already in place.

Standard changes and updates:

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 2
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and specify `results-all.master`
8. add standard `COMPONENT_TEST_TRANSFORMS`
9. add the runtime dependencies for the versioned `http-date` and `http-message` packages.
10. `gmake REQUIRED_PACKAGES`

`HTTP-Copokies-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
7. add the missing runtime dependencies for `http-date-$(PLV)` and `http-message-$(PLV)`

