### PR TITLE
Introducing zrepl with version 0.5.0

### DIFF
--- a/components/sysutils/zrepl/Makefile
+++ b/components/sysutils/zrepl/Makefile
@@ -1,0 +1,81 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Gary Mills
+#
+BUILD_BITS=	64
+BUILD_STYLE=	justmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		zrepl
+COMPONENT_VERSION=	0.5.0
+COMPONENT_SUMMARY=	A one-stop, integrated solution for ZFS replication
+COMPONENT_PROJECT_URL=	https://zrepl.github.io/
+COMPONENT_FMRI=		backup/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION=	Applications/System Utilities
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=	https://github.com/$(COMPONENT_NAME)/$(COMPONENT_NAME)/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=	\
+    sha256:4acfde9e7a09eca2de3de5c7d2987907ae446b345b69133e4b3c58a99c294465
+COMPONENT_LICENSE=	MIT
+COMPONENT_LICENSE_FILE=	LICENSE
+
+TEST_TARGET=$(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
+
+DATE=$(shell date -u +%Y-%m-%d-T%TZ)
+
+# The directory specified by the GOPATH environment variable must not
+# exist, or be empty.  During the "build" target, the GO compiler
+# downloads GO modules to subdirectories of this directory.  This
+# behavior is how GO resolves external symbols.
+
+COMPONENT_BUILD_ENV += GOOS="illumos"
+COMPONENT_BUILD_ENV += GOPATH="$(SOURCE_DIR)/gopath"
+COMPONENT_BUILD_ENV += PREFIX=/usr
+COMPONENT_BUILD_ENV += VERSION="v$(COMPONENT_VERSION)"
+COMPONENT_BUILD_ENV += DATE="'$(DATE)'"
+COMPONENT_BUILD_ENV += BUILT_BY="oi-userland"
+
+COMPONENT_INSTALL_ENV += GOOS="illumos"
+COMPONENT_INSTALL_ENV += GOPATH="$(SOURCE_DIR)/gopath"
+COMPONENT_INSTALL_ENV += PREFIX=/usr
+COMPONENT_INSTALL_ENV += VERSION="v$(COMPONENT_VERSION)"
+COMPONENT_INSTALL_ENV += DATE="'$(DATE)'"
+COMPONENT_INSTALL_ENV += BUILT_BY="oi-userland"
+
+# All installed files go to the artifact directory
+COMPONENT_INSTALL_ARGS += ARTIFACTDIR=$(PROTO_DIR)
+
+# Pre-create all the install directories
+COMPONENT_PRE_INSTALL_ACTION=$(MKDIR) "$(PROTO_DIR)/usr/bin" \
+    "$(PROTO_DIR)/usr/share/bash-completion/completions" \
+    "$(PROTO_DIR)/usr/share/zsh/site-functions" \
+    "$(PROTO_DIR)/usr/share/man/man5" \
+    "$(PROTO_DIR)/usr/share/man/man8" \
+    "$(PROTO_DIR)/usr/share/zrepl/config";
+
+# Install sample config files
+COMPONENT_POST_INSTALL_ACTION=$(CP) $(COMPONENT_DIR)/files/illumos.yml \
+    $(SOURCE_DIR)/config/samples/*.yml \
+    $(PROTO_DIR)/usr/share/zrepl/config
+
+# Add the files directory to the prototype search path list
+PKG_PROTO_DIRS += $(COMPONENT_DIR)/files
+
+# Build dependencies
+REQUIRED_PACKAGES+=developer/golang
+REQUIRED_PACKAGES+=library/python/docutils
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/sysutils/zrepl/files/exec_attr
+++ b/components/sysutils/zrepl/files/exec_attr
@@ -1,0 +1,1 @@
+Basic Solaris User:solaris:cmd:RO::/usr/bin/zrepl:privs=file_dac_read,file_dac_search

--- a/components/sysutils/zrepl/files/illumos.yml
+++ b/components/sysutils/zrepl/files/illumos.yml
@@ -1,0 +1,38 @@
+# Local transport on illumos
+jobs:
+  - type: sink
+    recv:
+      properties:
+        override: {
+	  "atime": "off"
+	}
+      placeholder:
+        encryption: inherit
+    name: "local_sink"
+    root_fs: "dpool/sink"
+    serve:
+      type: local
+      listener_name: localsink
+
+  - type: push
+    name: "backup_system"
+    connect:
+      type: local
+      listener_name: localsink
+      client_identity: local_backup
+    filesystems: {
+      "dpool/origin": true,
+    }
+    snapshotting:
+      type: periodic
+      interval: 10m
+      prefix: zrepl_
+    pruning:
+      keep_sender:
+      - type: not_replicated
+      - type: last_n
+        count: 10
+      keep_receiver:
+      - type: grid
+        grid: 1x1h(keep=all) | 24x1h | 35x1d | 6x30d
+        regex: "zrepl_.*"

--- a/components/sysutils/zrepl/files/zrepl
+++ b/components/sysutils/zrepl/files/zrepl
@@ -1,0 +1,82 @@
+#!/bin/sh
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2022 Gary Mills
+#
+
+. /lib/svc/share/smf_include.sh
+
+SVC_FMRI=svc:/application/backup/zrepl
+DEFAULT_FMRI=${SVC_FMRI}:default
+ZREPL_BIN=/usr/bin/zrepl
+ZREPL_YML=/etc/zrepl/zrepl.yml
+ZREPL_REF=${ZREPL_YML}-ref
+SOCK_DIR=/var/run/zrepl
+SOCK_PERM=0750
+SOCK_CTL=${SOCK_DIR}/control
+
+if [ ! -f ${ZREPL_YML} ]; then
+	echo "${ZREPL_YML} not found. Exiting."
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+if [ ! -f ${ZREPL_BIN} ]; then
+	echo "${ZREPL_BIN} not found. Exiting."
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+if [ ! -x ${ZREPL_BIN} ]; then
+	echo "${ZREPL_BIN} not executable. Exiting."
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+/usr/bin/cmp -s $ZREPL_YML $ZREPL_REF
+if [ $? -eq 0 ]; then
+	echo "${ZREPL_YML} not modified. Exiting."
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+${ZREPL_BIN} configcheck
+if [ $? -ne 0 ]; then
+	echo "${ZREPL_YML} has errors. Exiting."
+	exit $SMF_EXIT_ERR_CONFIG
+fi
+
+if [ ! -d ${SOCK_DIR} ]; then
+	/usr/bin/mkdir -m ${SOCK_PERM} ${SOCK_DIR}
+	if [ $? -ne 0 ]; then
+		echo "Failed to create ${SOCK_DIR}. Exiting."
+		exit $SMF_EXIT_ERR_CONFIG
+	fi
+fi
+
+# Start the zrepl daemon
+${ZREPL_BIN} daemon &
+
+# Wait for socket creation
+sleep 5
+
+# Fix permissions
+/usr/bin/chmod go+w ${SOCK_CTL}
+
+# Report zero
+exit $SMF_EXIT_OK
+

--- a/components/sysutils/zrepl/files/zrepl.xml
+++ b/components/sysutils/zrepl/files/zrepl.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+    CDDL HEADER START
+
+    The contents of this file are subject to the terms of the
+    Common Development and Distribution License (the "License").
+    You may not use this file except in compliance with the License.
+
+    You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+    or http://www.opensolaris.org/os/licensing.
+    See the License for the specific language governing permissions
+    and limitations under the License.
+
+    When distributing Covered Code, include this CDDL HEADER in each
+    file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+    If applicable, add the following below this CDDL HEADER, with the
+    fields enclosed by brackets "[]" replaced with your own identifying
+    information: Portions Copyright [yyyy] [name of copyright owner]
+
+    CDDL HEADER END
+   
+    Copyright 2022 Gary Mills
+
+    NOTE:  This service manifest is not editable; its contents will
+    be overwritten by package or patch operations, including
+    operating system upgrade.  Make customizations in a different
+    file.
+-->
+
+<service_bundle type='manifest' name='application/backup/zrepl:default'>
+
+<service
+	name='application/backup/zrepl'
+	type='service'
+	version='1'>
+
+	<instance name='default' enabled='false'>
+
+	<!--
+	  zrepl requires local directories.
+	-->
+	<dependency
+		name='zrepl_local'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/system/filesystem/local' />
+	</dependency>
+
+	<!--
+	  zrepl requires nameservice resolution.
+	-->
+	<dependency
+		name='zrepl_nameservice'
+		grouping='require_all'
+		restart_on='none'
+		type='service'>
+		<service_fmri value='svc:/milestone/name-services' />
+	</dependency>
+
+		<exec_method
+			type='method'
+			name='start'
+			exec='/lib/svc/method/zrepl'
+			timeout_seconds='60' />
+
+		<exec_method
+			type='method'
+			name='stop'
+			exec=':kill'
+			timeout_seconds='60' />
+
+		<exec_method
+			type='method'
+			name='refresh'
+			exec=':kill -HUP'
+			timeout_seconds='60' />
+
+		<template>
+			<common_name>
+				<loctext xml:lang='C'>
+				A one-stop, integrated solution for ZFS replication
+				</loctext>
+			</common_name>
+			<documentation>
+				<manpage title='zrepl' section='8'
+				    manpath='/usr/share/man' />
+			</documentation>
+		</template>
+
+	</instance>
+
+</service>
+
+</service_bundle>

--- a/components/sysutils/zrepl/files/zrepl.yml
+++ b/components/sysutils/zrepl/files/zrepl.yml
@@ -1,0 +1,29 @@
+# This is /etc/zrepl/zrepl.yml .  It must be modified before zrepl
+# will work.  Start with the sample configurations in
+# /usr/share/zrepl/config .  For more details on zrepl configurations,
+# see https://zrepl.github.io/configuration.html .
+# 
+# Zrepl is a one-stop ZFS backup and replication solution, written in
+# the GO language.  The OI version has man pages and sample
+# configuration files.  It also has SMF support.  All errors from the
+# daemon appear in /var/svc/log/application-backup-zrepl:default.log .
+# The zrepl client also has RBAC support.
+#     
+# You can test configurations with "zrepl configcheck" run as root.
+#     
+# To run the zrepl service, enable svc:/application/backup/zrepl:default
+# and watch the service log file.  If it reports "... has been
+# modified", add '"atime": "off"' to the configuration, as shown in one
+# of the sample config files.  Likewise, if it reports "cannot create
+# placeholder filesystem", add "encryption: inherit" to the
+# configuration.
+# 
+# You may notice other errors that do not require a configuration
+# change.  If the SMF log file reports "pool must be upgraded", you must
+# upgrade the pool.  The usual command is "zpool upgrade ...".  The
+# client commands like "zrepl status" and "zrepl version" require the
+# RBAC privilege file_dac_search .  You can provide that privilege by
+# prefixing the commmand with "pfexec".  Finally, if the backup
+# filesystems exist but are not mounted they can be mounted manually by
+# ZFS.  You will need to override or remove the property
+# "mountpoint=none" before the ZFS mount will succeed.

--- a/components/sysutils/zrepl/manifests/sample-manifest.p5m
+++ b/components/sysutils/zrepl/manifests/sample-manifest.p5m
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/zrepl
+file path=usr/share/bash-completion/completions/zrepl
+file path=usr/share/man/man5/zrepl.yml.5
+file path=usr/share/man/man8/zrepl.8
+file path=usr/share/zrepl/config/bandwidth_limit.yml
+file path=usr/share/zrepl/config/illumos.yml
+file path=usr/share/zrepl/config/local.yml
+file path=usr/share/zrepl/config/pull.yml
+file path=usr/share/zrepl/config/pull_ssh.yml
+file path=usr/share/zrepl/config/push.yml
+file path=usr/share/zrepl/config/quickstart_backup_to_external_disk.yml
+file path=usr/share/zrepl/config/quickstart_continuous_server_backup_receiver.yml
+file path=usr/share/zrepl/config/quickstart_continuous_server_backup_sender.yml
+file path=usr/share/zrepl/config/quickstart_fan_out_replication_source.yml
+file path=usr/share/zrepl/config/quickstart_fan_out_replication_target.yml
+file path=usr/share/zrepl/config/sink.yml
+file path=usr/share/zrepl/config/snap.yml
+file path=usr/share/zrepl/config/source.yml
+file path=usr/share/zrepl/config/source_ssh.yml
+file path=usr/share/zsh/site-functions/_zrepl

--- a/components/sysutils/zrepl/patches/01-install.patch
+++ b/components/sysutils/zrepl/patches/01-install.patch
@@ -1,0 +1,20 @@
+This patch adds an install target for illumos and OI
+
+--- zrepl-0.5.0/Makefile-orig	Sun Jan  9 05:51:00 2022
++++ zrepl-0.5.0/Makefile	Wed Apr 20 16:44:47 2022
+@@ -230,6 +230,15 @@
+ generate-platform-test-list:
+ 	$(GO_BUILD) -o $(ARTIFACTDIR)/generate-platform-test-list ./platformtest/tests/gen
+ 
++# Install target for illumos
++.PHONY: install
++install:
++	$(GO_BUILD) -o "$(ARTIFACTDIR)/usr/bin/zrepl"
++	$(ARTIFACTDIR)/usr/bin/zrepl gencompletion bash "$(ARTIFACTDIR)/usr/share/bash-completion/completions/zrepl"
++	$(ARTIFACTDIR)/usr/bin/zrepl gencompletion zsh "$(ARTIFACTDIR)/usr/share/zsh/site-functions/_zrepl"
++	rst2man.py docs/configuration/overview.rst $(ARTIFACTDIR)/usr/share/man/man5/zrepl.yml.5
++	rst2man.py docs/usage.rst $(ARTIFACTDIR)/usr/share/man/man8/zrepl.8
++
+ COVER_PLATFORM_BIN_PATH := $(ARTIFACTDIR)/platformtest-cover-$(ZREPL_TARGET_TUPLE)
+ cover-platform-bin:
+ 	$(GO_ENV_VARS) $(GO) test $(GO_BUILDFLAGS) \

--- a/components/sysutils/zrepl/patches/02-authlistener_grpc_adaptor.go.patch
+++ b/components/sysutils/zrepl/patches/02-authlistener_grpc_adaptor.go.patch
@@ -1,0 +1,18 @@
+This patch eliminates a segmentation violation with the local RPC
+transport method.
+
+--- zrepl-0.5.0/rpc/grpcclientidentity/authlistener_grpc_adaptor.go-orig	Sun Jan  9 05:51:00 2022
++++ zrepl-0.5.0/rpc/grpcclientidentity/authlistener_grpc_adaptor.go	Fri Jul  8 17:23:37 2022
+@@ -118,7 +118,11 @@
+ 		if !ok {
+ 			panic("peer.FromContext expected to return a peer in grpc.UnaryServerInterceptor")
+ 		}
+-		logger.WithField("peer_addr", p.Addr.String()).Debug("peer addr")
++		peerAddr := ""
++		if p.Addr != nil { // https://github.com/zrepl/zrepl/issues/598
++			peerAddr = p.Addr.String()
++		}
++		logger.WithField("peer_addr", peerAddr).Debug("peer addr")
+ 		a, ok := p.AuthInfo.(*authConnAuthType)
+ 		if !ok {
+ 			panic(fmt.Sprintf("NewInterceptors must be used in combination with grpc.NewTransportCredentials, but got auth type %T", p.AuthInfo))

--- a/components/sysutils/zrepl/pkg5
+++ b/components/sysutils/zrepl/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "developer/golang",
+        "library/python/docutils",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "backup/zrepl"
+    ],
+    "name": "zrepl"
+}

--- a/components/sysutils/zrepl/zrepl.p5m
+++ b/components/sysutils/zrepl/zrepl.p5m
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Gary Mills
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/zrepl
+file path=usr/share/bash-completion/completions/zrepl
+file path=usr/share/man/man5/zrepl.yml.5
+file path=usr/share/man/man8/zrepl.8
+file path=usr/share/zrepl/config/bandwidth_limit.yml
+file path=usr/share/zrepl/config/illumos.yml
+file path=usr/share/zrepl/config/local.yml
+file path=usr/share/zrepl/config/pull.yml
+file path=usr/share/zrepl/config/pull_ssh.yml
+file path=usr/share/zrepl/config/push.yml
+file path=usr/share/zrepl/config/quickstart_backup_to_external_disk.yml
+file path=usr/share/zrepl/config/quickstart_continuous_server_backup_receiver.yml
+file path=usr/share/zrepl/config/quickstart_continuous_server_backup_sender.yml
+file path=usr/share/zrepl/config/quickstart_fan_out_replication_source.yml
+file path=usr/share/zrepl/config/quickstart_fan_out_replication_target.yml
+file path=usr/share/zrepl/config/sink.yml
+file path=usr/share/zrepl/config/snap.yml
+file path=usr/share/zrepl/config/source.yml
+file path=usr/share/zrepl/config/source_ssh.yml
+file path=usr/share/zsh/site-functions/_zrepl
+
+# Files in the files directory
+file zrepl.yml path=etc/zrepl/zrepl.yml \
+    mode=0644 preserve=true
+file zrepl.yml path=etc/zrepl/zrepl.yml-ref \
+    mode=0444
+file zrepl.xml path=lib/svc/manifest/application/zrepl.xml
+file zrepl path=lib/svc/method/zrepl \
+    mode=0555
+file exec_attr path=etc/security/exec_attr.d/zrepl
+


### PR DESCRIPTION
Zrepl is a one-stop ZFS backup and replication solution, written in the GO language.  The OI version has man pages and sample configuration files.  It also has SMF support.  All errors from the daemon appear in /var/svc/log/application-backup-zrepl:default.log .  The zrepl client also has RBAC support.

The build, install, and publish steps were all successful, as was the package install.  There are no built-in tests.  External tests, a simulated backup, were also successful.

The configuration file is /etc/zrepl/zrepl.yml .  The default file must be modified to suit the circumstances of your systems.  You can test it with "zrepl configcheck" run as root.

To run the zrepl service, enable svc:/application/backup/zrepl:default and watch the service log file.  If it reports "... has been modified", add '"atime": "off"' to the configuration, as shown in one of the sample config files.  Likewise, if it reports "cannot create placeholder filesystem", add "encryption: inherit" to the configuration.

You may notice other errors that do not require a configuration change.  If the SMF log file reports "pool must be upgraded", you must upgrade the pool.  The usual command is "zpool upgrade ...".  The client commands like "zrepl status" and "zrepl version" require the RBAC privilege file_dac_search .  You can provide that privilege by prefixing the command with "pfexec".  Finally, if the backup filesystems exist but are not mounted they can be mounted manually by ZFS.  You will need to override or remove the property "mountpoint=none" before the ZFS mount will succeed.
