### PR TITLE
opensmalltalk/cog-spur: update to 5.0.3188

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -28,9 +28,9 @@ include ../../../../make-rules/shared-macros.mk
 # sometimes the Stack VM is generated from a different VMMaker as the Cog VM
 
 COMPONENT_NAME=		cog-spur
-COMPONENT_VERSION=	5.0.3184
-GIT_TAG=		sun-v5.0.50
-PLUGIN_REV=		5.0-202205111310-cog
+COMPONENT_VERSION=	5.0.3188
+GIT_TAG=		sun-v5.0.51
+PLUGIN_REV=		5.0-202206201602-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_FMRI=		runtime/smalltalk/cog-spur
@@ -44,7 +44,7 @@ COMPONENT_LICENSE_FILE=	squeak5.license
 
 COMPONENT_SRC=		opensmalltalk-vm-$(GIT_TAG)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:43272823ef39b4fc8a2908fda10966d2ab8fb2619e7ba88408c92827cce1f281
+COMPONENT_ARCHIVE_HASH=	sha256:f45807e5bcb48fce03a561df1c55c7824247f09f639e16857f002b3b9d201365
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 TEST_TARGET= $(NO_TESTS)

--- a/components/runtime/smalltalk/cog-spur/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/cog-spur/manifests/sample-manifest.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -32,46 +33,46 @@ file path=usr/doc/squeak/LICENSE
 file path=usr/doc/squeak/README.Contributing
 file path=usr/doc/squeak/README.Keyboard
 file path=usr/doc/squeak/README.Sound
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/B3DAcceleratorPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/DESPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/ImmX11Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/MD5Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/SHA2Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/UnixOSProcessPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/VectorEnginePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/XDisplayControlPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/squeak
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/vm-display-X11.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/vm-display-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/vm-sound-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202205111310-cog-64bit/vm-sound-pulse.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/B3DAcceleratorPlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/DESPlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/FileAttributesPlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/ImmX11Plugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/LocalePlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/MD5Plugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/SHA2Plugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/Squeak3D.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/SqueakFFIPrims.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/SqueakSSL.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/UUIDPlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/UnicodePlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/UnixOSProcessPlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/VectorEnginePlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/XDisplayControlPlugin.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/squeak
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/vm-display-X11.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/vm-display-null.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/vm-sound-null.so
-file path=usr/lib/squeak/5.0-202205111310-cog-32bit/vm-sound-pulse.so
-hardlink path=usr/share/man/man1/inisqueak.1 target=squeak.1
-file path=usr/share/man/man1/squeak.1
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/VectorEnginePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/squeak
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202206201602-cog-64bit/vm-sound-pulse.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/B3DAcceleratorPlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/DESPlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/FileAttributesPlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/ImmX11Plugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/LocalePlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/MD5Plugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/SHA2Plugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/Squeak3D.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/SqueakFFIPrims.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/SqueakSSL.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/UUIDPlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/UnicodePlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/UnixOSProcessPlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/VectorEnginePlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/XDisplayControlPlugin.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/squeak
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/vm-display-X11.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/vm-display-null.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/vm-sound-null.so
+file path=usr/lib/squeak/5.0-202206201602-cog-32bit/vm-sound-pulse.so
+file path=usr/share/man/man1/inisqueak.1
+hardlink path=usr/share/man/man1/squeak.1 target=inisqueak.1
 file path=usr/squeak

--- a/components/runtime/smalltalk/cog-spur/patches/02-sqSCCSVersion.patch
+++ b/components/runtime/smalltalk/cog-spur/patches/02-sqSCCSVersion.patch
@@ -1,15 +1,15 @@
---- opensmalltalk-vm-sun-v5.0.50/platforms/Cross/vm/sqSCCSVersion.h	Wed May 11 15:10:54 2022
-+++ p0/opensmalltalk-vm-sun-v5.0.50/platforms/Cross/vm/sqSCCSVersion.h	Thu May 12 17:46:47 2022
+--- opensmalltalk-vm-sun-v5.0.51/platforms/Cross/vm/sqSCCSVersion.h	Mon Jun 20 18:02:26 2022
++++ p0/opensmalltalk-vm-sun-v5.0.51/platforms/Cross/vm/sqSCCSVersion.h	Wed Jun 22 11:31:51 2022
 @@ -30,13 +30,13 @@
  
  #if SUBVERSION
  # define PREFIX "r"
 -static char SvnRawRevisionString[] = "$Rev$";
-+static char SvnRawRevisionString[] = "$Rev: 202205111310-cog $";
++static char SvnRawRevisionString[] = "$Rev: 202206201602-cog $";
  # define REV_START (SvnRawRevisionString + 6)
  
 -static char SvnRawRevisionDate[] = "$Date$";
-+static char SvnRawRevisionDate[] = "$Date: Wed May 11 15:10:54 2022 +0200 $";
++static char SvnRawRevisionDate[] = "$Date: Mon Jun 20 18:02:26 2022 +0200 $";
  # define DATE_START (SvnRawRevisionDate + 7)
  
 -static char SvnRawRepositoryURL[] = "$URL$";
@@ -22,12 +22,12 @@
  #elif GIT
  # define PREFIX ""
 -static char GitRawRevisionString[] = "$Rev$";
-+static char GitRawRevisionString[] = "$Rev: 202205111310-cog $";
++static char GitRawRevisionString[] = "$Rev: 202206201602-cog $";
  # define REV_START (GitRawRevisionString + 6)
  # define REV_TIME_START (GitRawRevisionString + 14)
  
 -static char GitRawRevisionDate[] = "$Date$";
-+static char GitRawRevisionDate[] = "$Date: Wed May 11 15:10:54 2022 +0200 $";
++static char GitRawRevisionDate[] = "$Date: Mon Jun 20 18:02:26 2022 +0200 $";
  # define DATE_START (GitRawRevisionDate + 7)
  
 -static char GitRawRepositoryURL[] = "$URL$";
@@ -35,7 +35,7 @@
  # define URL_START (GitRawRepositoryURL + 6)
  
 -static char GitRawRevisionShortHash[] = "$CommitHash$";
-+static char GitRawRevisionShortHash[] = "$CommitHash: 2c0b967aa $";
++static char GitRawRevisionShortHash[] = "$CommitHash: 363968390 $";
  # define SHORTHASH_START (GitRawRevisionShortHash + 13)
  
  static char *

--- a/components/runtime/smalltalk/cog-spur/patches/03-sqPluginsSCCSVersion.patch
+++ b/components/runtime/smalltalk/cog-spur/patches/03-sqPluginsSCCSVersion.patch
@@ -1,11 +1,11 @@
---- opensmalltalk-vm-sun-v5.0.50/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Wed May 11 15:10:54 2022
-+++ p0/opensmalltalk-vm-sun-v5.0.50/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Thu May 12 17:46:47 2022
+--- opensmalltalk-vm-sun-v5.0.51/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Mon Jun 20 18:02:26 2022
++++ p0/opensmalltalk-vm-sun-v5.0.51/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Wed Jun 22 11:31:51 2022
 @@ -9,10 +9,10 @@
   */
  
  #if SUBVERSION
 -static char SvnRawPluginsRevisionString[] = "$Rev$";
-+static char SvnRawPluginsRevisionString[] = "$Rev: 202205111310-cog $";
++static char SvnRawPluginsRevisionString[] = "$Rev: 202206201602-cog $";
  # define PLUGINS_REV_START (SvnRawPluginsRevisionString + 6)
  
 -static char SvnRawPluginsRepositoryURL[] = "$URL$";
@@ -18,7 +18,7 @@
  # undef URL_START
  #elif GIT
 -static char GitRawPluginsRevisionString[] = "$Rev$";
-+static char GitRawPluginsRevisionString[] = "$Rev: 202205111310-cog $";
++static char GitRawPluginsRevisionString[] = "$Rev: 202206201602-cog $";
  # define PLUGINS_REV_START (GitRawPluginsRevisionString + 6)
  
 -static char GitRawPluginsRepositoryURL[] = "$URL$";

--- a/components/runtime/smalltalk/cog-spur/plugins.int
+++ b/components/runtime/smalltalk/cog-spur/plugins.int
@@ -19,7 +19,7 @@ Float64ArrayPlugin \
 FloatArrayPlugin \
 FloatMathPlugin \
 IA32ABI \
-JoystickTabletPlugin \
+# JoystickTabletPlugin \
 JPEGReaderPlugin \
 JPEGReadWriter2Plugin \
 Klatt \

--- a/components/runtime/smalltalk/cog-spur/squeak.ips
+++ b/components/runtime/smalltalk/cog-spur/squeak.ips
@@ -6,7 +6,7 @@
 # Last edited: 2013-11-13 19:51:35 by piumarta on emilia
 
 PATH=/usr/bin:/bin
-PLUGIN_REV=5.0-202205111310-cog
+PLUGIN_REV=5.0-202206201602-cog
 
 realpath () {
     path="$1"


### PR DESCRIPTION

update OpenSmalltalk cog-spur to latest VM

remove the Joystick plugin because the old empty stub is now implemented - but for Linux only;
as far as I know there is little interest in providing Joystick support anyway for any platform, certainly for Illumos