### PR TITLE
have illumos-gate build sun-solaris with perl 534

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -95,9 +95,11 @@ $(BUILD_DIR)/$(MACH)/.built: $(SOURCE_DIR)/.patched
 	    -e 's|^export MULTI_PROTO=.*|export MULTI_PROTO=\"$(MULTI_PROTO)\"|' \
 	    -e 's|^export SHADOW_CCS=.*||' \
 	    -e 's|^export SHADOW_CCCS=.*||' ; \
-	  echo export PERL_VERSION=\"5.22\"; \
-	  echo export PERL_PKGVERS=\"-522\"; \
-	  echo export BUILDPERL64=\"#\"; \
+	  echo export PERL_VERSION=\"5.34\"; \
+	  echo export PERL_PKGVERS=\"-534\"; \
+	  echo export PERL_VARIANT=\"-thread-multi\"; \
+	  echo export BUILDPERL32=\"#\"; \
+	  echo export BUILDPERL64=\"\"; \
 	  echo export BUILDPY2=\"#\"; \
 	  echo export BUILDPY2TOOLS=\"#\"; \
 	  echo export BLD_JAVA_8=; \


### PR DESCRIPTION
This changes `components/openindiana/illumos-gate` so that instead of generating `runtime/perl-522/module/sun-solaris`, it generates `runtime/perl-534/module/sun-solaris`.

There are a lot of relevant comments from Alexander in PR #7640 that relate to this update.   The diff in 7640 should **not** be merged. I'll close that PR.

Note that I've rebuilt `illumos-gate` many times in the past couple weeks.  I seem to get unpredictable behavior with `illumos-gate`.  It has built and successfully "installed' (the entire `gmake build` process completes successfully) a couple of times, but most of the time everything builds successfully, but I get failures from the "install":

```
==== Build errors (non-DEBUG) ====

dmake: Warning: Target `install' not remade because of errors
The following command caused the error:
dmake: Warning: Don't know how to make target `/export/home/mooney/oi-userland/components/openindiana/illumos-gate/illumos-gate/proto/root_i386/opt/os-tests/tests/cores'
dmake: Warning: Target `install' not remade because of errors
The following command caused the error:
dmake: Warning: Target `install' not remade because of errors
dmake: Warning: Command failed for target `libdumper'
dmake: Warning: Target `install' not remade because of errors
The following command caused the error:
dmake: Warning: Target `install' not remade because of errors
dmake: Warning: Command failed for target `tests'
dmake: Warning: Target `install' not remade because of errors
dmake: Warning: Command failed for target `os-tests'
dmake: Warning: Target `install' not remade because of errors
The following command caused the error:
dmake: Warning: Target `install' not remade because of errors
```

I don't know if these relate to the chicken-or-egg problem that Alexander mentioned, but they seem unrelated to the perl changes I made.

Note that in addition to building `runtime/perl-534/module/sun-solaris`, I've also tested changing the `perl` and `system-perl` mediator to point to the 534 perl, and all of `illumos-gate` builds OK when using `perl-534`.

As I said in my question on `oi-dev`, I don't know where this should fit into the overall process of updating perl, but I wanted to get the PR in place so that other eyes can check it out and hopefully have some suggestions about where this should fit in the overall process.