### PR TITLE
pcre: Update to 8.45

### DIFF
--- a/components/library/pcre/Makefile
+++ b/components/library/pcre/Makefile
@@ -21,17 +21,18 @@
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2019, Michal Nowak
+# Copyright (c) 2022, Daniel Chan
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pcre
-COMPONENT_VERSION=	8.43
+COMPONENT_VERSION=	8.45
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:91e762520003013834ac1adb4a938d53b22a216341c061b0cf05603b290faf6b
-COMPONENT_ARCHIVE_URL=	ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/$(COMPONENT_ARCHIVE)
+	sha256:4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8
+COMPONENT_ARCHIVE_URL=	https://downloads.sourceforge.net/project/$(COMPONENT_NAME)/$(COMPONENT_NAME)/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_SUMMARY=	Perl-Compatible Regular Expressions
 COMPONENT_PROJECT_URL=  http://pcre.org/
 COMPONENT_FMRI=		library/pcre

--- a/components/library/pcre/pkg5
+++ b/components/library/pcre/pkg5
@@ -3,6 +3,7 @@
         "SUNWcs",
         "compress/bzip2",
         "library/zlib",
+        "shell/ksh93",
         "system/library",
         "system/library/g++-7-runtime",
         "system/library/gcc-7-runtime"


### PR DESCRIPTION
Update pcre to 8.45. Which will be used by Megasync.
Testing result is same as test/results-all.master