### PR TITLE
illumos-gate: python cleanup

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -99,10 +99,6 @@ $(BUILD_DIR)/$(MACH)/.built: $(SOURCE_DIR)/.patched
 	  echo export PERL_VARIANT=\"-thread-multi\" ; \
 	  echo export PERL_PKGVERS=\"-536\"; \
 	  echo export BUILDPERL32=\"#\"; \
-	  echo export BUILDPY2=\"#\"; \
-	  echo export BUILDPY2TOOLS=\"#\"; \
-	  echo export PYTHON3b_VERSION="3.9"; \
-	  echo export PYTHON3b_SUFFIX=""; \
 	  echo export BUILDPY3b=""; \
 	  echo export BLD_JAVA_8=; \
 	  echo export CW_NO_SHADOW=1; \


### PR DESCRIPTION
This removes setting of `BUILDPY2` and `BUILDPY2TOOLS` since they are no longer used by illumos-gate - see [#14769](https://www.illumos.org/issues/14769).  This also removes setting of `PYTHON3b_VERSION` and `PYTHON3b_SUFFIX` since these are defaults now in illumos-gate - see [usr/src/Makefile.master](https://kernelsources.org/source/xref/illumos-gate/usr/src/Makefile.master?r=70143b9f#220).

In addition, this change should allow smooth transition to post-[#14847](https://www.illumos.org/issues/14847) state.  With this PR merged no change should be needed in [oi-userland](https://github.com/OpenIndiana/oi-userland) after [#14847](https://www.illumos.org/issues/14847) is integrated to illumos-gate.