### PR TITLE
wxwidgets-3: fix header

### DIFF
--- a/components/library/wxwidgets-3/Makefile
+++ b/components/library/wxwidgets-3/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         wxwidgets-3
 COMPONENT_VERSION=      3.1.5
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=      wxWidgets - Cross-Platform GUI Library
 COMPONENT_PROJECT_URL=  https://www.wxwidgets.org/
 COMPONENT_FMRI=         library/graphics/wxwidgets-3
@@ -25,8 +26,8 @@ COMPONENT_CLASSIFICATION=Desktop (GNOME)/Libraries
 COMPONENT_SRC_NAME=     wxWidgets
 COMPONENT_SRC=          $(COMPONENT_SRC_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
-COMPONENT_ARCHIVE_URL=	https://github.com/wxWidgets/wxWidgets/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	sha256:d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224
+COMPONENT_ARCHIVE_URL=  https://github.com/wxWidgets/wxWidgets/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH= sha256:d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224
 COMPONENT_LICENSE=      wxWindows Library license
 
 TEST_TARGET=		$(NO_TESTS)

--- a/components/library/wxwidgets-3/patches/01-ambiguous-overload-error.patch
+++ b/components/library/wxwidgets-3/patches/01-ambiguous-overload-error.patch
@@ -1,0 +1,11 @@
+--- wxWidgets-3.1.5/include/wx/filename.h.orig	lun. janv. 24 16:18:50 2022
++++ wxWidgets-3.1.5/include/wx/filename.h	lun. janv. 24 16:19:05 2022
+@@ -465,7 +465,7 @@
+ 
+     // get the canonical path separator for this format
+     static wxUniChar GetPathSeparator(wxPathFormat format = wxPATH_NATIVE)
+-        { return GetPathSeparators(format)[0u]; }
++        { return GetPathSeparators(format)[0]; }
+ 
+     // is the char a path separator for this format?
+     static bool IsPathSeparator(wxChar ch, wxPathFormat format = wxPATH_NATIVE);


### PR DESCRIPTION
This causes compilation errors in 64-bit due to missing overload of the accessor for unsigned int, however here it is zero anyway...