### PR TITLE
makemaker.mk: set component defaults

### DIFF
--- a/make-rules/common.mk
+++ b/make-rules/common.mk
@@ -28,8 +28,6 @@
 # userland components.
 #
 
-include $(WS_MAKE_RULES)/prep.mk
-
 # Override this to limit builds and publication to a single architecture.
 BUILD_ARCH ?= $(MACH)
 ifneq ($(strip $(BUILD_ARCH)),$(MACH))
@@ -53,6 +51,8 @@ ifneq ($(strip $(BUILD_STYLE)),pkg)
 include $(WS_MAKE_RULES)/$(strip $(BUILD_STYLE)).mk
 endif
 endif
+
+include $(WS_MAKE_RULES)/prep.mk
 
 ifeq ($(strip $(BUILD_STYLE)),configure)
 # Assume these items should always be set in the configure environment.  strip

--- a/make-rules/makemaker.mk
+++ b/make-rules/makemaker.mk
@@ -21,8 +21,23 @@
 # Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
 #
 
-# perl-5.22 is 32 bit (only), perl-5.24 and later are 64 bit (only)
+# Component defaults
+COMPONENT_CLASSIFICATION ?=	Development/Perl
+COMPONENT_SRC ?=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
+COMPONENT_ARCHIVE ?=		$(COMPONENT_SRC).tar.gz
+COMPONENT_FMRI ?=		library/perl-5/$(shell echo $(COMPONENT_NAME) | tr [A-Z] [a-z])
+ifneq ($(strip $(COMPONENT_PERL_MODULE)),)
+COMPONENT_NAME ?=		$(subst ::,-,$(COMPONENT_PERL_MODULE))
+COMPONENT_PROJECT_URL ?=	https://metacpan.org/pod/$(COMPONENT_PERL_MODULE)
+endif
+ifneq ($(strip $(COMPONENT_CPAN_AUTHOR)),)
+COMPONENT_CPAN_AUTHOR1 =	$(shell echo $(COMPONENT_CPAN_AUTHOR) | cut -c 1)
+COMPONENT_CPAN_AUTHOR2 =	$(shell echo $(COMPONENT_CPAN_AUTHOR) | cut -c 1-2)
+COMPONENT_CPAN_AUTHOR_URL =	$(COMPONENT_CPAN_AUTHOR1)/$(COMPONENT_CPAN_AUTHOR2)/$(COMPONENT_CPAN_AUTHOR)
+COMPONENT_ARCHIVE_URL ?=	https://cpan.metacpan.org/authors/id/$(COMPONENT_CPAN_AUTHOR_URL)/$(COMPONENT_ARCHIVE)
+endif
 
+# Common perl environment
 COMMON_PERL_ENV +=	MAKE=$(GMAKE)
 COMMON_PERL_ENV +=	PATH=$(dir $(CC)):$(SPRO_VROOT)/bin:$(PATH)
 COMMON_PERL_ENV +=	LANG=""


### PR DESCRIPTION
With this the perl module Makefiles can be simplified to contain unique and non-repeating info only.  For example the recently added Mozilla-CA could be changed like this:
```
--- a/components/perl/Mozilla-CA/Makefile
+++ b/components/perl/Mozilla-CA/Makefile
@@ -19,18 +19,13 @@ USE_COMMON_TEST_MASTER = yes

 include ../../../make-rules/shared-macros.mk

-COMPONENT_NAME =               Mozilla-CA
+COMPONENT_PERL_MODULE =                Mozilla::CA
 HUMAN_VERSION =                        20211001
 COMPONENT_VERSION =            2021.10.1
-COMPONENT_FMRI =               library/perl-5/mozilla-ca
 COMPONENT_SUMMARY =            Mozilla::CA - Mozilla's CA cert bundle in PEM format
-COMPONENT_CLASSIFICATION =     Development/Perl
-COMPONENT_SRC =                        $(COMPONENT_NAME)-$(HUMAN_VERSION)
-COMPONENT_ARCHIVE =            $(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL =                https://metacpan.org/pod/Mozilla::CA
+COMPONENT_CPAN_AUTHOR =                ABH
 COMPONENT_ARCHIVE_HASH =       \
        sha256:122c8900000a9d388aa8e44f911cab6c118fe8497417917a84a8ec183971b449
-COMPONENT_ARCHIVE_URL =                https://cpan.metacpan.org/authors/id/A/AB/ABH/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE =            MPL v2.0

 include $(WS_MAKE_RULES)/common.mk
```