### PR TITLE
library/perl-5/xml-parser: rebuild for perl 5.34

### DIFF
--- a/components/perl/xml-parser/Makefile
+++ b/components/perl/xml-parser/Makefile
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 TIm Mooney.  All rights reserved.
 #
 
 #
@@ -27,22 +28,31 @@
 # with an incorrect version number.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		XML-Parser
 COMPONENT_VERSION=	2.44
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
+COMPONENT_FMRI=		library/perl-5/xml-parser
+COMPONENT_SUMMARY=	XML::Parser - A perl module for parsing XML documents
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/XML::Parser
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216
-COMPONENT_ARCHIVE_URL=	http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~toddr/
-COMPONENT_BUGDB=	perl-mod/xml-parser
+COMPONENT_ARCHIVE_URL=	https://cpan.metacpan.org/authors/id/T/TO/TODDR/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
+COMPONENT_LICENSE_FILE=	xml-parser.license
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/ips.mk
-include $(WS_TOP)/make-rules/makemaker.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
+
+include $(WS_MAKE_RULES)/common.mk
 
 # Enable ASLR for this component
 #ASLR_MODE = $(ASLR_ENABLE)
@@ -50,16 +60,28 @@ include $(WS_TOP)/make-rules/makemaker.mk
 # man pages go in the common area
 COMPONENT_INSTALL_ENV += INSTALLVENDORMAN3DIR=$(USRSHAREMAN3DIR)
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"'
 
-install:	$(INSTALL_32_and_64)
+# runtime dependency on LWP::UserAgent (from libwww-perl) needed for the
+# test suite
+REQUIRED_PACKAGES += library/perl-5/libwww-perl-522
+REQUIRED_PACKAGES += library/perl-5/libwww-perl-524
+REQUIRED_PACKAGES += library/perl-5/libwww-perl-534
 
-test:		$(TEST_32_and_64)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/expat
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534
 REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
-# Bogus dependency due to libssp
-REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)

--- a/components/perl/xml-parser/manifests/sample-manifest.p5m
+++ b/components/perl/xml-parser/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -38,6 +38,14 @@ file path=usr/perl5/5.24/man/man3/XML::Parser::Style::Objects.3
 file path=usr/perl5/5.24/man/man3/XML::Parser::Style::Stream.3
 file path=usr/perl5/5.24/man/man3/XML::Parser::Style::Subs.3
 file path=usr/perl5/5.24/man/man3/XML::Parser::Style::Tree.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/XML::Parser.3
+file path=usr/perl5/5.34/man/man3/XML::Parser::Expat.3
+file path=usr/perl5/5.34/man/man3/XML::Parser::Style::Debug.3
+file path=usr/perl5/5.34/man/man3/XML::Parser::Style::Objects.3
+file path=usr/perl5/5.34/man/man3/XML::Parser::Style::Stream.3
+file path=usr/perl5/5.34/man/man3/XML::Parser::Style::Subs.3
+file path=usr/perl5/5.34/man/man3/XML::Parser::Style::Tree.3
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/XML/Parser.pm
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/XML/Parser/Encodings/Japanese_Encodings.msg
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/XML/Parser/Encodings/README
@@ -104,3 +112,36 @@ file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/XML/Parser/St
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/XML/Parser/Style/Tree.pm
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/XML/Parser/.packlist
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/XML/Parser/Expat/Expat.so
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/Japanese_Encodings.msg
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/README
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/big5.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/euc-kr.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/ibm866.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/iso-8859-2.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/iso-8859-3.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/iso-8859-4.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/iso-8859-5.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/iso-8859-7.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/iso-8859-8.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/iso-8859-9.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/koi8-r.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/windows-1250.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/windows-1251.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/windows-1252.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/windows-1255.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/x-euc-jp-jisx0221.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/x-euc-jp-unicode.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/x-sjis-cp932.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/x-sjis-jdk117.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/x-sjis-jisx0221.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Encodings/x-sjis-unicode.enc
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Expat.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/LWPExternEnt.pl
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Style/Debug.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Style/Objects.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Style/Stream.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Style/Subs.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/XML/Parser/Style/Tree.pm
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/XML/Parser/.packlist
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/XML/Parser/Expat/Expat.so

--- a/components/perl/xml-parser/pkg5
+++ b/components/perl/xml-parser/pkg5
@@ -2,13 +2,19 @@
     "dependencies": [
         "SUNWcs",
         "library/expat",
-        "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "library/perl-5/libwww-perl-522",
+        "library/perl-5/libwww-perl-524",
+        "library/perl-5/libwww-perl-534",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
+        "system/library"
     ],
     "fmris": [
         "library/perl-5/xml-parser-522",
         "library/perl-5/xml-parser-524",
+        "library/perl-5/xml-parser-534",
         "library/perl-5/xml-parser"
     ],
     "name": "XML-Parser"

--- a/components/perl/xml-parser/test/results-all.master
+++ b/components/perl/xml-parser/test/results-all.master
@@ -1,0 +1,19 @@
+t/astress.t ........... ok
+t/cdata.t ............. ok
+t/decl.t .............. ok
+t/defaulted.t ......... ok
+t/encoding.t .......... ok
+t/external_ent.t ...... ok
+t/file.t .............. ok
+t/file_open_scalar.t .. ok
+t/finish.t ............ ok
+t/namespaces.t ........ ok
+t/parament.t .......... ok
+t/partial.t ........... ok
+t/skip.t .............. ok
+t/stream.t ............ ok
+t/styles.t ............ ok
+All tests successful.
+Files=15, Tests=141
+Result: PASS
+make[1]: Leaving directory '$(@D)'

--- a/components/perl/xml-parser/xml-parser-PERLVER.p5m
+++ b/components/perl/xml-parser/xml-parser-PERLVER.p5m
@@ -23,19 +23,28 @@
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
 
-set name=pkg.fmri value=pkg:/library/perl-5/xml-parser-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary \
-    value="XML::Parser - A perl module for parsing XML documents"
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=pkg.description value="This module provides ways to parse XML documents. It is built on top of XML::Parser::Expat."
 set name=com.oracle.info.description value="the XML::Parser Perl module"
-set name=info.classification \
-    value="org.opensolaris.category.2008:Development/Perl"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
-set name=org.opensolaris.arc-caseid value=LSARC/2004/251
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license xml-parser.license license='Artistic'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# requires LWP::UserAgent from libwww-perl
+depend type=require fmri=library/perl-5/libwww-perl-$(PLV)
+
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether having this package require
+# the non-PLV version of this  module, don\t enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 
 file path=usr/perl5/$(PERLVER)/man/man3/XML::Parser.3
 file path=usr/perl5/$(PERLVER)/man/man3/XML::Parser::Expat.3


### PR DESCRIPTION
rebuild `xml-parser` to add perl 5.34 support

This one needs the rebuild for `libwww-perl` which was merged a little bit ago, so once that rebuild has completed (if it hasn't already) the prereqs for this one will be in place.

Standard changes, except this was old enough that `Makefile` had `COMPONENT_BUGDB` (now removed) and the manifest had `org.opensolaris.arc-caseid` (now removed).

`Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. bump `COMPONENT_REVISION` to 3
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, `COMPONENT_LICENSE_FILE` and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. drop `COMPONENT_BUGDB`.
6. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
7. drop `build/install/test`
8. add `COMPONENT_TEST_MASTER` and specify `results-all.master`
9. add standard `COMPONENT_TEST_TRANSFORMS`
10. add the versioned runtime dependency for `libwww-perl` for the test suite
11. `gmake REQUIRED_PACKAGES`

`xml-parser-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)`
5. drop `org.opensolaris.arc-caseid`.  Not used by OI
6. add the runtime dependency on the same version of perl
7. add the commented-out stuff for the `non-PLV` version
8. add the runtime dependency on `library/perl-5/libwww-perl-$(PLV)`

