### PR TITLE
QyQT5: temporarily disable runtime dependency on pyqt5-sip

### DIFF
--- a/components/python/PyQt5/Makefile
+++ b/components/python/PyQt5/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		PyQt5
 COMPONENT_VERSION=	5.15.6
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Python bindings for the Qt cross platform application toolkit
 COMPONENT_PROJECT_URL=	https://pypi.org/project/PyQt5/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -43,8 +44,9 @@ COMPONENT_LICENSE_FILE= LICENSE
 PYTHON_VERSION=	3.9
 PYTHON_VERSIONS=	3.9
 
-
+TEST_TARGET=	$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
+
 PATH=$(QT5_BINDIR):$(PATH.gnu)
 COMPONENT_INSTALL_ENV += INSTALL_ROOT=$(PROTO_DIR)
 SIP_OPTIONS += --confirm-license
@@ -86,7 +88,7 @@ COMPONENT_INSTALL_ACTION = \
 	cp $(@D)/pyuic/uic/widget-plugins/__pycache__/* $(PROTO_DIR)/usr/lib/python$(PYTHON_VERSION)/site-packages/PyQt5/uic/widget-plugins/__pycache__/
 
 
-# Build dependencies
+# Manually added build dependencies
 REQUIRED_PACKAGES += library/python/pyqtbuilder
 REQUIRED_PACKAGES += library/python/sip
 

--- a/components/python/PyQt5/PyQt5.p5m
+++ b/components/python/PyQt5/PyQt5.p5m
@@ -22,7 +22,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend type=require fmri=library/python/pyqt5-sip
+# Disable the following runtime dependency if pyt5-sip is not yet installed. We would end in a cyclic dependency with it:
+#depend type=require fmri=library/python/pyqt5-sip
 
 file path=usr/bin/pylupdate5
 file path=usr/bin/pyrcc5


### PR DESCRIPTION
This is needed to break a cyclic dependency