### PR TITLE
runtime/perl-534/modules/sun-solaris: new FMRI for sun-solaris for perl 5.34

### DIFF
--- a/components/perl/sun_solaris/Makefile
+++ b/components/perl/sun_solaris/Makefile
@@ -11,26 +11,45 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright 2022 (c) Tim Mooney.  All rights reserved
 #
 
+BUILD_STYLE=makemaker
+BUILD_BITS=32_and_64
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME= sun-solaris
-
-COMPONENT_SUMMARY=Perl Sun::Solaris Modules
-COMPONENT_SRC= src
-
-PERL_VERSIONS = 5.16
+COMPONENT_NAME=		sun-solaris
 # Illumos component, no explicit version
-COMPONENT_VERSION= 5.11
+COMPONENT_VERSION=	0.5.11
+COMPONENT_REVISION=	1
+# keep FMRI in the manifest for now
+#COMPONENT_FMRI=
+COMPONENT_SUMMARY=	Perl Sun::Solaris Modules
+COMPONENT_CLASSIFICATION=Development/Perl
+COMPONENT_SRC=		src
+COMPONENT_LICENSE=	Artistic
+COMPONENT_LICENSE_FILE=	sun-solaris.license
 
-include ../../../make-rules/prep.mk
-include ../../../make-rules/ips.mk
-include ../../../make-rules/makemaker.mk
+
+PERL_VERSION  = 5.34
+PERL_VERSIONS = 5.34
+PERL_64_ONLY_VERSIONS= 5.34
+
+# because the manifest does not use -PERLVER and the version we're building
+# for may not be the default version, we need to ensure that PERL_ARCH is
+# defined correctly
+PERL = $(PERL.$(PERL_VERSION))
+PERL_ARCH = $(shell $(PERL) -e 'use Config; print $$Config{archname}')
+
+# these modules currently have no test suite
+TEST_TARGET=$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
+
 
 CLEAN_PATHS=required-pkgs.mk
 
-MODULES:=BSM  Exacct Exacct/Catalog Exacct/File Exacct/Object Intrs  Kstat  Lgrp  PerlGcc  Pg  Privilege  Project  Task  Ucred  Utils
+MODULES:=BSM  Exacct Exacct/Catalog Exacct/File Exacct/Object Intrs  Kstat  Lgrp  Pg  Privilege  Project  Task  Ucred  Utils
 
 $(BUILD_DIR)/%/.configured:     $(SOURCE_DIR)/.prep
 	($(RM) -r $(@D) ; $(MKDIR) $(@D))
@@ -52,6 +71,14 @@ $(BUILD_DIR)/%/.built:  $(BUILD_DIR)/%/.configured
 	$(COMPONENT_POST_BUILD_ACTION)
 	$(TOUCH) $@
 
+#
+# add u+w to the shared objects so publish can run elfedit on them.
+#
+COMPONENT_POST_INSTALL_ACTION = \
+	(for s in $$(find $(PROTO_DIR) -type f -name '*.so') ; do \
+		chmod u+w $$s ; \
+	done)
+
 $(BUILD_DIR)/%/.installed:      $(BUILD_DIR)/%/.built
 	$(COMPONENT_PRE_INSTALL_ACTION)
 	(for i in $(MODULES); do \
@@ -60,11 +87,8 @@ $(BUILD_DIR)/%/.installed:      $(BUILD_DIR)/%/.built
 	$(COMPONENT_POST_INSTALL_ACTION)
 	$(TOUCH) $@
 
-install: $(INSTALL_32) 
-
-build: $(BUILD_32)
-
-install: $(INSTALL_32)
-
 clean::  $(NO_CLEAN)
 
+# Auto-generated dependencies
+REQUIRED_PACKAGES += runtime/perl-534
+REQUIRED_PACKAGES += system/library

--- a/components/perl/sun_solaris/pkg5
+++ b/components/perl/sun_solaris/pkg5
@@ -1,10 +1,12 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-534",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "runtime/perl-516/module/sun-solaris"
+        "runtime/perl-534/module/sun-solaris"
     ],
     "name": "sun-solaris"
 }

--- a/components/perl/sun_solaris/sun-solaris-534.p5m
+++ b/components/perl/sun_solaris/sun-solaris-534.p5m
@@ -11,31 +11,37 @@
 
 #
 # Copyright 2013 Alexander Pyhalov.  All rights reserved.
+# Copyright (c) 2022 Tim Mooney.  All rights reserved.
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability volatile>
 
-set name=pkg.fmri value=pkg:/runtime/perl-516/module/sun-solaris@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/runtime/perl-534/module/sun-solaris@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary \
     value="Perl $(PERL_VERSION) Sun::Solaris Modules"
 set name=pkg.description value="Perl Sun::Solaris Modules"
-set name=info.classification \
-    value="org.opensolaris.category.2008:Development/Perl"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_UPSTREAM_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license sun-solaris.license license='Artistic'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# force a dependency on the Perl runtime
+depend fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERL_VERSION)/bin type=require
+
+# this FMRI does not exist:
 depend fmri=library/perl/module/sun-solaris type=optional
 
-dir  path=usr/perl5
-dir  path=usr/perl5/$(PERL_VERSION)
-dir  path=usr/perl5/$(PERL_VERSION)/bin
-file mode=0555 path=usr/perl5/$(PERL_VERSION)/bin/perlgcc
-dir  path=usr/perl5/$(PERL_VERSION)/man
-dir  path=usr/perl5/$(PERL_VERSION)/man/man1
-file path=usr/perl5/$(PERL_VERSION)/man/man1/perlgcc.1
-dir  path=usr/perl5/$(PERL_VERSION)/man/man3
+#dir  path=usr/perl5
+#dir  path=usr/perl5/$(PERL_VERSION)
+#dir  path=usr/perl5/$(PERL_VERSION)/bin
+# no longer packaged since perl is built with gcc on OI
+#file mode=0555 path=usr/perl5/$(PERL_VERSION)/bin/perlgcc
+#dir  path=usr/perl5/$(PERL_VERSION)/man
+#dir  path=usr/perl5/$(PERL_VERSION)/man/man1
+#file path=usr/perl5/$(PERL_VERSION)/man/man1/perlgcc.1
+#dir  path=usr/perl5/$(PERL_VERSION)/man/man3
 file path=usr/perl5/$(PERL_VERSION)/man/man3/Sun::Solaris::Exacct.3
 file path=usr/perl5/$(PERL_VERSION)/man/man3/Sun::Solaris::Exacct::Catalog.3
 file path=usr/perl5/$(PERL_VERSION)/man/man3/Sun::Solaris::Exacct::File.3
@@ -48,9 +54,9 @@ file path=usr/perl5/$(PERL_VERSION)/man/man3/Sun::Solaris::Privilege.3
 file path=usr/perl5/$(PERL_VERSION)/man/man3/Sun::Solaris::Project.3
 file path=usr/perl5/$(PERL_VERSION)/man/man3/Sun::Solaris::Task.3
 file path=usr/perl5/$(PERL_VERSION)/man/man3/Sun::Solaris::Ucred.3
-dir  path=usr/perl5/vendor_perl
-dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)
-dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)
+#dir  path=usr/perl5/vendor_perl
+#dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)
+#dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/Sun
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/Sun/Solaris
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/Sun/Solaris/Exacct
@@ -66,7 +72,7 @@ file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/Sun/Solaris/Project
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/Sun/Solaris/Task.pm
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/Sun/Solaris/Ucred.pm
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/Sun/Solaris/Utils.pm
-dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto
+#dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/BSM
@@ -76,58 +82,61 @@ dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Ex
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/.packlist
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Catalog
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Catalog/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Catalog/Catalog.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Catalog/Catalog.so
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Exacct.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Exacct.so
+# the '.bs' files are no longer installed
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Catalog/Catalog.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Catalog/Catalog.so mode=0555
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Exacct.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Exacct.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/File
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/File/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/File/File.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/File/File.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/File/File.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/File/File.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Object
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Object/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Object/Object.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Object/Object.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Object/Object.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Exacct/Object/Object.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Intrs
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Intrs/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Intrs/Intrs.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Intrs/Intrs.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Intrs/Intrs.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Intrs/Intrs.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Kstat
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Kstat/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Kstat/Kstat.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Kstat/Kstat.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Kstat/Kstat.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Kstat/Kstat.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp/Lgrp.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp/Lgrp.so
-dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/PerlGcc
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/PerlGcc/.packlist
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp/Lgrp.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Lgrp/Lgrp.so mode=0555
+# no longer included since we now use gcc for building perl
+#dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/PerlGcc
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/PerlGcc/.packlist
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Pg
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Pg/.packlist
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Privilege
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Privilege/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Privilege/Privilege.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Privilege/Privilege.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Privilege/Privilege.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Privilege/Privilege.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Project
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Project/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Project/Project.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Project/Project.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Project/Project.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Project/Project.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Task
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Task/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Task/Task.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Task/Task.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Task/Task.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Task/Task.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Ucred
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Ucred/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Ucred/Ucred.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Ucred/Ucred.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Ucred/Ucred.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Ucred/Ucred.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Utils
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Utils/.packlist
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Utils/Utils.bs
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Utils/Utils.so
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Utils/Utils.bs
+file path=usr/perl5/vendor_perl/$(PERL_VERSION)/$(PERL_ARCH)/auto/Sun/Solaris/Utils/Utils.so mode=0555
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris
 dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris/BSM
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris/BSM/_BSMparse.pm
-dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris/PerlGcc
-file path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris/PerlGcc/Config.pm
+# no longer included since we now use gcc for building perl
+#dir  path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris/PerlGcc
+#file path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris/PerlGcc/Config.pm
 file path=usr/perl5/vendor_perl/$(PERL_VERSION)/Sun/Solaris/Pg.pm


### PR DESCRIPTION
~~The changes here are far more complicated than any of the other perl module rebuilds done for perl 5.34.  This should be tagged "needs review", and it should be very carefully considered before merging.~~

This PR **should not** be merged.  As discussed in the comments below, the copy of `sun-solaris` that's in `oi-userland` is effectively a decoy.  It's not what's used to build `runtime/perl-522/module/sun-solaris`.  That module is built as part of our build process of `illumos-gate`, so the appropriate place to change what version of perl is involved is in `oi-userland/components/openindiana/illumos-gate`, specifically by adjusting what environment is set via the `Makefile`.

I'll be closing this PR, but the comments from Alexander may be useful reference for the actual PR #7733 
