### PR TITLE
shared-macros.mk: fixed overwriting of certain envvars

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -159,8 +159,8 @@ else
 MK_BITS=$(strip $(BUILD_BITS))
 endif
 
-PYTHON_VERSION =	2.7
-PYTHON_VERSIONS =	2.7
+PYTHON_VERSION?=	2.7
+PYTHON_VERSIONS?=	2.7
 
 PYTHON2_VERSIONS = 2.7
 PYTHON2_VERSION = 2.7
@@ -625,8 +625,8 @@ export CCACHE := $(shell \
         fi; \
     fi)
 
-GCC_VERSION =	7
-GCC_ROOT =	/usr/gcc/$(GCC_VERSION)
+GCC_VERSION?=	7
+GCC_ROOT?=	/usr/gcc/$(GCC_VERSION)
 
 GCC_LIBDIR.32 =	$(GCC_ROOT)/lib
 GCC_LIBDIR.64 =	$(GCC_ROOT)/lib/$(MACH64)
@@ -731,7 +731,7 @@ CXX =		$(CXX.$(COMPILER).$(BITS))
 F77 =		$(F77.$(COMPILER).$(BITS))
 FC =		$(FC.$(COMPILER).$(BITS))
 
-RUBY_VERSION =  2.3
+RUBY_VERSION?=  2.3
 RUBY_LIB_VERSION.2.2 = 2.2.0
 RUBY_LIB_VERSION.2.3 = 2.3.0
 RUBY.2.2 =	/usr/ruby/2.2/bin/ruby
@@ -784,7 +784,7 @@ JAVA_HOME = $(JAVA8_HOME)
 
 # This is the default BUILD version of perl
 # Not necessarily the system's default version, i.e. /usr/bin/perl
-PERL_VERSION =  5.22
+PERL_VERSION?=  5.22
 
 # Do *not* add 5.34 to PERL_VERSIONS/PERL_64_ONLY_VERSIONS yet.  We'll
 # enable it system-wide once all existing perl modules have been rebuilt


### PR DESCRIPTION
The Makefiles for many components seem to expect macro expansion to occur on assignment, for example:

- Setting `PYTHON_VERSION` to "3.9" should cause `PYTHON` to evaluate to `/usr/bin/python3.9`
- Setting `GCC_VERSION` to "10" should cause `GCC_ROOT` to evaluate to `/usr/gcc/10` 

Unfortunately, since macro expansion only occurs at the exact point `make-rules/shared-macros.mk` is included, these configuration variables are often ignored. In addition,  `make-rules/shared-macros.mk` also **overwrites** `GCC_VERSION`, `PYTHON_VERSION`, and others. This causes build errors.

The included commit resolves _part_  of the issue by conditionally assigning default values for some configuration variables. Makefiles will need to be updated to have configuration variables assigned _before_ including `make-rules/shared-macros.mk`. 