### PR TITLE
victor-mono: update to 1.5.3

### DIFF
--- a/components/fonts/victor-mono/Makefile
+++ b/components/fonts/victor-mono/Makefile
@@ -18,14 +18,15 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=				victor-mono
 COMPONENT_SUMMARY=			Victor Mono is an open-source monospaced font with optional semi-connected cursive italics and programming symbol ligatures.
-COMPONENT_VERSION= 			1.52
+# We already had 1.52 and cannot go back. Thus, we are using HUMAN_VERSION for the "real" version number
+COMPONENT_VERSION= 			1.53
+HUMAN_VERSION=				1.5.3
 COMPONENT_PROJECT_URL= 		https://rubjo.github.io/victor-mono/
 COMPONENT_SRC_NAME=			VictorMonoAll
 COMPONENT_SRC=				$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      	$(COMPONENT_SRC).zip
 COMPONENT_ARCHIVE_URL=		https://rubjo.github.io/victor-mono/$(COMPONENT_SRC_NAME).zip
-#COMPONENT_ARCHIVE_URL=		https://github.com/rubjo/victor-mono/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH= 	sha256:090cbcf1d95f147da981173f30d481386ae065480dfe150d8a0a287fb0bcc256
+COMPONENT_ARCHIVE_HASH= 	sha256:839aa255ca6554430b6be353338431485e9c1452545c278161cc108a7ee7b1ab
 COMPONENT_LICENSE=			SIL Open Font License, Version 1.1
 COMPONENT_LICENSE_FILE=		LICENSE.txt
 

--- a/components/fonts/victor-mono/victor-mono.p5m
+++ b/components/fonts/victor-mono/victor-mono.p5m
@@ -15,6 +15,7 @@
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)


### PR DESCRIPTION
Version numbers seem to have changed. Alas we cannot go back and thus need to use HUMAN_VERSION.