### PR TITLE
zlib: upstream crc32 workaround until 1.2.13

### DIFF
--- a/components/library/zlib/Makefile
+++ b/components/library/zlib/Makefile
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013  Erol Zavidic. All rights reserved.
+# Copyright (c) 2022  Tim Mooney.  All rights reserved.
 #
 
 BUILD_BITS= 32_and_64
@@ -29,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		zlib
 COMPONENT_VERSION=	1.2.12
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	The Zip compression library
 COMPONENT_PROJECT_URL=	https://zlib.net/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/library/zlib/patches/ec3df00224d4b396e2ac6586ab5d25f673caa4c2.patch
+++ b/components/library/zlib/patches/ec3df00224d4b396e2ac6586ab5d25f673caa4c2.patch
@@ -1,0 +1,51 @@
+From ec3df00224d4b396e2ac6586ab5d25f673caa4c2 Mon Sep 17 00:00:00 2001
+From: Mark Adler <madler@alumni.caltech.edu>
+Date: Wed, 30 Mar 2022 11:14:53 -0700
+Subject: [PATCH] Correct incorrect inputs provided to the CRC functions.
+
+The previous releases of zlib were not sensitive to incorrect CRC
+inputs with bits set above the low 32. This commit restores that
+behavior, so that applications with such bugs will continue to
+operate as before.
+---
+ crc32.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/crc32.c b/crc32.c
+index a1bdce5c2..451887bc7 100644
+--- a/crc32.c
++++ b/crc32.c
+@@ -630,7 +630,7 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
+ #endif /* DYNAMIC_CRC_TABLE */
+ 
+     /* Pre-condition the CRC */
+-    crc ^= 0xffffffff;
++    crc = (~crc) & 0xffffffff;
+ 
+     /* Compute the CRC up to a word boundary. */
+     while (len && ((z_size_t)buf & 7) != 0) {
+@@ -749,7 +749,7 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
+ #endif /* DYNAMIC_CRC_TABLE */
+ 
+     /* Pre-condition the CRC */
+-    crc ^= 0xffffffff;
++    crc = (~crc) & 0xffffffff;
+ 
+ #ifdef W
+ 
+@@ -1077,7 +1077,7 @@ uLong ZEXPORT crc32_combine64(crc1, crc2, len2)
+ #ifdef DYNAMIC_CRC_TABLE
+     once(&made, make_crc_table);
+ #endif /* DYNAMIC_CRC_TABLE */
+-    return multmodp(x2nmodp(len2, 3), crc1) ^ crc2;
++    return multmodp(x2nmodp(len2, 3), crc1) ^ (crc2 & 0xffffffff);
+ }
+ 
+ /* ========================================================================= */
+@@ -1112,5 +1112,5 @@ uLong crc32_combine_op(crc1, crc2, op)
+     uLong crc2;
+     uLong op;
+ {
+-    return multmodp(op, crc1) ^ crc2;
++    return multmodp(op, crc1) ^ (crc2 & 0xffffffff);
+ }


### PR DESCRIPTION
Until 1.2.13 is released with this workaround incorporated, include upstream's crc32 patch.

https://github.com/madler/zlib/issues/613