### PR TITLE
Assigned expected symbol versions to libXpm.so

### DIFF
--- a/components/x11/libXpm/Makefile
+++ b/components/x11/libXpm/Makefile
@@ -19,6 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME=    libXpm
 COMPONENT_VERSION= 3.5.13
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=    x11/library/libxpm
 COMPONENT_SUMMARY= libXpm - X Pixmap library 
 COMPONENT_ARCHIVE_HASH= \
@@ -36,8 +37,6 @@ CONFIGURE_OPTIONS+= --libdir=$(CONFIGURE_LIBDIR.$(BITS))
 CONFIGURE_OPTIONS+= --sbindir=$(USRSBINDIR$(BITS))
 CONFIGURE_OPTIONS+= --disable-static
 CONFIGURE_OPTIONS+= --enable-shared
-
-LD_OPTIONS_SO += -M$(COMPONENT_DIR)/mapfile-vers
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/x11/libXpm/patches/mapfile.patch
+++ b/components/x11/libXpm/patches/mapfile.patch
@@ -1,0 +1,16 @@
+Setting symbol versions as defined in mapfile-vers
+
+The original Makefile ignores the symbol version definitions
+
+--- libXpm-3.5.13/src/Makefile.am.0	2019-12-13 05:51:40.000000000 +0000
++++ libXpm-3.5.13/src/Makefile.am	2022-03-24 09:52:26.208953021 +0000
+@@ -5,7 +5,8 @@
+ AM_CPPFLAGS = -I$(top_srcdir)/include/X11/
+ AM_CFLAGS = $(CWARNFLAGS) $(XPM_CFLAGS)
+ 
+-libXpm_la_LDFLAGS = -version-number 4:11:0 -no-undefined
++libXpm_la_LDFLAGS = -version-number 4:11:0 -no-undefined \
++	-Wl,-M../../../mapfile-vers
+ libXpm_la_LIBADD =  $(XPM_LIBS)
+ 
+ libXpm_la_SOURCES =					\


### PR DESCRIPTION
The symbol versions defined in mapfile-vers were not used while linking because the variable $(LD_OPTIONS_SO) is not exported to the linker.
This causes a compatibility issue with older software.

See https://www.illumos.org/issues/14574