### PR TITLE
install-types: any perl version should be sufficient

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	51
+COMPONENT_REVISION=	52
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -133,8 +133,7 @@ depend type=require fmri=package/pkg
 depend type=require fmri=package/svr4
 depend type=require fmri=release/name
 depend type=require fmri=release/notices
-depend type=require fmri=runtime/perl-534
-depend type=require fmri=runtime/perl-534/module/sun-solaris
+depend type=require fmri=runtime/perl
 depend type=require fmri=service/fault-management
 depend type=require fmri=service/file-system/smb
 depend type=require fmri=service/management/sysding


### PR DESCRIPTION
In addition I believe we do not need to list `runtime/perl-XXX/module/sun-solaris` here explicitly since it should be pulled in via SUNWcs implicitly anyway.