### PR TITLE
sxhkd: add version 0.6.2

### DIFF
--- a/components/desktop/sxhkd/Makefile
+++ b/components/desktop/sxhkd/Makefile
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Benjamin S. Osenbach
+#
+
+BUILD_BITS=64 # for binaries or 32_and_64 for libraries
+BUILD_STYLE=justmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=sxhkd
+COMPONENT_VERSION=0.6.2
+COMPONENT_SUMMARY= Simple X hotkey daemon
+COMPONENT_PROJECT_URL=https://github.com/baskerville/sxhkd
+COMPONENT_FMRI=application/sxhkd
+COMPONENT_CLASSIFICATION=Applications/System Utilities
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=https://github.com/baskerville/sxhkd/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=sha256:1edc8b1a8b3631c10ba9cb9df1181830dacbbdf77adb558e31d5dd2029637386
+COMPONENT_LICENSE=BSD
+TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
+include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_BUILD_ENV += PREFIX=/usr
+
+COMPONENT_INSTALL_ENV += PREFIX=/usr
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += x11/library/libxcb
+REQUIRED_PACKAGES += x11/library/xcb-util-keysyms

--- a/components/desktop/sxhkd/manifests/sample-manifest.p5m
+++ b/components/desktop/sxhkd/manifests/sample-manifest.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/sxhkd
+file path=usr/share/doc/sxhkd/examples/background_shell/profile
+file path=usr/share/doc/sxhkd/examples/background_shell/shell
+file path=usr/share/doc/sxhkd/examples/background_shell/sxhkdrc
+file path=usr/share/doc/sxhkd/examples/background_shell/xinitrc
+file path=usr/share/doc/sxhkd/examples/notification/autostart
+file path=usr/share/doc/sxhkd/examples/notification/pam_environment
+file path=usr/share/doc/sxhkd/examples/notification/sxhkd_notify
+file path=usr/share/doc/sxhkd/examples/notification/xinitrc
+file path=usr/share/man/man1/sxhkd.1

--- a/components/desktop/sxhkd/pkg5
+++ b/components/desktop/sxhkd/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library",
+        "x11/library/libxcb",
+        "x11/library/xcb-util-keysyms"
+    ],
+    "fmris": [
+        "application/sxhkd"
+    ],
+    "name": "sxhkd"
+}

--- a/components/desktop/sxhkd/sxhkd.license
+++ b/components/desktop/sxhkd/sxhkd.license
@@ -1,0 +1,22 @@
+Copyright (c) 2013, Bastien Dejean
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/components/desktop/sxhkd/sxhkd.p5m
+++ b/components/desktop/sxhkd/sxhkd.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Benjamin S. Osenbach
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/sxhkd
+file path=usr/share/doc/sxhkd/examples/background_shell/profile
+file path=usr/share/doc/sxhkd/examples/background_shell/shell
+file path=usr/share/doc/sxhkd/examples/background_shell/sxhkdrc
+file path=usr/share/doc/sxhkd/examples/background_shell/xinitrc
+file path=usr/share/doc/sxhkd/examples/notification/autostart
+file path=usr/share/doc/sxhkd/examples/notification/pam_environment
+file path=usr/share/doc/sxhkd/examples/notification/sxhkd_notify
+file path=usr/share/doc/sxhkd/examples/notification/xinitrc
+file path=usr/share/man/man1/sxhkd.1


### PR DESCRIPTION
Adding Simple X Hotkey Daemon (sxhkd) so that users can keep their custom keybindings across different window managers. It's also a dependency for bspwm, which I hope to add as well