### PR TITLE
Correct dependencies for Python 3.9 Migration

### DIFF
--- a/components/openindiana/pkg/Makefile
+++ b/components/openindiana/pkg/Makefile
@@ -118,3 +118,6 @@ PACKAGE_NAMES += system/zones/brand/nlipkg
 # Manually added dependencies
 REQUIRED_PACKAGES += developer/opensolaris/pkg5
 REQUIRED_PACKAGES += system/zones/internal
+REQUIRED_PACKAGES += library/python/cherrypy-39
+REQUIRED_PACKAGES += library/python/rapidjson-39
+REQUIRED_PACKAGES += library/python/jsonschema-39


### PR DESCRIPTION
Due to the migration of IPS to Python 3.9, these additional packages are needed in order to build newer IPS packages:

+REQUIRED_PACKAGES += library/python/cherrypy-39
+REQUIRED_PACKAGES += library/python/rapidjson-39
+REQUIRED_PACKAGES += library/python/jsonschema-39
