### PR TITLE
gnupg;gnutls-3: fix keyserver errors

### DIFF
--- a/components/library/gnutls-3/Makefile
+++ b/components/library/gnutls-3/Makefile
@@ -31,7 +31,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		gnutls
 COMPONENT_MJR_VERSION=	3.6
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).16
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=  https://gnutls.org/
 COMPONENT_SUMMARY=	GNU transport layer security library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -49,6 +49,9 @@ CFLAGS += -I$(USRINCDIR)/idn2
 
 CONFIGURE_OPTIONS += --disable-guile
 CONFIGURE_OPTIONS += --disable-dependency-tracking
+CONFIGURE_OPTIONS += --with-default-trust-store-file=/etc/certs/ca-certificates.crt
+CONFIGURE_OPTIONS += --with-default-trust-store-dir=/etc/certs/CA
+COMPONENT_PRE_CONFIGURE_ACTION= ( cd $(SOURCE_DIR) && autoreconf -if )
 
 unexport SHELLOPTS
 

--- a/components/sysutils/gnupg/Makefile
+++ b/components/sysutils/gnupg/Makefile
@@ -29,18 +29,19 @@ BUILD_BITS= 64
 USE_COMMON_TEST_MASTER= no
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=		gnupg
-COMPONENT_VERSION=	2.3.7
-COMPONENT_SUMMARY=	GNU Privacy Guard
-COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_PROJECT_URL=	https://gnupg.org/
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
+COMPONENT_NAME=         gnupg
+COMPONENT_VERSION=      2.3.7
+COMPONENT_REVISION=     1
+COMPONENT_SUMMARY=      GNU Privacy Guard
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=  https://gnupg.org/
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
 COMPONENT_ARCHIVE_HASH= sha256:ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669
-COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/ftp/gcrypt/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
-COMPONENT_FMRI=		crypto/gnupg
-COMPONENT_CLASSIFICATION=	Applications/System Utilities
+COMPONENT_ARCHIVE_URL=  $(COMPONENT_PROJECT_URL)/ftp/gcrypt/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=         crypto/gnupg
+COMPONENT_CLASSIFICATION=Applications/System Utilities
 COMPONENT_DESCRIPTION=		A complete and free implementation of the OpenPGP Standard as defined by RFC4880
-COMPONENT_LICENSE=	GPLv3, GPLv2, LGPLv3, LGPLv2.1, Creative Commons 1.0, others
+COMPONENT_LICENSE=      GPLv3, GPLv2, LGPLv3, LGPLv2.1, Creative Commons 1.0, others
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -68,6 +69,7 @@ CONFIGURE_OPTIONS  +=		--infodir=$(CONFIGURE_INFODIR)
 CONFIGURE_OPTIONS  +=		--enable-nls
 CONFIGURE_OPTIONS  +=		--enable-largefile
 CONFIGURE_OPTIONS  +=		--disable-selinux-support
+CONFIGURE_OPTIONS  +=		--disable-libdns
 # gpg -> gpg2
 CONFIGURE_OPTIONS  +=		--enable-gpg-is-gpg2
 CONFIGURE_OPTIONS  +=		--with-pinentry-pgm=$(CONFIGURE_PREFIX)/lib/pinentry

--- a/components/sysutils/gnupg/manifests/sample-manifest.p5m
+++ b/components/sysutils/gnupg/manifests/sample-manifest.p5m
@@ -116,6 +116,7 @@ file path=usr/share/locale/da/LC_MESSAGES/gnupg2.mo
 file path=usr/share/locale/de/LC_MESSAGES/gnupg2.mo
 file path=usr/share/locale/el/LC_MESSAGES/gnupg2.mo
 file path=usr/share/locale/en/LC_MESSAGES/gnupg2.mo
+file path=usr/share/locale/en/en@boldquot/LC_MESSAGES/gnupg2.mo
 file path=usr/share/locale/en@boldquot/LC_MESSAGES/gnupg2.mo
 file path=usr/share/locale/en@quot/LC_MESSAGES/gnupg2.mo
 file path=usr/share/locale/eo/LC_MESSAGES/gnupg2.mo


### PR DESCRIPTION
BUG 1: gnupg was compiled to use libdns, which caused gnupg programs to be unable to resolve dns names.
BUG 2: gnutls-3 was not compiled with the system certificate store locations, which caused gnupg (and probably others) to be unable to validate certificates.

For the commit fixing bug 2, I have also disabled gnutls 32-bit. If 32-bit is required somewhere else (I haven't checked), the autogen package must be rebuilt to include 32-bit as well.