### PR TITLE
nut: drop 32 bit support

### DIFF
--- a/components/sysutils/nut/Makefile
+++ b/components/sysutils/nut/Makefile
@@ -13,12 +13,12 @@
 # Copyright 2016 Jim Klimov
 #
 
-BUILD_BITS= 32_and_64
+BUILD_BITS= 64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=	nut
 COMPONENT_VERSION=	2.7.4
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_SUMMARY=	Network UPS Tools (NUT)
 COMPONENT_DESCRIPTION=	Network UPS Tools (NUT) is a versatile power-device monitoring toolkit to facilitate safe shutdowns
 COMPONENT_SRC=	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -27,16 +27,13 @@ COMPONENT_ARCHIVE_HASH=	\
   sha256:d580915fdf7090655c1c7c98eb116b61952553f06f0039b1f93c9f5a13e2d36b
 COMPONENT_ARCHIVE_URL=	\
   https://github.com/networkupstools/$(COMPONENT_NAME)/archive/v$(COMPONENT_VERSION).tar.gz
-COMPONENT_PROJECT_URL=	http://networkupstools.org
+COMPONENT_PROJECT_URL=	https://networkupstools.org
 COMPONENT_FMRI=	system/management/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	System/Administration and Configuration
 COMPONENT_LICENSE=	GPLv2+
 COMPONENT_LICENSE_FILE=	COPYING
 
 include $(WS_MAKE_RULES)/common.mk
-
-CXXFLAGS.32=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
-CFLAGS.32=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 CXXFLAGS += $(CXXFLAGS.$(BITS))
 CFLAGS   += $(CFLAGS.$(BITS))
@@ -49,16 +46,12 @@ COMPONENT_PREP_ACTION =	( cd $(SOURCE_DIR) && ./autogen.sh )
 COMPONENT_PRE_CONFIGURE_ACTION =	( $(CLONEY) $(SOURCE_DIR) $(@D) )
 
 # We deliver only 64-bit binaries
-CONFIGURE_BINDIR.32 = $(USRBINDIR32)
-CONFIGURE_SBINDIR.32 = $(USRSBINDIR32)
 CONFIGURE_BINDIR.64 = $(USRBINDIR)
 CONFIGURE_SBINDIR.64 = $(USRSBINDIR)
 
-CONFIGURE_ENV.32+=	LDFLAGS="$(LDFLAGS.32)"
-CONFIGURE_ENV.64+=	LDFLAGS="$(LDFLAGS.64)"
+CONFIGURE_ENV     +=	LDFLAGS="$(LDFLAGS.64)"
 
-CONFIGURE_OPTIONS.32+=	LDFLAGS="$(LDFLAGS.32)"
-CONFIGURE_OPTIONS.64+=	LDFLAGS="$(LDFLAGS.64)"
+CONFIGURE_OPTIONS +=	LDFLAGS="$(LDFLAGS.64)"
 
 CONFIGURE_OPTIONS +=	--disable-static
 CONFIGURE_OPTIONS +=	--enable-shared
@@ -79,12 +72,9 @@ CONFIGURE_OPTIONS +=	--with-ssl
 CONFIGURE_OPTIONS +=	--with-openssl
 CONFIGURE_OPTIONS +=	--with-gd-includes=-I/usr/include/gd2
 
-CONFIGURE_OPTIONS.32 +=	--with-drvpath=/usr/lib/nut/bin/$(MACH32)
-CONFIGURE_OPTIONS.32 +=	--with-cgipath=/usr/lib/nut/cgi-bin/$(MACH32)
-CONFIGURE_OPTIONS.32 +=	--with-gd-libs=-L/usr/lib
-CONFIGURE_OPTIONS.64 +=	--with-drvpath=/usr/lib/nut/bin
-CONFIGURE_OPTIONS.64 +=	--with-cgipath=/usr/lib/nut/cgi-bin
-CONFIGURE_OPTIONS.64 +=	--with-gd-libs=-L/usr/lib/$(MACH64)
+CONFIGURE_OPTIONS +=	--with-drvpath=/usr/lib/nut/bin
+CONFIGURE_OPTIONS +=	--with-cgipath=/usr/lib/nut/cgi-bin
+CONFIGURE_OPTIONS +=	--with-gd-libs=-L/usr/lib/$(MACH64)
 
 # No separate toggle for this yet
 #CONFIGURE_OPTIONS +=	--with-nut-scanner=yes
@@ -111,23 +101,23 @@ CONFIGURE_OPTIONS +=	--with-net-snmp-config=$(USRBINDIR)/net-snmp-config-$(BITS)
 # Note: building the numerous documents of this projects is time-consuming
 # and we only need one copy. Also, we don't ship "dblatex" (needed here for
 # compiling PDFs) and probably don't require "html-chunked" chapters.
-CONFIGURE_OPTIONS.32 +=        --with-doc="no"
-CONFIGURE_OPTIONS.64 +=        --with-doc="man=yes"
+CONFIGURE_OPTIONS +=        --with-doc="man=yes"
 
 CONFIGURE_OPTIONS +=	$(CONFIGURE_OPTIONS.$(BITS))
 
 # Manually added dependencies:
 REQUIRED_PACKAGES += text/asciidoc
+REQUIRED_PACKAGES += library/augeas-tools
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/gd
 REQUIRED_PACKAGES += library/libtool/libltdl
 REQUIRED_PACKAGES += library/neon
 REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += shell/ksh93
+REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += system/library/usb/libusb

--- a/components/sysutils/nut/manifests/sample-manifest.p5m
+++ b/components/sysutils/nut/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -32,12 +32,6 @@ file path=etc/nut/upssched.conf.sample
 file path=etc/nut/upsset.conf.sample
 file path=etc/nut/upsstats-single.html.sample
 file path=etc/nut/upsstats.html.sample
-file path=usr/bin/$(MACH32)/nut-scanner
-file path=usr/bin/$(MACH32)/upsc
-file path=usr/bin/$(MACH32)/upscmd
-file path=usr/bin/$(MACH32)/upslog
-file path=usr/bin/$(MACH32)/upsrw
-file path=usr/bin/$(MACH32)/upssched-cmd
 file path=usr/bin/nut-scanner
 file path=usr/bin/upsc
 file path=usr/bin/upscmd
@@ -67,69 +61,6 @@ file path=usr/lib/$(MACH64)/libupsclient.so.4.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libnutclient.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libnutscan.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libupsclient.pc
-link path=usr/lib/libnutclient.so target=libnutclient.so.0.0.0
-link path=usr/lib/libnutclient.so.0 target=libnutclient.so.0.0.0
-file path=usr/lib/libnutclient.so.0.0.0
-link path=usr/lib/libnutscan.so target=libnutscan.so.1.0.0
-link path=usr/lib/libnutscan.so.1 target=libnutscan.so.1.0.0
-file path=usr/lib/libnutscan.so.1.0.0
-link path=usr/lib/libupsclient.so target=libupsclient.so.4.0.0
-link path=usr/lib/libupsclient.so.4 target=libupsclient.so.4.0.0
-file path=usr/lib/libupsclient.so.4.0.0
-file path=usr/lib/nut/bin/$(MACH32)/al175
-file path=usr/lib/nut/bin/$(MACH32)/apcsmart
-file path=usr/lib/nut/bin/$(MACH32)/apcsmart-old
-file path=usr/lib/nut/bin/$(MACH32)/apcupsd-ups
-file path=usr/lib/nut/bin/$(MACH32)/bcmxcp
-file path=usr/lib/nut/bin/$(MACH32)/bcmxcp_usb
-file path=usr/lib/nut/bin/$(MACH32)/belkin
-file path=usr/lib/nut/bin/$(MACH32)/belkinunv
-file path=usr/lib/nut/bin/$(MACH32)/bestfcom
-file path=usr/lib/nut/bin/$(MACH32)/bestfortress
-file path=usr/lib/nut/bin/$(MACH32)/bestuferrups
-file path=usr/lib/nut/bin/$(MACH32)/bestups
-file path=usr/lib/nut/bin/$(MACH32)/blazer_ser
-file path=usr/lib/nut/bin/$(MACH32)/blazer_usb
-file path=usr/lib/nut/bin/$(MACH32)/clone
-file path=usr/lib/nut/bin/$(MACH32)/clone-outlet
-file path=usr/lib/nut/bin/$(MACH32)/dummy-ups
-file path=usr/lib/nut/bin/$(MACH32)/etapro
-file path=usr/lib/nut/bin/$(MACH32)/everups
-file path=usr/lib/nut/bin/$(MACH32)/gamatronic
-file path=usr/lib/nut/bin/$(MACH32)/genericups
-file path=usr/lib/nut/bin/$(MACH32)/isbmex
-file path=usr/lib/nut/bin/$(MACH32)/ivtscd
-file path=usr/lib/nut/bin/$(MACH32)/liebert
-file path=usr/lib/nut/bin/$(MACH32)/liebert-esp2
-file path=usr/lib/nut/bin/$(MACH32)/masterguard
-file path=usr/lib/nut/bin/$(MACH32)/metasys
-file path=usr/lib/nut/bin/$(MACH32)/mge-shut
-file path=usr/lib/nut/bin/$(MACH32)/mge-utalk
-file path=usr/lib/nut/bin/$(MACH32)/microdowell
-file path=usr/lib/nut/bin/$(MACH32)/netxml-ups
-file path=usr/lib/nut/bin/$(MACH32)/nut-ipmipsu
-file path=usr/lib/nut/bin/$(MACH32)/nutdrv_atcl_usb
-file path=usr/lib/nut/bin/$(MACH32)/nutdrv_qx
-file path=usr/lib/nut/bin/$(MACH32)/oldmge-shut
-file path=usr/lib/nut/bin/$(MACH32)/oneac
-file path=usr/lib/nut/bin/$(MACH32)/optiups
-file path=usr/lib/nut/bin/$(MACH32)/powercom
-file path=usr/lib/nut/bin/$(MACH32)/powerman-pdu
-file path=usr/lib/nut/bin/$(MACH32)/powerpanel
-file path=usr/lib/nut/bin/$(MACH32)/rhino
-file path=usr/lib/nut/bin/$(MACH32)/richcomm_usb
-file path=usr/lib/nut/bin/$(MACH32)/riello_ser
-file path=usr/lib/nut/bin/$(MACH32)/riello_usb
-file path=usr/lib/nut/bin/$(MACH32)/safenet
-file path=usr/lib/nut/bin/$(MACH32)/skel
-file path=usr/lib/nut/bin/$(MACH32)/snmp-ups
-file path=usr/lib/nut/bin/$(MACH32)/solis
-file path=usr/lib/nut/bin/$(MACH32)/tripplite
-file path=usr/lib/nut/bin/$(MACH32)/tripplite_usb
-file path=usr/lib/nut/bin/$(MACH32)/tripplitesu
-file path=usr/lib/nut/bin/$(MACH32)/upscode2
-file path=usr/lib/nut/bin/$(MACH32)/usbhid-ups
-file path=usr/lib/nut/bin/$(MACH32)/victronups
 file path=usr/lib/nut/bin/al175
 file path=usr/lib/nut/bin/apcsmart
 file path=usr/lib/nut/bin/apcsmart-old
@@ -184,19 +115,9 @@ file path=usr/lib/nut/bin/tripplitesu
 file path=usr/lib/nut/bin/upscode2
 file path=usr/lib/nut/bin/usbhid-ups
 file path=usr/lib/nut/bin/victronups
-file path=usr/lib/nut/cgi-bin/$(MACH32)/upsimage.cgi
-file path=usr/lib/nut/cgi-bin/$(MACH32)/upsset.cgi
-file path=usr/lib/nut/cgi-bin/$(MACH32)/upsstats.cgi
 file path=usr/lib/nut/cgi-bin/upsimage.cgi
 file path=usr/lib/nut/cgi-bin/upsset.cgi
 file path=usr/lib/nut/cgi-bin/upsstats.cgi
-file path=usr/lib/pkgconfig/libnutclient.pc
-file path=usr/lib/pkgconfig/libnutscan.pc
-file path=usr/lib/pkgconfig/libupsclient.pc
-file path=usr/sbin/$(MACH32)/upsd
-file path=usr/sbin/$(MACH32)/upsdrvctl
-file path=usr/sbin/$(MACH32)/upsmon
-file path=usr/sbin/$(MACH32)/upssched
 file path=usr/sbin/upsd
 file path=usr/sbin/upsdrvctl
 file path=usr/sbin/upsmon

--- a/components/sysutils/nut/nut-libs.p5m
+++ b/components/sysutils/nut/nut-libs.p5m
@@ -46,19 +46,6 @@ file path=usr/lib/$(MACH64)/pkgconfig/libnutclient.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libnutscan.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libupsclient.pc
 
-file path=usr/lib/libnutclient.so.0.0.0
-link path=usr/lib/libnutclient.so target=libnutclient.so.0.0.0
-link path=usr/lib/libnutclient.so.0 target=libnutclient.so.0.0.0
-file path=usr/lib/libnutscan.so.1.0.0
-link path=usr/lib/libnutscan.so target=libnutscan.so.1.0.0
-link path=usr/lib/libnutscan.so.1 target=libnutscan.so.1.0.0
-file path=usr/lib/libupsclient.so.4.0.0
-link path=usr/lib/libupsclient.so target=libupsclient.so.4.0.0
-link path=usr/lib/libupsclient.so.4 target=libupsclient.so.4.0.0
-file path=usr/lib/pkgconfig/libnutclient.pc
-file path=usr/lib/pkgconfig/libnutscan.pc
-file path=usr/lib/pkgconfig/libupsclient.pc
-
 file path=usr/share/man/man3/libnutclient.3
 file path=usr/share/man/man3/libnutclient_commands.3
 file path=usr/share/man/man3/libnutclient_devices.3

--- a/components/sysutils/nut/pkg5
+++ b/components/sysutils/nut/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "library/augeas-tools",
         "library/gd",
         "library/libtool/libltdl",
         "library/neon",


### PR DESCRIPTION
Remove the remaining 32-bit parts from the nut-* packages.

@jimklimov did great work to get this packaged for both 32 bit and 64 bit, it's almost a shame to remove all the 32 bit stuff.

I don't have any way to test this rebuild, so if Jim or others can test, that would be great.

Other minor changes to the package:

- switch the URL to https
- add 'augeas-tools' as a missing build dependency.  If augeas-tools isn't present on the build system, the augeas lenses don't get installed/packaged.
- update `sample-manifest`
- I manually commented out `nut-libs` from the auto-generated dependencies, since that had been done previously too.