### PR TITLE
tools/python-integrate-project: set COMPONENT_ARCHIVE_URL

### DIFF
--- a/tools/python-integrate-project
+++ b/tools/python-integrate-project
@@ -88,6 +88,13 @@ if (($? != 0)) || [[ -z "$PYPI_PROJECT_RELEASE" ]] ; then
 	exit 1
 fi
 
+# Get download url
+DOWNLOAD_URL=$(printf "%s" "$PYPI_PROJECT_RELEASE" | /usr/bin/jq -r '.urls[]|select(.packagetype=="sdist")|.url')
+if (($? != 0)) || [[ -z "$DOWNLOAD_URL" || "$DOWNLOAD_URL" == "null" ]] ; then
+	printf "WARNING: Failed to get download url for project %s, version %s from pypi\n" "$PROJECT" "$VERSION" >&2
+	DOWNLOAD_URL="TODO"
+fi
+
 
 # Prepare the directory
 DIR="$DIR/$PROJECT"
@@ -153,6 +160,8 @@ COMPONENT_VERSION =		$VERSION
 COMPONENT_REVISION =		$((PREV_REV + 1))
 COMPONENT_SUMMARY =		$PROJECT - TODO
 COMPONENT_PROJECT_URL =		$HOMEPAGE
+COMPONENT_ARCHIVE_URL =		\\
+	$DOWNLOAD_URL
 COMPONENT_ARCHIVE_HASH =	\\
 	sha256:TODO
 COMPONENT_LICENSE =		license:TODO


### PR DESCRIPTION
The `pypi` URL scheme strikes back.

We discussed this in PR #9471 and we revert back to default `COMPONENT_ARCHIVE_URL` containing the `pypi` scheme in PR  #9477.  The problem is that the `COMPONENT_ARCHIVE_URL` is visible not only in the generated man pages (which we likely do not have), but also in the `pkg info` output:
```
# pkg info mergedeep
             Name: library/python/mergedeep
          Summary: mergedeep - A deep merge function for Python.
         Category: Development/Python
            State: Installed
        Publisher: openindiana.org
          Version: 1.3.4
           Branch: 2022.0.0.1
   Packaging Date: October  8, 2022 at 11:40:49 AM
Last Install Time: October  8, 2022 at 08:13:31 PM
             Size: 0.00 B
             FMRI: pkg://openindiana.org/library/python/mergedeep@1.3.4-2022.0.0.1:20221008T114049Z
      Project URL: https://github.com/clarketm/mergedeep
       Source URL: pypi:///mergedeep==1.3.4
#
```
There are basically two possible ways how to fix the problem:
1) add the `pypi` scheme to the [Uniform Resource Identifier (URI) Schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) list, or
2) replace the confusing `pypi` scheme by something well-known, like `http`/`https`.

Until the `pypi` scheme is added to the official list of known schemes, I propose to revert PR  #9477 by merging this PR.

Thanks.