### PR TITLE
setup.py.mk: make sure setup.py is executable

### DIFF
--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -90,7 +90,7 @@ $(BUILD_DIR)/config-%/$(CFG):
 $(BUILD_DIR)/%/.built:	$(SOURCE_DIR)/.prep $(BUILD_DIR)/config-%/$(CFG)
 	$(RM) -r $(@D) ; $(MKDIR) $(@D)
 	$(COMPONENT_PRE_BUILD_ACTION)
-	(cd $(SOURCE_DIR) ; $(ENV) HOME=$(BUILD_DIR)/config-$* $(COMPONENT_BUILD_ENV) \
+	(cd $(SOURCE_DIR) && $(CHMOD) +x ./setup.py && $(ENV) HOME=$(BUILD_DIR)/config-$* $(COMPONENT_BUILD_ENV) \
 		$(PYTHON.$(BITS)) ./setup.py build $(COMPONENT_BUILD_ARGS))
 	$(COMPONENT_POST_BUILD_ACTION)
 ifeq   ($(strip $(PARFAIT_BUILD)),yes)


### PR DESCRIPTION
If setup.py is not executable builds fail with
/usr/bin/env: ./setup.py: Permission denied