### PR TITLE
mate-screensaver: initial commit

### DIFF
--- a/components/desktop/mate/mate-screensaver/Makefile
+++ b/components/desktop/mate/mate-screensaver/Makefile
@@ -1,0 +1,69 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Carsten Grzemba
+#
+
+MATE_CATEGORY= APP
+BUILD_STYLE= configure
+include ../../../../make-rules/shared-macros.mk
+include $(WS_MAKE_RULES)/mate.mk
+
+COMPONENT_NAME=		mate-screensaver
+COMPONENT_MJR_VERSION=	1.26
+COMPONENT_MNR_VERSION=	1
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:4fbdb21ea4a59ea8de33ea9bf776d869753e49295604664c30e220e09659b8bc
+COMPONENT_CLASSIFICATION=	Applications/System Utilities
+COMPONENT_LICENSE= GPLv3
+COMPONENT_LICENSE_FILE= COPYING
+COMPONENT_SUMMARY= Mate Screensaver
+
+TEST_TARGET=		$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
+
+PATH=$(PATH.gnu)
+
+COMPONENT_PREP_ACTION=  cd $(@D) && NOCONFIGURE=1 ./autogen.sh
+
+# FLAVOUR = DBG
+
+CONFIGURE_OPTIONS+=	--with-console-kit
+CONFIGURE_OPTIONS+=	--enable-locking
+CONFIGURE_OPTIONS+=	--enable-pam
+CONFIGURE_OPTIONS+=	--enable-authentication-scheme=helper
+CONFIGURE_OPTIONS_DBG+=	--enable-debug
+CONFIGURE_OPTIONS+= $(CONFIGURE_OPTIONS_$(FLAVOUR))
+
+REQUIRED_PACKAGES += developer/build/autoconf-archive
+REQUIRED_PACKAGES += gnome/theme/background/os-backgrounds
+REQUIRED_PACKAGES += library/desktop/mate/libmatekbd
+REQUIRED_PACKAGES += x11/library/mesa
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
+REQUIRED_PACKAGES += library/desktop/gtk3
+REQUIRED_PACKAGES += library/desktop/libxklavier
+REQUIRED_PACKAGES += library/desktop/mate/libmatekbd
+REQUIRED_PACKAGES += library/desktop/mate/mate-desktop
+REQUIRED_PACKAGES += library/desktop/mate/mate-menus
+REQUIRED_PACKAGES += library/desktop/pango
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/libnotify
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/libdbus
+REQUIRED_PACKAGES += system/library/libdbus-glib
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11
+REQUIRED_PACKAGES += x11/library/libxext
+REQUIRED_PACKAGES += x11/library/libxscrnsaver
+REQUIRED_PACKAGES += x11/library/libxxf86vm

--- a/components/desktop/mate/mate-screensaver/manifests/sample-manifest.p5m
+++ b/components/desktop/mate/mate-screensaver/manifests/sample-manifest.p5m
@@ -1,0 +1,173 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/xdg/autostart/mate-screensaver.desktop
+file path=etc/xdg/menus/mate-screensavers.menu
+file path=usr/bin/mate-screensaver
+file path=usr/bin/mate-screensaver-command
+file path=usr/bin/mate-screensaver-preferences
+file path=usr/lib/$(MACH64)/mate/mate-screensaver-dialog
+file path=usr/lib/$(MACH64)/mate/mate-screensaver-gl-helper
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/floaters
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/mate-screensaver-pam-helper
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/popsquares
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/slideshow
+file path=usr/lib/$(MACH64)/pkgconfig/mate-screensaver.pc
+file path=usr/share/applications/mate-screensaver-preferences.desktop
+file path=usr/share/applications/screensavers/cosmos-slideshow.desktop
+file path=usr/share/applications/screensavers/footlogo-floaters.desktop
+file path=usr/share/applications/screensavers/gnomelogo-floaters.desktop
+file path=usr/share/applications/screensavers/personal-slideshow.desktop
+file path=usr/share/applications/screensavers/popsquares.desktop
+file path=usr/share/backgrounds/cosmos/background-1.xml
+file path=usr/share/backgrounds/cosmos/blue-marble-west.jpg
+file path=usr/share/backgrounds/cosmos/cloud.jpg
+file path=usr/share/backgrounds/cosmos/comet.jpg
+file path=usr/share/backgrounds/cosmos/earth-horizon.jpg
+file path=usr/share/backgrounds/cosmos/galaxy-ngc3370.jpg
+file path=usr/share/backgrounds/cosmos/helix-nebula.jpg
+file path=usr/share/backgrounds/cosmos/jupiter.jpg
+file path=usr/share/backgrounds/cosmos/sombrero.jpg
+file path=usr/share/backgrounds/cosmos/whirlpool.jpg
+file path=usr/share/dbus-1/services/org.mate.ScreenSaver.service
+file path=usr/share/desktop-directories/mate-screensaver.directory
+file path=usr/share/glib-2.0/schemas/org.mate.screensaver.gschema.xml
+file path=usr/share/locale/af/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/am/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ar/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/as/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ast/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/az/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/be/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bg/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bn_IN/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/br/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bs/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ca/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/cmn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/crh/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/cs/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/cy/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/da/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/de/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/dz/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/el/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_AU/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_CA/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_US/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/eo/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es_AR/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es_CO/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es_MX/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/et/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/eu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fa/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fi/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fr_CA/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/frp/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fur/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fy/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ga/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/gl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/gu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/he/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hi/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hy/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ia/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/id/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ie/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/is/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/it/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ja/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ka/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/kab/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/kk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/kn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ko/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ku/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ku_IQ/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ky/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/lt/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/lv/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mai/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mg/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ml/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ms/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nb/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nds/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ne/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/oc/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/or/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pa/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ps/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pt/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ro/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ru/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/rw/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sc/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/si/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sq/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sv/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ta/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/te/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/th/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/tr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/tt/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ug/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/uk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ur/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/uz/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/vi/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/wa/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/xh/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/man/man1/mate-screensaver-command.1
+file path=usr/share/man/man1/mate-screensaver-preferences.1
+file path=usr/share/man/man1/mate-screensaver.1
+file path=usr/share/mate-background-properties/cosmos.xml
+file path=usr/share/mate-screensaver/lock-dialog-default.ui
+file path=usr/share/pixmaps/gnome-logo-white.svg
+file path=usr/share/pixmaps/mate-logo-white.svg

--- a/components/desktop/mate/mate-screensaver/mate-screensaver.p5m
+++ b/components/desktop/mate/mate-screensaver/mate-screensaver.p5m
@@ -1,0 +1,173 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/xdg/autostart/mate-screensaver.desktop
+file path=etc/xdg/menus/mate-screensavers.menu
+file path=usr/bin/mate-screensaver
+file path=usr/bin/mate-screensaver-command
+file path=usr/bin/mate-screensaver-preferences
+file path=usr/lib/$(MACH64)/pkgconfig/mate-screensaver.pc
+file path=usr/lib/$(MACH64)/mate/mate-screensaver-dialog mode=0555
+file path=usr/lib/$(MACH64)/mate/mate-screensaver-gl-helper pkg.depend.bypass-generate=libGL.so.1 mode=0555
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/floaters mode=0555
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/mate-screensaver-pam-helper mode=4555
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/popsquares mode=0555
+file path=usr/lib/$(MACH64)/mate/mate-screensaver/slideshow mode=0555
+file path=usr/share/applications/mate-screensaver-preferences.desktop
+file path=usr/share/applications/screensavers/cosmos-slideshow.desktop
+file path=usr/share/applications/screensavers/footlogo-floaters.desktop
+file path=usr/share/applications/screensavers/gnomelogo-floaters.desktop
+file path=usr/share/applications/screensavers/personal-slideshow.desktop
+file path=usr/share/applications/screensavers/popsquares.desktop
+file path=usr/share/backgrounds/cosmos/background-1.xml
+file path=usr/share/backgrounds/cosmos/blue-marble-west.jpg
+file path=usr/share/backgrounds/cosmos/cloud.jpg
+file path=usr/share/backgrounds/cosmos/comet.jpg
+file path=usr/share/backgrounds/cosmos/earth-horizon.jpg
+file path=usr/share/backgrounds/cosmos/galaxy-ngc3370.jpg
+file path=usr/share/backgrounds/cosmos/helix-nebula.jpg
+file path=usr/share/backgrounds/cosmos/jupiter.jpg
+file path=usr/share/backgrounds/cosmos/sombrero.jpg
+file path=usr/share/backgrounds/cosmos/whirlpool.jpg
+file path=usr/share/dbus-1/services/org.mate.ScreenSaver.service
+file path=usr/share/desktop-directories/mate-screensaver.directory
+file path=usr/share/glib-2.0/schemas/org.mate.screensaver.gschema.xml
+file path=usr/share/locale/af/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/am/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ar/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/as/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ast/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/az/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/be/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bg/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bn_IN/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/br/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/bs/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ca/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ca@valencia/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/cmn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/crh/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/cs/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/cy/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/da/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/de/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/dz/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/el/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_AU/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_CA/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/en_US/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/eo/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es_AR/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es_CO/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/es_MX/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/et/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/eu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fa/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fi/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fr_CA/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/frp/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fur/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/fy/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ga/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/gl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/gu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/he/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hi/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/hy/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ia/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/id/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ie/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/is/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/it/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ja/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ka/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/kab/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/kk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/kn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ko/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ku/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ku_IQ/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ky/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/lt/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/lv/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mai/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mg/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ml/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/mr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ms/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nb/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nds/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ne/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/nn/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/oc/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/or/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pa/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ps/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pt/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ro/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ru/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/rw/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sc/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/si/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sl/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sq/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sr@latin/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/sv/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ta/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/te/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/th/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/tr/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/tt/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ug/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/uk/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/ur/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/uz/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/vi/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/wa/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/xh/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/locale/zu/LC_MESSAGES/mate-screensaver.mo
+file path=usr/share/man/man1/mate-screensaver-command.1
+file path=usr/share/man/man1/mate-screensaver-preferences.1
+file path=usr/share/man/man1/mate-screensaver.1
+file path=usr/share/mate-background-properties/cosmos.xml
+file path=usr/share/mate-screensaver/lock-dialog-default.ui
+file path=usr/share/pixmaps/gnome-logo-white.svg
+file path=usr/share/pixmaps/mate-logo-white.svg

--- a/components/desktop/mate/mate-screensaver/patches/01-def-environ.patch
+++ b/components/desktop/mate/mate-screensaver/patches/01-def-environ.patch
@@ -1,0 +1,15 @@
+avoid error:
+error: 'environ' undeclared (first use in this function)
+
+diff --git a/src/mate-screensaver-preferences.c b/src/mate-screensaver-preferences.c
+index 3c7621a..56685a4 100644
+--- a/src/mate-screensaver-preferences.c
++++ b/src/mate-screensaver-preferences.c
+@@ -25,7 +25,6 @@
+ 
+ #include "config.h"
+ 
+-#define _GNU_SOURCE
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <string.h>

--- a/components/desktop/mate/mate-screensaver/patches/02_pam-helper.patch
+++ b/components/desktop/mate/mate-screensaver/patches/02_pam-helper.patch
@@ -1,0 +1,15 @@
+we don't have such include file and it seems it is not needed 
+see also: https://github.com/mate-desktop/mate-screensaver/issues/272
+
+diff --git a/helper/pam-helper.c b/helper/pam-helper.c
+index 9c30c46..8291d63 100644
+--- a/helper/pam-helper.c
++++ b/helper/pam-helper.c
+@@ -33,7 +33,6 @@
+  */
+ 
+ #include <security/pam_appl.h>
+-#include <security/_pam_macros.h>
+ 
+ #include <sys/types.h>
+ #include <stdarg.h>

--- a/components/desktop/mate/mate-screensaver/patches/background-image.patch
+++ b/components/desktop/mate/mate-screensaver/patches/background-image.patch
@@ -1,0 +1,13 @@
+look more appropriate to have OI branding on the unlock screen.
+
+--- mate-screensaver-1.26.1/data/org.mate.screensaver.gschema.xml.in.old	2022-08-04 16:50:17.899658532 +0000
++++ mate-screensaver-1.26.1/data/org.mate.screensaver.gschema.xml.in	2022-08-04 16:50:37.229786423 +0000
+@@ -91,7 +91,7 @@
+       <description>Allow the session status message to be displayed when the screen is locked.</description>
+     </key>
+     <key name="picture-filename" type="s">
+-      <default>'@datadir@/backgrounds/mate/desktop/Stripes.png'</default>
++      <default>'/usr/share/pixmaps/backgrounds/openindiana/openindiana-default.jpg'</default>
+       <summary>Picture Filename</summary>
+       <description>File to use for the background image.</description>
+     </key>

--- a/components/desktop/mate/mate-screensaver/pkg5
+++ b/components/desktop/mate/mate-screensaver/pkg5
@@ -1,0 +1,35 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "developer/build/autoconf",
+        "developer/build/autoconf-archive",
+        "developer/build/pkg-config",
+        "developer/documentation-tool/gtk-doc",
+        "gnome/theme/background/os-backgrounds",
+        "library/desktop/cairo",
+        "library/desktop/gdk-pixbuf",
+        "library/desktop/gtk3",
+        "library/desktop/libxklavier",
+        "library/desktop/mate/libmatekbd",
+        "library/desktop/mate/mate-common",
+        "library/desktop/mate/mate-desktop",
+        "library/desktop/mate/mate-menus",
+        "library/desktop/pango",
+        "library/glib2",
+        "library/libnotify",
+        "shell/ksh93",
+        "system/library",
+        "system/library/libdbus",
+        "system/library/libdbus-glib",
+        "system/library/math",
+        "x11/library/libx11",
+        "x11/library/libxext",
+        "x11/library/libxscrnsaver",
+        "x11/library/libxxf86vm",
+        "x11/library/mesa"
+    ],
+    "fmris": [
+        "desktop/mate/mate-screensaver"
+    ],
+    "name": "mate-screensaver"
+}


### PR DESCRIPTION
Add mate-screensaver to oi-userland. So we can replace our outdated xscreensaver in the future.
Thanks to Geoffrey Weiss for contribution