### PR TITLE
userland-tools: use working gpg keyserver

### DIFF
--- a/tools/.gnupg/gpg.conf
+++ b/tools/.gnupg/gpg.conf
@@ -5,5 +5,8 @@
 # installations it should be enabled.
 require-cross-certification
 
-keyserver hkp://keys.gnupg.net
-keyserver-options honor-http-proxy auto-key-retrieve
+keyserver hkps://keyserver.ubuntu.com:443
+#keyserver hkps://keys.openpgp.org:443
+#keyserver hkps://keys.mailvelope.com:443
+
+keyserver-options auto-key-retrieve


### PR DESCRIPTION
keys.gnupg.net and *.sks-keyservers.net are both defunct.
There are a few options left for keyservers but I found that ubuntu's has the largest database.

PS: This won't actually work until #9290 is merged.