### PR TITLE
binutils: build with --enable-plugins

### DIFF
--- a/components/developer/binutils/Makefile
+++ b/components/developer/binutils/Makefile
@@ -32,6 +32,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		binutils
 COMPONENT_VERSION=	2.37
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	GNU collection of binary tools like ld, as
 COMPONENT_PROJECT_URL=	https://www.gnu.org/software/binutils/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -54,7 +55,7 @@ CONFIGURE_OPTIONS +=	--mandir=$(CONFIGURE_MANDIR)
 CONFIGURE_OPTIONS +=	--infodir=$(CONFIGURE_INFODIR)
 CONFIGURE_OPTIONS +=	--enable-64-bit-bfd
 CONFIGURE_OPTIONS +=    --enable-gold=no
-CONFIGURE_OPTIONS +=    --enable-plugins=no
+CONFIGURE_OPTIONS +=    --enable-plugins=yes
 CONFIGURE_OPTIONS +=    --enable-nls
 CONFIGURE_OPTIONS +=    --disable-libtool-lock
 CONFIGURE_OPTIONS +=    --enable-largefile=yes

--- a/components/developer/binutils/binutils.p5m
+++ b/components/developer/binutils/binutils.p5m
@@ -103,6 +103,7 @@ file path=usr/gnu/include/ctf-api.h
 file path=usr/gnu/include/ctf.h
 file path=usr/gnu/include/diagnostics.h
 file path=usr/gnu/include/dis-asm.h
+file path=usr/gnu/include/plugin-api.h
 file path=usr/gnu/include/symcat.h
 file path=usr/gnu/lib/$(MACH64)/bfd-plugins/libdep.so
 file path=usr/gnu/lib/$(MACH64)/libbfd.a

--- a/components/developer/binutils/manifests/sample-manifest.p5m
+++ b/components/developer/binutils/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2021 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -241,6 +241,7 @@ file path=usr/gnu/include/ctf-api.h
 file path=usr/gnu/include/ctf.h
 file path=usr/gnu/include/diagnostics.h
 file path=usr/gnu/include/dis-asm.h
+file path=usr/gnu/include/plugin-api.h
 file path=usr/gnu/include/symcat.h
 file path=usr/gnu/lib/$(MACH64)/bfd-plugins/libdep.so
 file path=usr/gnu/lib/$(MACH64)/libbfd.a


### PR DESCRIPTION
Plugin support is necessary to build the latest bhyve firmware, see #7878 
