### PR TITLE
history: megasync obsolete is no longer needed

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -824,7 +824,6 @@ network/dhcp/dhcpmgr/locale/sv@0.5.11,5.11-2018.0.0.0
 network/dhcp/dhcpmgr/locale/zh_cn@0.5.11-2013.0.0.0
 network/dhcp/dhcpmgr/locale/zh_hk_tw@0.5.11-2013.0.0.0
 network/dhcp/dhcpmgr@0.5.11,5.11-2022.0.1.0
-network/megasync@4.6.6,5.11-2022.0.0.1
 network/putty/putty-tools@0.76,5.11-2020.0.1.1 network/putty
 print/lp/filter/a2ps@4.14,5.11-2015.0.2.0 print/filter/a2ps@4.14,5.11-0.151.1.8.1
 print/lp/ipp/ipp-listener@0.5.11,5.11-2022.0.1.0


### PR DESCRIPTION
Megasync was moved from `openindiana.org` publisher to `hipster-encumbered` few months back and obsoleted in `openindiana.org`.  This is the current list all all `megasync` packages in both publishers:

```
# pkg list -afv network/megasync                                                                                                                                                                                                              FMRI                                                                         IFO
pkg://hipster-encumbered/network/megasync@4.6.6-2022.0.0.2:20220528T112857Z  i--
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220921T073716Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220920T104624Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220917T145117Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220917T141142Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220913T111259Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220830T195515Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220830T190230Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220827T132624Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220825T202305Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220825T194932Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220815T212351Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220815T202235Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220721T223342Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220721T204106Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220713T180201Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220713T065945Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220709T150630Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220709T140754Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220701T045455Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220630T210231Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220629T220420Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220629T212220Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220613T120533Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220613T111142Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220612T212712Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220610T175610Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220610T170644Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220610T161639Z     --o
pkg://openindiana.org/network/megasync@4.6.6-2022.0.0.1:20220528T110343Z     --o
#
```

Since there is no longer normal (not obsoleted) `megasync` in the `openindiana.org` repo, it is no longer possible to install it from there, so we could safely stop to build the obsoleted package too.  The obsoleted `pkg://openindiana.org/network/megasync` will stay in the repo until somebody remove it, but that won't happen soon anyway, so people who installed `megasync` from `openindiana.org` and didn't upgrade yet (to get the `megasync` removed) will still have chance to do so.