### PR TITLE
Added imath as a replacement of ilmbase

### DIFF
--- a/components/library/imath/Makefile
+++ b/components/library/imath/Makefile
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Daniel Chan
+#
+
+BUILD_BITS=		32_and_64
+BUILD_STYLE=	cmake
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		Imath
+COMPONENT_VERSION=	3.1.5
+COMPONENT_FMRI=		library/imath
+COMPONENT_CLASSIFICATION=System/Libraries
+COMPONENT_PROJECT_URL=	https://github.com/AcademySoftwareFoundation/$(COMPONENT_NAME)
+COMPONENT_SUMMARY=	C++ representation of 2D and 3D vectors
+COMPONENT_SRC=			$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	sha256:1e9c7c94797cf7b7e61908aed1f80a331088cc7d8873318f70376e4aed5f25fb
+COMPONENT_ARCHIVE_URL=  $(COMPONENT_PROJECT_URL)/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_LICENSE=	BSD 3-Clause
+COMPONENT_LICENSE_FILE=	LICENSE.md
+
+TEST_TARGET=		$(NO_TEST)
+include $(WS_MAKE_RULES)/common.mk
+PATH=$(PATH.gnu)
+CMAKE_OPTIONS += -DCMAKE_INSTALL_PREFIX=/usr
+CMAKE_OPTIONS.32 += -DCMAKE_INSTALL_LIBDIR=lib
+CMAKE_OPTIONS.64 += -DCMAKE_INSTALL_LIBDIR=lib/amd64
+
+# Build dependencies
+REQUIRED_PACKAGES += library/qt5
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/library/imath/imath.p5m
+++ b/components/library/imath/imath.p5m
@@ -1,0 +1,78 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Daniel Chan
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/Imath/ImathBox.h
+file path=usr/include/Imath/ImathBoxAlgo.h
+file path=usr/include/Imath/ImathColor.h
+file path=usr/include/Imath/ImathColorAlgo.h
+file path=usr/include/Imath/ImathConfig.h
+file path=usr/include/Imath/ImathEuler.h
+file path=usr/include/Imath/ImathExport.h
+file path=usr/include/Imath/ImathForward.h
+file path=usr/include/Imath/ImathFrame.h
+file path=usr/include/Imath/ImathFrustum.h
+file path=usr/include/Imath/ImathFrustumTest.h
+file path=usr/include/Imath/ImathFun.h
+file path=usr/include/Imath/ImathGL.h
+file path=usr/include/Imath/ImathGLU.h
+file path=usr/include/Imath/ImathInt64.h
+file path=usr/include/Imath/ImathInterval.h
+file path=usr/include/Imath/ImathLine.h
+file path=usr/include/Imath/ImathLineAlgo.h
+file path=usr/include/Imath/ImathMath.h
+file path=usr/include/Imath/ImathMatrix.h
+file path=usr/include/Imath/ImathMatrixAlgo.h
+file path=usr/include/Imath/ImathNamespace.h
+file path=usr/include/Imath/ImathPlane.h
+file path=usr/include/Imath/ImathPlatform.h
+file path=usr/include/Imath/ImathQuat.h
+file path=usr/include/Imath/ImathRandom.h
+file path=usr/include/Imath/ImathRoots.h
+file path=usr/include/Imath/ImathShear.h
+file path=usr/include/Imath/ImathSphere.h
+file path=usr/include/Imath/ImathTypeTraits.h
+file path=usr/include/Imath/ImathVec.h
+file path=usr/include/Imath/ImathVecAlgo.h
+file path=usr/include/Imath/half.h
+file path=usr/include/Imath/halfFunction.h
+file path=usr/include/Imath/halfLimits.h
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathConfigVersion.cmake
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathTargets-release.cmake
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathTargets.cmake
+link path=usr/lib/$(MACH64)/libImath-3_1.so target=libImath-3_1.so.29
+link path=usr/lib/$(MACH64)/libImath-3_1.so.29 target=libImath-3_1.so.29.4.0
+file path=usr/lib/$(MACH64)/libImath-3_1.so.29.4.0
+link path=usr/lib/$(MACH64)/libImath.so target=libImath-3_1.so
+file path=usr/lib/$(MACH64)/pkgconfig/Imath.pc
+file path=usr/lib/cmake/Imath/ImathConfig.cmake
+file path=usr/lib/cmake/Imath/ImathConfigVersion.cmake
+file path=usr/lib/cmake/Imath/ImathTargets-release.cmake
+file path=usr/lib/cmake/Imath/ImathTargets.cmake
+link path=usr/lib/libImath-3_1.so target=libImath-3_1.so.29
+link path=usr/lib/libImath-3_1.so.29 target=libImath-3_1.so.29.4.0
+file path=usr/lib/libImath-3_1.so.29.4.0
+link path=usr/lib/libImath.so target=libImath-3_1.so
+file path=usr/lib/pkgconfig/Imath.pc

--- a/components/library/imath/manifests/sample-manifest.p5m
+++ b/components/library/imath/manifests/sample-manifest.p5m
@@ -1,0 +1,78 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/Imath/ImathBox.h
+file path=usr/include/Imath/ImathBoxAlgo.h
+file path=usr/include/Imath/ImathColor.h
+file path=usr/include/Imath/ImathColorAlgo.h
+file path=usr/include/Imath/ImathConfig.h
+file path=usr/include/Imath/ImathEuler.h
+file path=usr/include/Imath/ImathExport.h
+file path=usr/include/Imath/ImathForward.h
+file path=usr/include/Imath/ImathFrame.h
+file path=usr/include/Imath/ImathFrustum.h
+file path=usr/include/Imath/ImathFrustumTest.h
+file path=usr/include/Imath/ImathFun.h
+file path=usr/include/Imath/ImathGL.h
+file path=usr/include/Imath/ImathGLU.h
+file path=usr/include/Imath/ImathInt64.h
+file path=usr/include/Imath/ImathInterval.h
+file path=usr/include/Imath/ImathLine.h
+file path=usr/include/Imath/ImathLineAlgo.h
+file path=usr/include/Imath/ImathMath.h
+file path=usr/include/Imath/ImathMatrix.h
+file path=usr/include/Imath/ImathMatrixAlgo.h
+file path=usr/include/Imath/ImathNamespace.h
+file path=usr/include/Imath/ImathPlane.h
+file path=usr/include/Imath/ImathPlatform.h
+file path=usr/include/Imath/ImathQuat.h
+file path=usr/include/Imath/ImathRandom.h
+file path=usr/include/Imath/ImathRoots.h
+file path=usr/include/Imath/ImathShear.h
+file path=usr/include/Imath/ImathSphere.h
+file path=usr/include/Imath/ImathTypeTraits.h
+file path=usr/include/Imath/ImathVec.h
+file path=usr/include/Imath/ImathVecAlgo.h
+file path=usr/include/Imath/half.h
+file path=usr/include/Imath/halfFunction.h
+file path=usr/include/Imath/halfLimits.h
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathConfigVersion.cmake
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathTargets-release.cmake
+file path=usr/lib/$(MACH64)/cmake/Imath/ImathTargets.cmake
+link path=usr/lib/$(MACH64)/libImath-3_1.so target=libImath-3_1.so.29
+link path=usr/lib/$(MACH64)/libImath-3_1.so.29 target=libImath-3_1.so.29.4.0
+file path=usr/lib/$(MACH64)/libImath-3_1.so.29.4.0
+link path=usr/lib/$(MACH64)/libImath.so target=libImath-3_1.so
+file path=usr/lib/$(MACH64)/pkgconfig/Imath.pc
+file path=usr/lib/cmake/Imath/ImathConfig.cmake
+file path=usr/lib/cmake/Imath/ImathConfigVersion.cmake
+file path=usr/lib/cmake/Imath/ImathTargets-release.cmake
+file path=usr/lib/cmake/Imath/ImathTargets.cmake
+link path=usr/lib/libImath-3_1.so target=libImath-3_1.so.29
+link path=usr/lib/libImath-3_1.so.29 target=libImath-3_1.so.29.4.0
+file path=usr/lib/libImath-3_1.so.29.4.0
+link path=usr/lib/libImath.so target=libImath-3_1.so
+file path=usr/lib/pkgconfig/Imath.pc

--- a/components/library/imath/pkg5
+++ b/components/library/imath/pkg5
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "library/qt5",
+        "shell/ksh93",
+        "system/library",
+        "system/library/g++-7-runtime",
+        "system/library/math"
+    ],
+    "fmris": [
+        "library/imath"
+    ],
+    "name": "Imath"
+}


### PR DESCRIPTION
IlmBase has been superceded by Imath since OpenEXR 3.0. 
The affected packages will be pushed.

pkg search -r -H -o pkg.name "depend:require:library/ilmbase" | sort -u
image/editor/gimp
library/audio/gstreamer1/plugin/bad
library/libfreeimage
SUNWilmbase
