### PR TITLE
libarchive: update to 3.6.0

### DIFF
--- a/components/library/libarchive/Makefile
+++ b/components/library/libarchive/Makefile
@@ -23,12 +23,11 @@
 # Copyright (c) 2019, Michal Nowak
 #
 
-PREFERRED_BITS=		64
-BUILD_BITS=		32_and_64
+BUILD_BITS=		64_and_32
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libarchive
-COMPONENT_VERSION=	3.5.2
+COMPONENT_VERSION=	3.6.0
 COMPONENT_SUMMARY=	multi-format archive and compression library
 COMPONENT_DESCRIPTION=	The libarchive(3LIB) library provides a flexible\
  interface for reading and writing archives in various formats such as\
@@ -40,7 +39,7 @@ COMPONENT_DESCRIPTION=	The libarchive(3LIB) library provides a flexible\
 COMPONENT_SRC=		libarchive-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://www.libarchive.org/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:5f245bd5176bc5f67428eb0aa497e09979264a153a074d35416521a5b8e86189
+COMPONENT_ARCHIVE_HASH=	sha256:a36613695ffa2905fdedc997b6df04a3006ccfd71d747a339b78aa8412c3d852
 COMPONENT_ARCHIVE_URL= https://www.libarchive.org/downloads/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=        library/libarchive
 COMPONENT_CLASSIFICATION=       System/Libraries


### PR DESCRIPTION
- sample-manifest didn't change
- gmake test run fine