### PR TITLE
illumos-gate: switch to perl 5.36

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -95,9 +95,9 @@ $(BUILD_DIR)/$(MACH)/.built: $(SOURCE_DIR)/.patched
 	    -e 's|^export MULTI_PROTO=.*|export MULTI_PROTO=\"$(MULTI_PROTO)\"|' \
 	    -e 's|^export SHADOW_CCS=.*||' \
 	    -e 's|^export SHADOW_CCCS=.*||' ; \
-	  echo export PERL_VERSION=\"5.34\"; \
+	  echo export PERL_VERSION=\"5.36\"; \
 	  echo export PERL_VARIANT=\"-thread-multi\" ; \
-	  echo export PERL_PKGVERS=\"-534\"; \
+	  echo export PERL_PKGVERS=\"-536\"; \
 	  echo export BUILDPERL32=\"#\"; \
 	  echo export BUILDPY2=\"#\"; \
 	  echo export BUILDPY2TOOLS=\"#\"; \


### PR DESCRIPTION
This is first part of making perl 5.36 the default perl.  The second one (the actual mediator update) will follow tomorrow once this one is merged, compiled, and installed on the build server.