### PR TITLE
libXvMC: update to 1.0.13

### DIFF
--- a/components/x11/libXvMC/Makefile
+++ b/components/x11/libXvMC/Makefile
@@ -18,11 +18,11 @@ include ../../../make-rules/shared-macros.mk
 include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME=    libXvMC
-COMPONENT_VERSION= 1.0.12
+COMPONENT_VERSION= 1.0.13
 COMPONENT_FMRI=    x11/library/libxvmc
-COMPONENT_SUMMARY= libXvMC - X Video Motion Compensation library 
-COMPONENT_ARCHIVE_HASH= \
-  sha256:6b3da7977b3f7eaf4f0ac6470ab1e562298d82c4e79077765787963ab7966dcd
+COMPONENT_SUMMARY= libXvMC - X Video Motion Compensation library
+COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.xz
+COMPONENT_ARCHIVE_HASH= sha256:0a9ebe6dea7888a747e5aca1b891d53cd7d3a5f141a9645f77d9b6a12cee657c
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/x11/libXvMC/pkg5
+++ b/components/x11/libXvMC/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
+        "shell/ksh93",
         "system/library",
         "x11/header/x11-protocols",
         "x11/library/libx11",


### PR DESCRIPTION
sample-manifest didn't change