### PR TITLE
Obsolete scim

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -934,6 +934,20 @@ system/input-method/iiim/twle-chewing@0.5.11,5.11-2018.0.0.0
 system/input-method/iiim/twle-core@0.5.11,5.11-2018.0.0.0
 system/input-method/iiim/twle-open@0.5.11,5.11-2018.0.0.0
 system/input-method/iiim@0.5.11,5.11-2018.0.0.0
+system/input-method/scim/anthy@1.2.4,5.11-2013.0.0.1
+system/input-method/scim/chewing@0.3.1,5.11-2013.0.0.1
+system/input-method/scim/hangul@0.3.2,5.11-2013.0.0.1
+system/input-method/scim/pinyin@0.5.91,5.11-2013.0.0.1
+system/input-method/scim/scim-m17n@0.5.11,5.11-2013.0.0.1
+system/input-method/scim/sunpinyin@1.0,5.11-2013.0.0.1
+system/input-method/scim/table@0.5.7,5.11-2013.0.0.1
+system/input-method/scim/table/chinese@0.5.7,5.11-2013.0.0.1
+system/input-method/scim/table/extra@0.5.7,5.11-2013.0.0.1
+system/input-method/scim/table/india@0.5.7,5.11-2013.0.0.1
+system/input-method/scim/table/japanese@0.5.7,5.11-2013.0.0.1
+system/input-method/scim/table/korean@0.5.7,5.11-2013.0.0.1
+system/input-method/scim/thai@0.1.0,5.11-2013.0.0.1
+system/input-method/scim@1.4.7,5.11-2013.0.0.1
 system/kernel/ultra-wideband@0.5.11,5.11-2022.0.1.0
 system/library/dbus-x11@1.12.8,5.11-2018.0.0.1 system/library/dbus/dbus-x11@1.12.8,5.11-2018.0.0.0
 system/library/g++-5-runtime@5.5.0,5.11-2020.0.1.2


### PR DESCRIPTION
We do have ibus, so scim is not needed.  Also, we do not have a build recipe for scim in oi-userland and it looks like the scim project is dead anyway.