### PR TITLE
Obsolete Cassini Ethernet (Sun GigaSwift Ethernet) driver (ce)

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -321,6 +321,7 @@ developer/clang-40@4.0.1,5.11-2018.0.0.6
 developer/clang-80@8.0.1,5.11-2020.0.1.2
 developer/clang-90@9.0.1,5.11-2020.0.1.2
 developer/cxa_finalize@0.1,5.11-2015.0.2.0
+developer/debug/mdb/module/module-ce@0.5.11,5.11-2013.0.0.1
 developer/documentation-tool/epydoc@3.0.1-2015.0.2.0
 developer/g++/icu@4.6,5.11-2014.1.3.0 developer/icu@4.6,5.11-2014.1.3.1 noincorporate
 developer/gcc-47@4.7.4,5.11-2015.0.2.0
@@ -373,6 +374,7 @@ documentation/gnome/gnome-devel-docs@2.32.0,5.11-2018.0.0.0
 driver/audio/audiovia97@0.5.11,5.11-2022.0.1.0
 driver/graphics/nvidia@0.340.108-2020.0.1.0 driver/graphics/nvidia-340@0.340.108,5.11-2020.0.1.0
 driver/network/arbel@0.5.11,5.11-2015.0.2.0
+driver/network/ce@0.5.11,5.11-2013.0.0.1
 driver/network/pcan@0.5.11,5.11-2022.0.1.0
 driver/network/pcwl@0.5.11,5.11-2022.0.1.0
 driver/serial/pcser@0.5.11,5.11-2022.0.1.0

--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	52
+COMPONENT_REVISION=	53
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk
@@ -34,3 +34,5 @@ install:
 
 clean:
 	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
+
+# Auto-generated dependencies

--- a/components/meta-packages/install-types/auto_install.p5m
+++ b/components/meta-packages/install-types/auto_install.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/auto_install@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="Cluster for the Automated Installer client"
 set name=info.classification value="org.opensolaris.category.2008:Meta Packages/Group Packages"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)

--- a/components/meta-packages/install-types/includes/minimal
+++ b/components/meta-packages/install-types/includes/minimal
@@ -10,7 +10,6 @@ depend type=require fmri=data/iso-codes
 depend type=require fmri=database/sqlite-3
 depend type=require fmri=developer/acpi
 depend type=require fmri=developer/debug/mdb
-depend type=require fmri=developer/debug/mdb/module/module-ce
 depend type=require fmri=developer/debug/mdb/module/module-fibre-channel
 depend type=require fmri=developer/debug/mdb/module/module-qlc
 depend type=require fmri=developer/dtrace
@@ -38,7 +37,6 @@ depend type=require fmri=driver/network/bge
 depend type=require fmri=driver/network/bnx
 depend type=require fmri=driver/network/bnxe
 depend type=require fmri=driver/network/bpf
-depend type=require fmri=driver/network/ce
 depend type=require fmri=driver/network/chxge
 depend type=require fmri=driver/network/dmfe
 depend type=require fmri=driver/network/e1000g

--- a/components/meta-packages/install-types/manifests/sample-manifest.p5m
+++ b/components/meta-packages/install-types/manifests/sample-manifest.p5m
@@ -10,13 +10,16 @@
 #
 
 #
-# Copyright 2016 Alexander Pyhalov
+# Copyright 2022 <contributor>
 #
 
-set name=pkg.fmri value=pkg:/minimal_install@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
-set name=pkg.summary value="Cluster with minimal applications set for servers"
-set name=info.classification value="org.opensolaris.category.2008:Meta Packages/Group Packages"
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-<include minimal>
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+

--- a/components/meta-packages/install-types/mate_install.p5m
+++ b/components/meta-packages/install-types/mate_install.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/mate_install@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="A meta-package that installs common applications for Mate Live CD and desktops"
 set name=info.classification value="org.opensolaris.category.2008:Meta Packages/Group Packages"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)

--- a/components/meta-packages/install-types/server_install.p5m
+++ b/components/meta-packages/install-types/server_install.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/server_install@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="Cluster with common applications for servers"
 set name=info.classification value="org.opensolaris.category.2008:Meta Packages/Group Packages"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)


### PR DESCRIPTION
There are many reasons to obsolete the `ce` driver, for example:

* it is SPARC only,
* It is no longer supported by `illumos-gate` - see [illumos#11328](https://www.illumos.org/issues/11328),
* it is closed source,
* it is buggy.