### PR TITLE
history: incorporate all renamed packages

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -286,7 +286,7 @@ database/postgres-96/mysql_fdw@2.5.3,5.11-2020.0.1.1
 database/postgres-96/pg_repack@1.4.7,5.11-2022.0.0.1
 database/postgres-96/tests@9.6.24,5.11-2022.0.0.1
 database/postgres-96@9.6.24,5.11-2022.0.0.1
-database/postgres/library/g++/libpqxx@4.0.1,5.11-2014.0.1.0 database/postgres/library/c++/libpqxx@4.0.1,5.11-2014.1.3.1 noincorporate
+database/postgres/library/g++/libpqxx@4.0.1,5.11-2014.0.1.1 database/postgres/library/c++/libpqxx@4.0.1,5.11-2014.1.3.1
 database/postgres/pg_upgrade@0.5.11,5.11-2015.0.2.0
 database/sqlite-3/documentation@3.7.6.3,5.11-2016.1.1.0
 desktop/administration/gnome-system-tools@2.30.0,5.11-2017.0.0.1
@@ -295,7 +295,7 @@ desktop/archive-manager/file-roller@2.32.2,5.11-2017.0.0.3
 desktop/avant-window-navigator@0.3.2.1,5.11-2017.0.0.3
 desktop/calculator/gcalctool@5.30.2-2018.0.0.1
 desktop/compiz/library/compizconfig-gconf@0.8.8,5.11-2018.0.0.2
-desktop/compiz/library/g++/libcompizconfig@0.8.8,5.11-2014.0.1.0 desktop/compiz/library/libcompizconfig@0.8.8,5.11-2014.1.3.0 noincorporate
+desktop/compiz/library/g++/libcompizconfig@0.8.8,5.11-2014.0.1.1 desktop/compiz/library/libcompizconfig@0.8.8,5.11-2014.1.3.0
 desktop/irc/xchat@2.8.8,5.11-2020.0.0.0 desktop/irc/hexchat
 desktop/mate/mate-icon-theme-faenza@1.20.0-2018.0.0.1
 desktop/media-player/moovida/moovida-plugins@0.5.11,5.11-2015.0.2.0
@@ -329,7 +329,7 @@ developer/clang-90@9.0.1,5.11-2020.0.1.2
 developer/cxa_finalize@0.1,5.11-2015.0.2.0
 developer/debug/mdb/module/module-ce@0.5.11,5.11-2013.0.0.1
 developer/documentation-tool/epydoc@3.0.1-2015.0.2.0
-developer/g++/icu@4.6,5.11-2014.1.3.0 developer/icu@4.6,5.11-2014.1.3.1 noincorporate
+developer/g++/icu@4.6,5.11-2014.1.3.1 developer/icu@4.6,5.11-2014.1.3.1
 developer/gcc-47@4.7.4,5.11-2015.0.2.0
 developer/gcc-48@4.8.5,5.11-2017.0.0.3
 developer/gcc-5@5.5.0,5.11-2020.0.1.2
@@ -591,9 +591,9 @@ library/cacao/cacao-dtrace@0.5.11,5.11-2017.0.0.0
 library/cacao/web-server@0.5.11,5.11-2017.0.0.0
 library/cacao@0.5.11,5.11-2017.0.0.0
 library/desktop/evolution-data-server@3.24.0,5.11-2020.0.1.4
-library/desktop/g++/cairomm@1.10.0,5.11-2014.1.3.0 library/desktop/c++/cairomm@1.10.0,5.11-2014.1.3.1 noincorporate
-library/desktop/g++/gtkmm@2.20.3,5.11-2014.1.3.0 library/desktop/c++/gtkmm@2.20.3,5.11-2014.1.3.1 noincorporate
-library/desktop/g++/pangomm@2.28.4,5.11-2014.1.3.0 library/desktop/c++/pangomm@2.28.4,5.11-2014.1.3.1 noincorporate
+library/desktop/g++/cairomm@1.10.0,5.11-2014.1.3.1 library/desktop/c++/cairomm@1.10.0,5.11-2014.1.3.1
+library/desktop/g++/gtkmm@2.20.3,5.11-2014.1.3.1 library/desktop/c++/gtkmm@2.20.3,5.11-2014.1.3.1
+library/desktop/g++/pangomm@2.28.4,5.11-2014.1.3.1 library/desktop/c++/pangomm@2.28.4,5.11-2014.1.3.1
 library/desktop/g++/webkitgtk@1.2.7,5.11-2017.0.0.0
 library/desktop/gnome-desktop@2.32.1,5.11-2018.0.0.5
 library/desktop/gobject/gir-repository@0.5.11,5.11-2015.0.2.0
@@ -618,10 +618,10 @@ library/desktop/search/tracker/tracker-firefox@0.6.96-2015.0.2.0
 library/desktop/webkitgtk@1.2.7,5.11-2017.0.0.6
 library/e/elementary@1.12.3,5.11-2017.0.0.1
 library/e/evas_generic_loaders@1.12.0,5.11-2017.0.0.2
-library/g++/glibmm@2.28.2,5.11-2014.1.3.2 library/c++/glibmm@2.28.2,5.11-2014.1.3.2 noincorporate
-library/g++/hdf5@1.8.13,5.11-2014.1.2.0 library/c++/hdf5@1.8.13,5.11-2014.1.3.1 noincorporate
-library/g++/sigcpp@2.2.10,5.11-2014.0.2.0 library/c++/sigcpp@2.2.10,5.11-2014.1.3.0 noincorporate
-library/g++/zeromq@3.2.4,5.11-2014.0.1.0 library/c++/zeromq@3.2.4,5.11-2014.1.3.1 noincorporate
+library/g++/glibmm@2.28.2,5.11-2014.1.3.3 library/c++/glibmm@2.28.2,5.11-2014.1.3.2
+library/g++/hdf5@1.8.13,5.11-2014.1.2.1 library/c++/hdf5@1.8.13,5.11-2014.1.3.1
+library/g++/sigcpp@2.2.10,5.11-2014.0.2.1 library/c++/sigcpp@2.2.10,5.11-2014.1.3.0
+library/g++/zeromq@3.2.4,5.11-2014.0.1.1 library/c++/zeromq@3.2.4,5.11-2014.1.3.1
 library/glib1@1.2.10,5.11-2013.0.0.1
 library/gnome/base-libs@2.30.0,5.11-2018.0.0.0
 library/gnome/gnome-component@2.32.1,5.11-2018.0.0.2


### PR DESCRIPTION
There is no reason to have renamed packages `noincorporate`d.  It should be always safe to incorporate them.