### PR TITLE
libdvdread: update to 6.0.1

### DIFF
--- a/components/encumbered/libdvdread/Makefile
+++ b/components/encumbered/libdvdread/Makefile
@@ -18,19 +18,16 @@ BUILD_BITS=64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         libdvdread
-COMPONENT_VERSION=      5.0.4
-COMPONENT_REVISION=     2
+COMPONENT_VERSION=      6.0.1
 COMPONENT_FMRI=         library/video/libdvdread
 COMPONENT_CLASSIFICATION=System/Multimedia Libraries
 COMPONENT_SUMMARY=      Library for reading DVD video disks
-COMPONENT_GIT_HASH=494311d309441846eae697f915b61d2980bfa69d
-COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_GIT_HASH)
-COMPONENT_ARCHIVE=      $(COMPONENT_NAME)-$(COMPONENT_VERSION).zip
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= \
-	sha256:c2aa771320ba98cd279ed0ddc204c9751a981eccdb84c121e25beadb21da9300
-# 5.0.4 is a bug fix release which was never released as tarball
+	sha256:28ce4f0063883ca4d37dfd40a2f6685503d679bca7d88d58e04ee8112382d5bd
 COMPONENT_ARCHIVE_URL=  \
-	https://github.com/mirror/libdvdread/archive/$(COMPONENT_GIT_HASH).zip
+	http://download.videolan.org/pub/videolan/libdvdread/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=  http://dvdnav.mplayerhq.hu
 COMPONENT_LICENSE=      GPLv2.0
 COMPONENT_LICENSE_FILE= COPYING


### PR DESCRIPTION

there also exists  a libdvdread 6.1.1

I have no idea whether this upgrades is breaking something butI would like to try to build VLC 3.0.17.4 with it

if this PR is accepted, I can give a try to build VLC  but I must say that I am familiar with building VLC