### PR TITLE
python/colorama: update to 0.4.5; rebuild for python 3.7 and 3.9 and …

### DIFF
--- a/components/python/colorama/Makefile
+++ b/components/python/colorama/Makefile
@@ -1,39 +1,36 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL"). You may
-# only use this file in accordance with the terms of the CDDL.
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 
 #
-# Copyright 2019-2020 Nona Hansel
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project colorama
 #
 
-BUILD_BITS=	NO_ARCH
-BUILD_STYLE=	setup.py
+BUILD_STYLE = setup.py
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=		colorama
-COMPONENT_VERSION=	0.4.4
-COMPONENT_SUMMARY=	Simple cross-platform colored terminal text in Python
-COMPONENT_PROJECT_URL=	https://github.com/tartley/colorama
-COMPONENT_FMRI=		library/python/colorama
-COMPONENT_CLASSIFICATION= Development/Python 
-COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_URL=	$(call pypi_url)	
-COMPONENT_ARCHIVE_HASH= \
-	sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b
-COMPONENT_LICENSE=	BSD 3 Clause
-COMPONENT_LICENSE_FILE=	LICENSE.txt
+COMPONENT_NAME =		colorama
+COMPONENT_VERSION =		0.4.5
+COMPONENT_SUMMARY =		colorama - Cross-platform colored terminal text.
+COMPONENT_PROJECT_URL =		https://github.com/tartley/colorama
+COMPONENT_ARCHIVE_URL =		\
+	https://files.pythonhosted.org/packages/2b/65/24d033a9325ce42ccbfa3ca2d0866c7e89cc68e5b9d92ecaba9feef631df/colorama-0.4.5.tar.gz
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4
+COMPONENT_LICENSE =		BSD-3-Clause
+COMPONENT_LICENSE_FILE =	LICENSE.txt
 
-PYTHON_VERSIONS=	3.5
+TEST_TARGET = $(NO_TESTS)
 
-TEST_TARGET:	$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 
 # Auto-generated dependencies

--- a/components/python/colorama/colorama-PYVER.p5m
+++ b/components/python/colorama/colorama-PYVER.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2019 Nona Hansel 
+# This file was automatically generated using python-integrate-project
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,13 +23,13 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/PKG-INFO
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/SOURCES.txt
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/dependency_links.txt
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
-file path=usr/lib/python3.5/vendor-packages/colorama/__init__.py
-file path=usr/lib/python3.5/vendor-packages/colorama/ansi.py
-file path=usr/lib/python3.5/vendor-packages/colorama/ansitowin32.py
-file path=usr/lib/python3.5/vendor-packages/colorama/initialise.py
-file path=usr/lib/python3.5/vendor-packages/colorama/win32.py
-file path=usr/lib/python3.5/vendor-packages/colorama/winterm.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/ansi.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/ansitowin32.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/initialise.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/win32.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/winterm.py

--- a/components/python/colorama/history
+++ b/components/python/colorama/history
@@ -1,0 +1,1 @@
+library/python/colorama-35@0.4.4,5.11-2020.0.1.1 noincorporate

--- a/components/python/colorama/manifests/sample-manifest.p5m
+++ b/components/python/colorama/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2022 <contributor>
 #
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,13 +23,13 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/PKG-INFO
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/SOURCES.txt
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/dependency_links.txt
-file path=usr/lib/python3.5/vendor-packages/colorama-$(COMPONENT_VERSION)-py3.5.egg-info/top_level.txt
-file path=usr/lib/python3.5/vendor-packages/colorama/__init__.py
-file path=usr/lib/python3.5/vendor-packages/colorama/ansi.py
-file path=usr/lib/python3.5/vendor-packages/colorama/ansitowin32.py
-file path=usr/lib/python3.5/vendor-packages/colorama/initialise.py
-file path=usr/lib/python3.5/vendor-packages/colorama/win32.py
-file path=usr/lib/python3.5/vendor-packages/colorama/winterm.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/ansi.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/ansitowin32.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/initialise.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/win32.py
+file path=usr/lib/python$(PYVER)/vendor-packages/colorama/winterm.py

--- a/components/python/colorama/pkg5
+++ b/components/python/colorama/pkg5
@@ -1,9 +1,12 @@
 {
     "dependencies": [
-        "SUNWcs"
+        "SUNWcs",
+        "shell/ksh93",
+        "system/library"
     ],
     "fmris": [
-        "library/python/colorama-35",
+        "library/python/colorama-37",
+        "library/python/colorama-39",
         "library/python/colorama"
     ],
     "name": "colorama"


### PR DESCRIPTION
…to get package for python 3.5 obsoleted

Please merge **AFTER** #9464.  Thanks.