### PR TITLE
disable qtcreator

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -23,6 +23,7 @@
 # /^package$/d
 #
 # Temporarily disable failing builds:
+/^editor\/qtcreator$/d
 /^library\/glib$/d
 /^library\/gobject-introspection$/d
 /^library\/libgdata$/d


### PR DESCRIPTION
Building qtcreator repeatedly failed when building by jenkins. It is ok when manually building, though.