### PR TITLE
openldap - change library naming convention back to old style

### DIFF
--- a/components/network/openldap/Makefile
+++ b/components/network/openldap/Makefile
@@ -25,22 +25,23 @@
 # Copyright (c) 2022, Friedrich Kink
 #
 
-BUILD_BITS=             64
+BUILD_BITS=             64_and_32
 USE_OPENSSL11=		yes
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=		openldap
-COMPONENT_VERSION=	2.6.1
-COMPONENT_SUMMARY=	OpenLDAP is an open source implementation of the Lightweight Directory Access Protocol
-COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tgz
-COMPONENT_PROJECT_URL=	https://www.openldap.org/
-COMPONENT_ARCHIVE_HASH=	sha256:9d576ea6962d7db8a2e2808574e8c257c15aef55f403a1fb5a0faf35de70e6f3
-COMPONENT_ARCHIVE_URL=	https://openldap.org/software/download/OpenLDAP/openldap-release/$(COMPONENT_ARCHIVE)
-COMPONENT_FMRI=			library/openldap
-COMPONENT_CLASSIFICATION=	System/Libraries
-COMPONENT_LICENSE=		The OpenLDAP Public License
-COMPONENT_LICENSE_FILE=		LICENSE
+COMPONENT_NAME=         openldap
+COMPONENT_VERSION=      2.6.1
+COMPONENT_REVISION=     1
+COMPONENT_SUMMARY=      OpenLDAP is an open source implementation of the Lightweight Directory Access Protocol
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tgz
+COMPONENT_PROJECT_URL=  https://www.openldap.org/
+COMPONENT_ARCHIVE_HASH= sha256:9d576ea6962d7db8a2e2808574e8c257c15aef55f403a1fb5a0faf35de70e6f3
+COMPONENT_ARCHIVE_URL=  https://openldap.org/software/download/OpenLDAP/openldap-release/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=         library/openldap
+COMPONENT_CLASSIFICATION=System/Libraries
+COMPONENT_LICENSE=      The OpenLDAP Public License
+COMPONENT_LICENSE_FILE= LICENSE
 
 SDFVER=			sdf-2.001
 SDFBLIB=		$(BUILD_DIR)/${SDFVER}/blib
@@ -53,9 +54,12 @@ COMPONENT_ARCHIVE_URL_1= ftp://ftp.eenet.ee/pub/cpan/authors/id/I/IA/IANC/$(COMP
 include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PRE_CONFIGURE_ACTION = ($(CLONEY) $(SOURCE_DIR) $(@D))
-COMPONENT_POST_CONFIGURE_ACTION = ( $(GSED) -i -e 's:perl5/5.22/lib/i86pc-solaris-64int:perl5/5.34/lib/i86pc-solaris-thread-multi-64:g' $(@D)/servers/slapd/back-perl/Makefile )
+COMPONENT_POST_CONFIGURE_ACTION.64 = ( $(GSED) -i -e 's:perl5/5.22/lib/i86pc-solaris-64int:perl5/5.34/lib/i86pc-solaris-thread-multi-64:g' $(@D)/servers/slapd/back-perl/Makefile )
+COMPONENT_POST_CONFIGURE_ACTION.32 = 
 
-PERL=		/usr/perl5/5.34/bin/perl
+PERL.64=		/usr/perl5/5.34/bin/perl
+PERL.32=		/usr/perl5/5.22/bin/perl
+PERL=			$(PERL.$(BITS))
 COMPONENT_PRE_BUILD_ACTION = \
 	 ( $(CP) $(USERLAND_ARCHIVES)$(COMPONENT_ARCHIVE_1) $(BUILD_DIR); \
 	 cd $(BUILD_DIR); \
@@ -95,14 +99,15 @@ CONFIGURE_OPTIONS += --with-threads
 CONFIGURE_OPTIONS += --with-tls=openssl
 CONFIGURE_OPTIONS += --with-mp=gmp
 CONFIGURE_OPTIONS += --with-odbc=unixodbc
-CONFIGURE_OPTIONS += LDFLAGS=-L$(OPENSSL_PREFIX)/lib/amd64
+CONFIGURE_OPTIONS.64 += LDFLAGS=-L$(OPENSSL_PREFIX)/lib/amd64
+CONFIGURE_OPTIONS.32 += LDFLAGS=-L$(OPENSSL_PREFIX)/lib
 CONFIGURE_OPTIONS += CPPFLAGS="-I$(OPENSSL_PREFIX)/include -I/usr/include/odbc"
 
 COMPONENT_TEST_ENV += LD_LIBRARY_PATH="$(PROTOUSRLIBDIR):$(PROTOUSRLIBDIR64):"
 COMPONENT_TEST_ENV += PATH="$(PROTOUSRSBINDIR):$(PROTOUSRBINDIR):/usr/bin"
 
 # common targets
-BUILD_TARGET:	$(BUILD_64)
+BUILD_TARGET:	$(BUILD_64_and_32)
 	(cd $(BUILD_DIR)/doc/guide/admin; \
 	$(PERL) -I$(SDFBLIB)/lib $(SDFBLIB)/script/sdf -2html guide.sdf; \
 	$(PERL) -I$(SDFBLIB)/lib $(SDFBLIB)/script/sdf -2html index.sdf)

--- a/components/network/openldap/files/ldap-olslapd
+++ b/components/network/openldap/files/ldap-olslapd
@@ -33,7 +33,7 @@ typeset -r VARRUNDIR=/var/openldap/run
 typeset -r VARDATADIR=/var/openldap/openldap-data
 typeset -r PIDFILE=${VARRUNDIR}/slapd.pid
 typeset -r CONF_FILE=/etc/openldap/slapd.conf
-typeset -r SLAPD="/usr/lib/slapd -u ${LDAPUSR} -g ${LDAPGRP} -f ${CONF_FILE}"
+typeset -r SLAPD="/usr/lib/amd64/slapd -u ${LDAPUSR} -g ${LDAPGRP} -f ${CONF_FILE}"
 
 [[ ! -f ${CONF_FILE} ]] && exit $SMF_EXIT_ERR_CONFIG
 

--- a/components/network/openldap/manifests/sample-manifest.p5m
+++ b/components/network/openldap/manifests/sample-manifest.p5m
@@ -24,68 +24,37 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=etc/openldap/ldap.conf
 file path=etc/openldap/ldap.conf.default
-file path=etc/openldap/schema.24944/README
-file path=etc/openldap/schema.24944/collective.ldif
-file path=etc/openldap/schema.24944/collective.schema
-file path=etc/openldap/schema.24944/corba.ldif
-file path=etc/openldap/schema.24944/corba.schema
-file path=etc/openldap/schema.24944/core.ldif
-file path=etc/openldap/schema.24944/core.schema
-file path=etc/openldap/schema.24944/cosine.ldif
-file path=etc/openldap/schema.24944/cosine.schema
-file path=etc/openldap/schema.24944/dsee.ldif
-file path=etc/openldap/schema.24944/dsee.schema
-file path=etc/openldap/schema.24944/duaconf.ldif
-file path=etc/openldap/schema.24944/duaconf.schema
-file path=etc/openldap/schema.24944/dyngroup.ldif
-file path=etc/openldap/schema.24944/dyngroup.schema
-file path=etc/openldap/schema.24944/inetorgperson.ldif
-file path=etc/openldap/schema.24944/inetorgperson.schema
-file path=etc/openldap/schema.24944/java.ldif
-file path=etc/openldap/schema.24944/java.schema
-file path=etc/openldap/schema.24944/misc.ldif
-file path=etc/openldap/schema.24944/misc.schema
-file path=etc/openldap/schema.24944/msuser.ldif
-file path=etc/openldap/schema.24944/msuser.schema
-file path=etc/openldap/schema.24944/namedobject.ldif
-file path=etc/openldap/schema.24944/namedobject.schema
-file path=etc/openldap/schema.24944/nis.ldif
-file path=etc/openldap/schema.24944/nis.schema
-file path=etc/openldap/schema.24944/openldap.ldif
-file path=etc/openldap/schema.24944/openldap.schema
-file path=etc/openldap/schema.24944/pmi.ldif
-file path=etc/openldap/schema.24944/pmi.schema
-file path=etc/openldap/schema.8567/README
-file path=etc/openldap/schema.8567/collective.ldif
-file path=etc/openldap/schema.8567/collective.schema
-file path=etc/openldap/schema.8567/corba.ldif
-file path=etc/openldap/schema.8567/corba.schema
-file path=etc/openldap/schema.8567/core.ldif
-file path=etc/openldap/schema.8567/core.schema
-file path=etc/openldap/schema.8567/cosine.ldif
-file path=etc/openldap/schema.8567/cosine.schema
-file path=etc/openldap/schema.8567/dsee.ldif
-file path=etc/openldap/schema.8567/dsee.schema
-file path=etc/openldap/schema.8567/duaconf.ldif
-file path=etc/openldap/schema.8567/duaconf.schema
-file path=etc/openldap/schema.8567/dyngroup.ldif
-file path=etc/openldap/schema.8567/dyngroup.schema
-file path=etc/openldap/schema.8567/inetorgperson.ldif
-file path=etc/openldap/schema.8567/inetorgperson.schema
-file path=etc/openldap/schema.8567/java.ldif
-file path=etc/openldap/schema.8567/java.schema
-file path=etc/openldap/schema.8567/misc.ldif
-file path=etc/openldap/schema.8567/misc.schema
-file path=etc/openldap/schema.8567/msuser.ldif
-file path=etc/openldap/schema.8567/msuser.schema
-file path=etc/openldap/schema.8567/namedobject.ldif
-file path=etc/openldap/schema.8567/namedobject.schema
-file path=etc/openldap/schema.8567/nis.ldif
-file path=etc/openldap/schema.8567/nis.schema
-file path=etc/openldap/schema.8567/openldap.ldif
-file path=etc/openldap/schema.8567/openldap.schema
-file path=etc/openldap/schema.8567/pmi.ldif
-file path=etc/openldap/schema.8567/pmi.schema
+file path=etc/openldap/schema.4269/README
+file path=etc/openldap/schema.4269/collective.ldif
+file path=etc/openldap/schema.4269/collective.schema
+file path=etc/openldap/schema.4269/corba.ldif
+file path=etc/openldap/schema.4269/corba.schema
+file path=etc/openldap/schema.4269/core.ldif
+file path=etc/openldap/schema.4269/core.schema
+file path=etc/openldap/schema.4269/cosine.ldif
+file path=etc/openldap/schema.4269/cosine.schema
+file path=etc/openldap/schema.4269/dsee.ldif
+file path=etc/openldap/schema.4269/dsee.schema
+file path=etc/openldap/schema.4269/duaconf.ldif
+file path=etc/openldap/schema.4269/duaconf.schema
+file path=etc/openldap/schema.4269/dyngroup.ldif
+file path=etc/openldap/schema.4269/dyngroup.schema
+file path=etc/openldap/schema.4269/inetorgperson.ldif
+file path=etc/openldap/schema.4269/inetorgperson.schema
+file path=etc/openldap/schema.4269/java.ldif
+file path=etc/openldap/schema.4269/java.schema
+file path=etc/openldap/schema.4269/misc.ldif
+file path=etc/openldap/schema.4269/misc.schema
+file path=etc/openldap/schema.4269/msuser.ldif
+file path=etc/openldap/schema.4269/msuser.schema
+file path=etc/openldap/schema.4269/namedobject.ldif
+file path=etc/openldap/schema.4269/namedobject.schema
+file path=etc/openldap/schema.4269/nis.ldif
+file path=etc/openldap/schema.4269/nis.schema
+file path=etc/openldap/schema.4269/openldap.ldif
+file path=etc/openldap/schema.4269/openldap.schema
+file path=etc/openldap/schema.4269/pmi.ldif
+file path=etc/openldap/schema.4269/pmi.schema
 file path=etc/openldap/schema/README
 file path=etc/openldap/schema/collective.ldif
 file path=etc/openldap/schema/collective.schema
@@ -121,6 +90,17 @@ file path=etc/openldap/slapd.conf
 file path=etc/openldap/slapd.conf.default
 file path=etc/openldap/slapd.ldif
 file path=etc/openldap/slapd.ldif.default
+link path=usr/bin/$(MACH32)/ldapadd target=ldapmodify
+file path=usr/bin/$(MACH32)/ldapcompare
+file path=usr/bin/$(MACH32)/ldapdelete
+file path=usr/bin/$(MACH32)/ldapexop
+file path=usr/bin/$(MACH32)/ldapmodify
+file path=usr/bin/$(MACH32)/ldapmodrdn
+file path=usr/bin/$(MACH32)/ldappasswd
+file path=usr/bin/$(MACH32)/ldapsearch
+file path=usr/bin/$(MACH32)/ldapurl
+file path=usr/bin/$(MACH32)/ldapvc
+file path=usr/bin/$(MACH32)/ldapwhoami
 link path=usr/bin/ldapadd target=ldapmodify
 file path=usr/bin/ldapcompare
 file path=usr/bin/ldapdelete
@@ -142,134 +122,186 @@ file path=usr/include/openldap/ldap_utf8.h
 file path=usr/include/openldap/ldif.h
 file path=usr/include/openldap/openldap.h
 file path=usr/include/openldap/slapi-plugin.h
-link path=usr/lib/$(MACH64)/liblber.so target=liblber.so.2.0.200
-link path=usr/lib/$(MACH64)/liblber.so.2 target=liblber.so.2.0.200
-file path=usr/lib/$(MACH64)/liblber.so.2.0.200
-link path=usr/lib/$(MACH64)/libldap.so target=libldap.so.2.0.200
-link path=usr/lib/$(MACH64)/libldap.so.2 target=libldap.so.2.0.200
-file path=usr/lib/$(MACH64)/libldap.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/accesslog.so target=accesslog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/accesslog.so.2 target=accesslog.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/accesslog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/argon2.so target=argon2.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/argon2.so.2 target=argon2.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/argon2.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/auditlog.so target=auditlog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/auditlog.so.2 target=auditlog.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/auditlog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/autoca.so target=autoca.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/autoca.so.2 target=autoca.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/autoca.so.2.0.200
+link path=usr/lib/$(MACH64)/liblber-2.6.so.2 target=liblber-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/liblber-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/liblber.so target=liblber-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/libldap-2.6.so.2 target=libldap-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/libldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/libldap.so target=libldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/accesslog-2.6.so.2 \
+    target=accesslog-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/accesslog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/accesslog.so \
+    target=accesslog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/argon2-2.6.so.2 \
+    target=argon2-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/argon2-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/argon2.so target=argon2-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/auditlog-2.6.so.2 \
+    target=auditlog-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/auditlog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/auditlog.so target=auditlog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/autoca-2.6.so.2 \
+    target=autoca-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/autoca-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/autoca.so target=autoca-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_asyncmeta-2.6.so.2 \
+    target=back_asyncmeta-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_asyncmeta-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/back_asyncmeta.so \
-    target=back_asyncmeta.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_asyncmeta.so.2 \
-    target=back_asyncmeta.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_asyncmeta.so.2.0.200
+    target=back_asyncmeta-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_dnssrv-2.6.so.2 \
+    target=back_dnssrv-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_dnssrv-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/back_dnssrv.so \
-    target=back_dnssrv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_dnssrv.so.2 \
-    target=back_dnssrv.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_dnssrv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_ldap.so target=back_ldap.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_ldap.so.2 target=back_ldap.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_ldap.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_mdb.so target=back_mdb.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_mdb.so.2 target=back_mdb.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_mdb.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_meta.so target=back_meta.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_meta.so.2 target=back_meta.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_meta.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_null.so target=back_null.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_null.so.2 target=back_null.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_null.so.2.0.200
+    target=back_dnssrv-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_ldap-2.6.so.2 \
+    target=back_ldap-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_ldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_ldap.so \
+    target=back_ldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_mdb-2.6.so.2 \
+    target=back_mdb-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_mdb-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_mdb.so target=back_mdb-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_meta-2.6.so.2 \
+    target=back_meta-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_meta-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_meta.so \
+    target=back_meta-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_null-2.6.so.2 \
+    target=back_null-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_null-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_null.so \
+    target=back_null-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_passwd-2.6.so.2 \
+    target=back_passwd-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_passwd-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/back_passwd.so \
-    target=back_passwd.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_passwd.so.2 \
-    target=back_passwd.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_passwd.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_perl.so target=back_perl.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_perl.so.2 target=back_perl.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_perl.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_relay.so target=back_relay.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_relay.so.2 \
-    target=back_relay.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_relay.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sock.so target=back_sock.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sock.so.2 target=back_sock.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_sock.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sql.so target=back_sql.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sql.so.2 target=back_sql.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_sql.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/collect.so target=collect.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/collect.so.2 target=collect.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/collect.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/constraint.so target=constraint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/constraint.so.2 \
-    target=constraint.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/constraint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dds.so target=dds.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dds.so.2 target=dds.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/dds.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/deref.so target=deref.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/deref.so.2 target=deref.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/deref.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dyngroup.so target=dyngroup.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dyngroup.so.2 target=dyngroup.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/dyngroup.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dynlist.so target=dynlist.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dynlist.so.2 target=dynlist.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/dynlist.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/homedir.so target=homedir.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/homedir.so.2 target=homedir.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/homedir.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/memberof.so target=memberof.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/memberof.so.2 target=memberof.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/memberof.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/otp.so target=otp.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/otp.so.2 target=otp.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/otp.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/pcache.so target=pcache.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/pcache.so.2 target=pcache.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/pcache.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/ppolicy.so target=ppolicy.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/ppolicy.so.2 target=ppolicy.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/ppolicy.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/refint.so target=refint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/refint.so.2 target=refint.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/refint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/remoteauth.so target=remoteauth.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/remoteauth.so.2 \
-    target=remoteauth.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/remoteauth.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/retcode.so target=retcode.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/retcode.so.2 target=retcode.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/retcode.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/rwm.so target=rwm.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/rwm.so.2 target=rwm.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/rwm.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/seqmod.so target=seqmod.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/seqmod.so.2 target=seqmod.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/seqmod.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/sssvlv.so target=sssvlv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/sssvlv.so.2 target=sssvlv.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/sssvlv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/syncprov.so target=syncprov.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/syncprov.so.2 target=syncprov.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/syncprov.so.2.0.200
+    target=back_passwd-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_perl-2.6.so.2 \
+    target=back_perl-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_perl-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_perl.so \
+    target=back_perl-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_relay-2.6.so.2 \
+    target=back_relay-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_relay-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_relay.so \
+    target=back_relay-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sock-2.6.so.2 \
+    target=back_sock-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_sock-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sock.so \
+    target=back_sock-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sql-2.6.so.2 \
+    target=back_sql-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_sql-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sql.so target=back_sql-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/collect-2.6.so.2 \
+    target=collect-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/collect-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/collect.so target=collect-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/constraint-2.6.so.2 \
+    target=constraint-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/constraint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/constraint.so \
+    target=constraint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dds-2.6.so.2 target=dds-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/dds-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dds.so target=dds-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/deref-2.6.so.2 target=deref-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/deref-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/deref.so target=deref-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dyngroup-2.6.so.2 \
+    target=dyngroup-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/dyngroup-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dyngroup.so target=dyngroup-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dynlist-2.6.so.2 \
+    target=dynlist-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/dynlist-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dynlist.so target=dynlist-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/homedir-2.6.so.2 \
+    target=homedir-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/homedir-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/homedir.so target=homedir-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/memberof-2.6.so.2 \
+    target=memberof-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/memberof-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/memberof.so target=memberof-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/otp-2.6.so.2 target=otp-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/otp-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/otp.so target=otp-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/pcache-2.6.so.2 \
+    target=pcache-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/pcache-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/pcache.so target=pcache-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/ppolicy-2.6.so.2 \
+    target=ppolicy-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/ppolicy-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/ppolicy.so target=ppolicy-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/refint-2.6.so.2 \
+    target=refint-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/refint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/refint.so target=refint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/remoteauth-2.6.so.2 \
+    target=remoteauth-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/remoteauth-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/remoteauth.so \
+    target=remoteauth-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/retcode-2.6.so.2 \
+    target=retcode-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/retcode-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/retcode.so target=retcode-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/rwm-2.6.so.2 target=rwm-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/rwm-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/rwm.so target=rwm-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/seqmod-2.6.so.2 \
+    target=seqmod-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/seqmod-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/seqmod.so target=seqmod-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/sssvlv-2.6.so.2 \
+    target=sssvlv-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/sssvlv-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/sssvlv.so target=sssvlv-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/syncprov-2.6.so.2 \
+    target=syncprov-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/syncprov-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/syncprov.so target=syncprov-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/translucent-2.6.so.2 \
+    target=translucent-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/translucent-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/translucent.so \
-    target=translucent.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/translucent.so.2 \
-    target=translucent.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/translucent.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/unique.so target=unique.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/unique.so.2 target=unique.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/unique.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/valsort.so target=valsort.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/valsort.so.2 target=valsort.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/valsort.so.2.0.200
+    target=translucent-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/unique-2.6.so.2 \
+    target=unique-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/unique-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/unique.so target=unique-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/valsort-2.6.so.2 \
+    target=valsort-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/valsort-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/valsort.so target=valsort-2.6.so.2.0.200
 file path=usr/lib/$(MACH64)/pkgconfig/lber.pc
 file path=usr/lib/$(MACH64)/pkgconfig/ldap.pc
 file path=usr/lib/$(MACH64)/slapd
+link path=usr/lib/liblber-2.6.so.2 target=liblber-2.6.so.2.0.200
+file path=usr/lib/liblber-2.6.so.2.0.200
+link path=usr/lib/liblber.so target=liblber-2.6.so.2.0.200
+link path=usr/lib/libldap-2.6.so.2 target=libldap-2.6.so.2.0.200
+file path=usr/lib/libldap-2.6.so.2.0.200
+link path=usr/lib/libldap.so target=libldap-2.6.so.2.0.200
+file path=usr/lib/pkgconfig/lber.pc
+file path=usr/lib/pkgconfig/ldap.pc
+link path=usr/sbin/$(MACH32)/slapacl target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slapadd target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slapauth target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slapcat target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slapdn target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slapindex target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slapmodify target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slappasswd target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slapschema target=../../lib/$(MACH64)/slapd
+link path=usr/sbin/$(MACH32)/slaptest target=../../lib/$(MACH64)/slapd
 link path=usr/sbin/slapacl target=../lib/$(MACH64)/slapd
 link path=usr/sbin/slapadd target=../lib/$(MACH64)/slapd
 link path=usr/sbin/slapauth target=../lib/$(MACH64)/slapd

--- a/components/network/openldap/openldap.p5m
+++ b/components/network/openldap/openldap.p5m
@@ -59,6 +59,20 @@ file files/ldap-olslapd path=lib/svc/method/ldap-olslapd
 
 link path=usr/bin/openldapadd target=openldapmodify
 
+link path=usr/lib/$(MACH64)/liblber-2.4.so target=liblber-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/liblber-2.6.so target=liblber-2.6.so.2.0.200
+# for backward compatibility
+link path=usr/lib/liblber-2.4.so target=liblber-2.6.so.2.0.200
+link path=usr/lib/liblber-2.6.so target=liblber-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/libldap-2.4.so target=libldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/libldap-2.6.so target=libldap-2.6.so.2.0.200
+# for backward compatibility
+link path=usr/lib/libldap-2.4.so target=libldap-2.6.so.2.0.200
+link path=usr/lib/libldap-2.6.so target=libldap-2.6.so.2.0.200
+# next two lines for backward compatibility (new version threadsafe no extra library needed)
+link path=usr/lib/libldap_r-2.4.so target=libldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/libldap_r-2.4.so target=libldap-2.6.so.2.0.200
+
 file path=etc/openldap/ldap.conf mode=0644 owner=root group=openldap preserve=true
 file path=etc/openldap/ldap.conf.default
 file path=etc/openldap/schema/README
@@ -114,131 +128,139 @@ file path=usr/include/openldap/ldap_utf8.h
 file path=usr/include/openldap/ldif.h
 file path=usr/include/openldap/openldap.h
 file path=usr/include/openldap/slapi-plugin.h
-link path=usr/lib/$(MACH64)/liblber.so target=liblber.so.2.0.200
-link path=usr/lib/$(MACH64)/liblber.so.2 target=liblber.so.2.0.200
-file path=usr/lib/$(MACH64)/liblber.so.2.0.200
-link path=usr/lib/$(MACH64)/libldap.so target=libldap.so.2.0.200
-link path=usr/lib/$(MACH64)/libldap.so.2 target=libldap.so.2.0.200
-file path=usr/lib/$(MACH64)/libldap.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/accesslog.so target=accesslog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/accesslog.so.2 target=accesslog.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/accesslog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/argon2.so target=argon2.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/argon2.so.2 target=argon2.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/argon2.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/auditlog.so target=auditlog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/auditlog.so.2 target=auditlog.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/auditlog.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/autoca.so target=autoca.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/autoca.so.2 target=autoca.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/autoca.so.2.0.200
+#link path=usr/lib/liblber.so target=liblber-2.6.so.2.0.200
+link path=usr/lib/liblber-2.6.so.2 target=liblber-2.6.so.2.0.200
+file path=usr/lib/liblber-2.6.so.2.0.200
+#link path=usr/lib/libldap.so target=libldap-2.6.so.2.0.200
+link path=usr/lib/libldap-2.6.so.2 target=libldap-2.6.so.2.0.200
+file path=usr/lib/libldap-2.6.so.2.0.200
+file path=usr/lib/pkgconfig/lber.pc
+file path=usr/lib/pkgconfig/ldap.pc
+link path=usr/lib/$(MACH64)/liblber-2.6.so.2 target=liblber-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/liblber-2.6.so.2.0.200
+#link path=usr/lib/$(MACH64)/liblber.so target=liblber-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/libldap-2.6.so.2 target=libldap-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/libldap-2.6.so.2.0.200
+#link path=usr/lib/$(MACH64)/libldap.so target=libldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/accesslog.so target=accesslog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/accesslog-2.6.so.2 target=accesslog-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/accesslog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/argon2.so target=argon2-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/argon2-2.6.so.2 target=argon2-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/argon2-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/auditlog.so target=auditlog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/auditlog-2.6.so.2 target=auditlog-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/auditlog-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/autoca.so target=autoca-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/autoca-2.6.so.2 target=autoca-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/autoca-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/back_asyncmeta.so \
-    target=back_asyncmeta.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_asyncmeta.so.2 \
-    target=back_asyncmeta.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_asyncmeta.so.2.0.200
+    target=back_asyncmeta-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_asyncmeta-2.6.so.2 \
+    target=back_asyncmeta-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_asyncmeta-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/back_dnssrv.so \
-    target=back_dnssrv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_dnssrv.so.2 \
-    target=back_dnssrv.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_dnssrv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_ldap.so target=back_ldap.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_ldap.so.2 target=back_ldap.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_ldap.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_mdb.so target=back_mdb.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_mdb.so.2 target=back_mdb.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_mdb.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_meta.so target=back_meta.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_meta.so.2 target=back_meta.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_meta.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_null.so target=back_null.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_null.so.2 target=back_null.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_null.so.2.0.200
+    target=back_dnssrv-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_dnssrv-2.6.so.2 \
+    target=back_dnssrv-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_dnssrv-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_ldap.so target=back_ldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_ldap-2.6.so.2 target=back_ldap-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_ldap-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_mdb.so target=back_mdb-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_mdb-2.6.so.2 target=back_mdb-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_mdb-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_meta.so target=back_meta-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_meta-2.6.so.2 target=back_meta-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_meta-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_null.so target=back_null-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_null-2.6.so.2 target=back_null-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_null-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/back_passwd.so \
-    target=back_passwd.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_passwd.so.2 \
-    target=back_passwd.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_passwd.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_perl.so target=back_perl.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_perl.so.2 target=back_perl.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_perl.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_relay.so target=back_relay.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_relay.so.2 \
-    target=back_relay.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_relay.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sock.so target=back_sock.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sock.so.2 target=back_sock.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_sock.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sql.so target=back_sql.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/back_sql.so.2 target=back_sql.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/back_sql.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/collect.so target=collect.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/collect.so.2 target=collect.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/collect.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/constraint.so target=constraint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/constraint.so.2 \
-    target=constraint.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/constraint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dds.so target=dds.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dds.so.2 target=dds.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/dds.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/deref.so target=deref.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/deref.so.2 target=deref.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/deref.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dyngroup.so target=dyngroup.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dyngroup.so.2 target=dyngroup.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/dyngroup.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dynlist.so target=dynlist.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/dynlist.so.2 target=dynlist.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/dynlist.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/homedir.so target=homedir.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/homedir.so.2 target=homedir.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/homedir.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/memberof.so target=memberof.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/memberof.so.2 target=memberof.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/memberof.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/otp.so target=otp.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/otp.so.2 target=otp.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/otp.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/pcache.so target=pcache.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/pcache.so.2 target=pcache.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/pcache.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/ppolicy.so target=ppolicy.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/ppolicy.so.2 target=ppolicy.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/ppolicy.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/refint.so target=refint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/refint.so.2 target=refint.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/refint.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/remoteauth.so target=remoteauth.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/remoteauth.so.2 \
-    target=remoteauth.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/remoteauth.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/retcode.so target=retcode.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/retcode.so.2 target=retcode.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/retcode.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/rwm.so target=rwm.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/rwm.so.2 target=rwm.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/rwm.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/seqmod.so target=seqmod.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/seqmod.so.2 target=seqmod.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/seqmod.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/sssvlv.so target=sssvlv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/sssvlv.so.2 target=sssvlv.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/sssvlv.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/syncprov.so target=syncprov.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/syncprov.so.2 target=syncprov.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/syncprov.so.2.0.200
+    target=back_passwd-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_passwd-2.6.so.2 \
+    target=back_passwd-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_passwd-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_perl.so target=back_perl-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_perl-2.6.so.2 target=back_perl-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_perl-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_relay.so target=back_relay-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_relay-2.6.so.2 \
+    target=back_relay-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_relay-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sock.so target=back_sock-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sock-2.6.so.2 target=back_sock-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_sock-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sql.so target=back_sql-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/back_sql-2.6.so.2 target=back_sql-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/back_sql-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/collect.so target=collect-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/collect-2.6.so.2 target=collect-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/collect-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/constraint.so target=constraint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/constraint-2.6.so.2 \
+    target=constraint-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/constraint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dds.so target=dds-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dds-2.6.so.2 target=dds-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/dds-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/deref.so target=deref-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/deref-2.6.so.2 target=deref-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/deref-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dyngroup.so target=dyngroup-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dyngroup-2.6.so.2 target=dyngroup-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/dyngroup-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dynlist.so target=dynlist-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/dynlist-2.6.so.2 target=dynlist-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/dynlist-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/homedir.so target=homedir-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/homedir-2.6.so.2 target=homedir-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/homedir-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/memberof.so target=memberof-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/memberof-2.6.so.2 target=memberof-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/memberof-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/otp.so target=otp-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/otp-2.6.so.2 target=otp-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/otp-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/pcache.so target=pcache-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/pcache-2.6.so.2 target=pcache-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/pcache-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/ppolicy.so target=ppolicy-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/ppolicy-2.6.so.2 target=ppolicy-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/ppolicy-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/refint.so target=refint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/refint-2.6.so.2 target=refint-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/refint-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/remoteauth.so target=remoteauth-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/remoteauth-2.6.so.2 \
+    target=remoteauth-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/remoteauth-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/retcode.so target=retcode-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/retcode-2.6.so.2 target=retcode-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/retcode-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/rwm.so target=rwm-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/rwm-2.6.so.2 target=rwm-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/rwm-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/seqmod.so target=seqmod-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/seqmod-2.6.so.2 target=seqmod-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/seqmod-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/sssvlv.so target=sssvlv-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/sssvlv-2.6.so.2 target=sssvlv-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/sssvlv-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/syncprov.so target=syncprov-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/syncprov-2.6.so.2 target=syncprov-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/syncprov-2.6.so.2.0.200
 link path=usr/lib/$(MACH64)/openldap/translucent.so \
-    target=translucent.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/translucent.so.2 \
-    target=translucent.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/translucent.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/unique.so target=unique.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/unique.so.2 target=unique.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/unique.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/valsort.so target=valsort.so.2.0.200
-link path=usr/lib/$(MACH64)/openldap/valsort.so.2 target=valsort.so.2.0.200
-file path=usr/lib/$(MACH64)/openldap/valsort.so.2.0.200
+    target=translucent-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/translucent-2.6.so.2 \
+    target=translucent-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/translucent-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/unique.so target=unique-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/unique-2.6.so.2 target=unique-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/unique-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/valsort.so target=valsort-2.6.so.2.0.200
+link path=usr/lib/$(MACH64)/openldap/valsort-2.6.so.2 target=valsort-2.6.so.2.0.200
+file path=usr/lib/$(MACH64)/openldap/valsort-2.6.so.2.0.200
 file path=usr/lib/$(MACH64)/pkgconfig/lber.pc
 file path=usr/lib/$(MACH64)/pkgconfig/ldap.pc
 file path=usr/lib/$(MACH64)/slapd mode=555

--- a/components/network/openldap/patches/LIBRELEASE.patch
+++ b/components/network/openldap/patches/LIBRELEASE.patch
@@ -1,0 +1,20 @@
+# between versions 2.4.x and 2.6.x build mechanism changed and libraries
+# libldap|lber are built now as libldap|lber.so.xxx which is different to
+# style libldap-2.4|lber-2.4
+# This brings two problems 
+# a) it clashes with the system ldap implementation (name libldap.so, too and
+# b) breaks backwards compatibility
+# this small patch brings back old naming convention
+--- openldap-2.6.1/build/top.mk	2022-01-19 19:32:34.000000000 +0000
++++ openldap-2.6.1/build/top.mk.new	2022-02-20 14:00:35.649028520 +0000
+@@ -73,8 +73,9 @@
+ MKVERSION = $(top_srcdir)/build/mkversion -v "$(VERSION)"
+ 
+ LIBTOOL = @LIBTOOL@
++LIBRELEASE = 2.6
+ LIBVERSION = @OPENLDAP_LIBVERSION@
+-LTVERSION = -version-info $(LIBVERSION)
++LTVERSION = -release $(LIBRELEASE) -version-info $(LIBVERSION)
+ 
+ # libtool --only flag for libraries: platform specific
+ NT_LTONLY_LIB = # --only-$(BUILD_LIBS_DYNAMIC)


### PR DESCRIPTION
Additionally only 64-bit version of slapd is built and started.