### PR TITLE
sqlite-3: don't deliver 64-bit libtclsqlite3.so because it doesn't work

### DIFF
--- a/components/database/sqlite/Makefile
+++ b/components/database/sqlite/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         sqlite
 COMPONENT_VERSION=      3.38.5
-COMPONENT_REVISION=		1
+COMPONENT_REVISION=		2
 TARBALL_VERSION=		3380500
 COMPONENT_SUMMARY=		in-process SQL database engine library
 COMPONENT_SRC=          sqlite-src-$(TARBALL_VERSION)

--- a/components/database/sqlite/sqlite-tcl.p5m
+++ b/components/database/sqlite/sqlite-tcl.p5m
@@ -46,5 +46,7 @@ depend type=require fmri=$(COMPONENT_FMRI)
 
 file path=usr/lib/tcl8.6/sqlite3/libtclsqlite3.so
 file path=usr/lib/tcl8.6/sqlite3/pkgIndex.tcl
-file path=usr/lib/$(MACH64)/sqlite3/libtclsqlite3.so
-file path=usr/lib/$(MACH64)/sqlite3/pkgIndex.tcl
+# The 64-bit version of the library doesn't work. The package database/sqlcipher delivers a working version of it.
+# So this is excluded for now.
+#file path=usr/lib/$(MACH64)/sqlite3/libtclsqlite3.so
+#file path=usr/lib/$(MACH64)/sqlite3/pkgIndex.tcl


### PR DESCRIPTION
There is a strange problem with the version of libtclsqlite3.so:
relocation error: file /usr/lib/amd64/sqlite3/libtclsqlite3.so: symbol
sqlite3_prepare_v3: referenced symbol not found

Plus, the package database/sqlcipher delivers the same library which seem to work.
This needs to be investigated further.