### PR TITLE
perl/Carp-Clan: rebuild for perl 5.36 and to get packages for perl 5.…

### DIFF
--- a/components/perl/Carp-Clan/Carp-Clan-PERLVER.p5m
+++ b/components/perl/Carp-Clan/Carp-Clan-PERLVER.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 Friedrich Kink
+# This file was automatically generated using perl-integrate-module
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -26,3 +26,10 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/perl5/$(PERLVER)/man/man3/Carp::Clan.3
 file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/auto/Carp/Clan/.packlist
 file path=usr/perl5/vendor_perl/$(PERLVER)/Carp/Clan.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+#depend type=require fmri=pkg:/runtime/perl-$(PLV)

--- a/components/perl/Carp-Clan/Makefile
+++ b/components/perl/Carp-Clan/Makefile
@@ -10,38 +10,25 @@
 #
 
 #
-# Copyright 2022 Friedrich Kink
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module Carp::Clan
 #
 
 BUILD_STYLE = makemaker
-BUILD_BITS = 32_and_64
-USE_COMMON_TEST_MASTER = yes
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=			Carp-Clan
-COMPONENT_VERSION=		6.8
-COMPONENT_HUMAN=		6.08
-COMPONENT_FMRI=			library/perl-5/carp-clan
-COMPONENT_SUMMARY=		Carp::Clan - Report errors from perspective of caller of a clan of modules
-COMPONENT_CLASSIFICATION=	Development/Perl
-COMPONENT_SRC=			$(COMPONENT_NAME)-$(COMPONENT_HUMAN)
-COMPONENT_ARCHIVE=		$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL=		https://metacpan.org/pod/Carp::Clan
-COMPONENT_ARCHIVE_HASH=		sha256:c75f92e34422cc5a65ab05d155842b701452434e9aefb649d6e2289c47ef6708
-COMPONENT_ARCHIVE_URL=		https://cpan.metacpan.org/authors/id/E/ET/ETHER/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE=		Artistic
-COMPONENT_LICENSE_FILE=		LICENSE
+COMPONENT_PERL_MODULE =		Carp::Clan
+HUMAN_VERSION =			6.08
+COMPONENT_REVISION =		1
+COMPONENT_SUMMARY =		Carp::Clan - Report errors from perspective of caller of a \\\\\\\"clan\\\\\\\" of modules
+COMPONENT_CPAN_AUTHOR =		ETHER
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:c75f92e34422cc5a65ab05d155842b701452434e9aefb649d6e2289c47ef6708
+COMPONENT_LICENSE =		Artistic-1.0 OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
 
 include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_TEST_TRANSFORMS += \
-        '-e "s/,  *[0-9]* wallclock.*//"' \
-        '-e "/^\#/d"' \
-        '-e "/^PERL/d"' \
-        '-e "/^make/d"'
-
 # Auto-generated dependencies
-REQUIRED_PACKAGES += runtime/perl-522
-REQUIRED_PACKAGES += runtime/perl-524
-REQUIRED_PACKAGES += runtime/perl-534
+PERL_REQUIRED_PACKAGES += runtime/perl

--- a/components/perl/Carp-Clan/history
+++ b/components/perl/Carp-Clan/history
@@ -1,0 +1,2 @@
+library/perl-5/carp-clan-522@6.8,5.11-2022.0.0.1
+library/perl-5/carp-clan-524@6.8,5.11-2022.0.0.1

--- a/components/perl/Carp-Clan/manifests/sample-manifest.p5m
+++ b/components/perl/Carp-Clan/manifests/sample-manifest.p5m
@@ -13,7 +13,7 @@
 # Copyright 2022 <contributor>
 #
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
@@ -26,3 +26,10 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/perl5/$(PERLVER)/man/man3/Carp::Clan.3
 file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/auto/Carp/Clan/.packlist
 file path=usr/perl5/vendor_perl/$(PERLVER)/Carp/Clan.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+#depend type=require fmri=pkg:/runtime/perl-$(PLV)

--- a/components/perl/Carp-Clan/pkg5
+++ b/components/perl/Carp-Clan/pkg5
@@ -1,16 +1,14 @@
 {
     "dependencies": [
         "SUNWcs",
-        "runtime/perl-522",
-        "runtime/perl-524",
         "runtime/perl-534",
+        "runtime/perl-536",
         "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "library/perl-5/carp-clan-522",
-        "library/perl-5/carp-clan-524",
         "library/perl-5/carp-clan-534",
+        "library/perl-5/carp-clan-536",
         "library/perl-5/carp-clan"
     ],
     "name": "Carp-Clan"


### PR DESCRIPTION
…22 and 5.24 obsoleted