### PR TITLE
Added plib 1.8.5

### DIFF
--- a/components/library/plib/Makefile
+++ b/components/library/plib/Makefile
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2021 Jake Goerzen
+
+BUILD_BITS=		64
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		plib
+COMPONENT_VERSION=	1.8.5
+COMPONENT_PROJECT_URL=	http://plib.sourceforge.net
+COMPONENT_SUMMARY=	PLIB - A Suite of Portable Game Libraries.
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:485b22bf6fdc0da067e34ead5e26f002b76326f6371e2ae006415dea6a380a32
+COMPONENT_ARCHIVE_URL=	http://plib.sourceforge.net/dist/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI =	library/plib
+COMPONENT_LICENSE=	LGPL
+COMPONENT_LICENSE_FILE=	COPYING
+COMPONENT_CLASSIFICATION =	System/Libraries
+
+include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_PRE_CONFIGURE_ACTION = cd $(COMPONENT_SRC) && autoreconf -if
+
+CONFIGURE_OPTIONS += --disable-static
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/library/plib/manifests/sample-manifest.p5m
+++ b/components/library/plib/manifests/sample-manifest.p5m
@@ -1,0 +1,130 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/plib/fnt.h
+file path=usr/include/plib/js.h
+file path=usr/include/plib/net.h
+file path=usr/include/plib/netBuffer.h
+file path=usr/include/plib/netChannel.h
+file path=usr/include/plib/netChat.h
+file path=usr/include/plib/netMessage.h
+file path=usr/include/plib/netMonitor.h
+file path=usr/include/plib/netSocket.h
+file path=usr/include/plib/pcx.h
+file path=usr/include/plib/psl.h
+file path=usr/include/plib/pu.h
+file path=usr/include/plib/puAux.h
+file path=usr/include/plib/puAuxLocal.h
+file path=usr/include/plib/puFLTK.h
+file path=usr/include/plib/puGLUT.h
+file path=usr/include/plib/puNative.h
+file path=usr/include/plib/puPW.h
+file path=usr/include/plib/puSDL.h
+file path=usr/include/plib/pw.h
+file path=usr/include/plib/sg.h
+file path=usr/include/plib/sl.h
+file path=usr/include/plib/slPortability.h
+file path=usr/include/plib/sm.h
+file path=usr/include/plib/ssg.h
+file path=usr/include/plib/ssgAux.h
+file path=usr/include/plib/ssgKeyFlier.h
+file path=usr/include/plib/ssgMSFSPalette.h
+file path=usr/include/plib/ssgaBillboards.h
+file path=usr/include/plib/ssgaFire.h
+file path=usr/include/plib/ssgaLensFlare.h
+file path=usr/include/plib/ssgaParticleSystem.h
+file path=usr/include/plib/ssgaScreenDump.h
+file path=usr/include/plib/ssgaShapes.h
+file path=usr/include/plib/ssgaSky.h
+file path=usr/include/plib/ssgaSphere.h
+file path=usr/include/plib/ssgaWaveSystem.h
+file path=usr/include/plib/ssgconf.h
+file path=usr/include/plib/ul.h
+file path=usr/include/plib/ulRTTI.h
+link path=usr/lib/$(MACH64)/libplibfnt.so \
+    target=libplibfnt.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibfnt.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibfnt.so.1 \
+    target=libplibfnt.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibjs.so \
+    target=libplibjs.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibjs.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibjs.so.1 \
+    target=libplibjs.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibnet.so \
+    target=libplibnet.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibnet.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibnet.so.1 \
+    target=libplibnet.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpsl.so \
+    target=libplibpsl.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpsl.so.1 \
+    target=libplibpsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpu.so \
+    target=libplibpu.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpu.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpu.so.1 \
+    target=libplibpu.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpuaux.so \
+    target=libplibpuaux.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpuaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpuaux.so.1 \
+    target=libplibpuaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpw.so \
+    target=libplibpw.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpw.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpw.so.1 \
+    target=libplibpw.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsg.so \
+    target=libplibsg.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibsg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsg.so.1 \
+    target=libplibsg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsl.so \
+    target=libplibsl.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsl.so.1 \
+    target=libplibsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsm.so \
+    target=libplibsm.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibsm.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsm.so.1 \
+    target=libplibsm.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssg.so \
+    target=libplibssg.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibssg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssg.so.1 \
+    target=libplibssg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssgaux.so \
+    target=libplibssgaux.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibssgaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssgaux.so.1 \
+    target=libplibssgaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibul.so \
+    target=libplibul.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibul.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibul.so.1 \
+    target=libplibul.so.$(COMPONENT_VERSION)

--- a/components/library/plib/patches/plib-1.8.5-shared-libs.patch
+++ b/components/library/plib/patches/plib-1.8.5-shared-libs.patch
@@ -1,0 +1,256 @@
+diff -ru ../plib-1.8.5/configure.in ./configure.in
+--- ../plib-1.8.5/configure.in	2008-03-11 03:09:43.000000000 +0100
++++ ./configure.in	2010-07-02 05:27:45.478055160 +0200
+@@ -36,7 +36,7 @@
+ AC_PROG_CXX
+ AC_PROG_CXXCPP
+ AC_PROG_INSTALL
+-AC_PROG_RANLIB
++AC_PROG_LIBTOOL
+ 
+ dnl Command line arguments
+ 
+diff -ru ../plib-1.8.5/src/fnt/Makefile.am ./src/fnt/Makefile.am
+--- ../plib-1.8.5/src/fnt/Makefile.am	2008-03-11 03:06:20.000000000 +0100
++++ ./src/fnt/Makefile.am	2010-07-02 06:17:35.838107988 +0200
+@@ -1,10 +1,13 @@
+ if BUILD_FNT
+ 
+-lib_LIBRARIES = libplibfnt.a
++lib_LTLIBRARIES = libplibfnt.la
+ 
+ include_HEADERS = fnt.h
+ 
+-libplibfnt_a_SOURCES = fnt.cxx fntTXF.cxx fntLocal.h fntBitmap.cxx
++libplibfnt_la_LDFLAGS = -version-info 9:5:8
++libplibfnt_la_LIBADD = $(top_builddir)/src/util/libplibul.la
++
++libplibfnt_la_SOURCES = fnt.cxx fntTXF.cxx fntLocal.h fntBitmap.cxx
+ 
+ INCLUDES = -I$(top_srcdir)/src/sg -I$(top_srcdir)/src/util
+ 
+diff -ru ../plib-1.8.5/src/js/Makefile.am ./src/js/Makefile.am
+--- ../plib-1.8.5/src/js/Makefile.am	2008-03-11 03:06:21.000000000 +0100
++++ ./src/js/Makefile.am	2010-07-02 06:12:40.559441988 +0200
+@@ -1,10 +1,13 @@
+ if BUILD_JS
+ 
+-lib_LIBRARIES = libplibjs.a
++lib_LTLIBRARIES = libplibjs.la
+ 
+ include_HEADERS = js.h
+ 
+-libplibjs_a_SOURCES = js.cxx jsLinux.cxx jsLinuxOld.cxx jsMacOS.cxx \
++libplibjs_la_LDFLAGS = -version-info 9:5:8
++libplibjs_la_LIBADD = $(top_builddir)/src/util/libplibul.la
++
++libplibjs_la_SOURCES = js.cxx jsLinux.cxx jsLinuxOld.cxx jsMacOS.cxx \
+                              jsMacOSX.cxx jsWindows.cxx jsBSD.cxx   \
+                              jsNone.cxx
+ 
+diff -ru ../plib-1.8.5/src/Makefile.am ./src/Makefile.am
+--- ../plib-1.8.5/src/Makefile.am	2008-03-11 03:06:24.000000000 +0100
++++ ./src/Makefile.am	2010-07-02 06:38:53.486390426 +0200
+@@ -1 +1 @@
+-SUBDIRS = util js sl pui puAux sg ssg fnt ssgAux net psl pw
++SUBDIRS = util js sl fnt pui sg ssg puAux ssgAux net psl pw
+diff -ru ../plib-1.8.5/src/net/Makefile.am ./src/net/Makefile.am
+--- ../plib-1.8.5/src/net/Makefile.am	2008-03-11 03:06:20.000000000 +0100
++++ ./src/net/Makefile.am	2010-07-02 06:14:40.710350074 +0200
+@@ -1,11 +1,14 @@
+ if BUILD_NET
+ 
+-lib_LIBRARIES = libplibnet.a
++lib_LTLIBRARIES = libplibnet.la
+ 
+ include_HEADERS = netBuffer.h netChannel.h netChat.h netMessage.h \
+ 	netMonitor.h netSocket.h net.h
+ 
+-libplibnet_a_SOURCES = netBuffer.cxx netChannel.cxx netChat.cxx \
++libplibnet_la_LDFLAGS = -version-info 9:5:8
++libplibnet_la_LIBADD = $(top_builddir)/src/util/libplibul.la
++
++libplibnet_la_SOURCES = netBuffer.cxx netChannel.cxx netChat.cxx \
+ 	netMessage.cxx netMonitor.cxx netSocket.cxx
+ 
+ INCLUDES = -I$(top_srcdir)/src/util
+diff -ru ../plib-1.8.5/src/psl/Makefile.am ./src/psl/Makefile.am
+--- ../plib-1.8.5/src/psl/Makefile.am	2008-03-11 03:06:24.000000000 +0100
++++ ./src/psl/Makefile.am	2010-07-02 06:13:48.314158343 +0200
+@@ -1,11 +1,14 @@
+ 
+ if BUILD_PSL
+ 
+-lib_LIBRARIES = libplibpsl.a
++lib_LTLIBRARIES = libplibpsl.la
+ 
+ include_HEADERS = psl.h
+ 
+-libplibpsl_a_SOURCES = psl.cxx pslCodeGen.cxx pslContext.cxx \
++libplibpsl_la_LDFLAGS = -version-info 9:5:8
++libplibpsl_la_LIBADD = $(top_builddir)/src/util/libplibul.la
++
++libplibpsl_la_SOURCES = psl.cxx pslCodeGen.cxx pslContext.cxx \
+                        pslCompiler.cxx pslSymbols.cxx pslToken.cxx \
+                        pslExpression.cxx pslProgram.cxx pslDump.cxx \
+                        pslError.cxx pslFileIO.cxx pslCompiler.h \
+diff -ru ../plib-1.8.5/src/puAux/Makefile.am ./src/puAux/Makefile.am
+--- ../plib-1.8.5/src/puAux/Makefile.am	2008-03-11 03:06:20.000000000 +0100
++++ ./src/puAux/Makefile.am	2010-07-02 06:16:04.001410273 +0200
+@@ -1,10 +1,13 @@
+ if BUILD_PUAUX
+ 
+-lib_LIBRARIES = libplibpuaux.a
++lib_LTLIBRARIES = libplibpuaux.la
+ 
+ include_HEADERS = puAux.h puAuxLocal.h
+ 
+-libplibpuaux_a_SOURCES = puAux.cxx                  \
++libplibpuaux_la_LDFLAGS = -version-info 9:5:8
++libplibpuaux_la_LIBADD = $(top_builddir)/src/util/libplibul.la $(top_builddir)/src/fnt/libplibfnt.la $(top_builddir)/src/pui/libplibpu.la $(top_builddir)/src/sg/libplibsg.la
++
++libplibpuaux_la_SOURCES = puAux.cxx                  \
+                          puAuxBiSlider.cxx          \
+                          puAuxBiSliderWithEnds.cxx  \
+                          puAuxComboBox.cxx          \
+diff -ru ../plib-1.8.5/src/pui/Makefile.am ./src/pui/Makefile.am
+--- ../plib-1.8.5/src/pui/Makefile.am	2008-03-11 03:06:23.000000000 +0100
++++ ./src/pui/Makefile.am	2010-07-02 06:14:25.110128517 +0200
+@@ -1,10 +1,13 @@
+ if BUILD_PUI
+ 
+-lib_LIBRARIES = libplibpu.a
++lib_LTLIBRARIES = libplibpu.la
+ 
+ include_HEADERS = pu.h puGLUT.h puFLTK.h puSDL.h puNative.h puPW.h
+ 
+-libplibpu_a_SOURCES = \
++libplibpu_la_LDFLAGS = -version-info 9:5:8
++libplibpu_la_LIBADD = $(top_builddir)/src/util/libplibul.la $(top_builddir)/src/fnt/libplibfnt.la
++
++libplibpu_la_SOURCES = \
+         pu.cxx            puBox.cxx       puButton.cxx puButtonBox.cxx    \
+         puArrowButton.cxx puDialogBox.cxx puFrame.cxx  puGroup.cxx        \
+         puInput.cxx       puInterface.cxx puLocal.h    puMenuBar.cxx      \
+diff -ru ../plib-1.8.5/src/pw/Makefile.am ./src/pw/Makefile.am
+--- ../plib-1.8.5/src/pw/Makefile.am	2008-03-11 03:06:20.000000000 +0100
++++ ./src/pw/Makefile.am	2010-07-02 05:27:45.487123738 +0200
+@@ -1,10 +1,11 @@
+ if BUILD_PW
+ 
+-lib_LIBRARIES = libplibpw.a
++lib_LTLIBRARIES = libplibpw.la
+ 
+ include_HEADERS = pw.h
+ 
+-libplibpw_a_SOURCES = pw.cxx pwX11.cxx pwWindows.cxx pwMacOSX.cxx
++libplibpw_la_LDFLAGS = -version-info 9:5:8
++libplibpw_la_SOURCES = pw.cxx pwX11.cxx pwWindows.cxx pwMacOSX.cxx
+ 
+ INCLUDES = -I$(top_srcdir)/src/util
+ 
+diff -ru ../plib-1.8.5/src/sg/Makefile.am ./src/sg/Makefile.am
+--- ../plib-1.8.5/src/sg/Makefile.am	2008-03-11 03:06:20.000000000 +0100
++++ ./src/sg/Makefile.am	2010-07-02 06:16:21.526342543 +0200
+@@ -1,10 +1,13 @@
+ if BUILD_SG
+ 
+-lib_LIBRARIES = libplibsg.a
++lib_LTLIBRARIES = libplibsg.la
+ 
+ include_HEADERS = sg.h
+ 
+-libplibsg_a_SOURCES = sg.cxx sgd.cxx \
++libplibsg_la_LDFLAGS = -version-info 9:5:8
++libplibsg_la_LIBADD = $(top_builddir)/src/util/libplibul.la
++
++libplibsg_la_SOURCES = sg.cxx sgd.cxx \
+                       sgIsect.cxx sgdIsect.cxx \
+                       sgPerlinNoise.cxx
+ 
+diff -ru ../plib-1.8.5/src/sl/Makefile.am ./src/sl/Makefile.am
+--- ../plib-1.8.5/src/sl/Makefile.am	2008-03-11 03:06:24.000000000 +0100
++++ ./src/sl/Makefile.am	2010-07-02 06:12:48.165324370 +0200
+@@ -1,16 +1,20 @@
+ if BUILD_SL
+ 
+-lib_LIBRARIES = libplibsl.a libplibsm.a
++lib_LTLIBRARIES = libplibsl.la libplibsm.la
+ 
+ include_HEADERS = sl.h slPortability.h sm.h
+ 
+-libplibsl_a_SOURCES = \
++libplibsl_la_LDFLAGS = -version-info 9:5:8
++libplibsl_la_LIBADD = $(top_builddir)/src/util/libplibul.la
++
++libplibsl_la_SOURCES = \
+ 	slDSP.cxx slSample.cxx slEnvelope.cxx \
+ 	slPlayer.cxx slMODPlayer.cxx slSamplePlayer.cxx \
+         slScheduler.cxx slMODdacio.cxx slMODfile.cxx \
+         slMODinst.cxx slMODnote.cxx slMODPrivate.h slMODfile.h
+ 
+-libplibsm_a_SOURCES = slPortability.h smMixer.cxx
++libplibsm_la_LDFLAGS = -version-info 9:5:8
++libplibsm_la_SOURCES = slPortability.h smMixer.cxx
+ 
+ INCLUDES = -I$(top_srcdir)/src/util
+ 
+diff -ru ../plib-1.8.5/src/ssg/Makefile.am ./src/ssg/Makefile.am
+--- ../plib-1.8.5/src/ssg/Makefile.am	2008-03-11 03:06:23.000000000 +0100
++++ ./src/ssg/Makefile.am	2010-07-02 06:13:29.638301515 +0200
+@@ -1,10 +1,13 @@
+ if BUILD_SSG
+ 
+-lib_LIBRARIES = libplibssg.a
++lib_LTLIBRARIES = libplibssg.la
+ 
+ include_HEADERS = ssg.h ssgconf.h ssgMSFSPalette.h ssgKeyFlier.h pcx.h
+ 
+-libplibssg_a_SOURCES = ssg.cxx ssgAnimation.cxx ssgBase.cxx \
++libplibssg_la_LDFLAGS = -version-info 9:5:8
++libplibssg_la_LIBADD = $(top_builddir)/src/util/libplibul.la $(top_builddir)/src/sg/libplibsg.la
++
++libplibssg_la_SOURCES = ssg.cxx ssgAnimation.cxx ssgBase.cxx \
+ 	ssgBaseTransform.cxx ssgBranch.cxx ssgContext.cxx ssgCutout.cxx \
+ 	ssgDList.cxx ssgEntity.cxx ssgIsect.cxx ssgLeaf.cxx ssgList.cxx \
+ 	ssgLoadDOF.cxx ssgLoadAC.cxx \
+diff -ru ../plib-1.8.5/src/ssgAux/Makefile.am ./src/ssgAux/Makefile.am
+--- ../plib-1.8.5/src/ssgAux/Makefile.am	2008-03-11 03:06:21.000000000 +0100
++++ ./src/ssgAux/Makefile.am	2010-07-02 06:17:02.592635791 +0200
+@@ -1,6 +1,6 @@
+ if BUILD_SSGAUX
+ 
+-lib_LIBRARIES = libplibssgaux.a
++lib_LTLIBRARIES = libplibssgaux.la
+ 
+ include_HEADERS = ssgAux.h             \
+                   ssgaShapes.h         \
+@@ -13,7 +13,10 @@
+                   ssgaFire.h           \
+                   ssgaBillboards.h
+ 
+-libplibssgaux_a_SOURCES = ssgAux.cxx               \
++libplibssgaux_la_LDFLAGS = -version-info 9:5:8
++libplibssgaux_la_LIBADD = $(top_builddir)/src/util/libplibul.la $(top_builddir)/src/ssg/libplibssg.la $(top_builddir)/src/sg/libplibsg.la
++
++libplibssgaux_la_SOURCES = ssgAux.cxx               \
+                           ssgaShapes.cxx           \
+                           ssgaPatch.cxx            \
+                           ssgaParticleSystem.cxx   \
+diff -ru ../plib-1.8.5/src/util/Makefile.am ./src/util/Makefile.am
+--- ../plib-1.8.5/src/util/Makefile.am	2008-03-11 03:06:23.000000000 +0100
++++ ./src/util/Makefile.am	2010-07-02 05:34:06.711150524 +0200
+@@ -1,10 +1,11 @@
+ if BUILD_UL
+ 
+-lib_LIBRARIES = libplibul.a
++lib_LTLIBRARIES = libplibul.la
+ 
+ include_HEADERS = ul.h ulRTTI.h
+ 
+-libplibul_a_SOURCES = ul.cxx ulClock.cxx ulError.cxx ulLinkedList.cxx \
++libplibul_la_LDFLAGS = -version-info 9:5:8
++libplibul_la_SOURCES = ul.cxx ulClock.cxx ulError.cxx ulLinkedList.cxx \
+         ulList.cxx ulLocal.h ulRTTI.cxx
+ 
+ endif

--- a/components/library/plib/pkg5
+++ b/components/library/plib/pkg5
@@ -1,0 +1,15 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library",
+        "system/library/g++-7-runtime",
+        "system/library/gcc-7-runtime",
+        "system/library/math",
+        "x11/library/libx11"
+    ],
+    "fmris": [
+        "library/plib"
+    ],
+    "name": "plib"
+}

--- a/components/library/plib/plib.p5m
+++ b/components/library/plib/plib.p5m
@@ -1,0 +1,132 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Jake Goerzen
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/plib/fnt.h
+file path=usr/include/plib/js.h
+file path=usr/include/plib/net.h
+file path=usr/include/plib/netBuffer.h
+file path=usr/include/plib/netChannel.h
+file path=usr/include/plib/netChat.h
+file path=usr/include/plib/netMessage.h
+file path=usr/include/plib/netMonitor.h
+file path=usr/include/plib/netSocket.h
+file path=usr/include/plib/pcx.h
+file path=usr/include/plib/psl.h
+file path=usr/include/plib/pu.h
+file path=usr/include/plib/puAux.h
+file path=usr/include/plib/puAuxLocal.h
+file path=usr/include/plib/puFLTK.h
+file path=usr/include/plib/puGLUT.h
+file path=usr/include/plib/puNative.h
+file path=usr/include/plib/puPW.h
+file path=usr/include/plib/puSDL.h
+file path=usr/include/plib/pw.h
+file path=usr/include/plib/sg.h
+file path=usr/include/plib/sl.h
+file path=usr/include/plib/slPortability.h
+file path=usr/include/plib/sm.h
+file path=usr/include/plib/ssg.h
+file path=usr/include/plib/ssgAux.h
+file path=usr/include/plib/ssgKeyFlier.h
+file path=usr/include/plib/ssgMSFSPalette.h
+file path=usr/include/plib/ssgaBillboards.h
+file path=usr/include/plib/ssgaFire.h
+file path=usr/include/plib/ssgaLensFlare.h
+file path=usr/include/plib/ssgaParticleSystem.h
+file path=usr/include/plib/ssgaScreenDump.h
+file path=usr/include/plib/ssgaShapes.h
+file path=usr/include/plib/ssgaSky.h
+file path=usr/include/plib/ssgaSphere.h
+file path=usr/include/plib/ssgaWaveSystem.h
+file path=usr/include/plib/ssgconf.h
+file path=usr/include/plib/ul.h
+file path=usr/include/plib/ulRTTI.h
+link path=usr/lib/$(MACH64)/libplibfnt.so \
+    target=libplibfnt.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibfnt.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibfnt.so.1 \
+    target=libplibfnt.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibjs.so \
+    target=libplibjs.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibjs.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibjs.so.1 \
+    target=libplibjs.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibnet.so \
+    target=libplibnet.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibnet.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibnet.so.1 \
+    target=libplibnet.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpsl.so \
+    target=libplibpsl.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpsl.so.1 \
+    target=libplibpsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpu.so \
+    target=libplibpu.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpu.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpu.so.1 \
+    target=libplibpu.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpuaux.so \
+    target=libplibpuaux.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpuaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpuaux.so.1 \
+    target=libplibpuaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpw.so \
+    target=libplibpw.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibpw.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibpw.so.1 \
+    target=libplibpw.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsg.so \
+    target=libplibsg.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibsg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsg.so.1 \
+    target=libplibsg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsl.so \
+    target=libplibsl.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsl.so.1 \
+    target=libplibsl.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsm.so \
+    target=libplibsm.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibsm.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibsm.so.1 \
+    target=libplibsm.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssg.so \
+    target=libplibssg.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibssg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssg.so.1 \
+    target=libplibssg.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssgaux.so \
+    target=libplibssgaux.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibssgaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibssgaux.so.1 \
+    target=libplibssgaux.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibul.so \
+    target=libplibul.so.$(COMPONENT_VERSION)
+file path=usr/lib/$(MACH64)/libplibul.so.$(COMPONENT_VERSION)
+link path=usr/lib/$(MACH64)/libplibul.so.1 \
+    target=libplibul.so.$(COMPONENT_VERSION)


### PR DESCRIPTION
This is an initial commit of PLIB version 1.8.5 a set of portable game libraries, which is one of the requirements to building flightgear and some other simulation software.