### PR TITLE
build-essential: runtime/perl-XXX/module/sun-solaris is not needed fo…

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -16,7 +16,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
-COMPONENT_VERSION =	3
+COMPONENT_VERSION =	4
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -128,7 +128,6 @@ depend fmri=library/perl-5/xml-parser type=require
 depend fmri=library/security/trousers type=require
 depend fmri=print/cups type=require
 depend fmri=print/filter/ghostscript type=require
-depend fmri=runtime/perl-534/module/sun-solaris type=require
 depend fmri=system/library/dbus type=require
 depend fmri=system/library/libdbus type=require
 depend fmri=system/library/libdbus-glib type=require


### PR DESCRIPTION
…r building illumos-gate

AFAIK, runtime/perl-XXX/module/sun-solaris is needed for _running_ illumos-gate.  It is not needed for building anything.