### PR TITLE
stack-spur: add resuls-all.master file

### DIFF
--- a/components/runtime/smalltalk/stack-spur/Makefile
+++ b/components/runtime/smalltalk/stack-spur/Makefile
@@ -35,6 +35,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		stack-spur
 COMPONENT_VERSION=	5.0.3254
+COMPONENT_REVISION=	1
 GIT_TAG=		sun-v5.0.54
 PLUGIN_REV=		5.0-202210151805
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
@@ -53,7 +54,8 @@ COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	sha256:9d4ed9f06796c036bcd6a7352036f12e33609071ce1d3499b144fd5095d8b324
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
-TEST_TARGET= $(NO_TESTS)
+# the tests are currently ran only on 64bit for opensmalltalk
+COMPONENT_TEST_CMD=	$(COMPONENT_TEST_RESULTS_DIR)/testrunner.sh $(BITS) $(COMPONENT_DIR) $(BUILD_DIR_64)
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/runtime/smalltalk/stack-spur/inisqueak5
+++ b/components/runtime/smalltalk/stack-spur/inisqueak5
@@ -41,10 +41,11 @@
 # subtle difference between SqueakV46.sources not SqueakV4.6.sources
 MAJOR=5.3
 MAJORV=50
-VERSION=5.3-19480
+VERSION=5.3-19481
 
 REMOTESRC="http://files.squeak.org/sources_files/"
 REMOTESOURCES=SqueakV${MAJORV}.sources.gz
+# currently only download 64bit image
 SUFFIX64="-64bit"
 REMOTEIMAGE=Squeak${VERSION}${SUFFIX64}
 REMOTEIMAGEZIP=${REMOTEIMAGE}.zip
@@ -68,6 +69,8 @@ startup=true
 batch=false
 interactive=true
 remote=true
+# in 5.3 19480 and 19481 the sources seem to be in the zip image 
+remotesrc=false
 
 while true; do
   case "$1" in
@@ -110,7 +113,7 @@ missing()
   exit 1
 }
 
-if ${remote}; then
+if ${remotesrc}; then
   echo "Downloading $REMOTESOURCES from $REMOTESRC"
   wget -O $REMOTESOURCES $REMOTESRC/$REMOTESOURCES
   case $? in
@@ -122,7 +125,18 @@ if ${remote}; then
    0) ;;
    *) echo "Unable to unzip $REMOTESOURCES"; exit 1;
   esac
+fi
+
+if ${remote}; then
   echo "Downloading $REMOTEIMAGEZIP from $REMOTEDIR"
+  if [ -f $REMOTEIMAGEZIP ]
+  then
+    rm $REMOTEIMAGEZIP Squeak${VERSION}${SUFFIX64}.image Squeak${VERSION}${SUFFIX64}.changes
+    case $? in
+      0) ;;
+      *) echo "Unable to clean up existing $REMOTEIMAGEZIP"; exit 1;
+    esac
+  fi
   wget -O $REMOTEIMAGEZIP $REMOTEDIR/$REMOTEIMAGEZIP
   case $? in
    0) ;;

--- a/components/runtime/smalltalk/stack-spur/test/results-all.master
+++ b/components/runtime/smalltalk/stack-spur/test/results-all.master
@@ -1,0 +1,26 @@
+SUnit Results
+Squeak5.3
+solaris2.11
+Open Smalltalk Stack VM [StackInterpreterPrimitives VMMaker.oscog-eem.3254]
+Failed Tests
+'AllocationTest>>#testOneGigAllocation'
+'BasicBehaviorClassMetaclassTest>>#testClassDescriptionAllSubInstances'
+'BitBltTest>>#testAllAlphasRgbMul'
+'OrderedDictionaryTest>>#testGrow'
+Errors
+'BitmapStreamTests>>#testMatrixTransform2x3WithImageSegment'
+'BitmapStreamTests>>#testShortIntegerArrayWithImageSegment'
+'BitmapStreamTests>>#testShortPointArrayWithImageSegment'
+'BitmapStreamTests>>#testShortRunArrayWithImageSegment'
+'BitmapStreamTests>>#testWordArrayWithImageSegment'
+'MCDependencySorterTest>>#testCascadingUnresolved'
+'MCDependencySorterTest>>#testCycle'
+'MCDependencySorterTest>>#testExtraProvisions'
+'MCDependencySorterTest>>#testMultiRequirementOrdering'
+'MCDependencySorterTest>>#testSimpleOrdering'
+'MCDependencySorterTest>>#testSimpleUnresolved'
+'MCDependencySorterTest>>#testUnusedAlternateProvider'
+'SocketTest>>#testSocketReuse'
+Total Number of Passed Tests: 4718
+Total Number of Failures: 4
+Total Number of Errors: 13

--- a/components/runtime/smalltalk/stack-spur/test/testrunner.sh
+++ b/components/runtime/smalltalk/stack-spur/test/testrunner.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+BITS=$1
+COMPONENT_DIR=$2
+BUILD_DIR=$3
+TEST_TARGET=$4
+
+LOGFILE=testrunner-log.$BITS
+
+# the tests could be ran after pkg install as:
+#       inisqueak -n;squeak squeak.image testrunner.st
+# or interactively simply by opening a Squeak image and going to TestRunner
+
+# however here we want to do this on the newly built 64bit VM
+# so we start squeak from the BUILD_DIR directory
+# we only test the 64bit VM because inisqueak downloads a 64bit image
+# in the future we could improve inisqueak to also download the 32bit image
+
+# WARNING HACK : fake 32bit results because we don't want to run 32bit test
+case $BITS in
+ 32) cat $COMPONENT_DIR/test/results-all.master ;exit 0;;
+ 64) ;;
+  *) echo "Unknown BITS $BITS";exit 1;;
+esac
+
+# make sure that the newly built VM loads plugins fro the build dir
+# SQUEAK_PLUGINS=$PLUGIN_DIR
+# export SQUEAK_PLUGINS
+
+# download squeak.image to current directory
+$COMPONENT_DIR/inisqueak5 -n > $LOGFILE 2>&1
+
+# start squeak binary from the build dir
+$BUILD_DIR/squeak squeak.image $COMPONENT_DIR/test/testrunner.st > $LOGFILE 2>&1
+
+# testrunner.st saves output in a file , dump that file as output
+cat results-64.vm
+

--- a/components/runtime/smalltalk/stack-spur/test/testrunner.st
+++ b/components/runtime/smalltalk/stack-spur/test/testrunner.st
@@ -1,0 +1,26 @@
+| file result testRunner |
+testRunner _ TestRunner new runAll.
+result _ testRunner result.
+file _ StandardFileStream fileNamed:'results-64.vm'.
+file nextPutAll: 'SUnit Results'; lf.
+file nextPutAll: Smalltalk version; lf.
+file nextPutAll: Smalltalk osVersion; lf.
+file nextPutAll: Smalltalk vmVersion; lf.
+file nextPutAll: 'Failed Tests'; lf.
+testRunner failedList do:
+		[ : each | each printOn:file.  file lf ].
+file nextPutAll: 'Errors'; lf.
+testRunner errorList do:
+		[ : each | each printOn:file.  file lf ].
+file nextPutAll: 'Total Number of Passed Tests: '.
+result passedCount printOn:file.
+file lf.
+file nextPutAll: 'Total Number of Failures: '.
+result failureCount printOn:file.
+file lf.
+file nextPutAll: 'Total Number of Errors: '.
+result errorCount printOn:file.
+file lf.
+file close.
+Smalltalk quitPrimitive.
+


### PR DESCRIPTION
This is an experimental attempt to add a results-all.master file for the Stack Spur VM for OpenSmalltalk.

The strategy works for any Squeak vm, and in fact the current Makefile is incorrect because it uses whatever squeak VM is installed

The idea is to run all tests of the SUnit test framework, including sound/audio/video (GUI) tests.

The results are then saved in a file results-all.master