### PR TITLE
Properly handle require-any dependency type for REQUIRED_PACKAGES

### DIFF
--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -523,9 +523,11 @@ REQUIRED_PACKAGES::     $(RESOLVED) $(REQUIRED_PACKAGES_RESOLVED)
 	$(GMAKE) RESOLVE_DEPS= $(BUILD_DIR)/.resolved-$(MACH)
 	@$(GSED) -i -e '/^# Auto-generated dependencies$$/,$$d' Makefile
 	@echo "# Auto-generated dependencies" >>Makefile
-	@$(PKGMOGRIFY) $(WS_TRANSFORMS)/$@ $(RESOLVED) $(REQUIRED_PACKAGES_RESOLVED) | \
-		$(GSED) -e '/^[\t ]*$$/d' -e '/^#/d' $(REQUIRED_PACKAGES_TRANSFORM) \
-			| sort -u >>Makefile
+	$(PKGMOGRIFY) $(WS_TRANSFORMS)/$@ $(RESOLVED) $(REQUIRED_PACKAGES_RESOLVED) \
+		| $(GSED) -e '/^[\t ]*$$/d' -e '/^#/d' \
+		| tr '|' '\n' \
+		| $(GSED) -e 's,pkg:/,,g' -e 's/@.*$$//g' $(REQUIRED_PACKAGES_TRANSFORM) \
+		| sort -u >>Makefile
 	@echo "*** Please edit your Makefile and verify the new or updated content at the end ***"
 
 

--- a/make-rules/makemaker.mk
+++ b/make-rules/makemaker.mk
@@ -198,8 +198,7 @@ GENERATE_EXTRA_CMD ?= \
 REQUIRED_PACKAGES_RESOLVED += $(BUILD_DIR)/META.depend.res
 $(BUILD_DIR)/META.depend.res: $(SOURCE_DIR)/.prep
 	[ -f $(SOURCE_DIR)/META.json ] && $(CAT) $(SOURCE_DIR)/META.json \
-		| $(WS_TOOLS)/perl-meta-deps $(WS_MACH) $(BUILD_DIR) $(PERL_VERSION) \
-		| $(GSED) -e 's/@[^ ]*//g' -e 's/\(fmri=[^ ]*\)/\1@0/g' > $@ || true
+		| $(WS_TOOLS)/perl-meta-deps $(WS_MACH) $(BUILD_DIR) $(PERL_VERSION) || true
 	$(TOUCH) $@
 
 # perl-meta-deps requires jq

--- a/transforms/REQUIRED_PACKAGES
+++ b/transforms/REQUIRED_PACKAGES
@@ -1,4 +1,26 @@
-# print a line "REQUIRED_PACKAGES += {pkg-short-name}"
-<transform depend fmri=pkg:/(.+)@.+ -> print REQUIRED_PACKAGES += %<1> >
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Marcel Telka
+#
+
+#
+# Convert depend action to REQUIRED_PACKAGES line.  In a case the depend action
+# contains multiple fmri attributes (usual for require-any dependency type)
+# multiple REQUIRED_PACKAGES entries are printed separated by '|'.  The output
+# will be post-processed later to convert '|' to newline and to remove leading
+# 'pkg:/' and tailing version info from package name.
+#
+<transform depend fmri=pkg:/.+ -> print %(fmri;sep="|";prefix="REQUIRED_PACKAGES += ") >
+
 # drop all actions
 <transform -> drop >


### PR DESCRIPTION
This fixes a case when a package requires _any_ version of another multiversioned package (for example `perl`, and possibly others like `python`, etc.), but the published package is constructed with dependency on one single version of such a package only.

I noticed this issue while looking at `library/gd` which currently depends on `runtime/perl-524` only:

```
$ pkg contents -mr library/gd | grep perl
depend fmri=pkg:/runtime/perl-524@5.24.3-2020.0.1.3 type=require
$
```

With this fix and after `library/gd` is rebuilt (with `gmake REQUIRED_PACKAGES` before the actual build) we should see its dependency like this:

```
depend fmri=pkg:/runtime/perl-524@5.24.3-2020.0.1.3 fmri=pkg:/runtime/perl-534@5.34.1-2022.0.0.1 fmri=pkg:/runtime/perl-522@5.22.4-2022.0.0.3 fmri=pkg:/runtime/perl-536@5.36.0-2022.0.0.0 type=require-any
```

Note: `library/gd` requires _any_ version of `perl` because it delivers `usr/bin/bdftogd` with this shebang:

```
#!/usr/bin/perl -w
```