### PR TITLE
library/perl-5/xml-sax: rebuild for perl 5.34

### DIFF
--- a/components/perl/xml-sax/Makefile
+++ b/components/perl/xml-sax/Makefile
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2020, Aurelien Larcher
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 BUILD_BITS=32_and_64
 BUILD_STYLE=makemaker
@@ -30,23 +31,29 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		XML-SAX
 COMPONENT_VERSION=	1.2
 HUMAN_VERSION=		1.02
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		library/perl-5/xml-sax
+COMPONENT_SUMMARY=	XML::SAX - Simple API for XML
 COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/XML::SAX
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:4506c387043aa6a77b455f00f57409f3720aa7e553495ab2535263b4ed1ea12a
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GR/GRANTM/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~grantm/
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/G/GR/GRANTM/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	Artistic
 COMPONENT_LICENSE_FILE=	xml-sax.license
+
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
 include $(WS_MAKE_RULES)/common.mk
 
 # man pages go in the common area
 COMPONENT_INSTALL_ENV += INSTALLVENDORMAN3DIR=$(USRSHAREMAN3DIR)
 
-COMPONENT_TEST_TARGETS = test
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 COMPONENT_TEST_TRANSFORMS += \
 	'-e "/^PERL_DL_NONLAZY/d" ' \
@@ -55,9 +62,14 @@ COMPONENT_TEST_TRANSFORMS += \
 	'-e "s|\(^Files=\).*|\1|" '
 
 # Build dependencies
-REQUIRED_PACKAGES += library/perl-5/xml-sax-base
-REQUIRED_PACKAGES += library/perl-5/xml-namespacesupport
+REQUIRED_PACKAGES += library/perl-5/xml-sax-base-522
+REQUIRED_PACKAGES += library/perl-5/xml-sax-base-524
+REQUIRED_PACKAGES += library/perl-5/xml-sax-base-534
+REQUIRED_PACKAGES += library/perl-5/xml-namespacesupport-522
+REQUIRED_PACKAGES += library/perl-5/xml-namespacesupport-524
+REQUIRED_PACKAGES += library/perl-5/xml-namespacesupport-534
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += runtime/perl-522
 REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/xml-sax/manifests/sample-manifest.p5m
+++ b/components/perl/xml-sax/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -36,6 +36,13 @@ file path=usr/perl5/5.24/man/man3/XML::SAX::Intro.3
 file path=usr/perl5/5.24/man/man3/XML::SAX::ParserFactory.3
 file path=usr/perl5/5.24/man/man3/XML::SAX::PurePerl.3
 file path=usr/perl5/5.24/man/man3/XML::SAX::PurePerl::Reader.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/XML::SAX.3
+file path=usr/perl5/5.34/man/man3/XML::SAX::DocumentLocator.3
+file path=usr/perl5/5.34/man/man3/XML::SAX::Intro.3
+file path=usr/perl5/5.34/man/man3/XML::SAX::ParserFactory.3
+file path=usr/perl5/5.34/man/man3/XML::SAX::PurePerl.3
+file path=usr/perl5/5.34/man/man3/XML::SAX::PurePerl::Reader.3
 file path=usr/perl5/vendor_perl/5.22/XML/SAX.pm
 file path=usr/perl5/vendor_perl/5.22/XML/SAX/DocumentLocator.pm
 file path=usr/perl5/vendor_perl/5.22/XML/SAX/Intro.pod
@@ -78,3 +85,24 @@ file path=usr/perl5/vendor_perl/5.24/XML/SAX/PurePerl/Reader/UnicodeExt.pm
 file path=usr/perl5/vendor_perl/5.24/XML/SAX/PurePerl/UnicodeExt.pm
 file path=usr/perl5/vendor_perl/5.24/XML/SAX/PurePerl/XMLDecl.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/XML/SAX/.packlist
+file path=usr/perl5/vendor_perl/5.34/XML/SAX.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/DocumentLocator.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/Intro.pod
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/ParserFactory.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/DTDDecls.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/DebugHandler.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/DocType.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/EncodingDetect.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Exception.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/NoUnicodeExt.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Productions.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Reader.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Reader/NoUnicodeExt.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Reader/Stream.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Reader/String.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Reader/URI.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/Reader/UnicodeExt.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/UnicodeExt.pm
+file path=usr/perl5/vendor_perl/5.34/XML/SAX/PurePerl/XMLDecl.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/XML/SAX/.packlist

--- a/components/perl/xml-sax/pkg5
+++ b/components/perl/xml-sax/pkg5
@@ -1,15 +1,22 @@
 {
     "dependencies": [
         "SUNWcs",
-        "library/perl-5/xml-namespacesupport",
-        "library/perl-5/xml-sax-base",
+        "library/perl-5/xml-namespacesupport-522",
+        "library/perl-5/xml-namespacesupport-524",
+        "library/perl-5/xml-namespacesupport-534",
+        "library/perl-5/xml-sax-base-522",
+        "library/perl-5/xml-sax-base-524",
+        "library/perl-5/xml-sax-base-534",
         "runtime/perl-522",
         "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/xml-sax-522",
         "library/perl-5/xml-sax-524",
+        "library/perl-5/xml-sax-534",
         "library/perl-5/xml-sax"
     ],
     "name": "XML-SAX"

--- a/components/perl/xml-sax/xml-sax-PERLVER.p5m
+++ b/components/perl/xml-sax/xml-sax-PERLVER.p5m
@@ -11,10 +11,11 @@
 
 #
 # Copyright 2020 Aurelien Larcher
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="XML::SAX - Simple API for XML"
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -30,8 +31,9 @@ depend fmri=__TBD pkg.debug.depend.file=perl \
 depend fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) \
         type=require
 
-# force a dependency on xml-namespacesupport
+# force dependencies on xml-namespacesupport and xml-sax-base
 depend fmri=library/perl-5/xml-namespacesupport-$(PLV) type=require
+depend fmri=library/perl-5/xml-sax-base-$(PLV) type=require
 
 file path=usr/perl5/$(PERLVER)/man/man3/XML::SAX.3
 file path=usr/perl5/$(PERLVER)/man/man3/XML::SAX::DocumentLocator.3


### PR DESCRIPTION
rebuild `xml-sax` for perl 5.34

Aurélien touched this package in 2020, so there was much less to update here than most other packages.  The big change was that I altered the build dependencies he had specified to not use the meta-packages.

`Makefile`:
1. add `COMPONENT_REVISION=1`
2. add `COMPONENT_SUMMARY` with a value from the manifest
3. move the `COMPONENT_PROJECT_URL` to where it usually is in the list and update for https and current location
4. update `COMPONENT_ARCHIVE_URL` for https and current location
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `COMPONENT_TEST_TARGETS`.  Not needed since `makemaker.mk` was fixed
7. change the specified build dependencies to use the versioned packages, rather than the meta-packages
8. `gmake REQUIRED_PACKAGES`

`xml-sax-PERLVER.p5m`:
1. update `pkg.summary` to reference `$(COMPONENT_SUMMARY)` from the `Makefile`
2. add the missing dependency on `library/perl-5/xml-sax-base-$(PLV)`
3. note that I did not modify the other dependencies that Aurélien had specified, including the dependency on the meta-package

