### PR TITLE
userland-tools: fix python3.9 SyntaxWarning

### DIFF
--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -118,7 +118,7 @@ def FindComponentPaths(path, debug=False, subdir='components',
 
             # Only 'openindiana' category.
             category = line.split('/')[0]
-            if category is 'openindiana':
+            if category == 'openindiana':
                 continue
 
             filename = os.path.basename(line)
@@ -131,10 +131,10 @@ def FindComponentPaths(path, debug=False, subdir='components',
 
         # Add meta-packages/history only if we build the main repository, where
         # subdir is equal to 'components'.
-        if subdir is 'components':
+        if subdir == 'components':
             paths.append('meta-packages/history')
         # Add encumbered/meta-packages/history only if we build the encumbered repository
-        if subdir is 'components/encumbered':
+        if subdir == 'components/encumbered':
             paths.append('encumbered/meta-packages/history')
 
         paths = list(set(paths))

--- a/tools/userland-mangler
+++ b/tools/userland-mangler
@@ -202,7 +202,7 @@ def mangle_manpage(manifest, action, text):
 #
 def mangle_elf(manifest, action, src, dest):
         strip_elf_runpath = action.attrs.pop('mangler.elf.strip_runpath', 'true')
-        if strip_elf_runpath is 'false':
+        if strip_elf_runpath == 'false':
                 return
 
         #
@@ -290,7 +290,7 @@ def mangle_script(manifest, action, text):
 #
 def mangle_cddl(manifest, action, text):
         strip_cddl = action.attrs.pop('mangler.strip_cddl', 'false')
-        if strip_cddl is 'false':
+        if strip_cddl == 'false':
                 return text
         cddl_re = re.compile('^[^\n]*CDDL HEADER START.+CDDL HEADER END[^\n]*$',
                              re.MULTILINE|re.DOTALL)


### PR DESCRIPTION
Affects userland-mangler and bass-o-matic.