### PR TITLE
Rebuild packages after imagemagick update

### DIFF
--- a/components/desktop/awesome/Makefile
+++ b/components/desktop/awesome/Makefile
@@ -21,7 +21,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         awesome
 COMPONENT_VERSION=      4.3
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=  https://awesomewm.org
 COMPONENT_SUMMARY=      A highly configurable, next generation framework window manager for X.
 COMPONENT_FMRI=         desktop/window-manager/$(COMPONENT_NAME)

--- a/components/desktop/rss-glx/Makefile
+++ b/components/desktop/rss-glx/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		rss-glx
 COMPONENT_VERSION= 	0.91
 HUMAN_VERSION=		0.9.1
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	XScreenSaver - Really Slick ScreenSaver OpenGL display modules
 COMPONENT_PROJECT_URL=	http://sourceforge.net/projects/rss-glx/
 COMPONENT_CLASSIFICATION = System/X11

--- a/components/desktop/tango-icon-theme/Makefile
+++ b/components/desktop/tango-icon-theme/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         tango-icon-theme
 COMPONENT_VERSION=      0.8.90
-COMPONENT_REVISION=     2
+COMPONENT_REVISION=     3
 COMPONENT_PROJECT_URL=  http://tango.freedesktop.org/
 COMPONENT_SUMMARY=      Tango icon theme
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -40,3 +40,4 @@ CONFIGURE_OPTIONS+=	--sysconfdir=/etc
 
 # Manually added dependency
 REQUIRED_PACKAGES+= image/imagemagick
+REQUIRED_PACKAGES += library/desktop/xdg/icon-naming-utils

--- a/components/games/freeciv/Makefile
+++ b/components/games/freeciv/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		freeciv
 COMPONENT_VERSION=	2.6.6
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Free and Open Source empire-building strategy game inspired by the history of human civilization.
 COMPONENT_PROJECT_URL=	http://www.freeciv.org
 COMPONENT_FMRI=		games/freeciv

--- a/components/image/inkscape/Makefile
+++ b/components/image/inkscape/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		inkscape
 COMPONENT_VERSION=	0.92.4
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_FMRI=		image/editor/inkscape
 COMPONENT_CLASSIFICATION=	Applications/Graphics and Imaging
 COMPONENT_SUMMARY=	Opensource professional vector graphics editor


### PR DESCRIPTION
This is to rebuild tango-icon-theme, rss-glx, awesome, inkscape, freeciv after imagemagick update, so if you decide to integrate, please do so _after_ you merge #7742 and new imagemagick is installed on the build machine.  Please note that this also adds one missing build dependency for tango-icon-theme.