### PR TITLE
library/perl-5/http-negotiate: rebuild for 5.34

### DIFF
--- a/components/perl/HTTP-Negotiate/HTTP-Negotiate-PERLVER.p5m
+++ b/components/perl/HTTP-Negotiate/HTTP-Negotiate-PERLVER.p5m
@@ -11,18 +11,31 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/http-negotiate-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="HTTP::Negotiate - choose a variant to serve"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license HTTP-Negotiate.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# depends upon HTTP::Headers, which is part of HTTP::Message
+depend type=require fmri=library/perl-5/http-message-$(PLV)
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/HTTP::Negotiate.3 mode=0444
 file path=usr/perl5/vendor_perl/$(PERLVER)/HTTP/Negotiate.pm mode=0444

--- a/components/perl/HTTP-Negotiate/Makefile
+++ b/components/perl/HTTP-Negotiate/Makefile
@@ -22,29 +22,55 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		HTTP-Negotiate
 COMPONENT_VERSION=	6.01
 IPS_COMPONENT_VERSION=	6.1
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
+COMPONENT_FMRI=		library/perl-5/http-negotiate
+COMPONENT_SUMMARY=	HTTP::Negotiate - choose a variant to serve
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/HTTP-Negotiate/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/HTTP::Negotiate
 COMPONENT_ARCHIVE_HASH=	\
     sha256:1c729c1ea63100e878405cda7d66f9adfd3ed4f1d6cacaca0ee9152df728e016
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/makemaker.mk
-include $(WS_MAKE_RULES)/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-COMPONENT_TEST_TARGETS = test
+include $(WS_MAKE_RULES)/common.mk
 
-build:		$(BUILD_32_and_64)
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-install:	$(INSTALL_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-test:		$(TEST_32_and_64)
+# runtime dependency on HTTP::Headers (from HTTP::Message) needed to
+# run the test suite
+REQUIRED_PACKAGES += library/perl-5/http-message-522
+REQUIRED_PACKAGES += library/perl-5/http-message-524
+REQUIRED_PACKAGES += library/perl-5/http-message-534
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/HTTP-Negotiate/manifests/sample-manifest.p5m
+++ b/components/perl/HTTP-Negotiate/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,7 +26,11 @@ file path=usr/perl5/5.22/lib/i86pc-solaris-64int/perllocal.pod
 file path=usr/perl5/5.22/man/man3/HTTP::Negotiate.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/HTTP::Negotiate.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/HTTP::Negotiate.3
 file path=usr/perl5/vendor_perl/5.22/HTTP/Negotiate.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/HTTP/Negotiate/.packlist
 file path=usr/perl5/vendor_perl/5.24/HTTP/Negotiate.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/HTTP/Negotiate/.packlist
+file path=usr/perl5/vendor_perl/5.34/HTTP/Negotiate.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/HTTP/Negotiate/.packlist

--- a/components/perl/HTTP-Negotiate/pkg5
+++ b/components/perl/HTTP-Negotiate/pkg5
@@ -1,11 +1,19 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/perl-5/http-message-522",
+        "library/perl-5/http-message-524",
+        "library/perl-5/http-message-534",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/http-negotiate-522",
         "library/perl-5/http-negotiate-524",
+        "library/perl-5/http-negotiate-534",
         "library/perl-5/http-negotiate"
     ],
     "name": "HTTP-Negotiate"

--- a/components/perl/HTTP-Negotiate/test/results-all.master
+++ b/components/perl/HTTP-Negotiate/test/results-all.master
@@ -1,0 +1,11 @@
+Redundant argument in printf at t/negotiate.t line 109.
+Redundant argument in printf at t/negotiate.t line 109.
+Redundant argument in printf at t/negotiate.t line 109.
+Redundant argument in printf at t/negotiate.t line 109.
+Redundant argument in printf at t/negotiate.t line 109.
+Redundant argument in printf at t/negotiate.t line 109.
+t/negotiate.t .. ok
+All tests successful.
+Files=1, Tests=5
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild `http-negotiate` to add support for perl 5.34

You've already merged the `http-message` rebuild, so all the prereqs are in place for this package rebuild.

Standard set of changes and updates:

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 2
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and specify `results-all.master`
8. add standard `COMPONENT_TEST_TRANSFORMS`
9. add the versioned dependencies for `http-message`, needed to run the test suite
10. `gmake REQUIRED_PACKAGES`

`HTTP-Negotiate-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
7. add the missing runtime dependency upon `library/perl-5/http-message-$(PLV)`

