### PR TITLE
make-rules/makemaker-defaults.mk: do not convert '_' to '-' in default package fmri

### DIFF
--- a/make-rules/makemaker-defaults.mk
+++ b/make-rules/makemaker-defaults.mk
@@ -18,7 +18,7 @@ COMPONENT_VERSION ?=		$(shell $(WS_TOOLS)/perl-version-convert $(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION ?=	Development/Perl
 COMPONENT_SRC ?=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_ARCHIVE ?=		$(COMPONENT_SRC).tar.gz
-COMPONENT_FMRI ?=		library/perl-5/$(shell echo $(COMPONENT_NAME) | tr [A-Z]_ [a-z]-)
+COMPONENT_FMRI ?=		library/perl-5/$(shell echo $(COMPONENT_NAME) | tr [A-Z] [a-z])
 ifneq ($(strip $(COMPONENT_PERL_MODULE)),)
 COMPONENT_PERL_DISTRIBUTION ?=	$(subst ::,-,$(COMPONENT_PERL_MODULE))
 COMPONENT_PROJECT_URL ?=	https://metacpan.org/pod/$(COMPONENT_PERL_MODULE)


### PR DESCRIPTION
Underscore is common character in package names (fmris) so there is no need to convert '_' to '-' for perl packages.  This will also make perl package fmris a bit more predictable.

Currently there are only two components affected by this: `perl/IP-Country-DB_File` and `perl/Tree-DAG_Node`.  Once this PR is merged I'll trigger their rebuild to get their packages renamed.

Thanks.