### PR TITLE
build-essential: Replace illumos-gcc by gcc-10

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -17,6 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
 COMPONENT_VERSION=	1.0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -117,7 +117,7 @@ depend fmri=runtime/python-39 type=require
 # illumos-gate build dependencies
 depend fmri=developer/as type=require
 depend fmri=developer/astdev type=require
-depend fmri=developer/illumos-gcc type=require
+depend fmri=developer/gcc-10 type=require
 depend fmri=developer/opensolaris/osnet type=require
 depend fmri=library/glib2 type=require
 depend fmri=library/idnkit/header-idnkit type=require


### PR DESCRIPTION
illumos-gcc is not needed for building illumos-gate, but gcc-10 is.