### PR TITLE
prep-unpack.mk: replace developer/java/jdk by developer/java/openjdk8

### DIFF
--- a/make-rules/prep-unpack.mk
+++ b/make-rules/prep-unpack.mk
@@ -61,7 +61,7 @@ USERLAND_REQUIRED_PACKAGES += compress/lzip
 USERLAND_REQUIRED_PACKAGES += compress/xz
 USERLAND_REQUIRED_PACKAGES += compress/zip
 USERLAND_REQUIRED_PACKAGES += compress/zstd
-USERLAND_REQUIRED_PACKAGES += developer/java/jdk
+USERLAND_REQUIRED_PACKAGES += developer/java/openjdk8
 USERLAND_REQUIRED_PACKAGES += runtime/ruby
 
 endif


### PR DESCRIPTION
... because developer/java/jdk was renamed to developer/java/openjdk8 many years ago and we should not force developers to install renamed packages.