### PR TITLE
Upgrade of terminator to 2.1.1 with python 3.9

### DIFF
--- a/components/python/terminator/Makefile
+++ b/components/python/terminator/Makefile
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2021 Gary Mills
 # Copyright (c) 2014 Alexander Pyhalov
 #
 
@@ -17,16 +18,18 @@ BUILD_BITS= 64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		terminator
-COMPONENT_VERSION=	1.92
+COMPONENT_VERSION=	2.1.1
 COMPONENT_PROJECT_URL=	https://gnome-terminator.org/
-COMPONENT_COMMIT=	0cbdbd89a23eaea52ae0fa30d3d6a6c6b9b3fbda
-COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_COMMIT)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).zip
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:9dea305337fba9e6c87f704b167ee12e3e32e063a9861b82817f04ef95af4f38
-COMPONENT_ARCHIVE_URL=	https://github.com/gnome-terminator/terminator/archive/$(COMPONENT_COMMIT).zip
+    sha256:ee1907bc9bfe03244f6d8074b214ef1638a964b38e21ca2ad4cca993d0c1d31e
+COMPONENT_ARCHIVE_URL=	https://github.com/gnome-terminator/$(COMPONENT_NAME)/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
 
-PYTHON_VERSIONS=	3.5
+PYTHON_VERSIONS=	3.9
+
+# Tests require an X environment
+TEST_TARGET=		$(NO_TESTS)
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -36,12 +39,12 @@ PYTHON_DATA=/usr
 
 COMPONENT_POST_INSTALL_ACTION += \
         (cd $(PROTO_DIR)/usr/bin && \
-	  $(MV) -f terminator terminator-$(PYTHON_VERSION) && \
-	  $(MV) -f remotinator remotinator-$(PYTHON_VERSION) \
+	  $(MV) terminator terminator-$(PYTHON_VERSION) && \
+	  $(MV) remotinator remotinator-$(PYTHON_VERSION) \
 	)
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += library/python/psutil-35
-REQUIRED_PACKAGES += library/python/pygobject-3-35
-REQUIRED_PACKAGES += library/python/python-dbus-35
-REQUIRED_PACKAGES += runtime/python-35
+REQUIRED_PACKAGES += library/python/psutil-39
+REQUIRED_PACKAGES += library/python/pygobject-3-39
+REQUIRED_PACKAGES += library/python/python-dbus-39
+REQUIRED_PACKAGES += runtime/python-39

--- a/components/python/terminator/manifests/generic-manifest.p5m
+++ b/components/python/terminator/manifests/generic-manifest.p5m
@@ -3,72 +3,65 @@
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
-#
 # A full copy of the text of the CDDL should have accompanied this
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
-#
 
-#
 # Copyright 2022 <contributor>
-#
-
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
-
-file path=usr/bin/remotinator-3.9
-file path=usr/bin/terminator-3.9
-file path=usr/lib/python3.9/vendor-packages/terminator-$(COMPONENT_VERSION)-py3.9.egg-info/PKG-INFO
-file path=usr/lib/python3.9/vendor-packages/terminator-$(COMPONENT_VERSION)-py3.9.egg-info/SOURCES.txt
-file path=usr/lib/python3.9/vendor-packages/terminator-$(COMPONENT_VERSION)-py3.9.egg-info/dependency_links.txt
-file path=usr/lib/python3.9/vendor-packages/terminator-$(COMPONENT_VERSION)-py3.9.egg-info/requires.txt
-file path=usr/lib/python3.9/vendor-packages/terminator-$(COMPONENT_VERSION)-py3.9.egg-info/top_level.txt
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/__init__.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/borg.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/config.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/configjson.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/container.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/cwd.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/debugserver.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/editablelabel.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/encoding.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/factory.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/ipc.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/keybindings.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/layoutlauncher.glade
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/layoutlauncher.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/notebook.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/optionparse.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/paned.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugin.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/__init__.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/activitywatch.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/command_notify.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/custom_commands.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/logger.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/maven.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/terminalshot.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/testplugin.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/plugins/url_handlers.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/preferences.glade
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/prefseditor.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/regex.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/searchbar.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/signalman.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/terminal.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/terminal_popup_menu.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/terminator.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/titlebar.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/translation.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/util.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/version.py
-file path=usr/lib/python3.9/vendor-packages/terminatorlib/window.py
+file path=usr/bin/remotinator-$(PYVER)
+file path=usr/bin/terminator-$(PYVER)
+file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/requires.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/borg.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/config.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/configjson.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/container.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/cwd.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/debugserver.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/editablelabel.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/encoding.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/factory.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/ipc.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/keybindings.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/layoutlauncher.glade
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/layoutlauncher.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/notebook.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/optionparse.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/paned.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugin.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/activitywatch.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/command_notify.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/custom_commands.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/logger.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/maven.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/terminalshot.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/testplugin.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/url_handlers.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/preferences.glade
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/prefseditor.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/regex.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/searchbar.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/signalman.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/terminal.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/terminal_popup_menu.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/terminator.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/titlebar.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/translation.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/util.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/version.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/window.py
 file path=usr/share/applications/terminator.desktop
 file path=usr/share/icons/HighContrast/16x16/actions/terminator_active_broadcast_all.png
 file path=usr/share/icons/HighContrast/16x16/actions/terminator_active_broadcast_group.png

--- a/components/python/terminator/pkg5
+++ b/components/python/terminator/pkg5
@@ -1,14 +1,15 @@
 {
     "dependencies": [
         "SUNWcs",
-        "library/python/psutil-35",
-        "library/python/pygobject-3-35",
-        "library/python/python-dbus-35",
-        "runtime/python-35",
+        "library/python/psutil-39",
+        "library/python/pygobject-3-39",
+        "library/python/python-dbus-39",
+        "runtime/python-39",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "terminal/terminator-35",
+        "terminal/terminator-39",
         "terminal/terminator"
     ],
     "name": "terminator"

--- a/components/python/terminator/terminator-GENFRAG.p5m
+++ b/components/python/terminator/terminator-GENFRAG.p5m
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2022 Gary Mills
 # Copyright 2020 Alexander Pyhalov
 #
 

--- a/components/python/terminator/terminator-PYVER.p5m
+++ b/components/python/terminator/terminator-PYVER.p5m
@@ -9,6 +9,7 @@
 #
 
 #
+# Copyright 2022 Gary Mills
 # Copyright 2016 Alexander Pyhalov
 #
 
@@ -32,7 +33,7 @@ depend type=require \
     fmri=library/python/configobj-$(PYV)
 
 # Used via gi, not auto-detected
-depend type=require fmri=library/desktop/vte-291@0.42.5,5.11-2018.0.0.0
+depend type=require fmri=library/desktop/vte-291
 
 # Make links mediated when default python mediator changes
 link path=usr/bin/remotinator target=remotinator-$(PYVER)
@@ -40,6 +41,7 @@ link path=usr/bin/terminator target=terminator-$(PYVER)
 
 file path=usr/bin/remotinator-$(PYVER)
 file path=usr/bin/terminator-$(PYVER)
+
 file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
 file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
 file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
@@ -48,6 +50,7 @@ file path=usr/lib/python$(PYVER)/vendor-packages/terminator-$(COMPONENT_VERSION)
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/borg.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/config.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/configjson.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/container.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/cwd.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/debugserver.py
@@ -64,6 +67,7 @@ file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/paned.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugin.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/activitywatch.py
+file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/command_notify.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/custom_commands.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/logger.py
 file path=usr/lib/python$(PYVER)/vendor-packages/terminatorlib/plugins/maven.py


### PR DESCRIPTION
Terminator is a terminal emulator that provides multiple GNOME terminals in one window.  This PR upgrades the terminator version from 1.92 to 2.1.1, and the python version from 3.5 to 3.9 .

The built-in tests do not work, instead getting a segmentation fault.  Consequently, they are disabled.  The terminator install adds an entry to the Applications menu on the Mate desktop.

The build, install, and publish steps were successful.  There are no built-in tests.  I was able to install and test the terminator-39 package on a system that had a graphic console.  There, everything I tried was successful.  The terminal window appeared when invoked from the menu.  The context menu appeared with a right-click in the terminal window.  The split and close operations from that menu worked as expected.
