### PR TITLE
mongodb-34: fixes for build errors in fully upgraded system

### DIFF
--- a/components/database/mongodb-34/Makefile
+++ b/components/database/mongodb-34/Makefile
@@ -40,7 +40,7 @@ INSTALL_TOOLS=	$(BUILD_DIR)/tools/.installed
 
 MONGO_PREFIX=	usr/mongodb/$(COMPONENT_MAJOR_VERSION)
 
-GMAKE=scons
+GMAKE=/usr/bin/python $(SOURCE_DIR)/src/third_party/scons-2.5.0/scons.py
 
 COMPONENT_BUILD_ARGS += TARGET_ARCH=x86_64
 COMPONENT_BUILD_ARGS += CXXFLAGS="$(CXXFLAGS)"
@@ -115,7 +115,6 @@ REQUIRED_PACKAGES += library/python/pymongo-27
 REQUIRED_PACKAGES += library/python/pyyaml
 
 # Build dependencies
-REQUIRED_PACKAGES += developer/build/scons
 REQUIRED_PACKAGES += developer/gcc-6
 REQUIRED_PACKAGES += developer/golang
 

--- a/components/database/mongodb-34/Makefile
+++ b/components/database/mongodb-34/Makefile
@@ -68,7 +68,7 @@ GOROOT=$(shell go env | grep GOROOT | awk -F= '{ print $$2 }' | tr -d '"')
 $(BUILD_TOOLS):	$(BUILD_64)
 	$(MKDIR) $(@D)/bin
 	$(CP) -a $(SOURCE_DIR)/src/mongo/gotools/* $(@D) 
-	cd $(@D)/src/github.com/mongodb/mongo-tools && GOROOT=$(GOROOT) /usr/bin/bash build.sh ssl
+	cd $(@D)/src/github.com/mongodb/mongo-tools && GOROOT=$(GOROOT) GO111MODULE=auto /usr/bin/bash build.sh ssl
 	$(TOUCH) $(@)
 
 $(INSTALL_TOOLS): $(BUILD_TOOLS) $(INSTALL_64)

--- a/components/database/mongodb-34/patches/10-ccache-SConstruct.patch
+++ b/components/database/mongodb-34/patches/10-ccache-SConstruct.patch
@@ -1,0 +1,14 @@
+--- SConstruct.orig	Thu Sep  9 23:53:33 2021
++++ mongodb-src-r3.4.19/SConstruct	Thu Sep  9 23:54:45 2021
+@@ -907,6 +907,11 @@
+                )
+ 
+ env = Environment(variables=env_vars, **envDict)
++for ccache_env in ('CC_gcc_32','CC_gcc_64','CXX_gcc_32','CXX_gcc_64'):
++	try:
++		env['ENV'][ccache_env]=os.environ[ccache_env]
++	except KeyError:
++		pass
+ del envDict
+ 
+ env.AddMethod(env_os_is_wrapper, 'TargetOSIs')


### PR DESCRIPTION
mongodb-34 fails to build in fully upgraded system. Issues and fixes are identical to mongodb-40 (see #7648).
