### PR TITLE
make-rules: move pipe to GENERATE_EXTRA_CMD

### DIFF
--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -310,10 +310,6 @@ publish:		pre-publish update-metadata $(PUBLISH_STAMP)
 
 sample-manifest:	$(GENERATED).p5m
 
-# By default GENERATE_EXTRA_CMD is a no-op.
-# Since it is used in pipeline it needs to copy input to output.
-GENERATE_EXTRA_CMD ?= $(CAT)
-
 $(GENERATED).p5m:	install $(GENERATE_EXTRA_DEPS)
 	[ ! -d $(SAMPLE_MANIFEST_DIR) ] && $(MKDIR) $(SAMPLE_MANIFEST_DIR) || true
 	$(PKGSEND) generate $(PKG_HARDLINKS:%=--target %) $(PROTO_DIR) | \
@@ -323,8 +319,7 @@ $(GENERATED).p5m:	install $(GENERATE_EXTRA_DEPS)
 		-e '/usr\/lib\/python3\..*\/__pycache__\/.*/d'  | \
 		$(PKGFMT) | \
 		uniq | \
-		cat $(METADATA_TEMPLATE) - | \
-		$(GENERATE_EXTRA_CMD) | \
+		cat $(METADATA_TEMPLATE) - $(GENERATE_EXTRA_CMD) | \
 		$(TEE) $@ $(SAMPLE_MANIFEST_FILE) >/dev/null
 	if [ "$(GENERATE_GENERIC_TRANSFORMS)X" != "X" ]; \
 	then sed $(GENERATE_GENERIC_TRANSFORMS) $(SAMPLE_MANIFEST_FILE) \

--- a/make-rules/makemaker.mk
+++ b/make-rules/makemaker.mk
@@ -166,7 +166,7 @@ $(BUILD_DIR)/%/.tested:    $(BUILD_DIR)/%/.built
 
 # We need to add -$(PLV) to package fmri and generate runtime dependencies based on META.json
 GENERATE_EXTRA_DEPS += $(BUILD_DIR)/META.json
-GENERATE_EXTRA_CMD ?= \
+GENERATE_EXTRA_CMD += | \
 	$(GSED) -e 's/^\(set name=pkg.fmri [^@]*\)\(.*\)$$/\1-$$(PLV)\2/' | \
 	$(CAT) - <( \
 		echo "" ; \


### PR DESCRIPTION
This will make GENERATE_EXTRA_CMD more predictable and easier to understand and use.