### PR TITLE
temporarily disable failing gst-editing-services1

### DIFF
--- a/components/encumbered/components.ignore
+++ b/components/encumbered/components.ignore
@@ -1,1 +1,3 @@
 # this is a sed script
+/^library/audio/gstreamer1/editing-services$/d
+


### PR DESCRIPTION
Build fails probably because it needs updated libs.