### PR TITLE
shared-macros.mk: set default USE_COMMON_TEST_MASTER to true

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -455,7 +455,7 @@ COMPONENT_TEST_BUILD_DIR =	$(BUILD_DIR)/test/$(MACH$(BITS))
 COMPONENT_TEST_RESULTS_DIR =	$(COMPONENT_DIR)/test
 
 # set the default master test results file
-USE_COMMON_TEST_MASTER?=no
+USE_COMMON_TEST_MASTER ?= yes
 ifeq ($(strip $(USE_COMMON_TEST_MASTER)),yes)
 COMPONENT_TEST_MASTER =		$(COMPONENT_TEST_RESULTS_DIR)/results-all.master
 else


### PR DESCRIPTION
Most components are (or should be) built 64-bit only so they (should) use single test results anyway.  Those that are not, and needs separate test results based on bitness (or in case of perl modules: based on perl version), should state this explicitly in their Makefile.