### PR TITLE
disable some failing packages until we can provide fixes

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -22,3 +22,13 @@
 # # <reason why is package disabled>
 # /^package$/d
 #
+# Temporarily disable failing builds:
+/^desktop\/gnome2\/atk$/d
+/^library\/glib$/d
+/^library\/gobject-introspection$/d
+/^library\/libgdata$/d
+/^library\/pangox-compat$/d
+/^library\/pangomm$/d
+/^library\/ptlib$/d
+/^python\/pygtk2$/d
+


### PR DESCRIPTION
We have some packages that fail to build for one reason or another. This disables some of the failing packages until we are able to provide fixes.