### PR TITLE
Updating bash 5.2 to patchlevel2

### DIFF
--- a/components/shell/bash/patches/bash52-001.patchelevel1.patch
+++ b/components/shell/bash/patches/bash52-001.patchelevel1.patch
@@ -1,0 +1,46 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-001
+
+Bug-Reported-by:	Emanuele Torre <torreemanuele6@gmail.com>
+Bug-Reference-ID:	<CAA7hNqeR1eSdiGK8mjQSqJPo815JYoG-Ekz-5PrAJTEYy2e6hg@mail.gmail.com>
+Bug-Reference-URL:	https://lists.gnu.org/archive/html/bug-bash/2022-09/msg00060.html
+
+Bug-Description:
+
+Expanding unset arrays in an arithmetic context can cause a segmentation fault.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2/subst.c	2022-08-31 17:36:46.000000000 -0400
+--- subst.c	2022-09-30 09:12:05.000000000 -0400
+***************
+*** 10858,10862 ****
+    t = expand_subscript_string (exp, quoted & ~(Q_ARITH|Q_DOUBLE_QUOTES));
+    free (exp);
+!   exp = sh_backslash_quote (t, abstab, 0);
+    free (t);
+  
+--- 10858,10862 ----
+    t = expand_subscript_string (exp, quoted & ~(Q_ARITH|Q_DOUBLE_QUOTES));
+    free (exp);
+!   exp = t ? sh_backslash_quote (t, abstab, 0) : savestring ("");
+    free (t);
+  
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 0
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 1
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/components/shell/bash/patches/bash52-002.patchlevel2.patch
+++ b/components/shell/bash/patches/bash52-002.patchlevel2.patch
@@ -1,0 +1,46 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.2
+Patch-ID:	bash52-002
+
+Bug-Reported-by:	Kan-Ru Chen <koster@debian.org>
+Bug-Reference-ID:
+Bug-Reference-URL:	https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1021109
+
+Bug-Description:
+
+Starting bash with an invalid locale specification for LC_ALL/LANG/LC_CTYPE
+can cause the shell to crash.
+
+Patch (apply with `patch -p0'):
+
+*** ../bash-5.2-patched/lib/readline/nls.c	2022-08-15 09:38:51.000000000 -0400
+--- lib/readline/nls.c	2022-10-05 09:23:22.000000000 -0400
+***************
+*** 142,145 ****
+--- 142,149 ----
+      lspec = "";
+    ret = setlocale (LC_CTYPE, lspec);	/* ok, since it does not change locale */
++   if (ret == 0 || *ret == 0)
++     ret = setlocale (LC_CTYPE, (char *)NULL);
++   if (ret == 0 || *ret == 0)
++     ret = RL_DEFAULT_LOCALE;
+  #else
+    ret = (lspec == 0 || *lspec == 0) ? RL_DEFAULT_LOCALE : lspec;
+
+*** ../bash-5.2/patchlevel.h	2020-06-22 14:51:03.000000000 -0400
+--- patchlevel.h	2020-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 1
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 2
+  
+  #endif /* _PATCHLEVEL_H_ */


### PR DESCRIPTION
This updates the Patchlevel of our bash to 5.2.p2 which also fixes the case where the shell segfaults if given an invalid LC_CTYPE Env var. Tested on the buildsystem. @jclulow @richlowe This is the fix for my issues you helped me diagnose in IRC thanks :)