### PR TITLE
Fixup missed header file

### DIFF
--- a/components/developer/gcc-11/Makefile
+++ b/components/developer/gcc-11/Makefile
@@ -19,7 +19,7 @@ BUILD_BITS=64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_VERSION= 11.3.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SRC= gcc-releases-gcc-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_URL=	https://github.com/gcc-mirror/gcc/archive/releases/$(COMPONENT_ARCHIVE)

--- a/components/developer/gcc-11/gcc-11.p5m
+++ b/components/developer/gcc-11/gcc-11.p5m
@@ -1099,6 +1099,7 @@ file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/fma4int
 file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/fmaintrin.h variant.arch=i386
 file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/fxsrintrin.h variant.arch=i386
 file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/gcov.h
+file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/mwaitintrin.h
 file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/gfniintrin.h variant.arch=i386
 file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/hresetintrin.h variant.arch=i386
 file path=usr/gcc/11/lib/gcc/$(GNU_TRIPLET)/$(COMPONENT_VERSION)/include/ia32intrin.h variant.arch=i386


### PR DESCRIPTION
Gcc11 has a missing Header file. This fixup fixes that by delivering the missing file. My scripts have found no other potential missing headers. But there might be more.
