### PR TITLE
bass-o-matic: support job servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,6 @@ download setup prep build install pre-publish publish validate clean clobber \
 test component-hook unpack patch: $(SUBDIRS)
 
 $(SUBDIRS):	FORCE
-	@+echo "$(TARGET) $@" ; $(GMAKE) -C $@ $(TARGET)
+	@+echo "$(TARGET) $@" ; $(GMAKE) -s -C $@ $(TARGET)
 
 FORCE:

--- a/components/Makefile
+++ b/components/Makefile
@@ -180,7 +180,7 @@ ifdef CANONICAL_REPO
 endif
 
 $(COMPONENT_DIRS.nosetup):	$(WS_LOGS) FORCE
-	@cd $(@:%.nosetup=%) && echo "$(TARGET) $(@:%.nosetup=%)" && \
+	@+cd $(@:%.nosetup=%) && echo "$(TARGET) $(@:%.nosetup=%)" && \
 	 $(BASS_O_MATIC) --make $(TARGET) $(LOG)
 
 .PHONY:

--- a/tools/bass-o-matic
+++ b/tools/bass-o-matic
@@ -192,7 +192,17 @@ def main():
                         format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',)
 
     if make_arg:
-        proc = subprocess.Popen(['gmake', '-s'] + [make_arg])
+        MAKE=os.getenv("MAKE","gmake")
+
+        # https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html
+        JOBFLAGS=re.match('.* (--jobserver-auth=([0-9]+),([0-9]+)) ?.*',os.getenv("MAKEFLAGS",""))
+        if JOBFLAGS:
+            JOBFDS=( JOBFLAGS.group(2), JOBFLAGS.group(3) )
+            JOBFLAGS=[JOBFLAGS.group(1)]
+        else:
+            JOBFDS=()
+            JOBFLAGS=[]
+        proc = subprocess.Popen([MAKE, '-s'] + [make_arg] + JOBFLAGS,pass_fds=JOBFDS)
         rc = proc.wait()
         sys.exit(rc)
 


### PR DESCRIPTION
Fixes warning messages when doing `gmake -jx clean`.