### PR TITLE
unzip: update fix for CVE-2014-8139; add test results

### DIFF
--- a/components/archiver/unzip/Makefile
+++ b/components/archiver/unzip/Makefile
@@ -22,11 +22,13 @@
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 #
 
+BUILD_STYLE = justmake
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		unzip
 COMPONENT_VERSION=	6.0
-COMPONENT_REVISION=	5
+COMPONENT_REVISION=	6
 COMPONENT_SRC=		$(COMPONENT_NAME)60
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tgz
 COMPONENT_ARCHIVE_HASH=	\
@@ -38,9 +40,7 @@ COMPONENT_FMRI=		compress/unzip
 
 LD_OPTIONS=
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/justmake.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 # remove the unwanted file.
 COMPONENT_PREP_ACTION = $(RM) $(SOURCE_DIR)/crc_i386.S
@@ -58,15 +58,8 @@ COMPONENT_TEST_ARGS     += -f unix/Makefile
 COMPONENT_INSTALL_ARGS += BINDIR=$(PROTOUSRBINDIR)
 COMPONENT_INSTALL_ARGS += MANDIR=$(PROTOUSRSHAREMAN1DIR)
 
-# common targets
-
-build:		$(BUILD_64)
-
-install:	$(INSTALL_64)
-
-test:		$(TEST_64)
-
 BUILD_PKG_DEPENDENCIES =	$(BUILD_TOOLS)
 
-REQUIRED_PACKAGES += SUNWcs
+# Auto-generated dependencies
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library

--- a/components/archiver/unzip/manifests/sample-manifest.p5m
+++ b/components/archiver/unzip/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/archiver/unzip/patches/CVE-2014-8139.patch
+++ b/components/archiver/unzip/patches/CVE-2014-8139.patch
@@ -1,7 +1,7 @@
-From: sms
-Subject: Fix CVE-2014-8139: CRC32 verification heap-based overflow
-Bug-Debian: http://bugs.debian.org/773722
+This patch is verbatim copy of unzip-6.0-cve-2014-8139.patch from unzip-6.0-57.fc36.src.rpm
 
+diff --git a/extract.c b/extract.c
+index 9ef80b3..c741b5f 100644
 --- a/extract.c
 +++ b/extract.c
 @@ -1,5 +1,5 @@
@@ -11,16 +11,16 @@ Bug-Debian: http://bugs.debian.org/773722
  
    See the accompanying file LICENSE, version 2009-Jan-02 or later
    (the contents of which are also included in unzip.h) for terms of use.
-@@ -298,6 +298,8 @@
+@@ -298,6 +298,8 @@ char ZCONST Far TruncNTSD[] =
  #ifndef SFX
     static ZCONST char Far InconsistEFlength[] = "bad extra-field entry:\n \
       EF block length (%u bytes) exceeds remaining EF data (%u bytes)\n";
-+   static ZCONST char Far TooSmallEFlength[] = "bad extra-field entry:\n \
++   static ZCONST char Far TooSmallEBlength[] = "bad extra-field entry:\n \
 +     EF block length (%u bytes) invalid (< %d)\n";
     static ZCONST char Far InvalidComprDataEAs[] =
       " invalid compressed data for EAs\n";
  #  if (defined(WIN32) && defined(NTSD_EAS))
-@@ -2023,7 +2025,8 @@
+@@ -2020,7 +2022,8 @@ static int TestExtraField(__G__ ef, ef_len)
          ebID = makeword(ef);
          ebLen = (unsigned)makeword(ef+EB_LEN);
  
@@ -30,20 +30,52 @@ Bug-Debian: http://bugs.debian.org/773722
             /* Discovered some extra field inconsistency! */
              if (uO.qflag)
                  Info(slide, 1, ((char *)slide, "%-22s ",
-@@ -2032,6 +2035,16 @@
-               ebLen, (ef_len - EB_HEADSIZE)));
-             return PK_ERR;
-         }
-+        else if (ebLen < EB_HEADSIZE)
-+        {
-+            /* Extra block length smaller than header length. */
-+            if (uO.qflag)
-+                Info(slide, 1, ((char *)slide, "%-22s ",
-+                  FnFilter1(G.filename)));
-+            Info(slide, 1, ((char *)slide, LoadFarString(TooSmallEFlength),
-+              ebLen, EB_HEADSIZE));
-+            return PK_ERR;
-+        }
+@@ -2155,11 +2158,29 @@ static int TestExtraField(__G__ ef, ef_len)
+                 }
+                 break;
+             case EF_PKVMS:
+-                if (makelong(ef+EB_HEADSIZE) !=
+-                    crc32(CRCVAL_INITIAL, ef+(EB_HEADSIZE+4),
+-                          (extent)(ebLen-4)))
+-                    Info(slide, 1, ((char *)slide,
+-                      LoadFarString(BadCRC_EAs)));
++                /* 2015-01-30 SMS.  Added sufficient-bytes test/message
++                 * here.  (Removed defective ebLen test above.)
++                 *
++                 * If sufficient bytes (EB_PKVMS_MINLEN) are available,
++                 * then compare the stored CRC value with the calculated
++                 * CRC for the remainder of the data (and complain about
++                 * a mismatch).
++                 */
++                if (ebLen < EB_PKVMS_MINLEN)
++                {
++                    /* Insufficient bytes available. */
++                    Info( slide, 1,
++                     ((char *)slide, LoadFarString( TooSmallEBlength),
++                     ebLen, EB_PKVMS_MINLEN));
++                }
++                else if (makelong(ef+ EB_HEADSIZE) !=
++                 crc32(CRCVAL_INITIAL,
++                 (ef+ EB_HEADSIZE+ EB_PKVMS_MINLEN),
++                 (extent)(ebLen- EB_PKVMS_MINLEN)))
++                {
++                     Info(slide, 1, ((char *)slide,
++                       LoadFarString(BadCRC_EAs)));
++                }
+                 break;
+             case EF_PKW32:
+             case EF_PKUNIX:
+diff --git a/unzpriv.h b/unzpriv.h
+index 005cee0..5c83a6e 100644
+--- a/unzpriv.h
++++ b/unzpriv.h
+@@ -1806,6 +1806,8 @@
+ #define EB_NTSD_VERSION   4    /* offset of NTSD version byte */
+ #define EB_NTSD_MAX_VER   (0)  /* maximum version # we know how to handle */
  
-         switch (ebID) {
-             case EF_OS2:
++#define EB_PKVMS_MINLEN   4    /* minimum data length of PKVMS extra block */
++
+ #define EB_ASI_CRC32      0    /* offset of ASI Unix field's crc32 checksum */
+ #define EB_ASI_MODE       4    /* offset of ASI Unix permission mode field */
+ 
+

--- a/components/archiver/unzip/pkg5
+++ b/components/archiver/unzip/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [

--- a/components/archiver/unzip/test/results-all.master
+++ b/components/archiver/unzip/test/results-all.master
@@ -1,0 +1,38 @@
+make[1]: Entering directory '$(@D)'
+#####  This is a Unix-specific target.  (Just so you know.)
+#####     Make sure unzip, funzip and unzipsfx are compiled and
+#####     in this directory.
+#####  testing extraction
+Archive:  testmake.zip
+  inflating: testmake.zipinfo        
+#####  testing zipinfo (unzip -Z)
+1,4c1,3
+< Archive:  testmake.zip
+< Zip file size: 527 bytes, number of entries: 2
+< -rw-a--     2.3 ntf      126 tx defX 98-Nov-19 22:46 notes
+< -rw-a--     2.3 ntf      236 tx defX 98-Nov-19 22:46 testmake.zipinfo
+---
+> Archive:  testmake.zip   527 bytes   2 files
+> -rw-a--     2.3 ntf      126 tx defX 19-Nov-98 22:46 notes
+> -rw-a--     2.3 ntf      236 tx defX 19-Nov-98 22:46 testmake.zipinfo
+#####  WARNING:  zipinfo output doesn't match stored version
+#####     (If the only difference is the file times, compare your
+#####      timezone with the Central European timezone, which is one
+#####      hour east of Greenwich but effectively 2 hours east
+#####      during summer Daylight Savings Time.  The upper two
+#####      lines should correspond to your local time when the
+#####      files were created, on 19 November 1998 at 10:46pm CET.
+#####      If the times are consistent, please ignore this warning.)
+#####  testing unzip -d exdir option
+Archive:  testmake.zip
+  inflating: testun/notes            
+This file is part of testmake.zip for UnZip 5.4 and
+later.  It has DOS/OS2/NT style CR-LF line-endings.
+It's pretty short.
+#####  testing unzip -o and funzip (ignore funzip warning)
+funzip warning: zipfile has more than one entry--rest ignored
+#####  testing unzipsfx (self-extractor)
+UnZipSFX 6.00 of 20 April 2009, by Info-ZIP (http://www.info-zip.org).
+  inflating: notes                   
+#####  testing complete.
+make[1]: Leaving directory '$(@D)'

--- a/components/archiver/unzip/unzip.p5m
+++ b/components/archiver/unzip/unzip.p5m
@@ -12,6 +12,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.description value="The Info-Zip (unzip) decompression utility"
 set name=pkg.summary value="Info-Zip (unzip)"
 set name=com.oracle.info.description value="the unzip decompression utility"


### PR DESCRIPTION
This fixes the following issue:

  $ touch foo
  $ jar cvf foo.jar foo
  $ unzip -t foo.jar
  Archive:  foo.jar
      testing: META-INF/               bad extra-field entry:
        EF block length (0 bytes) invalid (< 4)
      testing: META-INF/MANIFEST.MF     OK
      testing: foo                      OK
  At least one error was detected in foo.jar.
  $

More details at https://bugzilla.redhat.com/show_bug.cgi?id=1174844#c6