### PR TITLE
fftw-3: update to 3.3.10 and enable sse2

### DIFF
--- a/components/library/fftw-3/Makefile
+++ b/components/library/fftw-3/Makefile
@@ -12,26 +12,24 @@
 # Copyright (c) 2015 Alexander Pyhalov
 # Copyright (c) 2018 Michal Nowak
 #
-
+BUILD_BITS= 32_and_64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		fftw
-COMPONENT_VERSION=	3.3.8
-COMPONENT_PROJECT_URL=	http://www.fftw.org/
+COMPONENT_VERSION=	3.3.10
+COMPONENT_PROJECT_URL=	https://www.fftw.org/
 COMPONENT_SUMMARY=	FFTW - library for calculating discrete Fourier transforms
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-  sha256:6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
-COMPONENT_ARCHIVE_URL=	http://www.fftw.org/$(COMPONENT_ARCHIVE)
+  sha256:56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467
+COMPONENT_ARCHIVE_URL=	https://www.fftw.org/$(COMPONENT_ARCHIVE)
 COMPONENT_CLASSIFICATION=Development/High Performance Computing
 COMPONENT_FMRI=		library/fftw-3
 COMPONENT_LICENSE_FILE=	COPYING
 COMPONENT_LICENSE=	GPLv2
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 VARIANT_FFTW = $(BUILD_DIR)/fftw
 VARIANT_FFTW_FLOAT = $(BUILD_DIR)/fftw-f
@@ -56,17 +54,12 @@ CONFIGURE_OPTIONS += --enable-threads
 CONFIGURE_OPTIONS += --enable-shared
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --with-combined-threads
+CONFIGURE_OPTIONS += --enable-sse2
 
 $(INSTALL_32):	$(BUILD_32) $(INSTALL_64)
 $(INSTALL_64):	$(BUILD_64)
 
-# common targets
-build:		$(BUILD_32_and_64)
-
-install:	$(INSTALL_32_and_64)
-
-test:		$(TEST_32_and_64)
-
-REQUIRED_PACKAGES += SUNWcs
+# Auto-generated dependencies
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/library/fftw-3/fftw-3.p5m
+++ b/components/library/fftw-3/fftw-3.p5m
@@ -27,10 +27,8 @@ file files/libfftw3.3.sunman path=usr/share/man/man3/libfftw3.3
 
 file path=usr/bin/$(MACH64)/fftw-wisdom
 file path=usr/bin/$(MACH64)/fftw-wisdom-to-conf
-file path=usr/bin/$(MACH64)/fftwf-wisdom
 file path=usr/bin/fftw-wisdom
 file path=usr/bin/fftw-wisdom-to-conf
-file path=usr/bin/fftwf-wisdom
 file path=usr/include/fftw3.f
 file path=usr/include/fftw3.f03
 file path=usr/include/fftw3.h
@@ -38,31 +36,18 @@ file path=usr/include/fftw3l.f03
 file path=usr/include/fftw3q.f03
 file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3Config.cmake
 file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3ConfigVersion.cmake
-file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3fConfig.cmake
-file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3fConfigVersion.cmake
-link path=usr/lib/$(MACH64)/libfftw3.so target=libfftw3.so.3.5.8
-link path=usr/lib/$(MACH64)/libfftw3.so.3 target=libfftw3.so.3.5.8
-file path=usr/lib/$(MACH64)/libfftw3.so.3.5.8
-link path=usr/lib/$(MACH64)/libfftw3f.so target=libfftw3f.so.3.5.8
-link path=usr/lib/$(MACH64)/libfftw3f.so.3 target=libfftw3f.so.3.5.8
-file path=usr/lib/$(MACH64)/libfftw3f.so.3.5.8
+link path=usr/lib/$(MACH64)/libfftw3.so target=libfftw3.so.3.6.10
+link path=usr/lib/$(MACH64)/libfftw3.so.3 target=libfftw3.so.3.6.10
+file path=usr/lib/$(MACH64)/libfftw3.so.3.6.10
 file path=usr/lib/$(MACH64)/pkgconfig/fftw3.pc
-file path=usr/lib/$(MACH64)/pkgconfig/fftw3f.pc
 file path=usr/lib/cmake/fftw3/FFTW3Config.cmake
 file path=usr/lib/cmake/fftw3/FFTW3ConfigVersion.cmake
-file path=usr/lib/cmake/fftw3/FFTW3fConfig.cmake
-file path=usr/lib/cmake/fftw3/FFTW3fConfigVersion.cmake
-link path=usr/lib/libfftw3.so target=libfftw3.so.3.5.8
-link path=usr/lib/libfftw3.so.3 target=libfftw3.so.3.5.8
-file path=usr/lib/libfftw3.so.3.5.8
-link path=usr/lib/libfftw3f.so target=libfftw3f.so.3.5.8
-link path=usr/lib/libfftw3f.so.3 target=libfftw3f.so.3.5.8
-file path=usr/lib/libfftw3f.so.3.5.8
+link path=usr/lib/libfftw3.so target=libfftw3.so.3.6.10
+link path=usr/lib/libfftw3.so.3 target=libfftw3.so.3.6.10
+file path=usr/lib/libfftw3.so.3.6.10
 file path=usr/lib/pkgconfig/fftw3.pc
-file path=usr/lib/pkgconfig/fftw3f.pc
 file path=usr/share/info/fftw3.info
 file path=usr/share/info/fftw3.info-1
 file path=usr/share/info/fftw3.info-2
 file path=usr/share/man/man1/fftw-wisdom-to-conf.1
 file path=usr/share/man/man1/fftw-wisdom.1
-file path=usr/share/man/man1/fftwf-wisdom.1

--- a/components/library/fftw-3/manifests/sample-manifest.p5m
+++ b/components/library/fftw-3/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2017 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,10 +25,8 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/$(MACH64)/fftw-wisdom
 file path=usr/bin/$(MACH64)/fftw-wisdom-to-conf
-file path=usr/bin/$(MACH64)/fftwf-wisdom
 file path=usr/bin/fftw-wisdom
 file path=usr/bin/fftw-wisdom-to-conf
-file path=usr/bin/fftwf-wisdom
 file path=usr/include/fftw3.f
 file path=usr/include/fftw3.f03
 file path=usr/include/fftw3.h
@@ -35,32 +34,19 @@ file path=usr/include/fftw3l.f03
 file path=usr/include/fftw3q.f03
 file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3Config.cmake
 file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3ConfigVersion.cmake
-file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3fConfig.cmake
-file path=usr/lib/$(MACH64)/cmake/fftw3/FFTW3fConfigVersion.cmake
-link path=usr/lib/$(MACH64)/libfftw3.so target=libfftw3.so.3.5.8
-link path=usr/lib/$(MACH64)/libfftw3.so.3 target=libfftw3.so.3.5.8
-file path=usr/lib/$(MACH64)/libfftw3.so.3.5.8
-link path=usr/lib/$(MACH64)/libfftw3f.so target=libfftw3f.so.3.5.8
-link path=usr/lib/$(MACH64)/libfftw3f.so.3 target=libfftw3f.so.3.5.8
-file path=usr/lib/$(MACH64)/libfftw3f.so.3.5.8
+link path=usr/lib/$(MACH64)/libfftw3.so target=libfftw3.so.3.6.10
+link path=usr/lib/$(MACH64)/libfftw3.so.3 target=libfftw3.so.3.6.10
+file path=usr/lib/$(MACH64)/libfftw3.so.3.6.10
 file path=usr/lib/$(MACH64)/pkgconfig/fftw3.pc
-file path=usr/lib/$(MACH64)/pkgconfig/fftw3f.pc
 file path=usr/lib/cmake/fftw3/FFTW3Config.cmake
 file path=usr/lib/cmake/fftw3/FFTW3ConfigVersion.cmake
-file path=usr/lib/cmake/fftw3/FFTW3fConfig.cmake
-file path=usr/lib/cmake/fftw3/FFTW3fConfigVersion.cmake
-link path=usr/lib/libfftw3.so target=libfftw3.so.3.5.8
-link path=usr/lib/libfftw3.so.3 target=libfftw3.so.3.5.8
-file path=usr/lib/libfftw3.so.3.5.8
-link path=usr/lib/libfftw3f.so target=libfftw3f.so.3.5.8
-link path=usr/lib/libfftw3f.so.3 target=libfftw3f.so.3.5.8
-file path=usr/lib/libfftw3f.so.3.5.8
+link path=usr/lib/libfftw3.so target=libfftw3.so.3.6.10
+link path=usr/lib/libfftw3.so.3 target=libfftw3.so.3.6.10
+file path=usr/lib/libfftw3.so.3.6.10
 file path=usr/lib/pkgconfig/fftw3.pc
-file path=usr/lib/pkgconfig/fftw3f.pc
 file path=usr/share/info/dir
 file path=usr/share/info/fftw3.info
 file path=usr/share/info/fftw3.info-1
 file path=usr/share/info/fftw3.info-2
 file path=usr/share/man/man1/fftw-wisdom-to-conf.1
 file path=usr/share/man/man1/fftw-wisdom.1
-file path=usr/share/man/man1/fftwf-wisdom.1

--- a/components/library/fftw-3/pkg5
+++ b/components/library/fftw-3/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
+        "shell/ksh93",
         "system/library",
         "system/library/math"
     ],


### PR DESCRIPTION
Building the single precision version doesn't work and thus the fftwf- variants are missing now.

Three questions:
1. What needs to be changed to support building the 2nd variant? It doesn't work anymore.
2. Is it worth supporting the single precision variant nowadays?
3. I have activated SSE2 support as it is provided since Pentium 4. Is this a good idea?