### PR TITLE
Automatically create mediated symlinks for perl binaries and man pages

### DIFF
--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -75,6 +75,7 @@ LICENSE_TRANSFORMS =		$(WS_TOP)/transforms/license-changes
 PUBLISH_TRANSFORMS +=	$(LICENSE_TRANSFORMS)
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/variant-cleanup
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/autopyc
+PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/perl
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/defaults
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/actuators
 PUBLISH_TRANSFORMS +=	$(WS_TOP)/transforms/devel

--- a/transforms/perl
+++ b/transforms/perl
@@ -1,0 +1,22 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Marcel Telka
+#
+
+# Create mediated symlinks in /usr/bin for perl binaries
+<transform file link hardlink path=usr/perl5/(5.[0-9]+)(/bin/[^/]+)$ -> emit \
+    link path=usr%<2> target=../perl5/%<1>%<2> mediator=perl mediator-version=%<1> >
+
+# Create mediated symlinks in /usr/share/man for perl man pages
+<transform file link hardlink path=usr/perl5/(5.[0-9]+)(/man/man[^/]+/[^/]+)$ -> emit \
+    link path=usr/share%<2> target=../../../perl5/%<1>%<2> mediator=perl mediator-version=%<1> >


### PR DESCRIPTION
This will make perl (including perl modules) a first class citizens and things like `man Digest::SHA3` will start to work without twiddling with MANPATH.