### PR TITLE
tracker: fix mode for some helpers

### DIFF
--- a/components/desktop/tracker/Makefile
+++ b/components/desktop/tracker/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         tracker
 COMPONENT_VERSION=      1.8.3
-COMPONENT_REVISION=     8
+COMPONENT_REVISION=     9
 COMPONENT_SUMMARY=      Desktop search tool
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz

--- a/components/desktop/tracker/tracker.p5m
+++ b/components/desktop/tracker/tracker.p5m
@@ -113,12 +113,12 @@ link path=usr/lib/$(MACH64)/tracker-1.0/libtracker-extract.so.0 \
     target=libtracker-extract.so.0.0.0
 file path=usr/lib/$(MACH64)/tracker-1.0/libtracker-extract.so.0.0.0
 file path=usr/lib/$(MACH64)/tracker-1.0/writeback-modules/libwriteback-taglib.so
-file path=usr/lib/tracker-extract
-file path=usr/lib/tracker-miner-apps
-file path=usr/lib/tracker-miner-fs
-file path=usr/lib/tracker-miner-user-guides
-file path=usr/lib/tracker-store
-file path=usr/lib/tracker-writeback
+file path=usr/lib/tracker-extract mode=0555
+file path=usr/lib/tracker-miner-apps mode=0555
+file path=usr/lib/tracker-miner-fs mode=0555
+file path=usr/lib/tracker-miner-user-guides mode=0555
+file path=usr/lib/tracker-store mode=0555
+file path=usr/lib/tracker-writeback mode=0555
 file path=usr/share/appdata/tracker-needle.appdata.xml
 file path=usr/share/appdata/tracker-preferences.appdata.xml
 file path=usr/share/applications/tracker-needle.desktop


### PR DESCRIPTION
These were dropped with the last fix but are obviously needed:
Jul 28 20:28:10 saturn mate-session[1302]: [ID 702911 daemon.warning] WARNING: Could not launch application 'tracker-miner-fs.desktop': Unable to start application: Kindprozess »/usr/lib/tracker-miner-fs« konnte nicht ausgeführt werden (Zugriff verweigert)
Jul 28 20:28:10 saturn mate-session[1302]: [ID 702911 daemon.warning] WARNING: Could not launch application 'tracker-miner-apps.desktop': Unable to start application: Kindprozess »/usr/lib/tracker-miner-apps« konnte nicht ausgeführt werden (Zugriff verweigert)
Jul 28 20:28:10 saturn mate-session[1302]: [ID 702911 daemon.warning] WARNING: Could not launch application 'tracker-extract.desktop': Unable to start application: Kindprozess »/usr/lib/tracker-extract« konnte nicht ausgeführt werden (Zugriff verweigert)
Jul 28 20:28:10 saturn mate-session[1302]: [ID 702911 daemon.warning] WARNING: Could not launch application 'tracker-miner-user-guides.desktop': Unable to start application: Kindprozess »/usr/lib/tracker-miner-user-guides« konnte nicht ausgeführt werden (Zugriff verweigert)
