### PR TITLE
perl/Mozilla-CA: rebuild for perl 5.36 and to get packages for perl 5…

### DIFF
--- a/components/perl/Mozilla-CA/Makefile
+++ b/components/perl/Mozilla-CA/Makefile
@@ -10,29 +10,24 @@
 #
 
 #
-# Copyright 2022 Marcel Telka
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module Mozilla::CA
 #
 
 BUILD_STYLE = makemaker
-BUILD_BITS = 32_and_64
-USE_COMMON_TEST_MASTER = yes
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME =		Mozilla-CA
+COMPONENT_PERL_MODULE =		Mozilla::CA
 HUMAN_VERSION =			20211001
-COMPONENT_VERSION =		2021.10.1
-COMPONENT_FMRI =		library/perl-5/mozilla-ca
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		Mozilla::CA - Mozilla's CA cert bundle in PEM format
-COMPONENT_CLASSIFICATION =	Development/Perl
-COMPONENT_SRC =			$(COMPONENT_NAME)-$(HUMAN_VERSION)
-COMPONENT_ARCHIVE =		$(COMPONENT_SRC).tar.gz
-COMPONENT_PROJECT_URL =		https://metacpan.org/pod/Mozilla::CA
+COMPONENT_CPAN_AUTHOR =		ABH
 COMPONENT_ARCHIVE_HASH =	\
 	sha256:122c8900000a9d388aa8e44f911cab6c118fe8497417917a84a8ec183971b449
-COMPONENT_ARCHIVE_URL =		https://cpan.metacpan.org/authors/id/A/AB/ABH/$(COMPONENT_ARCHIVE)
-COMPONENT_LICENSE =		MPL v2.0
+COMPONENT_LICENSE =		MPL-2.0
 
 include $(WS_MAKE_RULES)/common.mk
 
 # Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += runtime/perl

--- a/components/perl/Mozilla-CA/Mozilla-CA-PERLVER.p5m
+++ b/components/perl/Mozilla-CA/Mozilla-CA-PERLVER.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 Marcel Telka
+# This file was automatically generated using perl-integrate-module
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,3 +27,10 @@ file path=usr/perl5/$(PERLVER)/man/man3/Mozilla::CA.3
 file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/auto/Mozilla/CA/.packlist
 file path=usr/perl5/vendor_perl/$(PERLVER)/Mozilla/CA.pm
 file path=usr/perl5/vendor_perl/$(PERLVER)/Mozilla/CA/cacert.pem
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+#depend type=require fmri=pkg:/runtime/perl-$(PLV)

--- a/components/perl/Mozilla-CA/Mozilla-CA.license
+++ b/components/perl/Mozilla-CA/Mozilla-CA.license
@@ -1,3 +1,7 @@
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    For the bundled Mozilla CA PEM file the following applies:
+
+        This Source Code Form is subject to the terms of the Mozilla Public
+        License, v. 2.0. If a copy of the MPL was not distributed with this
+        file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    The Mozilla::CA distribution itself is available under the same license.

--- a/components/perl/Mozilla-CA/history
+++ b/components/perl/Mozilla-CA/history
@@ -1,0 +1,2 @@
+library/perl-5/mozilla-ca-522@2021.10.1,5.11-2022.0.0.1
+library/perl-5/mozilla-ca-524@2021.10.1,5.11-2022.0.0.1

--- a/components/perl/Mozilla-CA/manifests/sample-manifest.p5m
+++ b/components/perl/Mozilla-CA/manifests/sample-manifest.p5m
@@ -13,7 +13,7 @@
 # Copyright 2022 <contributor>
 #
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
@@ -28,3 +28,10 @@ file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/auto/Mozilla/CA/.packlis
 file path=usr/perl5/vendor_perl/$(PERLVER)/Mozilla/CA.pm
 file path=usr/perl5/vendor_perl/$(PERLVER)/Mozilla/CA/cacert.pem
 file path=usr/perl5/vendor_perl/$(PERLVER)/Mozilla/mk-ca-bundle.pl
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+#depend type=require fmri=pkg:/runtime/perl-$(PLV)

--- a/components/perl/Mozilla-CA/perl-integrate-module.conf
+++ b/components/perl/Mozilla-CA/perl-integrate-module.conf
@@ -1,0 +1,22 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Marcel Telka
+#
+
+%hook-no-license%
+printf "%s\n" "$COPYRIGHT" > "$DISTRIBUTION.license"
+LICENSE="MPL-2.0"
+USE_DEFAULT_PERL_LICENSE=0
+
+%hook-manifest%
+sed -i -e '/mk-ca-bundle/d' "$DISTRIBUTION-PERLVER.p5m"

--- a/components/perl/Mozilla-CA/pkg5
+++ b/components/perl/Mozilla-CA/pkg5
@@ -1,13 +1,14 @@
 {
     "dependencies": [
         "SUNWcs",
+        "runtime/perl-534",
+        "runtime/perl-536",
         "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "library/perl-5/mozilla-ca-522",
-        "library/perl-5/mozilla-ca-524",
         "library/perl-5/mozilla-ca-534",
+        "library/perl-5/mozilla-ca-536",
         "library/perl-5/mozilla-ca"
     ],
     "name": "Mozilla-CA"

--- a/components/perl/Mozilla-CA/test/results-all.master
+++ b/components/perl/Mozilla-CA/test/results-all.master
@@ -2,4 +2,3 @@ t/locate-file.t .. ok
 All tests successful.
 Files=1, Tests=3
 Result: PASS
-make[1]: Leaving directory '$(@D)'


### PR DESCRIPTION
….22 and 5.24 obsoleted