### PR TITLE
shared-macros.mk: versioned PYTHON definitions cleanup

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -745,21 +745,25 @@ PYTHON_VENDOR_PACKAGES.32 = $(PYTHON.$(PYTHON_VERSION).VENDOR_PACKAGES.32)
 PYTHON_VENDOR_PACKAGES.64 = $(PYTHON.$(PYTHON_VERSION).VENDOR_PACKAGES.64)
 PYTHON_VENDOR_PACKAGES = $(PYTHON_VENDOR_PACKAGES.$(BITS))
 
+# python2 was built for both 32- and 64-bits.
+# python3 is built for 64-bits only.
+
+PYTHON.2.7 =	/usr/bin/python2.7
 PYTHON.2.7.32 =	/usr/bin/python2.7
 PYTHON.2.7.64 =	/usr/bin/$(MACH64)/python2.7
 
-PYTHON.3.5.32 =	/usr/bin/python3.5
-PYTHON.3.5.64 =	/usr/bin/python3.5
+PYTHON.3.5 =	/usr/bin/python3.5
+PYTHON.3.5.64 =	$(PYTHON.3.5)
 
-PYTHON.3.7.32 =	/usr/bin/python3.7
-PYTHON.3.7.64 =	/usr/bin/python3.7
+PYTHON.3.7 =	/usr/bin/python3.7
+PYTHON.3.7.64 =	$(PYTHON.3.7)
 
-PYTHON.3.9.32 =	/usr/bin/python3.9
-PYTHON.3.9.64 =	/usr/bin/python3.9
+PYTHON.3.9 =	/usr/bin/python3.9
+PYTHON.3.9.64 =	$(PYTHON.3.9)
 
 PYTHON.32 =	$(PYTHON.$(PYTHON_VERSION).32)
 PYTHON.64 =	$(PYTHON.$(PYTHON_VERSION).64)
-PYTHON =	$(PYTHON.$(PYTHON_VERSION).$(BITS))
+PYTHON =	$(PYTHON.$(PYTHON_VERSION))
 
 # The default is site-packages, but that directory belongs to the end-user.
 # Modules which are shipped by the OS but not with the core Python distribution


### PR DESCRIPTION
The recent removal of default `BITS=32` uncovered the issue with versioned `PYTHON` definitions: they rely on `BITS` for tasks that are not tied to bits, for example `gmake env-check`.  While looked at it I also noticed that `PYTHON.3.X.32` exists while python3 is not build for 32-bits.  That's strange and confusing.  I attempted to clean-up this mess a bit.

I expect that after this change building of some components might fail in a case they depend on `PYTHON.3.X.32`, but currently they just fool themselves that 32-bit python3 exists.  I believe it is better to fix them than to leave them in sweet ignorance.

Feel free to ping me once such component is identified and I'll try to fix it.

I believe `PYTHON.32`, `PYTHON.64`, and `PYTHON.3.X.64` should be later removed too.  If somebody needs to run python they should be happy with `PYTHON.3.X` (or just `PYTHON`) and they should not care about python's bits.  Note: I assume python2 will die soon.

Thanks.