### PR TITLE
libass: update to 0.16.0 and enable assembly optimisations

### DIFF
--- a/components/library/libass/Makefile
+++ b/components/library/libass/Makefile
@@ -18,13 +18,13 @@ BUILD_BITS=			32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libass
-COMPONENT_VERSION=	0.15.2
+COMPONENT_VERSION=	0.16.0
 COMPONENT_FMRI=		library/video/libass
 COMPONENT_SUMMARY=	Portable renderer for the ASS/SSA (Substation Alpha) subtitle format
 COMPONENT_CLASSIFICATION=System/Multimedia Libraries
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:1b2a54dda819ef84fa2dee3069cf99748a886363d2adb630fde87fe046e2d1d5
+COMPONENT_ARCHIVE_HASH= sha256:fea8019b1887cab9ab00c1e58614b4ec2b1cee339b3f7e446f5fab01b032d430
 COMPONENT_ARCHIVE_URL=	https://github.com/libass/libass/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://github.com/libass/libass
 COMPONENT_LICENSE=	ISC
@@ -32,9 +32,13 @@ COMPONENT_LICENSE=	ISC
 TEST_TARGET=		$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 
-CONFIGURE_OPTIONS += --disable-asm
 CONFIGURE_OPTIONS += --disable-static
+CONFIGURE_OPTIONS += --with-pic
+CONFIGURE_OPTIONS.64 += --host=amd64-pc-solaris2.11
+CONFIGURE_OPTIONS.32 += --host=i686-pc-solaris2.11
 
+# build requirement
+REQUIRED_PACKAGES += developer/assembler/nasm
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/fribidi

--- a/components/library/libass/libass.p5m
+++ b/components/library/libass/libass.p5m
@@ -25,11 +25,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.1.3
-link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.1.3
-file path=usr/lib/$(MACH64)/libass.so.9.1.3
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.1.4
+link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.1.4
+file path=usr/lib/$(MACH64)/libass.so.9.1.4
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-link path=usr/lib/libass.so target=libass.so.9.1.3
-link path=usr/lib/libass.so.9 target=libass.so.9.1.3
-file path=usr/lib/libass.so.9.1.3
+link path=usr/lib/libass.so target=libass.so.9.1.4
+link path=usr/lib/libass.so.9 target=libass.so.9.1.4
+file path=usr/lib/libass.so.9.1.4
 file path=usr/lib/pkgconfig/libass.pc

--- a/components/library/libass/manifests/sample-manifest.p5m
+++ b/components/library/libass/manifests/sample-manifest.p5m
@@ -24,11 +24,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.1.3
-link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.1.3
-file path=usr/lib/$(MACH64)/libass.so.9.1.3
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.1.4
+link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.1.4
+file path=usr/lib/$(MACH64)/libass.so.9.1.4
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-link path=usr/lib/libass.so target=libass.so.9.1.3
-link path=usr/lib/libass.so.9 target=libass.so.9.1.3
-file path=usr/lib/libass.so.9.1.3
+link path=usr/lib/libass.so target=libass.so.9.1.4
+link path=usr/lib/libass.so.9 target=libass.so.9.1.4
+file path=usr/lib/libass.so.9.1.4
 file path=usr/lib/pkgconfig/libass.pc

--- a/components/library/libass/pkg5
+++ b/components/library/libass/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "developer/assembler/nasm",
         "library/c++/harfbuzz",
         "library/fribidi",
         "shell/ksh93",


### PR DESCRIPTION
0.16.0 did not change or remove any interfaces *(except on MS Windows)*.
Binaries linking against assembly-enabled libass builds were tested locally.