### PR TITLE
disable opensearch build

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -26,6 +26,7 @@
 /^library\/pangomm$/d
 /^library\/ptlib$/d
 # Our build server fails to build the following packages (the builds succeed on other build systems):
+/^database\/opensearch$/d
 /^runtime\/openjdk-11$/d
 /^runtime\/sbcl$/d
 /^web\/icedtea-web$/d


### PR DESCRIPTION
Also opensearch doesn't build on our build server.