### PR TITLE
Package history cleanup

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -1,62 +1,8 @@
-OSOLvpanels-apache@0.5.11,5.11-0.133
-OSOLvpanels-firewall@0.5.11,5.11-0.133
-OSOLvpanels-hypervisor@0.5.11,5.11-0.151
-OSOLvpanels-mysql@0.5.11,5.11-0.130
-OSOLvpanels-sharemgr@0.5.11,5.11-0.171
-OSOLvpanels-sysid@0.5.11,5.11-0.171
-OSOLvpanels@0.5.11,5.11-0.133
 SUNWIPython@0.5.11,5.11-0.175.0.0.0.0.0 library/python/ipython@5.0.0-2016.0.0.1
 SUNWPython-extra@0.5.11,5.11-2015.0.2.0
 SUNWPython25@2.5,5.11-2015.0.2.0
-SUNWPython26@2.6.4,5.11-0.133
 SUNWPython@2.4.6,5.11-2015.0.2.0
-SUNWTcl@8.4.18,5.11-0.133 runtime/tcl-8@8.4.18-0.133
-SUNWTk@8.4.18,5.11-0.133 runtime/tk-8@8.4.18-0.133
-SUNWa2ps@4.13,5.11-0.133 print/lp/filter/a2ps@4.13-0.133
-SUNWaalib@1.4.5,5.11-0.133 library/aalib@1.4.5-0.133
-SUNWaconf@2.63,5.11-0.133 developer/build/autoconf@2.63-0.133
-SUNWant@1.7.1,5.11-0.133 developer/build/ant@1.7.1-0.133
-SUNWantlr2@2.7.7,5.11-0.175.0.0.0.0.0 developer/parser/antlr-2@2.7.7-0.133
-SUNWapch22@2.2.14,5.11-0.133 web/server/apache-22@2.2.14-0.133
-SUNWapch22d@2.2.14,5.11-0.133 web/server/apache-22/documentation@2.2.14-0.133
-SUNWapch22m-dtrace@0.3.1,5.11-0.133 web/server/apache-22/plugin/plugin-dtrace@0.3.1,5.11-0.134
-SUNWapch22m-fcgid@2.3.4,5.11-0.133 web/server/apache-22/plugin/plugin-fastcgi@2.3.4,5.11-0.134
-SUNWapch22m-jk@1.2.28,5.11-0.133 web/server/apache-22/plugin/plugin-tomcat@1.2.28,5.11-0.134
-SUNWapch22m-php52@5.2.12,5.11-0.133 web/server/apache-22/plugin/plugin-php52@5.2.12,5.11-0.134
-SUNWapch22m-php5@2.2.6,5.11-0.130 SUNWapch22m-php52@5.2.12,5.11-0.133
-SUNWapch22m-proxy-html@3.1.1,5.11-0.133 web/server/apache-22/plugin/plugin-html-plugin@3.1.1,5.11-0.134
-SUNWapch22m-security@2.5.9,5.11-0.133 web/server/apache-22/plugin/plugin-security@2.5.9,5.11-0.134
-SUNWapch22m-sed@2.2.14,5.11-0.133 web/server/apache-22/plugin/plugin-sed@2.2.14,5.11-0.134
-SUNWapch22m-xml2enc@1.0.1,5.11-0.133 web/server/apache-22/plugin/plugin-xml2enc@1.0.1,5.11-0.134
-SUNWapch2@2.2.3,5.11-0.130 SUNWapch22@2.2.14,5.11-0.133
-SUNWapch2d@2.2.3,5.11-0.130 SUNWapch22d@2.2.14,5.11-0.133
-SUNWapr13@1.3.9,5.11-0.133 web/library/apache/apr-13@1.3.9,5.11-0.134
-SUNWapr13doc@1.3,5.11-0.133 web/library/apache/apr-13/documentation@1.3,5.11-0.134
-SUNWapu13-ldap@1.3.9,5.11-0.133 web/library/apache/apr-util-13/apr-ldap@1.3.9,5.11-0.134
-SUNWapu13@1.3.9,5.11-0.133 web/library/apache/apr-util-13@1.3.9,5.11-0.134
-SUNWapu13dbd-mysql@1.3.9,5.11-0.133 web/library/apache/apr-util-13/dbd-mysql@1.3.9,5.11-0.134
-SUNWapu13dbd-sqlite@1.3.9,5.11-0.133 web/library/apache/apr-util-13/dbd-sqlite@1.3.9,5.11-0.134
-SUNWapu13doc@1.3,5.11-0.133 web/library/apache/apr-util-13/documentation@1.3,5.11-0.134
 SUNWarbel@0.5.11,5.11-2015.0.2.0
-SUNWareca@7.1,5.11-0.133
-SUNWautogen@5.9,5.11-0.133 developer/build/autogen@5.9-0.133
-SUNWbash@4.0.28,5.11-0.133 shell/bash@4.0.28-0.133
-SUNWbcc@0.16.17,5.11-0.133 developer/bcc@0.16.17-0.133
-SUNWbeanshell@2.0,5.11-0.133 runtime/java/beanshell@2.0-0.133
-SUNWbind@9.6.1.2,5.11-0.133 service/network/dns/bind@9.6.1.2-0.133
-SUNWbindc@9.6.1.2,5.11-0.133 network/dns/bind@9.6.1.2-0.133
-SUNWbinutils@2.19,5.11-0.133 developer/gnu-binutils@2.19-0.133
-SUNWbison@2.3,5.11-0.133 developer/parser/bison@2.3-0.133
-SUNWbzip@1.0.5,5.11-0.133 compress/bzip2@1.0.5-0.133
-SUNWcedu@0.5.11,5.11-0.130 driver/network/ce@0.5.11,5.11-0.151.1.8
-SUNWclisp@2.47,5.11-0.133 runtime/clisp@2.47-0.133
-SUNWcmake@2.6.2,5.11-0.133 developer/build/cmake@2.6.2-0.133
-SUNWconflict@0.2004.9.1,5.11-0.133 shell/conflict@0.2004.9.1-0.133
-SUNWconvmv@1.14,5.11-0.133 text/convmv@1.14-0.133
-SUNWcups-libs@1.4.2,5.11-0.133 library/print/cups-libs@1.4.2-0.133
-SUNWcups@1.4.2,5.11-0.133 print/cups@1.4.2-0.133
-SUNWcurl@7.19.5,5.11-0.133 web/curl@7.19.5-0.133
-SUNWcvs@1.12.13,5.11-0.133 developer/versioning/cvs@1.12.13-0.133
 SUNWdbus-bindings@0.5.11,5.11-2015.0.2.0
 SUNWdesktop-other-l10n-cs@0.5.11,5.11-2015.0.2.0
 SUNWdesktop-other-l10n-de@0.5.11,5.11-2015.0.2.0
@@ -77,46 +23,10 @@ SUNWdesktop-other-l10n-zhCN@0.5.11,5.11-2015.0.2.0
 SUNWdesktop-other-l10n-zhHK@0.5.11,5.11-2015.0.2.0
 SUNWdesktop-other-l10n-zhTW@0.5.11,5.11-2015.0.2.0
 SUNWdesktop-search-firefox@0.5.11,5.11-2015.0.2.0
-SUNWdesktop-startup@0.5.11,5.11-0.133 system/display-manager/desktop-startup@0.5.11-0.151.1.8
-SUNWdistro-license-copyright@0.5.11,5.11-0.133 release/copyright@0.5.11-0.151
-SUNWdistro-license@0.5.11,5.11-0.130 SUNWdistro-license-copyright@0.5.11,5.11-0.133
-SUNWdoxygen@1.5.7.1,5.11-0.133 developer/documentation-tool/doxygen@1.5.7.1-0.133
-SUNWejabberd@2.0.5,5.11-0.133 web/server/ejabberd@2.0.5-0.133
-SUNWelinks@0.11.6,5.11-0.133 web/browser/elinks@0.11.6-0.133
 SUNWepydoc@3.0.1,5.11-2015.0.2.0
-SUNWerlang-doc@12.1.1,5.11-0.133 runtime/erlang/documentation@12.1.1-0.133
-SUNWerlang@12.1.1,5.11-0.133 runtime/erlang@12.1.1-0.133
-SUNWexpect@5.43,5.11-0.133 shell/expect@5.43-0.133
-SUNWfcgi-doc@2.4.0,5.11-0.133 library/fastcgi/documentation@2.4.0-0.133
-SUNWfcgi@2.4.0,5.11-0.133 library/fastcgi@2.4.0-0.133
-SUNWfetchmail@6.3.13,5.11-0.133 mail/fetchmail@6.3.13-0.133
-SUNWffilters@3.0.2,5.11-0.133 print/lp/filter/foomatic-rip@3.0.2-0.133
-SUNWfilebench@0.5.11,5.11-0.133 benchmark/filebench@0.5.11,5.11-0.133
 SUNWfirefoxl10n-extra@0.5.11,5.11-2015.0.2.0
 SUNWfirefoxl10n-sv-SE@0.5.11,5.11-2015.0.2.0
-SUNWflexlex@2.5.35,5.11-0.133 developer/lexer/flex@2.5.35-0.133
-SUNWflexruntime@2.5.35,5.11-0.133 system/library/flex-runtime@2.5.35-0.133
-SUNWfoomatic-db-engine@0.20080903,5.11-0.133 print/cups/filter/foomatic-db-engine@0.20080903-0.133
-SUNWfoomatic-db@0.20080903,5.11-0.133 print/cups/filter/foomatic-db@0.20080903-0.133
-SUNWfping@2.4.2,5.11-0.133 diagnostic/fping@2.4.2-0.133
-SUNWfppd@0.2008.8.18,5.11-0.133 print/lp/filter/foomatic-ppds@0.2008.8.18-0.133
-SUNWftp@0.5.11,5.11-0.133 service/network/ftp@0.5.11,5.11-0.133
-SUNWgawk@3.1.5,5.11-0.133 text/gawk@3.1.5-0.133
-SUNWgcc@3.4.3,5.11-0.133 developer/gcc-3@3.4.3-0.133
-SUNWgccruntime@3.4.3,5.11-0.133 system/library/gcc-3-runtime@3.4.3-0.133
-SUNWgcmn@0.5.11,5.11-0.133 system/prerequisite/gnu@0.5.11-0.133
-SUNWgd2@2.0.34,5.11-0.133 library/gd@2.0.34-0.133
-SUNWgdb@6.8,5.11-0.133 developer/debug/gdb@6.8-0.133
-SUNWggrp@2.5.4,5.11-0.133 text/gnu-grep@2.5.4-0.133
-SUNWghostscript@8.64,5.11-0.133 print/filter/ghostscript@8.64,5.11-0.133
-SUNWgimpprint@4.2.6,5.11-0.130 SUNWgutenprint@5.2.4,5.11-0.133
 SUNWgir-repository@0.5.11,5.11-2015.0.2.0
-SUNWgit@1.5.6.5,5.11-0.133 developer/versioning/git@1.5.6.5-0.133
-SUNWgm4@1.4.12,5.11-0.133 developer/macro/gnu-m4@1.4.12-0.133
-SUNWgmake@3.81,5.11-0.133 developer/build/gnu-make@3.81-0.133
-SUNWgnome-a11y-poke-root@0.5.11,5.11-0.130 SUNWgnome-a11y-poke@0.5.11,5.11-0.133
-SUNWgnome-a11y-poke@0.5.11,5.11-0.133
-SUNWgnome-dtstart@0.5.11,5.11-0.130 SUNWdesktop-startup@0.5.11,5.11-0.133
 SUNWgnome-img-editor-help-cs@0.5.11,5.11-2015.0.2.0
 SUNWgnome-img-editor-help-de@0.5.11,5.11-2015.0.2.0
 SUNWgnome-img-editor-help-es@0.5.11,5.11-2015.0.2.0
@@ -168,61 +78,9 @@ SUNWgnome-l10nmessages-zhTW@0.5.11,5.11-2015.0.2.0
 SUNWgnome-python-desktop@0.5.11,5.11-2015.0.2.0
 SUNWgnome-python-extras@0.5.11,5.11-2015.0.2.0
 SUNWgnome-python-libs@0.5.11,5.11-2015.0.2.0
-SUNWgnome-themes-hires@0.5.11,5.11-0.130 SUNWhicolor-icon-theme@0.5.11,5.11-0.133
-SUNWgnome-xml-root@0.5.11,5.11-0.130 SUNWgnome-xml@0.5.11,5.11-0.133
-SUNWgnome-xml-share@0.5.11,5.11-0.130 SUNWgnome-xml@0.5.11,5.11-0.133
-SUNWgnome-xml@0.5.11,5.11-0.133 data/docbook@0.5.11-0.151.1.8
-SUNWgnu-automake-110@1.10,5.11-0.133 developer/build/automake-110@1.10-0.133
 SUNWgnu-automake-19@1.9.6,5.11-5.12.0.0.0.16.0
-SUNWgnu-coreutils@7.4,5.11-0.133 file/gnu-coreutils@7.4-0.133
-SUNWgnu-dbm@1.8.3,5.11-0.133 library/database/gdbm@1.8.3-0.133
-SUNWgnu-diffutils@2.8.7,5.11-0.133 text/gnu-diffutils@2.8.7-0.133
-SUNWgnu-emacs-el@23.1,5.11-0.133 editor/gnu-emacs/gnu-emacs-lisp@23.1-0.133
-SUNWgnu-emacs-gtk@23.1,5.11-0.133 editor/gnu-emacs/gnu-emacs-gtk@23.1-0.133
-SUNWgnu-emacs-nox@23.1,5.11-0.133 editor/gnu-emacs/gnu-emacs-no-x11@23.1-0.133
-SUNWgnu-emacs-x@23.1,5.11-0.133 editor/gnu-emacs/gnu-emacs-x11@23.1-0.133
-SUNWgnu-emacs@23.1,5.11-0.133 editor/gnu-emacs@23.1-0.133
-SUNWgnu-findutils@0.5.11,5.11-0.175.0.0.0.0.0 file/gnu-findutils@0.5.11-0.133
-SUNWgnu-gettext@0.16.1,5.11-0.133 text/gnu-gettext@0.16.1-0.133
-SUNWgnu-gperf@3.0.3,5.11-0.133 developer/gperf@3.0.3-0.133
-SUNWgnu-idn@1.9,5.11-0.133 library/libidn@1.9-0.133
-SUNWgnu-mc@4.6.1,5.11-0.133 file/mc@4.6.1-0.133
-SUNWgnu-mp@4.3.1,5.11-0.133 library/gmp@4.3.1,5.11-0.133
-SUNWgnu-mpfr@2.4.1,5.11-0.133 library/mpfr@2.4.1,5.11-0.133
-SUNWgnu-readline@5.2,5.11-0.133 library/readline@5.2-0.133
-SUNWgnu-which@2.16,5.11-0.133 shell/which@2.16-0.133
-SUNWgnupg@2.0.13,5.11-0.133 crypto/gnupg@2.0.13-0.133
-SUNWgnuplot@4.2.6,5.11-0.133 image/gnuplot@4.2.6-0.133
-SUNWgocr@0.46,5.11-0.133 image/gocr@0.46-0.133
-SUNWgpch@2.5.9,5.11-0.133 text/gnu-patch@2.5.9-0.133
-SUNWgrails@1.0.3,5.11-0.133 library/java/grails@1.0.3-0.133
-SUNWgroff@0.5.11,5.11-0.175.0.0.0.0.0 text/groff@0.5.11-0.133
-SUNWgscr@8.15.1,5.11-0.130 SUNWghostscript@8.64,5.11-0.133
-SUNWgsed@4.2.1,5.11-0.133 text/gnu-sed@4.2.1-0.133
-SUNWgsfot@6.0,5.11-0.133 print/filter/ghostscript/fonts/gnu-gs-fonts-other@6.0,5.11-0.133
-SUNWgsfst@6.0,5.11-0.133 print/filter/ghostscript/fonts/gnu-gs-fonts-std@6.0,5.11-0.133
 SUNWgst-python@0.5.11,5.11-2015.0.2.0
-SUNWgtar@1.22,5.11-0.133 archiver/gnu-tar@1.22-0.133
 SUNWgtk-vnc-python24@0.5.11,5.11-2015.0.2.0
-SUNWguile@1.8.4,5.11-0.133 library/guile@1.8.4-0.133
-SUNWgutenprint@5.2.4,5.11-0.133 print/filter/gutenprint@5.2.4,5.11-0.133
-SUNWgvim@7.2.308,5.11-0.133 editor/gvim@7.2.308-0.133
-SUNWgzip@1.3.5,5.11-0.133 compress/gzip@1.3.5-0.133
-SUNWhal-cups-utils@0.6.19,5.11-0.133 print/cups/hal-cups-utils@0.6.19-0.133
-SUNWhexedit@1.2.12,5.11-0.133 editor/hexedit@1.2.12-0.133
-SUNWhicolor-icon-theme@0.5.11,5.11-0.133 gnome/theme/hicolor-icon-theme@0.5.11-0.151.1.8
-SUNWhpijs@3.9.8,5.11-0.133 print/filter/hplip@3.9.8.5.11-0.133
-SUNWhttping@1.3.0,5.11-0.133 diagnostic/httping@1.3.0-0.133
-SUNWhwdata@0.5.11,5.11-0.133 system/data/hardware-registry@0.5.11,5.11-0.133
-SUNWiftop@0.17,5.11-0.133 diagnostic/iftop@0.17-0.133
-SUNWilmbase@1.0.1,5.11-0.133 library/ilmbase@1.0.1-0.133
-SUNWimagick@6.3.4.2,5.11-0.133 image/imagemagick@6.3.4.2-0.133
-SUNWiperf@2.0.4,5.11-0.133 benchmark/iperf@2.0.4-0.133
-SUNWipmi@1.8.10,5.11-0.133 system/ipmi/ipmitool@1.8.10,5.11-0.151
-SUNWircii@0.2006.7.25,5.11-0.133 network/chat/ircii@0.2006.7.25-0.133
-SUNWjre-config-plugin@0.5.11,5.11-0.133 web/browser/firefox/plugin/plugin-java@0.5.11,5.11-0.134
-SUNWjunit@4.5,5.11-0.133 developer/java/junit@4.5-0.133
-SUNWlablgtk@2.10.1,5.11-0.170
 SUNWlang-ar-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-common-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-common@0.5.11,5.11-2015.0.2.0
@@ -243,85 +101,18 @@ SUNWlang-srRS@0.5.11,5.11-2015.0.2.0
 SUNWlang-zhCN-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-zhHK-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-zhTW-extra@0.5.11,5.11-2015.0.2.0
-SUNWlcms@1.17,5.11-0.133
-SUNWldtp@1.7.1,5.11-0.133
-SUNWless@436,5.11-0.133 text/less@436-0.133
-SUNWlexpt@2.0.1,5.11-0.133 library/expat@2.0.1-0.133
-SUNWlftp@3.7.15,5.11-0.133 network/ftp/lftp@3.7.15-0.133
 SUNWlibcompizconfig@0.5.11,5.11-2015.0.2.0
-SUNWlibconfuse@2.6,5.11-0.133 library/libconfuse@2.6-0.133
-SUNWlibevent@1.3.5,5.11-0.133 library/libevent@1.3.5-0.133
 SUNWlibm@0.5.11,5.11-2015.0.3.0
-SUNWlibmcrypt@2.5.8,5.11-0.133 system/library/security/libmcrypt@2.5.8-0.133
-SUNWlibmemcached@0.16,5.11-0.133 library/libmemcached@0.16-0.133
-SUNWlibmng@1.0.10,5.11-0.133 library/graphics/libmng@1.0.10-0.133
 SUNWlibms@0.5.11,5.11-2015.0.3.0
-SUNWlibnet@1.1.2.1,5.11-0.133 system/library/libnet@1.1.2.1-0.133
-SUNWlibopenusb@1.0.1,5.11-0.133
-SUNWlibpcap@1.0.0,5.11-0.133 system/library/libpcap@1.0.0-0.133
-SUNWlibpopt@0.5.11,5.11-0.175.0.0.0.0.0 library/popt@0.5.11-0.133
-SUNWlibrsync@0.9.7,5.11-0.133 library/librsync@0.9.7-0.133
-SUNWlibsigsegv@2.6,5.11-0.133 library/libsigsegv@2.6-0.133
-SUNWlibsmbclient@3.0.37,5.11-0.133 library/samba/libsmbclient@3.0.37-0.133
-SUNWlibsndfile@1.0.17,5.11-0.133 library/libsndfile@1.0.23-0.133
-SUNWlibstdcxx4@4.2.1,5.11-0.133
-SUNWlibtool@1.5.22,5.11-0.133 developer/build/libtool@1.5.22-0.133
-SUNWlibtorrent@0.12.2,5.11-0.133 library/libtorrent@0.12.2-0.133
-SUNWlibusb@0.5.11,5.11-0.133 system/library/usb/libusb@0.5.11-0.133
-SUNWlibusbugen@0.5.11,5.11-0.133 system/library/usb/libusbugen@0.5.11-0.133
 SUNWlibvirt@0.5.11,5.11-2015.0.2.0
-SUNWlighttpd14@1.4.23,5.11-0.133 web/server/lighttpd@1.4.23,5.11-0.134
-SUNWlinks@1.0,5.11-0.133 web/browser/links@1.0-0.133
-SUNWlogilab-astng@0.19.0,5.11-0.133 library/python-2/logilab-astng@0.19.0,5.11-0.133
-SUNWlogilab-common@0.40.0,5.11-0.133 library/python-2/logilab-common@0.40.0,5.11-0.133
-SUNWltdl@1.5.22,5.11-0.133 library/libtool/libltdl@1.5.22-0.133
-SUNWlua@5.1.4,5.11-0.133 runtime/lua@5.1.4-0.133
-SUNWlxml-python26@2.7.6,5.11-0.133
 SUNWlxml-python@2.7.6,5.11-2015.0.2.0
-SUNWlxml@2.7.6,5.11-0.133 library/libxml2@2.7.6-0.133
-SUNWlxsl-python26@1.1.26,5.11-0.133
-SUNWlxsl-python@1.1.26,5.11-0.133
-SUNWlxsl@1.1.26,5.11-0.133 library/libxslt@1.1.26-0.133
-SUNWmeld@1.1.5.1,5.11-0.133 developer/meld@1.1.5.1-0.133
-SUNWmemcached-java@2.0.1,5.11-0.133 library/java/memcached-java@2.0.1-0.133
-SUNWmemcached@1.4.1,5.11-0.133 service/memcached@1.4.1-0.133
-SUNWmercurial@1.3.1,5.11-0.133 developer/versioning/mercurial@1.3.1-0.133
-SUNWmkcd@2.1.1.63,5.11-0.133 media/cdrtools@2.1.1.63,5.11-0.133
 SUNWmoovida-plugins@0.5.11,5.11-2015.0.2.0
 SUNWmoovida@0.5.11,5.11-2015.0.2.0
-SUNWmutt@1.5.20,5.11-0.133 mail/mutt@1.5.20-0.133
-SUNWmysql-base@0.5.11,5.11-0.133 database/mysql-common@0.5.11-0.133
-SUNWmysql-python26@0.5.11,5.11-0.175.0.0.0.0.0
 SUNWmysql-python@0.5.11,5.11-2015.0.2.0
-SUNWmysql51@5.1.37,5.11-0.133
-SUNWmysql51lib@5.1.37,5.11-0.133
-SUNWmysql51test@5.1.37,5.11-0.133
 SUNWmysql5@5.0.86,5.11-2015.0.2.0
 SUNWmysql5jdbc@5.1.5,5.11-2015.0.2.0
 SUNWmysql5test@5.0.86,5.11-2015.0.2.0
-SUNWncft@3.2.2,5.11-0.133 network/ftp/ncftp@3.2.3-0.133
-SUNWncurses@0.5.11,5.11-0.175.0.0.0.0.0 library/ncurses@0.5.11-0.133
-SUNWneon@0.29.0,5.11-0.133 library/neon@0.29.0-0.133
-SUNWnet-snmp-addons@5.4.1,5.11-0.133 system/management/snmp/net-snmp/addons@5.4.1-0.133
-SUNWnet-snmp-core@5.4.1,5.11-0.133 system/management/snmp/net-snmp@5.4.1-0.133
-SUNWnet-snmp-doc@5.4.1,5.11-0.133 system/management/snmp/net-snmp/documentation@5.4.1-0.133
-SUNWnet-snmp-utils@5.4.1,5.11-0.132 SUNWnet-snmp-core@5.4.1,5.11-0.133
-SUNWnethack@3.4.3,5.11-0.133 games/nethack@3.4.3-0.133
-SUNWnimbus-hires@0.5.11,5.11-0.133 gnome/theme/nimbus-hires@0.1.5-0.151.1.8
-SUNWnmap@4.75,5.11-0.133 diagnostic/nmap@4.75-0.133
-SUNWntp@4.2.5.172,5.11-0.133 service/network/ntp@4.2.5.172-0.133
-SUNWopenexr@1.6.1,5.11-0.133 library/openexr@1.6.1-0.133
-SUNWopenldap@2.4.11,5.11-0.133 library/openldap@2.4.11-0.133
-SUNWopensolaris-welcome@0.5.11,5.11-0.133 release/openindiana-welcome@0.5.11,5.11-0.148
-SUNWopenssl-fips-140@1.2,5.11-0.133
-SUNWopenssl@0.9.8.12,5.11-0.133 library/security/openssl@0.9.8.12-0.133
-SUNWp7zip@4.55,5.11-0.133 compress/p7zip@4.55-0.133
 SUNWpampkcs11@0.6.0,5.11-2018.0.0.0
-SUNWpconsole@1.0,5.11-0.133 terminal/pconsole@1.0-0.133
-SUNWpcre@7.8,5.11-0.133 library/pcre@7.8-0.133
-SUNWperl-net-ssleay@1.35,5.11-0.133 library/perl-5/net-ssleay@1.35-0.133
-SUNWperl-pmtools@1.10,5.11-0.133 library/perl-5/pmtools@1.10-0.133
-SUNWperl-xml-parser@0.5.11,5.11-0.133 library/perl-5/xml-parser@0.5.11-0.133
 SUNWphp52-apc@3.0.19,5.11-2015.0.2.0
 SUNWphp52-idn@0.2.0,5.11-2015.0.2.0
 SUNWphp52-memcache@2.2.5,5.11-2015.0.2.0
@@ -338,26 +129,11 @@ SUNWphp524man@5.2.4,5.11-2015.0.2.0
 SUNWphp524usr@5.2.4,5.11-2015.0.2.0
 SUNWphp52@5.2.12,5.11-2015.0.2.0
 SUNWphp52d@5.2.12,5.11-2015.0.2.0
-SUNWpipe-viewer@1.1.4,5.11-0.133 shell/pipe-viewer@1.1.4-0.133
-SUNWpmdbi@1.58,5.11-0.133 library/perl-5/database@1.58,5.11-0.133
-SUNWprivoxy@3.0.8,5.11-0.133 web/proxy/privoxy@3.0.8-0.133
-SUNWprocmail@3.22,5.11-0.175.0.0.0.0.0 mail/procmail@3.22-0.133
-SUNWproduct-registry-root@0.5.11,5.11-0.130 system/management/product-registry@0.5.11,5.11-0.151
-SUNWpsutils@0.5.11,5.11-0.133 print/psutils@0.5.11-0.133
-SUNWpth@2.0.7,5.11-0.133 library/pth@2.0.7,5.11-0.133
-SUNWpwgen@2.6,5.11-0.133 crypto/pwgen@2.6-0.133
-SUNWpycups@1.9.46,5.11-0.133 library/python-2/pycups@1.9.46,5.11-0.133
-SUNWpylint@0.18.0,5.11-0.133 developer/python/pylint@0.18.0-0.133
 SUNWpysqlite@2.4.1,5.11-2015.0.2.0
-SUNWpython-cherrypy@3.1.2,5.11-0.133 library/python-2/cherrypy@3.1.2-0.133
 SUNWpython-imaging@0.5.11,5.11-2015.0.2.0
 SUNWpython-lxml@2.1.2,5.11-2015.0.2.0
-SUNWpython-mako@0.2.2,5.11-0.133 library/python-2/mako@0.2.2-0.133
 SUNWpython-notify@0.5.11,5.11-2015.0.2.0
-SUNWpython-ply@3.1,5.11-0.133 library/python-2/ply@3.1-0.133
-SUNWpython-pycurl@7.19.0.1,5.11-0.133 library/python-2/pycurl@7.19.0.1-0.133
 SUNWpython-pyopenssl@0.8,5.11-2015.0.2.0
-SUNWpython-setuptools@0.5.11,5.11-0.175.0.0.0.0.0
 SUNWpython-twisted-web2@0.5.11,5.11-2015.0.2.0
 SUNWpython-twisted@0.5.11,5.11-2015.0.2.0
 SUNWpython-xdg@0.5.11,5.11-2015.0.2.0
@@ -365,56 +141,10 @@ SUNWpython-zope-interface@0.5.11,5.11-2015.0.2.0
 SUNWpython24-cssutils@0.5.11,5.11-2015.0.2.0
 SUNWpython24-ctypes@0.5.11,5.11-2015.0.2.0
 SUNWpython24-simplejson@0.5.11,5.11-2015.0.2.0
-SUNWpython26-cssutils@0.5.11,5.11-0.175.0.0.0.0.0
-SUNWpython26-imaging@0.5.11,5.11-0.175.0.0.0.0.0
-SUNWpython26-lxml@2.1.2,5.11-0.144
-SUNWpython26-pyopenssl@0.8,5.11-0.133
-SUNWpython26-setuptools@0.5.11-0.175.0.0.0.0.0
 SUNWpython26-simplejson@0.5.11,5.11-2015.0.2.0
-SUNWpython26-twisted-web2@0.5.11,5.11-0.175.0.0.0.0.0
-SUNWpython26-twisted@0.5.11,5.11-0.175.0.0.0.1.0
-SUNWpython26-zope-interface@0.5.11,5.11-0.175.0.0.0.0.0
 SUNWpyyaml24@0.5.11,5.11-2015.0.2.0
 SUNWquagga@0.99.8,5.11-2018.0.0.0
-SUNWquilt@0.47,5.11-0.133 developer/quilt@0.47-0.133
-SUNWrdiff-backup@1.2.1,5.11-0.133 backup/rdiff-backup@1.2.1-0.133
 SUNWrmwb@0.5.11,5.11-2015.0.2.0
-SUNWrpm@0.5.11,5.11-0.133 package/rpm@0.5.11-0.133
-SUNWrsync@3.0.6,5.11-0.133 network/rsync@3.0.6-0.133
-SUNWrtorrent@0.8.2,5.11-0.133 network/rtorrent@0.8.2-0.133
-SUNWruby18@1.8.7.174,5.11-0.133
-SUNWsane-backend@1.0.19,5.11-0.133 image/scanner/xsane/sane-backends@1.0.19-0.133
-SUNWsane-frontend@1.0.14,5.11-0.133 image/scanner/xsane/sane-frontend@1.0.14-0.133
-SUNWscreen@4.0.3,5.11-0.133 terminal/screen@4.0.3-0.133
-SUNWsexy-python@0.5.11,5.11-0.133
-SUNWsfwdemo@0.5.11,5.11-0.130 SUNWnet-snmp-doc@5.4.1,5.11-0.133
-SUNWsg3utils@1.26,5.11-0.175.0.0.0.0.0 system/storage/sg3_utils@1.26-0.133
-SUNWslang@2.2.2,5.11-0.133 library/slang@2.2.2-0.133
-SUNWslib@3.1.1,5.11-0.133 library/slib@3.1.1-0.133
-SUNWslrn@0.9.9.1,5.11-0.133 network/nntp/slrn@0.9.9.1-0.133
-SUNWsmagt@5.0.9,5.11-0.130 SUNWnet-snmp-addons@5.4.1,5.11-0.133
-SUNWsmba@3.0.37,5.11-0.133 service/network/samba@3.0.37-0.133
-SUNWsmcmd@5.0.9,5.11-0.130 SUNWnet-snmp-utils@5.4.1,5.11-0.132
-SUNWsmdoc@5.0.9,5.11-0.130 SUNWnet-snmp-doc@5.4.1,5.11-0.133
-SUNWsmmgr@5.0.9,5.11-0.130 SUNWnet-snmp-core@5.4.1,5.11-0.133
-SUNWsnort@2.8.4.1,5.11-0.133 diagnostic/snort@2.8.4.1-0.133
-SUNWsound-exchange@14.3.0,5.11-0.133 audio/sox@14.3.0-0.133
-SUNWspawn-fcgi@1.6.3,5.11-0.133 web/fastcgi/spawn-fcgi@1.6.3-0.133
-SUNWsquid@2.7.6,5.11-0.133 web/proxy/squid@2.7.6-0.133
-SUNWstunnel@4.25,5.11-0.175.0.0.0.0.0 service/security/stunnel@4.25-0.133
-SUNWsudo@1.7.0,5.11-0.133 security/sudo@1.7.0-0.133
-SUNWsvn-java@1.6.5,5.11-0.133 library/java/subversion@1.6.5-0.133
-SUNWsvn-perl@1.6.5,5.11-0.133 library/perl-5/subversion@1.6.5-0.133
-SUNWsvn-python@1.6.5,5.11-0.133 library/python-2/subversion@1.6.5-0.133
-SUNWsvn@1.6.5,5.11-0.133 developer/versioning/subversion@1.6.5-0.133
-SUNWswig@1.3.35,5.11-0.133 developer/swig@1.3.35-0.133
-SUNWtcat-examples@6.0.20,5.11-0.133 web/java-servlet/tomcat/tomcat-examples@6.0.24-0.133
-SUNWtcat@6.0.20,5.11-0.133 web/java-servlet/tomcat@6.0.24-0.133
-SUNWtcltls@1.6,5.11-0.133 runtime/tcl-8/tcl-openssl@1.6-0.133
-SUNWtcpdump@4.0.0,5.11-0.133 diagnostic/tcpdump@4.0.0-0.133
-SUNWtcsh@6.17.0,5.11-0.133 shell/tcsh@6.17.0-0.133
-SUNWtecla@1.6.0,5.11-0.133 library/libtecla@1.6.0,5.11-0.133
-SUNWtexi@4.7,5.11-0.133 text/texinfo@4.7-0.133
 SUNWtgnome-l10n-ui-de@0.5.11,5.11-2015.0.2.0
 SUNWtgnome-l10n-ui-es@0.5.11,5.11-2015.0.2.0
 SUNWtgnome-l10n-ui-fr@0.5.11,5.11-2015.0.2.0
@@ -427,31 +157,14 @@ SUNWtgnome-l10n-ui-sv@0.5.11,5.11-2015.0.2.0
 SUNWtgnome-l10n-ui-zhCN@0.5.11,5.11-2015.0.2.0
 SUNWtgnome-l10n-ui-zhHK@0.5.11,5.11-2015.0.2.0
 SUNWtgnome-l10n-ui-zhTW@0.5.11,5.11-2015.0.2.0
-SUNWthunderbird-calendar@0.5.11,5.11-0.133 mail/thunderbird/plugin/plugin-lightning@0.5.11,5.11-0.134
 SUNWthunderbirdl10n-extra@0.5.11,5.11-2015.0.2.0
 SUNWthunderbirdl10n-sv-SE@0.5.11,5.11-2015.0.2.0
-SUNWtidy@1.0.0,5.11-0.133 text/tidy@1.0.0-0.133
-SUNWtop@3.8,5.11-0.133 diagnostic/top@3.8-0.133
-SUNWtss@0.3.2,5.11-0.133 library/security/trousers@0.3.2-0.133
-SUNWunison@2.27.57,5.11-0.170
-SUNWunixodbc@2.2.14,5.11-0.133 library/unixodbc@2.2.14-0.133
-SUNWunrar@3.8.5,5.11-0.133 archiver/unrar@3.8.5-0.133
-SUNWunzip@5.53.7,5.11-0.133 compress/unzip@5.53.7-0.133
 SUNWurlgrabber@3.1.0,5.11-2015.0.2.0
-SUNWvim@7.2.308,5.11-0.133 editor/vim@7.2.308-0.133
 SUNWvirt-manager@0.6.1,5.11-2015.0.2.0
 SUNWvirtinst@0.5.11,5.11-2015.0.2.0
 SUNWvtsts@0.5.11,5.11-2015.0.2.0
-SUNWwebalizer@2.20.1,5.11-0.175.0.0.0.0.0 web/analytics/webalizer@2.20.1-0.133
-SUNWwget@1.12,5.11-0.133 web/wget@1.12-0.133
-SUNWwireshark@1.2.5,5.11-0.133 diagnostic/wireshark@1.2.6-0.133
-SUNWwxwidgets@2.8.10,5.11-0.133 library/graphics/wxwidgets@2.8.10,5.11-0.133
 SUNWxvm@3.4.2,5.11-2015.0.2.0
 SUNWxvmhvm@0.5.11,5.11-2015.0.2.0
-SUNWzfs-auto-snapshot@0.5.11,5.11-0.133 service/storage/zfs-auto-snapshot@0.5.11,5.11-0.142
-SUNWzip@2.32,5.11-0.133 compress/zip@2.32-0.133
-SUNWzlib@1.2.3,5.11-0.133 library/zlib@1.2.3-0.133
-SUNWzsh@4.3.9,5.11-0.133 shell/zsh@4.3.9-0.133
 babel_install@0.1,5.11-2015.0.2.0
 backup/areca@7.1,5.11-2016.0.1.0
 backup/borg-34@1.1.10-2020.0.1.1
@@ -469,21 +182,17 @@ consolidation/l10n/l10n-redistributable@0.5.11,5.11-2015.0.2.0
 consolidation/ub_javavm/ub_javavm-incorporation@0.5.11,5.11-2015.0.0.0
 consolidation/vpanels/vpanels-incorporation@0.5.11,5.11-2015.0.2.0
 database/couchdb-21@2.1.1,5.11-2020.0.1.3
-database/database/postgres-82/locale/ja@8.2.17,5.11-0.148
 database/mariadb-55/client@5.5.55,5.11-2017.0.0.3
 database/mariadb-55/library@5.5.55,5.11-2017.0.0.3
 database/mariadb-55/tests@5.5.55,5.11-2017.0.0.3
 database/mariadb-55@5.5.55,5.11-2017.0.0.3
 database/mongodb-33@3.3.12-2018.0.0.4
-database/mysql-5/connector/jdbc@5.1.5,5.11-0.134
-database/mysql-5/tests@5.0.86,5.11-0.134
 database/mysql-50/connector/jdbc@5.1.5,5.11-2015.0.2.0
 database/mysql-50/tests@5.0.91,5.11-2015.0.2.0
 database/mysql-50@5.0.91,5.11-2015.0.2.0
 database/mysql-51/library@5.1.37-2015.0.1.0
 database/mysql-51/tests@5.1.37-2015.0.1.0
 database/mysql-51@5.1.37-2015.0.1.0
-database/mysql-5@5.0.86,5.11-0.134
 database/percona-server-55/client@5.5.54.38.7,5.11-2017.0.0.1
 database/percona-server-55/library@5.5.54.38.7,5.11-2017.0.0.1
 database/percona-server-55/tests@5.5.54.38.7,5.11-2017.0.0.1
@@ -1040,7 +749,6 @@ library/python-2/python-zope-interface-24@0.5.11,5.11-2015.0.2.0
 library/python-2/pyyaml-24@0.5.11,5.11-2015.0.2.0
 library/python-2/setuptools-24@0.5.11,5.11-2015.0.2.0
 library/python-2/simplejson-24@0.5.11,5.11-2015.0.2.0
-library/python-2/simplejson-devel-26@0.5.11,5.11-0.135
 library/python-2/tkinter-26@2.6.9,5.11-2016.0.1.0
 library/python/coherence-27@0.6.6.2,5.11-2020.0.0.0
 library/python/coherence@0.6.6.2,5.11-2020.0.0.0
@@ -1090,7 +798,6 @@ mail/thunderbird/locale/ru@0.5.11,5.11-2015.0.2.0
 mail/thunderbird/locale/sv@0.5.11,5.11-2015.0.2.0
 mail/thunderbird/locale/zh_cn@0.5.11,5.11-2015.0.2.0
 mail/thunderbird/locale/zh_tw@0.5.11,5.11-2015.0.2.0
-mail/thunderbird/plugin/plugin-lightning@0.5.11,5.11-0.134 mail/thunderbird/plugin/thunderbird-lightning@0.5.11-0.151.1.8
 mail/thunderbird/plugin/thunderbird-lightning@52.9.1,5.11-2020.0.1.2
 metapackages/gui-install@0.1,5.11-2017.0.0.28
 network/dhcp/dhcpmgr/locale/cs@0.5.11,5.11-2018.0.0.0
@@ -1104,13 +811,10 @@ network/dhcp/dhcpmgr/locale/sv@0.5.11,5.11-2018.0.0.0
 network/dhcp/dhcpmgr/locale/zh_cn@0.5.11-2013.0.0.0
 network/dhcp/dhcpmgr/locale/zh_hk_tw@0.5.11-2013.0.0.0
 network/megasync@4.6.6,5.11-2022.0.0.1
-network/unison@2.27.57,5.11-0.170
 print/lp/filter/a2ps@4.14,5.11-2015.0.2.0 print/filter/a2ps@4.14,5.11-0.151.1.8.1
 print/mp@0.5.11,5.11-2018.0.0.0
 python/powerline-35@2.7,5.11-2020.0.1.2
 redistributable@0.1,5.11-2015.0.2.0
-release/copyright@0.5.11,5.11-0.151 release/notices@0.5.11-0.151.1.8
-release/openindiana-welcome@0.5.11,5.11-0.148 release/os-welcome@0.5.11-0.151.1.8
 release/registration@0.5.11,5.11-2018.0.0.0
 runtime/java/openjdk7@1.7.141,5.11-2020.0.1.5
 runtime/java/openjdk7/runtime64@1.7.141,5.11-2020.0.1.5
@@ -1122,7 +826,6 @@ runtime/nodejs-6@6.17.1-2020.0.1.1 runtime/nodejs-10@10.20.1-2020.0.1.0
 runtime/nodejs-7@7.10.1,5.11-2018.0.0.2
 runtime/nodejs-8@8.17.0-2020.0.1.1 runtime/nodejs-10@10.20.1-2020.0.1.0
 runtime/nodejs@0.12.18-2020.0.1.3 runtime/nodejs-10@10.20.1-2020.0.1.0
-runtime/ocaml/lablgtk@2.10.1,5.11-0.170
 runtime/perl-510/extra@5.10.0,5.11-2015.0.1.0
 runtime/perl-510/module/sun-solaris@0.5.11,5.11-2015.0.1.0
 runtime/perl-510@5.10.0,5.11-2015.0.1.0
@@ -1161,7 +864,6 @@ service/management/sysidtool@0.5.11,5.11-2015.0.2.0 service/management/sysding@0
 service/network/ftp@1.3.5-2014.1.2.0 service/network/ftp/proftpd@0.5.11,5.11-2014.0.0.0
 service/network/samba/samba36@3.6.25,5.11-2015.0.2.3
 service/postrun@1.0,5.11-2015.0.2.0
-service/storage/zfs-auto-snapshot@0.5.11,5.11-0.142 desktop/time-slider@0.2.97-0.151.1.8
 slim_install@0.1,5.11-2015.0.2.0  metapackages/gui-install@0.1,5.11-2016.0.0.0
 storage/fsexam@0.8.1,5.11-2017.0.0.1
 system/data/timezone@5.11,5.11-2015.0.2.0
@@ -1199,7 +901,6 @@ system/input-method/iiim/twle-chewing@0.5.11,5.11-2018.0.0.0
 system/input-method/iiim/twle-core@0.5.11,5.11-2018.0.0.0
 system/input-method/iiim/twle-open@0.5.11,5.11-2018.0.0.0
 system/input-method/iiim@0.5.11,5.11-2018.0.0.0
-system/ipmi/ipmitool@1.8.10,5.11-0.151 system/management/ipmitool@1.8.10-0.151.1.8
 system/library/dbus-x11@1.12.8,5.11-2018.0.0.1 system/library/dbus/dbus-x11@1.12.8,5.11-2018.0.0.0
 system/library/g++-5-runtime@5.5.0,5.11-2020.0.1.2
 system/library/gcc-5-runtime@5.5.0,5.11-2020.0.1.2
@@ -1225,7 +926,6 @@ system/library/security/crypto/pkcs11_kms@0.5.11,5.11-2015.0.2.0
 system/library/sysidtool@0.5.11,5.11-2015.0.2.0
 system/library/usb/openusb@1.0.1-2018.0.0.2
 system/locale/ar-extra@0.5.11,5.11-2015.0.2.0
-system/locale/en_us@0.5.11,5.11-0.148
 system/locale/support/afrikaans@0.1,5.11-2015.0.2.0
 system/locale/support/albanian@0.1,5.11-2015.0.2.0
 system/locale/support/all@0.1,5.11-2015.0.2.0
@@ -1295,7 +995,6 @@ system/locale/support/thai@0.1,5.11-2015.0.2.0
 system/locale/support/turkish@0.1,5.11-2015.0.2.0
 system/locale/support/ukrainian@0.1,5.11-2015.0.2.0
 system/locale/support/vietnamese@0.1,5.11-2015.0.2.0
-system/locale@0.5.11,5.11-0.148
 system/management/product-registry@0.5.11,5.11-2015.0.2.0
 system/management/rad/module/rad-zones-bridge@0.5.11,5.11-2015.0.2.0
 system/management/rad/pkg@0.5.11,5.11-2015.0.2.0
@@ -1311,11 +1010,9 @@ system/management/visual-panels/panel-browser@0.5.11,5.11-2015.0.2.0
 system/management/visual-panels/panel-coreadm@0.5.11,5.11-2015.0.2.0
 system/management/visual-panels/panel-examples@0.5.11,5.11-2015.0.2.0
 system/management/visual-panels/panel-firewall@0.5.11,5.11-2015.0.2.0
-system/management/visual-panels/panel-hypervisor@0.5.11,5.11-0.151
 system/management/visual-panels/panel-sharemgr@0.5.11,5.11-2015.0.2.0
 system/management/visual-panels/panel-smf@0.5.11,5.11-2015.0.2.0
 system/management/visual-panels/panel-svcs@0.5.11,5.11-2015.0.2.0
-system/management/visual-panels/panel-sysid@0.5.11,5.11-0.171
 system/management/visual-panels/panel-sysmon@0.5.11,5.11-2015.0.2.0
 system/management/visual-panels/panel-time@0.5.11,5.11-2015.0.2.0
 system/management/visual-panels/panel-usermgr@0.5.11,5.11-2015.0.2.0
@@ -1348,16 +1045,8 @@ web/browser/firefox/locale/ru_ru@0.5.11,5.11-2015.0.2.0
 web/browser/firefox/locale/sv_se@0.5.11,5.11-2015.0.2.0
 web/browser/firefox/locale/zh_cn@0.5.11,5.11-2015.0.2.0
 web/browser/firefox/locale/zh_tw@0.5.11,5.11-2015.0.2.0
-web/browser/firefox/plugin/plugin-java@0.5.11,5.11-0.134 web/browser/firefox/plugin/firefox-java@0.5.11-0.151.1.8
 web/java-servlet/tomcat/tomcat-examples@6.0.48,5.11-2018.0.0.3
 web/java-servlet/tomcat@6.0.48,5.11-2018.0.0.3
-web/library/apache/apr-13/documentation@1.3,5.11-0.134:20130305T140017Z library/apr/documentation@1.5.0,5.11-2014.0.1.0
-web/library/apache/apr-13@1.3.9,5.11-0.134 library/apr-13@1.4.6-0.151.1.8
-web/library/apache/apr-util-13/apr-ldap@1.3.9,5.11-0.134 library/apr-util-13/apr-ldap@1.5.1-0.151.1.8
-web/library/apache/apr-util-13/dbd-mysql@1.3.9,5.11-0.134 library/apr-util-13/dbd-mysql@1.5.1-0.151.1.8
-web/library/apache/apr-util-13/dbd-sqlite@1.3.9,5.11-0.134 library/apr-util-13/dbd-sqlite@1.5.1-0.151.1.8
-web/library/apache/apr-util-13/documentation@1.3,5.11-0.134 library/apr-util-13/documentation@1.3-0.151.1.8
-web/library/apache/apr-util-13@1.3.9,5.11-0.134 library/apr-util-13@1.5.1-0.151.1.8
 web/php-52/documentation@5.2.17,5.11-2015.0.2.0
 web/php-52/extension/php-apc@3.0.19,5.11-2015.0.2.0
 web/php-52/extension/php-idn@0.2.0,5.11-2015.0.2.0
@@ -1601,21 +1290,12 @@ web/server/apache-22/module/apache-wsgi-27@4.5.7,5.11-2017.0.0.1
 web/server/apache-22/module/apache-wsgi-34@4.5.7,5.11-2017.0.0.1
 web/server/apache-22/module/apache-wsgi@4.5.7,5.11-2017.0.0.1
 web/server/apache-22/module/apache-xml2enc@1.0.3,5.11-2017.0.0.1
-web/server/apache-22/plugin/plugin-dtrace@0.3.1,5.11-0.134 web/server/apache-22/module/apache-dtrace@0.3.1-0.151.1.8
-web/server/apache-22/plugin/plugin-fastcgi@2.3.4,5.11-0.134 web/server/apache-22/module/apache-fcgid@2.3.4-0.151.1.8
-web/server/apache-22/plugin/plugin-html-plugin@3.1.1,5.11-0.134 web/server/apache-22/module/apache-proxy_html@3.1.1-0.151.1.8
-web/server/apache-22/plugin/plugin-php52@5.2.12,5.11-0.134 web/server/apache-22/module/apache-php5@5.2.17-0.151.1.8
-web/server/apache-22/plugin/plugin-security@2.5.9,5.11-0.134 web/server/apache-22/module/apache-security@2.5.9-0.151.1.8
-web/server/apache-22/plugin/plugin-sed@2.2.14,5.11-0.134 web/server/apache-22/module/apache-sed@2.2.24-0.151.1.8
-web/server/apache-22/plugin/plugin-tomcat@1.2.28,5.11-0.134 web/server/apache-22/module/apache-jk@1.2.28-0.151.1.8
-web/server/apache-22/plugin/plugin-xml2enc@1.0.1,5.11-0.134 web/server/apache-22/module/apache-xml2enc@1.0.1-0.151.1.8
 web/server/apache-22@2.2.31,5.11-2017.0.0.2
 web/server/apache-24/module/apache-php54@5.4.45,5.11-2016.0.0.1
 web/server/apache-24/module/apache-php55@5.5.38,5.11-2016.0.0.1
 web/server/apache-24/module/apache-php56@5.6.35,5.11-2018.0.0.1
 web/server/apache-24/module/apache-php70@7.0.33,5.11-2020.0.1.6
 web/server/apache-24/module/apache-php73@7.3.21,5.11-2020.0.1.4
-web/server/lighttpd@1.4.23,5.11-0.134 web/server/lighttpd-14@1.4.23-0.151.1.8
 web/urlgrabber@3.1.0-2015.0.2.0
 x11/server/xorg/driver/xorg-video-apm@1.2.3,5.11-2015.0.0.0
 x11/server/xorg/driver/xorg-video-ark@0.7.3,5.11-2015.0.0.0


### PR DESCRIPTION
illumos did similar cleanup more than [5 years ago](https://www.illumos.org/issues/8002) making smooth direct upgrade from OpenSolaris impossible.
These packages were usually obsoleted/renamed more than 10 years ago.