### PR TITLE
Extension of configobj to python 3.7 and 3.9

### DIFF
--- a/components/python/configobj/Makefile
+++ b/components/python/configobj/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2022 Gary Mills
 # Copyright 2016 Alexander Pyhalov
 #
 
@@ -20,7 +21,7 @@ PATH=/usr/bin:/usr/gnu/bin:/usr/sbin
 
 COMPONENT_NAME=		configobj
 COMPONENT_VERSION=	5.0.6
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_PROJECT_URL=	https://github.com/DiffSK/configobj
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -28,7 +29,7 @@ COMPONENT_ARCHIVE_HASH=	\
     sha256:a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902
 COMPONENT_ARCHIVE_URL=	https://pypi.python.org/packages/source/c/configobj/$(COMPONENT_ARCHIVE)
 
-PYTHON_VERSIONS=	2.7 3.5
+PYTHON_VERSIONS=	2.7 3.5 3.7 3.9
 
 TEST_TARGET= $(NO_TESTS)
 

--- a/components/python/configobj/manifests/generic-manifest.p5m
+++ b/components/python/configobj/manifests/generic-manifest.p5m
@@ -3,29 +3,18 @@
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
-#
 # A full copy of the text of the CDDL should have accompanied this
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-#
 
-#
-# Copyright 2022 Gary Mills
-# Copyright 2016 Alexander Pyhalov
-#
-
-set name=pkg.fmri value=pkg:/library/python/configobj-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="Config file reading, writing and validation"
-set name=info.classification value="org.opensolaris.category.2008:Development/Python"
+# Copyright 2022 <contributor>
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-
-license configobj.license license='BSD'
-
-# Force a dependency on the python runtime package
-depend type=require fmri=runtime/python-$(PYV)
-
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/lib/python$(PYVER)/vendor-packages/_version.py
 file path=usr/lib/python$(PYVER)/vendor-packages/configobj-$(COMPONENT_VERSION)-py$(PYVER).egg-info
 file path=usr/lib/python$(PYVER)/vendor-packages/configobj.py

--- a/components/python/configobj/manifests/sample-manifest.p5m
+++ b/components/python/configobj/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,3 +30,11 @@ file path=usr/lib/python3.5/vendor-packages/_version.py
 file path=usr/lib/python3.5/vendor-packages/configobj-$(COMPONENT_VERSION)-py3.5.egg-info
 file path=usr/lib/python3.5/vendor-packages/configobj.py
 file path=usr/lib/python3.5/vendor-packages/validate.py
+file path=usr/lib/python3.7/vendor-packages/_version.py
+file path=usr/lib/python3.7/vendor-packages/configobj-$(COMPONENT_VERSION)-py3.7.egg-info
+file path=usr/lib/python3.7/vendor-packages/configobj.py
+file path=usr/lib/python3.7/vendor-packages/validate.py
+file path=usr/lib/python3.9/vendor-packages/_version.py
+file path=usr/lib/python3.9/vendor-packages/configobj-$(COMPONENT_VERSION)-py3.9.egg-info
+file path=usr/lib/python3.9/vendor-packages/configobj.py
+file path=usr/lib/python3.9/vendor-packages/validate.py

--- a/components/python/configobj/pkg5
+++ b/components/python/configobj/pkg5
@@ -1,10 +1,13 @@
 {
     "dependencies": [
-        "SUNWcs"
+        "SUNWcs",
+        "shell/ksh93"
     ],
     "fmris": [
         "library/python/configobj-27",
         "library/python/configobj-35",
+        "library/python/configobj-37",
+        "library/python/configobj-39",
         "library/python/configobj"
     ],
     "name": "configobj"


### PR DESCRIPTION
Configobj is a python module that manages configuration files through reading, writing and validation.  This PR adds packages for python versions 3.7 and 3.9 .  The software version is unchanged at 5.0.6, as that is already the latest version.  The previous version of configobj in OI had packages for python versions 2.7 and 3.5 only.  This product has no build dependencies.  The only noticible change is the addition of a runtime dependency on the python runtime packages.

The build, install, and publish steps were all successful, as was the package install.  There are no built-in tests.
