### PR TITLE
library/perl-5/html-parser: rebuild for perl 5.34

### DIFF
--- a/components/perl/HTML-Parser/HTML-Parser-PERLVER.p5m
+++ b/components/perl/HTML-Parser/HTML-Parser-PERLVER.p5m
@@ -11,18 +11,35 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/library/perl-5/html-parser-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="HTML::Parser - HTML parser class"
-set name=info.classification value=org.opensolaris.category.2008:Development/Perl
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license HTML-Parser.license license="Artistic"
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability committed>
+
+# HTML::Parser requires HTML::Tagset
+depend type=require fmri=library/perl-5/html-tagset-$(PLV)
+
+# HTML::Parser recommends (but does not require) HTTP::Headers (from
+# HTTP::Message)
+depend type=optional fmri=library/perl-5/html-message-$(PLV)
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+#depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/HTML::Entities.3
 file path=usr/perl5/$(PERLVER)/man/man3/HTML::Filter.3

--- a/components/perl/HTML-Parser/Makefile
+++ b/components/perl/HTML-Parser/Makefile
@@ -22,35 +22,59 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2014, Alexander Pyhalov. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
-
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		HTML-Parser
 COMPONENT_VERSION=	3.72
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
+COMPONENT_FMRI=		library/perl-5/html-parser
+COMPONENT_SUMMARY=	HTML::Parser - HTML parser class
+COMPONENT_CLASSIFICATION=Development/Perl
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~gaas/HTML-Parser/
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/HTML::Parser
 COMPONENT_ARCHIVE_HASH=	\
     sha256:ec28c7e1d9e67c45eca197077f7cdc41ead1bb4c538c7f02a3296a4bb92f608b
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/G/GA/GAAS/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/makemaker.mk
-include $(WS_TOP)/make-rules/ips.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
+include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TARGETS = test
+#
+# need different results per version because 5.24+ has threading while
+# 5.22 does not.
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-$(PERL_VERSION).master
 
-build:		$(BUILD_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
+# runtime requirements HTML::Tagset needed to run the test suite
+# HTTP::Headers (from HTTP::Message) is recommended, so include it too
+REQUIRED_PACKAGES += library/perl-5/html-tagset-522
+REQUIRED_PACKAGES += library/perl-5/html-tagset-524
+REQUIRED_PACKAGES += library/perl-5/html-tagset-534
+REQUIRED_PACKAGES += library/perl-5/http-message-522
+REQUIRED_PACKAGES += library/perl-5/http-message-524
+REQUIRED_PACKAGES += library/perl-5/http-message-534
 
-test:		$(TEST_32_and_64)
-
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/perl/HTML-Parser/manifests/sample-manifest.p5m
+++ b/components/perl/HTML-Parser/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,6 +38,14 @@ file path=usr/perl5/5.24/man/man3/HTML::LinkExtor.3
 file path=usr/perl5/5.24/man/man3/HTML::Parser.3
 file path=usr/perl5/5.24/man/man3/HTML::PullParser.3
 file path=usr/perl5/5.24/man/man3/HTML::TokeParser.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/HTML::Entities.3
+file path=usr/perl5/5.34/man/man3/HTML::Filter.3
+file path=usr/perl5/5.34/man/man3/HTML::HeadParser.3
+file path=usr/perl5/5.34/man/man3/HTML::LinkExtor.3
+file path=usr/perl5/5.34/man/man3/HTML::Parser.3
+file path=usr/perl5/5.34/man/man3/HTML::PullParser.3
+file path=usr/perl5/5.34/man/man3/HTML::TokeParser.3
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/HTML/Entities.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/HTML/Filter.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/HTML/HeadParser.pm
@@ -56,3 +64,12 @@ file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/HTML/PullPars
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/HTML/TokeParser.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/HTML/Parser/.packlist
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/HTML/Parser/Parser.so
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/HTML/Entities.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/HTML/Filter.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/HTML/HeadParser.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/HTML/LinkExtor.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/HTML/Parser.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/HTML/PullParser.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/HTML/TokeParser.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/HTML/Parser/.packlist
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/HTML/Parser/Parser.so

--- a/components/perl/HTML-Parser/pkg5
+++ b/components/perl/HTML-Parser/pkg5
@@ -1,13 +1,22 @@
 {
     "dependencies": [
         "SUNWcs",
-        "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "library/perl-5/html-tagset-522",
+        "library/perl-5/html-tagset-524",
+        "library/perl-5/html-tagset-534",
+        "library/perl-5/http-message-522",
+        "library/perl-5/http-message-524",
+        "library/perl-5/http-message-534",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
+        "system/library"
     ],
     "fmris": [
         "library/perl-5/html-parser-522",
         "library/perl-5/html-parser-524",
+        "library/perl-5/html-parser-534",
         "library/perl-5/html-parser"
     ],
     "name": "HTML-Parser"

--- a/components/perl/HTML-Parser/test/results-5.22.master
+++ b/components/perl/HTML-Parser/test/results-5.22.master
@@ -1,0 +1,52 @@
+t/api_version.t ...... ok
+t/argspec-bad.t ...... ok
+t/argspec.t .......... ok
+t/argspec2.t ......... ok
+t/attr-encoded.t ..... ok
+t/callback.t ......... ok
+t/case-sensitive.t ... ok
+t/cases.t ............ ok
+t/comment.t .......... ok
+t/crashme.t .......... ok
+t/declaration.t ...... ok
+t/default.t .......... ok
+t/document.t ......... ok
+t/dtext.t ............ ok
+t/entities.t ......... ok
+t/entities2.t ........ ok
+t/filter-methods.t ... ok
+t/filter.t ........... ok
+t/handler-eof.t ...... ok
+t/handler.t .......... ok
+t/headparser-http.t .. ok
+t/headparser.t ....... ok
+t/ignore.t ........... ok
+t/largetags.t ........ ok
+t/linkextor-base.t ... ok
+t/linkextor-rel.t .... ok
+t/magic.t ............ ok
+t/marked-sect.t ...... ok
+t/msie-compat.t ...... ok
+t/offset.t ........... ok
+t/options.t .......... ok
+t/parsefile.t ........ ok
+t/parser.t ........... ok
+t/plaintext.t ........ ok
+t/pod.t .............. skipped: Test::Pod 1.00 required for testing POD
+t/process.t .......... ok
+t/pullparser.t ....... ok
+t/script.t ........... ok
+t/skipped-text.t ..... ok
+t/stack-realloc.t .... ok
+t/textarea.t ......... ok
+t/threads.t .......... skipped: Not configured for threads
+t/tokeparser.t ....... ok
+t/uentities.t ........ ok
+t/unbroken-text.t .... ok
+t/unicode-bom.t ...... ok
+t/unicode.t .......... ok
+t/xml-mode.t ......... ok
+All tests successful.
+Files=48, Tests=450
+Result: PASS
+make[1]: Leaving directory '$(@D)'

--- a/components/perl/HTML-Parser/test/results-5.24.master
+++ b/components/perl/HTML-Parser/test/results-5.24.master
@@ -1,0 +1,52 @@
+t/api_version.t ...... ok
+t/argspec-bad.t ...... ok
+t/argspec.t .......... ok
+t/argspec2.t ......... ok
+t/attr-encoded.t ..... ok
+t/callback.t ......... ok
+t/case-sensitive.t ... ok
+t/cases.t ............ ok
+t/comment.t .......... ok
+t/crashme.t .......... ok
+t/declaration.t ...... ok
+t/default.t .......... ok
+t/document.t ......... ok
+t/dtext.t ............ ok
+t/entities.t ......... ok
+t/entities2.t ........ ok
+t/filter-methods.t ... ok
+t/filter.t ........... ok
+t/handler-eof.t ...... ok
+t/handler.t .......... ok
+t/headparser-http.t .. ok
+t/headparser.t ....... ok
+t/ignore.t ........... ok
+t/largetags.t ........ ok
+t/linkextor-base.t ... ok
+t/linkextor-rel.t .... ok
+t/magic.t ............ ok
+t/marked-sect.t ...... ok
+t/msie-compat.t ...... ok
+t/offset.t ........... ok
+t/options.t .......... ok
+t/parsefile.t ........ ok
+t/parser.t ........... ok
+t/plaintext.t ........ ok
+t/pod.t .............. skipped: Test::Pod 1.00 required for testing POD
+t/process.t .......... ok
+t/pullparser.t ....... ok
+t/script.t ........... ok
+t/skipped-text.t ..... ok
+t/stack-realloc.t .... ok
+t/textarea.t ......... ok
+t/threads.t .......... ok
+t/tokeparser.t ....... ok
+t/uentities.t ........ ok
+t/unbroken-text.t .... ok
+t/unicode-bom.t ...... ok
+t/unicode.t .......... ok
+t/xml-mode.t ......... ok
+All tests successful.
+Files=48, Tests=451
+Result: PASS
+make[1]: Leaving directory '$(@D)'

--- a/components/perl/HTML-Parser/test/results-5.34.master
+++ b/components/perl/HTML-Parser/test/results-5.34.master
@@ -1,0 +1,52 @@
+t/api_version.t ...... ok
+t/argspec-bad.t ...... ok
+t/argspec.t .......... ok
+t/argspec2.t ......... ok
+t/attr-encoded.t ..... ok
+t/callback.t ......... ok
+t/case-sensitive.t ... ok
+t/cases.t ............ ok
+t/comment.t .......... ok
+t/crashme.t .......... ok
+t/declaration.t ...... ok
+t/default.t .......... ok
+t/document.t ......... ok
+t/dtext.t ............ ok
+t/entities.t ......... ok
+t/entities2.t ........ ok
+t/filter-methods.t ... ok
+t/filter.t ........... ok
+t/handler-eof.t ...... ok
+t/handler.t .......... ok
+t/headparser-http.t .. ok
+t/headparser.t ....... ok
+t/ignore.t ........... ok
+t/largetags.t ........ ok
+t/linkextor-base.t ... ok
+t/linkextor-rel.t .... ok
+t/magic.t ............ ok
+t/marked-sect.t ...... ok
+t/msie-compat.t ...... ok
+t/offset.t ........... ok
+t/options.t .......... ok
+t/parsefile.t ........ ok
+t/parser.t ........... ok
+t/plaintext.t ........ ok
+t/pod.t .............. skipped: Test::Pod 1.00 required for testing POD
+t/process.t .......... ok
+t/pullparser.t ....... ok
+t/script.t ........... ok
+t/skipped-text.t ..... ok
+t/stack-realloc.t .... ok
+t/textarea.t ......... ok
+t/threads.t .......... ok
+t/tokeparser.t ....... ok
+t/uentities.t ........ ok
+t/unbroken-text.t .... ok
+t/unicode-bom.t ...... ok
+t/unicode.t .......... ok
+t/xml-mode.t ......... ok
+All tests successful.
+Files=48, Tests=451
+Result: PASS
+make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
rebuild `html-parser` to add support for perl 5.34

The dependencies this package needs (`html-tagset`, optionally `http-message`) have already been merged, so the prereqs are all in place.

About the only thing different about this package update is that I marked `library/perl-5/http-message-$(PLV)` as `type=optional` in the manifest.  It's recommended (and I included it in the `Makefile` for the test suite, since the build box will have it anyway), but not required.

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 3
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
6. drop `build/install/test`
7. add `COMPONENT_TEST_MASTER` and specify `results-$(PERL_VERSION).master`, since there are differences (because of threading) between the perl versions.
8. add standard `COMPONENT_TEST_TRANSFORMS`
9. add the versioned runtime dependencies for both `http-message` and `html-tagset`, so they're present for the test suite
10. `gmake REQUIRED_PACKAGES`

`HTML-Parser-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
7. add the missing runtime dependency on `library/perl-5/html-tagset-$(PLV)`
8. add the missing _optional_ runtime dependency on `library/perl-5/http-message-$(PLV)`

