### PR TITLE
history: incorporate library/gnu-libiconv

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -629,7 +629,7 @@ library/gnome/gnome-libs@2.30.1,5.11-2018.0.0.1
 library/gnome/libgnomekbd@2.32.0,5.11-2018.0.0.1
 library/gnome/print/gnome-print/gnome-print-papi@2.30.0,5.11-2014.0.0.0
 library/gnome/print/gnome-print@2.30.0,5.11-2014.0.0.0
-library/gnu-libiconv@1.14,5.11-2017.0.0.1 noincorporate
+library/gnu-libiconv@1.14,5.11-2017.0.0.2
 library/gnutls@2.12.24,5.11-2018.0.0.4
 library/ilmbase@2.2.0,5.11-2020.0.1.1
 library/java/cairo-java@1.0.8,5.11-2017.0.0.0


### PR DESCRIPTION
Currently it is safe to incorporate obsoleted `library/gnu-libiconv` so let's do it.