### PR TITLE
component.mk: add missing file header

### DIFF
--- a/make-rules/component.mk
+++ b/make-rules/component.mk
@@ -1,3 +1,26 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2017 Gary Mills
+# Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+#
 
 # A simple rule to print the value of any macro.  Ex:
 #    $ gmake print-REQUIRED_PACKAGES


### PR DESCRIPTION
The content of this file was moved from `shared-macros.mk` (and then modified) so I copied the CDDL header as of time when the code move happened.