### PR TITLE
Generate better perl sample-manifest

### DIFF
--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -306,6 +306,7 @@ $(GENERATED).p5m:	install
 		-e '/\.la$$/d' -e '/\.pyo$$/d' -e '/usr\/lib\/python[23]\..*\.pyc$$/d' \
 		-e '/usr\/lib\/python3\..*\/__pycache__\/.*/d'  | \
 		$(PKGFMT) | \
+		uniq | \
 		cat $(METADATA_TEMPLATE) - | \
 		$(TEE) $@ $(SAMPLE_MANIFEST_FILE) >/dev/null
 	if [ "$(GENERATE_GENERIC_TRANSFORMS)X" != "X" ]; \

--- a/transforms/generate-cleanup
+++ b/transforms/generate-cleanup
@@ -57,6 +57,12 @@
 <transform dir file link hardlink -> \
 	edit path "/(sparc|i386)-(sun|pc)-solaris\d\.\d+" "/$!(GNU_TRIPLET)">
 
+# perl support
+<transform dir file link hardlink -> \
+	edit path "^(usr/perl5/.*/)i86pc-solaris-(64int|thread-multi-64)/" "\1$!(PERL_ARCH)/">
+<transform dir file link hardlink -> \
+	edit path "^(usr/perl5/(vendor_perl/)?)5\.[^/]*" "\1$!(PERLVER)">
+
 <transform dir file link hardlink -> \
 	edit target "/(sparcv9|amd64)$" "/$!(MACH64)">
 <transform dir file link hardlink -> \


### PR DESCRIPTION
This replaces perl version numbers (like 5.22, 5.24, or 5.34) by `$(PERLVER)` and perl archs (like `i86pc-solaris-64int` or `i86pc-solaris-thread-multi-64`) by `$(PERL_ARCH)` in sample-manifest.  This is what we actually need in real perl manifests.