### PR TITLE
Update pkglint userland checker, the old presents false positives for run…

### DIFF
--- a/tools/pkglintrc
+++ b/tools/pkglintrc
@@ -25,7 +25,7 @@
 pkglint.ext.content = pkglint.userland
 
 # Used by the publisher_in_fmri method in .../tools/python/pkglint/userland.py
-userland.manifest.allowed_pubs = userland userland-localizable
+userland.manifest002.allowed_pubs = userland userland-localizable
 
 # turn off reporting of 'pkg.linted*' attributes in manifests.  We already
 # get a pkglint001.5 INFO message with the WARNING or ERROR that we have


### PR DESCRIPTION
Our old pkglint userland checker complains about runpaths which are correct. So we should update this tool.
Thanks to Oracle!

e.g.
ERROR userland.action001.3        bad RUNPATH, 'opt/SUNWsamfs/bin/archive' includes '/opt/SUNWsamfs/lib'
ERROR userland.action001.3        bad RUNPATH, 'opt/SUNWsamfs/bin/notify' includes '/opt/SUNWsamfs/lib'
ERROR userland.action001.3        bad RUNPATH, 'opt/SUNWsamfs/bin/request' includes '/opt/SUNWsamfs/lib'
