### PR TITLE
Switch cloney to hardlinks instead of softlinks

### DIFF
--- a/tools/cloney
+++ b/tools/cloney
@@ -52,5 +52,5 @@ gfind . -type f -o -type l | \
     while read i;
 do
 	rm -f "${destdir}/$i"
-	ln -s "${srcdir}/$i" "${destdir}/$i"
+	ln "${srcdir}/$i" "${destdir}/$i"
 done


### PR DESCRIPTION
Softlinks are causing more and more problems when using cloney. As the whole repo must be within the same Filesystem anyway it is safe to switch to hardlinks