### PR TITLE
libgtop: fix build and drop 32-bit

### DIFF
--- a/components/library/libgtop/Makefile
+++ b/components/library/libgtop/Makefile
@@ -14,12 +14,12 @@
 # Copyright 2020 Marco van Wieringen
 #
 
-BUILD_BITS= 32_and_64
-
+BUILD_BITS= 64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libgtop
 COMPONENT_VERSION= 2.40.0
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= Library to get system specific data
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
@@ -27,7 +27,7 @@ COMPONENT_ARCHIVE_HASH= \
   sha256:78f3274c0c79c434c03655c1b35edf7b95ec0421430897fb1345a98a265ed2d4
 COMPONENT_ARCHIVE_URL= \
   https://download.gnome.org/sources/$(COMPONENT_NAME)/2.40/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL = http://www.gnome.org
+COMPONENT_PROJECT_URL = https://www.gnome.org
 COMPONENT_CLASSIFICATION = System/Libraries
 COMPONENT_FMRI = library/libgtop
 COMPONENT_LICENSE = GPLv2
@@ -52,6 +52,7 @@ COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 # Build dependencies
 REQUIRED_PACKAGES += developer/build/automake-111
 
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += x11/library/libxau

--- a/components/library/libgtop/libgtop.p5m
+++ b/components/library/libgtop/libgtop.p5m
@@ -25,8 +25,6 @@ license $(COMPONENT_LICENSE_FILE) license="$(COMPONENT_LICENSE)"
 
 <transform file path=usr/share/locale/([^/]+)(\..+){0,1}(/.+){0,1} -> default facet.locale.%<\1> true>
 
-file path=usr/bin/$(MACH64)/libgtop_daemon2
-file path=usr/bin/$(MACH64)/libgtop_server2
 file path=usr/bin/libgtop_daemon2
 file path=usr/bin/libgtop_server2
 file path=usr/include/libgtop-2.0/glibtop.h
@@ -76,11 +74,6 @@ link path=usr/lib/$(MACH64)/libgtop-2.0.so target=libgtop-2.0.so.11.0.1
 link path=usr/lib/$(MACH64)/libgtop-2.0.so.11 target=libgtop-2.0.so.11.0.1
 file path=usr/lib/$(MACH64)/libgtop-2.0.so.11.0.1
 file path=usr/lib/$(MACH64)/pkgconfig/libgtop-2.0.pc
-file path=usr/lib/libgtop-2.0.a
-link path=usr/lib/libgtop-2.0.so target=libgtop-2.0.so.11.0.1
-link path=usr/lib/libgtop-2.0.so.11 target=libgtop-2.0.so.11.0.1
-file path=usr/lib/libgtop-2.0.so.11.0.1
-file path=usr/lib/pkgconfig/libgtop-2.0.pc
 file path=usr/share/gir-1.0/GTop-2.0.gir
 file path=usr/share/info/libgtop2.info
 file path=usr/share/locale/am/LC_MESSAGES/libgtop.mo

--- a/components/library/libgtop/manifests/sample-manifest.p5m
+++ b/components/library/libgtop/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,8 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/libgtop_daemon2
-file path=usr/bin/$(MACH64)/libgtop_server2
 file path=usr/bin/libgtop_daemon2
 file path=usr/bin/libgtop_server2
 file path=usr/include/libgtop-2.0/glibtop.h
@@ -73,12 +72,8 @@ link path=usr/lib/$(MACH64)/libgtop-2.0.so target=libgtop-2.0.so.11.0.1
 link path=usr/lib/$(MACH64)/libgtop-2.0.so.11 target=libgtop-2.0.so.11.0.1
 file path=usr/lib/$(MACH64)/libgtop-2.0.so.11.0.1
 file path=usr/lib/$(MACH64)/pkgconfig/libgtop-2.0.pc
-file path=usr/lib/libgtop-2.0.a
-link path=usr/lib/libgtop-2.0.so target=libgtop-2.0.so.11.0.1
-link path=usr/lib/libgtop-2.0.so.11 target=libgtop-2.0.so.11.0.1
-file path=usr/lib/libgtop-2.0.so.11.0.1
-file path=usr/lib/pkgconfig/libgtop-2.0.pc
 file path=usr/share/gir-1.0/GTop-2.0.gir
+file path=usr/share/info/dir
 file path=usr/share/info/libgtop2.info
 file path=usr/share/locale/am/LC_MESSAGES/libgtop.mo
 file path=usr/share/locale/ar/LC_MESSAGES/libgtop.mo

--- a/components/library/libgtop/pkg5
+++ b/components/library/libgtop/pkg5
@@ -3,6 +3,7 @@
         "SUNWcs",
         "developer/build/automake-111",
         "library/glib2",
+        "shell/ksh93",
         "system/library",
         "x11/library/libxau"
     ],


### PR DESCRIPTION
32-bit can be dropped because its dependencies are all 64-bit now.