### PR TITLE
Add cmocka 1.1.5

### DIFF
--- a/components/developer/cmocka/Makefile
+++ b/components/developer/cmocka/Makefile
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022, Daniel Chan
+#
+
+BUILD_BITS=		64
+BUILD_STYLE=		cmake
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=         cmocka
+COMPONENT_MAJOR_VERSION=1.1
+COMPONENT_VERSION=      $(COMPONENT_MAJOR_VERSION).5
+COMPONENT_PROJECT_URL=  https://cmocka.org/
+COMPONENT_FMRI=         library/cmocka
+COMPONENT_CLASSIFICATION=Development/C
+COMPONENT_SUMMARY=      Unit testing framework for C with support for mock objects
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	sha256:51eba78277d51f0299617bedffc388b2b4ea478f5cc9876cc2544dae79638cb0
+COMPONENT_ARCHIVE_URL=	https://gitlab.com/cmocka/cmocka/-/archive/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=      Apache 2.0
+COMPONENT_LICENSE_FILE= COPYING     
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/developer/cmocka/cmocka.p5m
+++ b/components/developer/cmocka/cmocka.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Daniel Chan
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/cmocka.h
+file path=usr/include/cmocka_pbc.h
+file path=usr/lib/$(MACH64)/cmake/cmocka/cmocka-config-version.cmake
+file path=usr/lib/$(MACH64)/cmake/cmocka/cmocka-config.cmake
+link path=usr/lib/$(MACH64)/libcmocka.so target=libcmocka.so.0
+link path=usr/lib/$(MACH64)/libcmocka.so.0 target=libcmocka.so.0.7.0
+file path=usr/lib/$(MACH64)/libcmocka.so.0.7.0
+file path=usr/lib/$(MACH64)/pkgconfig/cmocka.pc

--- a/components/developer/cmocka/manifests/sample-manifest.p5m
+++ b/components/developer/cmocka/manifests/sample-manifest.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/cmocka.h
+file path=usr/include/cmocka_pbc.h
+file path=usr/lib/$(MACH64)/cmake/cmocka/cmocka-config-version.cmake
+file path=usr/lib/$(MACH64)/cmake/cmocka/cmocka-config.cmake
+link path=usr/lib/$(MACH64)/libcmocka.so target=libcmocka.so.0
+link path=usr/lib/$(MACH64)/libcmocka.so.0 target=libcmocka.so.0.7.0
+file path=usr/lib/$(MACH64)/libcmocka.so.0.7.0
+file path=usr/lib/$(MACH64)/pkgconfig/cmocka.pc

--- a/components/developer/cmocka/pkg5
+++ b/components/developer/cmocka/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "library/cmocka"
+    ],
+    "name": "cmocka"
+}


### PR DESCRIPTION
This is to add comcka 1.1.5, which provides a testing framework for C.