### PR TITLE
make-rules;tools/Makefile: disable parallelism

### DIFF
--- a/components/Makefile
+++ b/components/Makefile
@@ -156,7 +156,7 @@ tools:
 	echo "export PATH WS_TOP" >>$@
 
 $(COMPONENT_DIRS):	$(WS_LOGS) setup FORCE
-	@cd $@ && echo "$(TARGET) $@" && \
+	@+cd $@ && echo "$(TARGET) $@" && \
 	 $(BASS_O_MATIC) --make $(TARGET) $(LOG)
 
 incorporation:

--- a/make-rules/common-lisp.mk
+++ b/make-rules/common-lisp.mk
@@ -25,6 +25,8 @@
 # Since common lisp libraries are all source code, there is no need for
 # BUILD_64 and INSTALL_64.
 
+.NOTPARALLEL:
+
 INSTALL_DIR =	$(PROTOCLDIR)/source/$(COMPONENT_NAME)
 
 $(BUILD_DIR)/%/.built:	$(SOURCE_DIR)/.prep

--- a/make-rules/common.mk
+++ b/make-rules/common.mk
@@ -27,6 +27,7 @@
 # This file sets up the standard, default options and base requirements for
 # userland components.
 #
+.NOTPARALLEL:
 
 # Assume components use a configure script-style build by default.
 BUILD_STYLE ?= configure

--- a/make-rules/gem.mk
+++ b/make-rules/gem.mk
@@ -18,6 +18,7 @@
 #
 # CDDL HEADER END
 #
+.NOTPARALLEL:
 
 #
 # Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.

--- a/make-rules/ips.mk
+++ b/make-rules/ips.mk
@@ -35,6 +35,7 @@
 #
 # This set of rules makes the "publish" target the default target for make(1)
 #
+.NOTPARALLEL:
 
 PKGDEPEND =	/usr/bin/pkgdepend
 PKGFMT =	/usr/bin/pkgfmt

--- a/make-rules/prep.mk
+++ b/make-rules/prep.mk
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
 #
+.NOTPARALLEL:
 
 include $(WS_MAKE_RULES)/prep-download.mk
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -20,6 +20,7 @@
 #
 # Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
 #
+.NOTPARALLEL:
 
 include ../make-rules/shared-macros.mk
 


### PR DESCRIPTION
Disabling per-component parallelism as some targets are run out-of-order or multiple times due to ordering and dependency issues. 
Fixes an issue when rebuilding the toplevel directory using -jx, the tools/ directory fails to build.