### PR TITLE
xscreensaver: workaround for #14940

### DIFF
--- a/components/desktop/xscreensaver/Makefile
+++ b/components/desktop/xscreensaver/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=         xscreensaver
 COMPONENT_VERSION=      6.4
 HUMAN_VERSION=      	6.04
-COMPONENT_REVISION =	1
+COMPONENT_REVISION =	2
 COMPONENT_PROJECT_URL=  https://www.jwz.org/xscreensaver/
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz

--- a/components/desktop/xscreensaver/patches/20-disable-new-login.patch
+++ b/components/desktop/xscreensaver/patches/20-disable-new-login.patch
@@ -1,0 +1,12 @@
+--- a/driver/dialog.c	Fri Aug 26 19:59:18 2022
++++ b/driver/dialog.c	Fri Aug 26 19:59:01 2022
+@@ -1159,7 +1159,8 @@
+                   xgwa.your_event_mask | SubstructureNotifyMask);
+   }
+ 
+-
++  /* switching users is broken as of 2022-08-26 */
++  ws->newlogin_button_state.disabled_p = True;
+   ws->newlogin_button_state.cmd = ws->newlogin_cmd;
+   ws->demo_button_state.cmd =
+     get_string_resource (ws->dpy, "demoCommand", "Command");


### PR DESCRIPTION
I'm just disabling the "New Login" button until user switching can be fixed.