### PR TITLE
python/configobj: rebuild to get packages for python 2.7 and 3.5 obso…

### DIFF
--- a/components/python/configobj/Makefile
+++ b/components/python/configobj/Makefile
@@ -21,7 +21,7 @@ PATH=/usr/bin:/usr/gnu/bin:/usr/sbin
 
 COMPONENT_NAME=		configobj
 COMPONENT_VERSION=	5.0.6
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_PROJECT_URL=	https://github.com/DiffSK/configobj
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -29,8 +29,10 @@ COMPONENT_ARCHIVE_HASH=	\
     sha256:a2f5650770e1c87fb335af19a9b7eb73fc05ccf22144eb68db7d00cd2bcb0902
 COMPONENT_ARCHIVE_URL=	https://pypi.python.org/packages/source/c/configobj/$(COMPONENT_ARCHIVE)
 
-PYTHON_VERSIONS=	2.7 3.5 3.7 3.9
+PYTHON_VERSIONS =	3.7 3.9
 
 TEST_TARGET= $(NO_TESTS)
 
 include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies

--- a/components/python/configobj/configobj-PYVER.p5m
+++ b/components/python/configobj/configobj-PYVER.p5m
@@ -15,6 +15,7 @@
 #
 
 set name=pkg.fmri value=pkg:/library/python/configobj-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="Config file reading, writing and validation"
 set name=info.classification value="org.opensolaris.category.2008:Development/Python"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/python/configobj/history
+++ b/components/python/configobj/history
@@ -1,3 +1,5 @@
 library/python-2/configobj-26@5.0.6,5.11-2016.0.1.0
 library/python-2/configobj@5.0.6,5.11-2016.0.1.0 library/python/configobj@5.0.6,5.11-2016.0.1.0
-library/python-2/configobj-27@5.0.6,5.11-2016.0.1.0 library/python/configobj-27@5.0.6,5.11-2016.0.1.0
+library/python-2/configobj-27@5.0.6,5.11-2016.0.1.0
+library/python/configobj-27@5.0.6,5.11-2022.0.0.4
+library/python/configobj-35@5.0.6,5.11-2022.0.0.4

--- a/components/python/configobj/manifests/generic-manifest.p5m
+++ b/components/python/configobj/manifests/generic-manifest.p5m
@@ -9,6 +9,7 @@
 
 # Copyright 2022 <contributor>
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/python/configobj/manifests/sample-manifest.p5m
+++ b/components/python/configobj/manifests/sample-manifest.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,14 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/lib/python2.7/vendor-packages/_version.py
-file path=usr/lib/python2.7/vendor-packages/configobj-$(COMPONENT_VERSION)-py2.7.egg-info
-file path=usr/lib/python2.7/vendor-packages/configobj.py
-file path=usr/lib/python2.7/vendor-packages/validate.py
-file path=usr/lib/python3.5/vendor-packages/_version.py
-file path=usr/lib/python3.5/vendor-packages/configobj-$(COMPONENT_VERSION)-py3.5.egg-info
-file path=usr/lib/python3.5/vendor-packages/configobj.py
-file path=usr/lib/python3.5/vendor-packages/validate.py
 file path=usr/lib/python3.7/vendor-packages/_version.py
 file path=usr/lib/python3.7/vendor-packages/configobj-$(COMPONENT_VERSION)-py3.7.egg-info
 file path=usr/lib/python3.7/vendor-packages/configobj.py

--- a/components/python/configobj/pkg5
+++ b/components/python/configobj/pkg5
@@ -4,8 +4,6 @@
         "shell/ksh93"
     ],
     "fmris": [
-        "library/python/configobj-27",
-        "library/python/configobj-35",
         "library/python/configobj-37",
         "library/python/configobj-39",
         "library/python/configobj"


### PR DESCRIPTION
…leted

No package depends on `configobj-27` and/or `configobj-35` so we can safely obsolete them. Please note both python 2.7 and 3.5 are no longer supported for at least two years now.