### PR TITLE
Add runtime/perl metapackage

### DIFF
--- a/components/meta-packages/perl/Makefile
+++ b/components/meta-packages/perl/Makefile
@@ -1,0 +1,30 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Marcel Telka
+#
+
+BUILD_STYLE = pkg
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		perl
+COMPONENT_VERSION =		$(PERL_VERSION)
+COMPONENT_SUMMARY =		Perl - Highly capable, feature-rich programming language
+COMPONENT_PROJECT_URL =		https://www.perl.org/
+COMPONENT_FMRI =		runtime/perl
+COMPONENT_CLASSIFICATION =	Development/Perl
+
+include $(WS_MAKE_RULES)/common.mk
+
+PKG_MACROS += PLV=$(shell echo $(PERL_VERSION) | tr -d .)
+
+# Auto-generated dependencies

--- a/components/meta-packages/perl/manifests/sample-manifest.p5m
+++ b/components/meta-packages/perl/manifests/sample-manifest.p5m
@@ -1,0 +1,25 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+

--- a/components/meta-packages/perl/perl.p5m
+++ b/components/meta-packages/perl/perl.p5m
@@ -1,0 +1,23 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Marcel Telka
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+depend fmri=runtime/perl-$(PLV) type=require

--- a/components/meta-packages/perl/pkg5
+++ b/components/meta-packages/perl/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "runtime/perl"
+    ],
+    "name": "perl"
+}

--- a/make-rules/common.mk
+++ b/make-rules/common.mk
@@ -121,14 +121,21 @@ TEST_TARGET ?=
 endif
 
 # For pkg-based build style, assume there are no build, install, or test steps;
-# just a package to be published.
+# just a package to be published.  However, 'gmake sample-manifest' requires
+# build dir.  Since sample-manifest generation depends on install target we
+# will abuse it to get the required dir created.
 ifeq ($(strip $(BUILD_STYLE)),pkg)
 BUILD_TARGET=
-INSTALL_TARGET=
+INSTALL_TARGET = $(BUILD_DIR)/.installed
 TEST_TARGET=
 SYSTEM_TEST_TARGET=
-build install:
+build:
 test system-test:	$(NO_TESTS)
+
+$(BUILD_DIR)/.installed:
+	$(RM) -r $(BUILD_DIR)
+	$(MKDIR) $(BUILD_DIR)
+	$(TOUCH) $@
 endif
 
 # If TEST_TARGET is NO_TESTS, assume no system tests by default.


### PR DESCRIPTION
So people could just do `pkg install perl` to get the latest fully supported perl installed.  This will also make sure that they have always at least one perl installed (the best one), even after all current `runtime/perl-5xx` packages are obsoleted.  Without this people have to run `pkg install perl-5xx` from time to time.

Imagine a guy who did `pkg install perl-522 perl-524` a year ago (all perl versions available at that time) and since that he just do `pkg update` from time to time.  Once we obsolete both perl-522 and perl-524, and the guy runs his `pkg update`, he will find that perl is gone.  The `runtime/perl` package is here to avoid that.