### PR TITLE
userland tools: use python-3.9 instead of 3.5

### DIFF
--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/tools/component-translate
+++ b/tools/component-translate
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.

--- a/tools/userland-component
+++ b/tools/userland-component
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 
 #
 # This file and its contents are supplied under the terms of the

--- a/tools/userland-fetch
+++ b/tools/userland-fetch
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/tools/userland-incorporator
+++ b/tools/userland-incorporator
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/tools/userland-mangler
+++ b/tools/userland-mangler
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/tools/userland-mapping
+++ b/tools/userland-mapping
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 
 #
 # This file and its contents are supplied under the terms of the

--- a/tools/userland-unpack
+++ b/tools/userland-unpack
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #


### PR DESCRIPTION
After pkg5 #116 has been merged we need to use python-3.9.