### PR TITLE
vlc: update to 3.0.17.4

### DIFF
--- a/components/encumbered/vlc/Makefile
+++ b/components/encumbered/vlc/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Aurelien Larcher
+# Copyright 2022 David Stes
 #
 
 BUILD_BITS=64
@@ -18,14 +19,13 @@ BUILD_BITS=64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= vlc
-COMPONENT_VERSION= 3.0.16
-COMPONENT_REVISION= 1
+COMPONENT_VERSION= 3.0.17.4
 COMPONENT_FMRI = media/vlc
 COMPONENT_CLASSIFICATION = Applications/Sound and Video
 COMPONENT_SUMMARY= Cross-platform media player and streaming server
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH=	sha256:ffae35fc64f625c175571d2346bc5f6207be99762517f15423e74f18399410f6
+COMPONENT_ARCHIVE_HASH=	sha256:8c5a62d88a4fb45c1b095cf10befef217dfa87aedcec5184b9e7d590b6dd4133
 COMPONENT_ARCHIVE_URL=	https://download.videolan.org/pub/videolan/vlc/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://www.videolan.org/vlc
 COMPONENT_LICENSE = GPLv2.0,LGPLv2.1
@@ -107,6 +107,7 @@ CONFIGURE_OPTIONS += --enable-mad
 CONFIGURE_OPTIONS += --disable-merge-ffmpeg
 CONFIGURE_OPTIONS += --disable-gst-decode
 CONFIGURE_OPTIONS += --enable-avcodec
+CONFIGURE_OPTIONS += --disable-dav1d
 CONFIGURE_OPTIONS += --disable-libva
 CONFIGURE_OPTIONS += --disable-dxva2
 CONFIGURE_OPTIONS += --enable-avformat
@@ -201,7 +202,7 @@ REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += audio/faad2
 REQUIRED_PACKAGES += audio/mpg123
 REQUIRED_PACKAGES += audio/twolame
-REQUIRED_PACKAGES += codec/dav1d
+# REQUIRED_PACKAGES += codec/dav1d
 REQUIRED_PACKAGES += codec/flac
 REQUIRED_PACKAGES += codec/libtheora
 REQUIRED_PACKAGES += codec/speex

--- a/components/encumbered/vlc/manifests/sample-manifest.p5m
+++ b/components/encumbered/vlc/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2021 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -255,7 +255,6 @@ file path=usr/lib/$(MACH64)/vlc/plugins/codec/libavcodec_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcc_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcdg_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcvdsub_plugin.so
-file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdav1d_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdca_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libddummy_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdvbsub_plugin.so

--- a/components/encumbered/vlc/pkg5
+++ b/components/encumbered/vlc/pkg5
@@ -4,7 +4,6 @@
         "audio/faad2",
         "audio/mpg123",
         "audio/twolame",
-        "codec/dav1d",
         "codec/flac",
         "codec/libtheora",
         "codec/speex",

--- a/components/encumbered/vlc/vlc.p5m
+++ b/components/encumbered/vlc/vlc.p5m
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2015 Aurelien Larcher
+# Copyright 2022 David Stes
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -273,7 +274,7 @@ file path=usr/lib/$(MACH64)/vlc/plugins/codec/libavcodec_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcc_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcdg_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libcvdsub_plugin.so
-file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdav1d_plugin.so
+# file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdav1d_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdca_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libddummy_plugin.so
 file path=usr/lib/$(MACH64)/vlc/plugins/codec/libdvbsub_plugin.so


### PR DESCRIPTION
This updates to 3.0.17.4 which is possible thanks to the previous update of libdvdnav and libdvdread to 6.0.1.

Note that there is a problem with the codec/dav1d but I think this is a upstream problem

Also see Debian Bug#1008609: vlc: FTBFS with dav1d 1.0.0
https://code.videolan.org/videolan/vlc/-/merge_requests/1611
https://code.videolan.org/videolan/vlc/-/merge_requests/1618

Anyway for my basic usage of VLC of trying to play some DVD's when I check the codec used for the DVD in my case, it is MPEG-1/2   and I have tested that my DVD play with both VLC 2.2.8 (best results) and with 3.0.16 and 3.0.17.4.