### PR TITLE
minimal_install: remove system/library/processor, obseleted by illumos#14802

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	50
+COMPONENT_REVISION=	51
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -181,7 +181,6 @@ depend type=require fmri=system/library/libfcoe
 depend type=require fmri=system/library/math
 depend type=require fmri=system/library/mozilla-nss
 depend type=require fmri=system/library/platform
-depend type=require fmri=system/library/processor
 depend type=require fmri=system/library/security/gss
 depend type=require fmri=system/library/security/gss/diffie-hellman
 depend type=require fmri=system/library/security/gss/spnego


### PR DESCRIPTION
This probably fixes building the OI installers, but also anything else using minimal_install.

Please do check this out though, I'm not expert in these things any longer.