### PR TITLE
library/perl-5/xml-simple: rebuild for perl 5.34

### DIFF
--- a/components/perl/xml-simple/Makefile
+++ b/components/perl/xml-simple/Makefile
@@ -19,38 +19,72 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		XML-Simple
 COMPONENT_VERSION=	2.22
+COMPONENT_REVISION=	1
+COMPONENT_FMRI=		library/perl-5/xml-simple
+COMPONENT_SUMMARY=	XML::Simple - Easy API to maintain XML (esp config files)
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_PROJECT_URL=	https://metacpan.org/pod/XML::Simple
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:b9450ef22ea9644ae5d6ada086dc4300fa105be050a2030ebd4efd28c198eb49
 COMPONENT_ARCHIVE_URL=	\
-    http://www.cpan.org/authors/id/G/GR/GRANTM/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	http://search.cpan.org/~grantm/
-COMPONENT_BUGDB=	perl-mod/xml-parser
+    https://cpan.metacpan.org/authors/id/G/GR/GRANTM/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=	Artistic
+COMPONENT_LICENSE_FILE=	xml-simple.license
 
-include $(WS_TOP)/make-rules/prep.mk
-include $(WS_TOP)/make-rules/ips.mk
-include $(WS_TOP)/make-rules/makemaker.mk
+# until all perl modules have been rebuilt with 5.34, each module sets
+# this manually, before including common.mk
+PERL_VERSIONS = 5.22 5.24 5.34
+PERL_64_ONLY_VERSIONS = 5.24 5.34
 
-# Enable ASLR for this component
-ASLR_MODE = $(ASLR_ENABLE)
+include $(WS_MAKE_RULES)/common.mk
 
 # man pages go in the common area
 COMPONENT_INSTALL_ENV += INSTALLVENDORMAN3DIR=$(USRSHAREMAN3DIR)
 
-COMPONENT_TEST_TARGETS = test
+#
+# use the same results for comparison for all builds
+#
+COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 
-build:		$(BUILD_32_and_64)
+#
+# filter out all output up to and including the test_harness line
+# filter out timing information and anything else that varies between builds
+# also remove all the module version display in the test output
+#
+COMPONENT_TEST_TRANSFORMS += \
+	'-e "1,/test_harness/d"' \
+	'-e "s/,  *[0-9]* wallclock.*//"' \
+	'-e "/^\#/d"'
 
-install:	$(INSTALL_32_and_64)
+#
+# XML::Simple can use either XML::Parser (which it doesn't list as a
+# requirement) or XML::SAX, with or without XML::SAX::Expat (which it
+# does list as a requirement, but which we don't currently ship).
+# The listed build dependencies are (currently) enough for all the
+# tests to pass.
+#
+REQUIRED_PACKAGES += library/perl-5/xml-namespacesupport-522
+REQUIRED_PACKAGES += library/perl-5/xml-namespacesupport-524
+REQUIRED_PACKAGES += library/perl-5/xml-namespacesupport-534
+REQUIRED_PACKAGES += library/perl-5/xml-parser-522
+REQUIRED_PACKAGES += library/perl-5/xml-parser-524
+REQUIRED_PACKAGES += library/perl-5/xml-parser-534
+REQUIRED_PACKAGES += library/perl-5/xml-sax-522
+REQUIRED_PACKAGES += library/perl-5/xml-sax-524
+REQUIRED_PACKAGES += library/perl-5/xml-sax-534
 
-	#
-	# Must have xml-parser installed for these tests to pass.
-	#
-test:		$(TEST_32_and_64)
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-522
+REQUIRED_PACKAGES += runtime/perl-524
+REQUIRED_PACKAGES += runtime/perl-534

--- a/components/perl/xml-simple/manifests/sample-manifest.p5m
+++ b/components/perl/xml-simple/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -28,9 +28,15 @@ file path=usr/perl5/5.22/man/man3/XML::Simple::FAQ.3
 file path=usr/perl5/5.24/lib/i86pc-solaris-thread-multi-64/perllocal.pod
 file path=usr/perl5/5.24/man/man3/XML::Simple.3
 file path=usr/perl5/5.24/man/man3/XML::Simple::FAQ.3
+file path=usr/perl5/5.34/lib/i86pc-solaris-thread-multi-64/perllocal.pod
+file path=usr/perl5/5.34/man/man3/XML::Simple.3
+file path=usr/perl5/5.34/man/man3/XML::Simple::FAQ.3
 file path=usr/perl5/vendor_perl/5.22/XML/Simple.pm
 file path=usr/perl5/vendor_perl/5.22/XML/Simple/FAQ.pod
 file path=usr/perl5/vendor_perl/5.22/i86pc-solaris-64int/auto/XML/Simple/.packlist
 file path=usr/perl5/vendor_perl/5.24/XML/Simple.pm
 file path=usr/perl5/vendor_perl/5.24/XML/Simple/FAQ.pod
 file path=usr/perl5/vendor_perl/5.24/i86pc-solaris-thread-multi-64/auto/XML/Simple/.packlist
+file path=usr/perl5/vendor_perl/5.34/XML/Simple.pm
+file path=usr/perl5/vendor_perl/5.34/XML/Simple/FAQ.pod
+file path=usr/perl5/vendor_perl/5.34/i86pc-solaris-thread-multi-64/auto/XML/Simple/.packlist

--- a/components/perl/xml-simple/pkg5
+++ b/components/perl/xml-simple/pkg5
@@ -1,11 +1,25 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/perl-5/xml-namespacesupport-522",
+        "library/perl-5/xml-namespacesupport-524",
+        "library/perl-5/xml-namespacesupport-534",
+        "library/perl-5/xml-parser-522",
+        "library/perl-5/xml-parser-524",
+        "library/perl-5/xml-parser-534",
+        "library/perl-5/xml-sax-522",
+        "library/perl-5/xml-sax-524",
+        "library/perl-5/xml-sax-534",
+        "runtime/perl-522",
+        "runtime/perl-524",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
         "library/perl-5/xml-simple-522",
         "library/perl-5/xml-simple-524",
+        "library/perl-5/xml-simple-534",
         "library/perl-5/xml-simple"
     ],
     "name": "XML-Simple"

--- a/components/perl/xml-simple/test/results-all.master
+++ b/components/perl/xml-simple/test/results-all.master
@@ -1,0 +1,17 @@
+t/0_Config.t ............ ok
+t/1_XMLin.t ............. ok
+t/2_XMLout.t ............ ok
+t/3_Storable.t .......... ok
+t/4_MemShare.t .......... ok
+t/5_MemCopy.t ........... ok
+t/6_ObjIntf.t ........... ok
+t/7_SaxStuff.t .......... ok
+t/8_Namespaces.t ........ ok
+t/9_Strict.t ............ ok
+t/A_XMLParser.t ......... ok
+t/B_Hooks.t ............. ok
+t/release-pod-syntax.t .. skipped: these tests are for release candidate testing
+All tests successful.
+Files=13, Tests=501
+Result: PASS
+make[1]: Leaving directory '$(@D)'

--- a/components/perl/xml-simple/xml-simple-PERLVER.p5m
+++ b/components/perl/xml-simple/xml-simple-PERLVER.p5m
@@ -19,28 +19,39 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
 
-set name=pkg.fmri value=pkg:/library/perl-5/xml-simple-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary \
-    value="XML::Simple - Easy API to maintain XML (esp config files)"
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=pkg.description value="The XML::Simple module provides a simple API layer on top of an underlying XML parsing module (either XML::Parser or one of the SAX2 parser modules)."
 set name=com.oracle.info.description value="the XML::Simple Perl module"
-set name=info.classification \
-    value="org.opensolaris.category.2008:Development/Perl"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
-set name=org.opensolaris.arc-caseid value=LSARC/2004/251
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license xml-simple.license license='Artistic'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend fmri=library/perl-5/xml-simple@2.18-0.167 type=optional
-depend fmri=library/perl-5/xml-parser type=require
+# this can use either XML::Parser or XML::SAX (with or without
+# XML::SAX::Expat), but we currently make xml-parser the required one
+depend fmri=library/perl-5/xml-parser-$(PLV) type=require
+depend fmri=library/perl-5/xml-namespacesupport-$(PLV) type=require
+depend fmri=library/perl-5/xml-sax-$(PLV) type=require
+# if we ever package xml-sax-expat, it should be here as type=optional
 
 #file path=usr/perl5/$(PERLVER)/lib/$(PERL_ARCH)/perllocal.pod
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+	pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin type=require
+
+# Until there is consensus on whether we should have this package require
+# the non-PLV version of this  module, don't enable this.
+# depend type=require \
+#	fmri=$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+
 file path=usr/perl5/$(PERLVER)/man/man3/XML::Simple.3
 file path=usr/perl5/$(PERLVER)/man/man3/XML::Simple::FAQ.3
 file path=usr/perl5/vendor_perl/$(PERLVER)/XML/Simple.pm


### PR DESCRIPTION
rebuild `xml-simple` to add support for perl 5.34

A few things to note with this one:
1. XML::Simple lists XML::SAX and XML::SAX::Expat (which are separate modules) as requirements, along with XML::NamespaceSupport, and it doesn't list XML::Parser at all, but it can dynamically use either XML::Parser, XML::SAX, or XML::SAX + XML::SAX::Expat.  We don't currently package XML::SAX::Expat, so the build step complains about that, but as long as XML::Parser + XML::SAX are present, the tests all pass.
2. the Makefile had the `ASLR_ENABLE` config, but this package doesn't build any binaries, so I removed it
3. the manifest had `depend fmri=library/perl-5/xml-simple@2.18-0.167 type=optional`, I think so that the `xml-simple-$(PLV)` would (optionally) require the meta-package.  I removed that dependency.

 `Makefile`:
1. add `BUILD_STYLE=makemaker`, `BUILD_BITS=32_and_64`, and include `common.mk`
2. add `COMPONENT_REVISION=1`
3. add `COMPONENT_FMRI`, `COMPONENT_SUMMARY`, `COMPONENT_CLASSIFICATION`, `COMPONENT_LICENSE_FILE` and `COMPONENT_LICENSE` with values from the manifest
4. update the URLs to use https and current locations
5. drop `COMPONENT_BUGDB`
6. specify `PERL_VERSIONS` and `PERL_64_ONLY_VERSIONS`, to get this to also build for perl 5.34
7. drop `ASLR_MODE = $(ASLR_ENABLE)`.  This package doesn't build any binaries
8. drop `build/install/test`
9. add `COMPONENT_TEST_MASTER` and specify `results-all.master`
10. add standard `COMPONENT_TEST_TRANSFORMS`
11. add the versioned runtime requirements needed to run the test suite
12. `gmake REQUIRED_PACKAGES`

`xml-simple-PERLVER.p5m`:
1. reference `$(COMPONENT_FMRI)` from the `Makefile`
2. ditto for `$(COMPONENT_SUMMARY)`
3. ditto for `$(COMPONENT_CLASSIFICATION)`
4. ditto for `$(COMPONENT_LICENSE)` and `$(COMPONENT_LICENSE_FILE)`
5. add the runtime dependency on the same version of perl
6. add the commented-out stuff for the `non-PLV` version
7. **remove** the `depend fmri=library/perl-5/xml-simple@2.18-0.167 type=optional`.  That's an interesting way to have the versioned package (optionally) require the meta-package, but this is the only package that was doing it and we're probably moving away from that dependency.
8. add the runtime dependencies on `xml-parser-$(PLV)`, `xml-namespacesupport-$(PLV)`, and `xml-sax-$(PLV)`.


