### PR TITLE
illumos: Ship python 3.9 versions of illumos modules

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -100,6 +100,9 @@ $(BUILD_DIR)/$(MACH)/.built: $(SOURCE_DIR)/.patched
 	  echo export BUILDPERL64=\"#\"; \
 	  echo export BUILDPY2=\"#\"; \
 	  echo export BUILDPY2TOOLS=\"#\"; \
+	  echo export PYTHON3b_VERSION="3.9"; \
+	  echo export PYTHON3b_SUFFIX=""; \
+	  echo export BUILDPY3b=""; \
 	  echo export BLD_JAVA_8=; \
 	  echo export CW_NO_SHADOW=1; \
 	  echo export __GNUC=\"\"; \
@@ -642,7 +645,8 @@ print-package-names:
 	fi
 	grep -v -x -F -f packages.ignore.in pkg5.complete.fmris > pkg5.fmris
 	cat pkg5.fmris
- 
+
 REQUIRED_PACKAGES += developer/gcc-7
 REQUIRED_PACKAGES += developer/illumos-closed
 REQUIRED_PACKAGES += runtime/python-35
+REQUIRED_PACKAGES += runtime/python-39


### PR DESCRIPTION
This will allow, in a later change, smooth movement of package/pkg to python 3.9, since libbe will already be there for us.

I've tested this with a python3.9-using pkg of mine, in as much as letting it create boot environments etc.
@citrus-it did the work to add these flags, and should check I'm not messing them up 