### PR TITLE
build-essential: update perl runtime dependencies

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -16,7 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
-COMPONENT_VERSION =	2
+COMPONENT_VERSION =	3
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -106,7 +106,8 @@ depend fmri=developer/java/openjdk8 type=require
 depend fmri=developer/java/junit type=require
 
 # Runtimes
-depend fmri=runtime/perl-524 type=require
+depend fmri=runtime/perl-534 type=require
+depend fmri=runtime/perl-536 type=require
 depend fmri=runtime/ruby type=require
 depend fmri=runtime/lua type=require
 depend fmri=library/apr-util type=require


### PR DESCRIPTION
A minor step to get old perls retired.