### PR TITLE
python/pycodestyle: obsolete packages for python 2.7 and 3.5

### DIFF
--- a/components/python/pycodestyle/Makefile
+++ b/components/python/pycodestyle/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pycodestyle
 COMPONENT_VERSION=	2.5.0
+COMPONENT_REVISION =	1
 COMPONENT_CLASSIFICATION=Development/Python
 COMPONENT_FMRI=		library/python/pycodestyle
 COMPONENT_SUMMARY=	pycodestyle - Python style guide checker
@@ -40,7 +41,7 @@ COMPONENT_ARCHIVE_HASH=	\
 COMPONENT_ARCHIVE_URL=	$(call pypi_url)
 COMPONENT_LICENSE=	MIT
 
-PYTHON_VERSIONS=	2.7 3.5 3.7 3.9
+PYTHON_VERSIONS=	3.7 3.9
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -82,11 +83,7 @@ COMPONENT_SYSTEM_TEST_ARGS =
 ASLR_MODE = $(ASLR_NOT_APPLICABLE)
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += library/python/setuptools-27
-REQUIRED_PACKAGES += library/python/setuptools-35
 REQUIRED_PACKAGES += library/python/setuptools-37
 REQUIRED_PACKAGES += library/python/setuptools-39
-REQUIRED_PACKAGES += runtime/python-27
-REQUIRED_PACKAGES += runtime/python-35
 REQUIRED_PACKAGES += runtime/python-37
 REQUIRED_PACKAGES += runtime/python-39

--- a/components/python/pycodestyle/history
+++ b/components/python/pycodestyle/history
@@ -1,7 +1,9 @@
-library/python/pep8-35@1.7.0-2020.0.1.6 library/python/pycodestyle-35
-library/python/pep8-27@1.7.0-2020.0.1.6 library/python/pycodestyle-27
+library/python/pep8-27@1.7.0-2020.0.1.7
+library/python/pep8-35@1.7.0-2020.0.1.7
 library/python/pep8@1.7.0-2020.0.1.6 library/python/pycodestyle
 library/python/pep8-34@1.7.0-2020.0.1.2
 library/python-2/pep8-26@1.4.6,5.11-2016.0.1.0
-library/python-2/pep8-27@1.4.6,5.11-2016.0.1.0 library/python/pep8-27
-library/python-2/pep8@1.4.6,5.11-2016.0.1.0 library/python/pep8
+library/python-2/pep8-27@1.4.6,5.11-2016.0.1.1
+library/python-2/pep8@1.4.6,5.11-2016.0.1.1 library/python/pycodestyle
+library/python/pycodestyle-27@2.5.0,5.11-2020.0.1.1
+library/python/pycodestyle-35@2.5.0,5.11-2020.0.1.1

--- a/components/python/pycodestyle/manifests/generic-manifest.p5m
+++ b/components/python/pycodestyle/manifests/generic-manifest.p5m
@@ -7,15 +7,15 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
-
 file path=usr/bin/pycodestyle-$(PYVER)
 file path=usr/lib/python$(PYVER)/vendor-packages/pep8.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO

--- a/components/python/pycodestyle/manifests/sample-manifest.p5m
+++ b/components/python/pycodestyle/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,28 +23,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/pycodestyle-2.7
-file path=usr/bin/pycodestyle-3.5
 file path=usr/bin/pycodestyle-3.7
 file path=usr/bin/pycodestyle-3.9
-file path=usr/lib/python2.7/vendor-packages/pep8.py
-file path=usr/lib/python2.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py2.7.egg-info/PKG-INFO
-file path=usr/lib/python2.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py2.7.egg-info/SOURCES.txt
-file path=usr/lib/python2.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py2.7.egg-info/dependency_links.txt
-file path=usr/lib/python2.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py2.7.egg-info/entry_points.txt
-file path=usr/lib/python2.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py2.7.egg-info/namespace_packages.txt
-file path=usr/lib/python2.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py2.7.egg-info/not-zip-safe
-file path=usr/lib/python2.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py2.7.egg-info/top_level.txt
-file path=usr/lib/python2.7/vendor-packages/pycodestyle.py
-file path=usr/lib/python3.5/vendor-packages/pep8.py
-file path=usr/lib/python3.5/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.5.egg-info/PKG-INFO
-file path=usr/lib/python3.5/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.5.egg-info/SOURCES.txt
-file path=usr/lib/python3.5/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.5.egg-info/dependency_links.txt
-file path=usr/lib/python3.5/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.5.egg-info/entry_points.txt
-file path=usr/lib/python3.5/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.5.egg-info/namespace_packages.txt
-file path=usr/lib/python3.5/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.5.egg-info/not-zip-safe
-file path=usr/lib/python3.5/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
-file path=usr/lib/python3.5/vendor-packages/pycodestyle.py
 file path=usr/lib/python3.7/vendor-packages/pep8.py
 file path=usr/lib/python3.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.7.egg-info/PKG-INFO
 file path=usr/lib/python3.7/vendor-packages/pycodestyle-$(COMPONENT_VERSION)-py3.7.egg-info/SOURCES.txt

--- a/components/python/pycodestyle/pkg5
+++ b/components/python/pycodestyle/pkg5
@@ -1,18 +1,13 @@
 {
     "dependencies": [
         "SUNWcs",
-        "library/python/setuptools-27",
-        "library/python/setuptools-35",
         "library/python/setuptools-37",
         "library/python/setuptools-39",
-        "runtime/python-27",
-        "runtime/python-35",
         "runtime/python-37",
-        "runtime/python-39"
+        "runtime/python-39",
+        "shell/ksh93"
     ],
     "fmris": [
-        "library/python/pycodestyle-27",
-        "library/python/pycodestyle-35",
         "library/python/pycodestyle-37",
         "library/python/pycodestyle-39",
         "library/python/pycodestyle"

--- a/components/python/pycodestyle/pycodestyle-PYVER.p5m
+++ b/components/python/pycodestyle/pycodestyle-PYVER.p5m
@@ -10,6 +10,7 @@
 # Copyright 2020 Aurelien Larcher
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)


### PR DESCRIPTION
No package depends on `pycodestyle-27` and/or `pycodestyle-35` so we can safely obsolete them. Please note both python 2.7 and 3.5 are no longer supported for at least two years now.