### PR TITLE
Switching gdb from python 3.7 to python 3.9

### DIFF
--- a/components/developer/gdb/Makefile
+++ b/components/developer/gdb/Makefile
@@ -35,7 +35,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gdb
 COMPONENT_VERSION=	8.0
-# COMPONENT_REVISION=	0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	GDB: The GNU Project Debugger
 COMPONENT_CLASSIFICATION=Development/System
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -46,9 +46,6 @@ COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/gnu/gdb/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://www.gnu.org/software/gdb/
 
 CONFIGURE_DEFAULT_DIRS=no
-
-# Set python version used by this product
-PYTHON_VERSION=3.7
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -193,18 +190,15 @@ COMPONENT_POST_INSTALL_ACTION = \
 # altering the results of the debugging experiment.
 ASLR_MODE=$(ASLR_DISABLE)
 
+GENERATE_EXTRA_CMD += | $(GNU_GREP) -v -E '/.*\.pyc$$'
+
 # Auto-generated dependencies
-REQUIRED_PACKAGES += SUNWcs
+PYTHON_REQUIRED_PACKAGES += runtime/python
 REQUIRED_PACKAGES += compress/xz
 REQUIRED_PACKAGES += developer/babeltrace
 REQUIRED_PACKAGES += library/expat
 REQUIRED_PACKAGES += library/ncurses
-REQUIRED_PACKAGES += library/readline
 REQUIRED_PACKAGES += library/zlib
-REQUIRED_PACKAGES += runtime/python-37
 REQUIRED_PACKAGES += shell/ksh93
-REQUIRED_PACKAGES += system/library/g++-7-runtime
-REQUIRED_PACKAGES += system/library/gcc-7-runtime
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
-REQUIRED_PACKAGES += text/texinfo

--- a/components/developer/gdb/gdb.p5m
+++ b/components/developer/gdb/gdb.p5m
@@ -21,11 +21,13 @@
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2019, Andreas Wacknitz
 # Copyright 2021 Gary Mills
+# Copyright 2022 Till Wegmueller
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
 set name=pkg.fmri \
     value=pkg:/developer/debug/gdb@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=pkg.description \
     value="GDB, the GNU Debugger, is a source-level debugger for Ada, C, C++, Objective-C, Pascal and many other languages.  GDB allows you to see what is going on inside another program while it executes, or what another program was doing at the moment it crashed."
@@ -34,9 +36,14 @@ set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
 file path=usr/bin/gdb
 file path=usr/bin/gdbtui mode=0555
+file path=usr/include/ansidecl.h
+file path=usr/include/dis-asm.h
 file path=usr/include/gdb/jit-reader.h
+file path=usr/include/plugin-api.h
+file path=usr/include/symcat.h
 file path=usr/share/gdb/python/gdb/FrameDecorator.py
 file path=usr/share/gdb/python/gdb/FrameIterator.py
 file path=usr/share/gdb/python/gdb/__init__.py

--- a/components/developer/gdb/manifests/sample-manifest.p5m
+++ b/components/developer/gdb/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2021 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -38,24 +39,7 @@ file path=usr/lib/$(MACH64)/libopcodes.a
 file path=usr/share/gdb/python/gdb/FrameDecorator.py
 file path=usr/share/gdb/python/gdb/FrameIterator.py
 file path=usr/share/gdb/python/gdb/__init__.py
-file path=usr/share/gdb/python/gdb/__pycache__/FrameDecorator.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/FrameIterator.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/__init__.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/frames.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/printing.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/prompt.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/types.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/unwinder.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/__pycache__/xmethod.cpython-37.pyc
 file path=usr/share/gdb/python/gdb/command/__init__.py
-file path=usr/share/gdb/python/gdb/command/__pycache__/__init__.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/command/__pycache__/explore.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/command/__pycache__/frame_filters.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/command/__pycache__/pretty_printers.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/command/__pycache__/prompt.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/command/__pycache__/type_printers.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/command/__pycache__/unwinders.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/command/__pycache__/xmethods.cpython-37.pyc
 file path=usr/share/gdb/python/gdb/command/explore.py
 file path=usr/share/gdb/python/gdb/command/frame_filters.py
 file path=usr/share/gdb/python/gdb/command/pretty_printers.py
@@ -65,16 +49,10 @@ file path=usr/share/gdb/python/gdb/command/unwinders.py
 file path=usr/share/gdb/python/gdb/command/xmethods.py
 file path=usr/share/gdb/python/gdb/frames.py
 file path=usr/share/gdb/python/gdb/function/__init__.py
-file path=usr/share/gdb/python/gdb/function/__pycache__/__init__.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/function/__pycache__/as_string.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/function/__pycache__/caller_is.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/function/__pycache__/strfns.cpython-37.pyc
 file path=usr/share/gdb/python/gdb/function/as_string.py
 file path=usr/share/gdb/python/gdb/function/caller_is.py
 file path=usr/share/gdb/python/gdb/function/strfns.py
 file path=usr/share/gdb/python/gdb/printer/__init__.py
-file path=usr/share/gdb/python/gdb/printer/__pycache__/__init__.cpython-37.pyc
-file path=usr/share/gdb/python/gdb/printer/__pycache__/bound_registers.cpython-37.pyc
 file path=usr/share/gdb/python/gdb/printer/bound_registers.py
 file path=usr/share/gdb/python/gdb/printing.py
 file path=usr/share/gdb/python/gdb/prompt.py

--- a/components/developer/gdb/pkg5
+++ b/components/developer/gdb/pkg5
@@ -5,15 +5,11 @@
         "developer/babeltrace",
         "library/expat",
         "library/ncurses",
-        "library/readline",
         "library/zlib",
-        "runtime/python-37",
+        "runtime/python-39",
         "shell/ksh93",
         "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime",
-        "system/library/math",
-        "text/texinfo"
+        "system/library/math"
     ],
     "fmris": [
         "developer/debug/gdb"


### PR DESCRIPTION
Note that I had to disable libpython lookup as it broke for 3.9 while it works for 3.7 I did not find out why. I manually added the dependency. The Sample-manifest changed but we do not deliver the pyc files