### PR TITLE
make-rules: support for single perl/python version builds

### DIFF
--- a/make-rules/common.mk
+++ b/make-rules/common.mk
@@ -35,6 +35,26 @@ BUILD_STYLE ?= configure
 # Some build styles might want to set some defaults before prep.mk is included.
 -include $(WS_MAKE_RULES)/$(strip $(BUILD_STYLE))-defaults.mk
 
+# The SINGLE_PERL_VERSION variable is used to select building a component for
+# single or multiple Perl versions.  By default we build for single Perl
+# version only unless the component is a Perl module.  If the default value of
+# SINGLE_PERL_VERSION is not what is needed for a component it could be
+# overridden in component's Makefile.
+SINGLE_PERL_VERSION ?= yes
+ifeq ($(strip $(SINGLE_PERL_VERSION)),yes)
+PERL_VERSIONS = $(PERL_VERSION)
+endif
+
+# The SINGLE_PYTHON_VERSION variable is used to select building a component for
+# single or multiple Python versions.  By default we build for single Python
+# version only unless the component is a Python project.  If the default value
+# of SINGLE_PYTHON_VERSION is not what is needed for a component it could be
+# overridden in component's Makefile.
+SINGLE_PYTHON_VERSION ?= yes
+ifeq ($(strip $(SINGLE_PYTHON_VERSION)),yes)
+PYTHON_VERSIONS = $(PYTHON_VERSION)
+endif
+
 include $(WS_MAKE_RULES)/prep.mk
 
 # Override this to limit builds and publication to a single architecture.

--- a/make-rules/makemaker-defaults.mk
+++ b/make-rules/makemaker-defaults.mk
@@ -39,3 +39,6 @@ ASLR_MODE = $(ASLR_DISABLE)
 else
 ASLR_MODE = $(ASLR_ENABLE)
 endif
+
+# By default we build Perl modules for all supported Perl versions
+SINGLE_PERL_VERSION ?= no

--- a/make-rules/setup.py-defaults.mk
+++ b/make-rules/setup.py-defaults.mk
@@ -28,3 +28,6 @@ ASLR_MODE = $(ASLR_DISABLE)
 else
 ASLR_MODE = $(ASLR_ENABLE)
 endif
+
+# By default we build Python projects for all supported Python versions
+SINGLE_PYTHON_VERSION ?= no

--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -105,6 +105,7 @@ $(BUILD_DIR)/%/.installed:	$(BUILD_DIR)/%/.built
 	$(COMPONENT_POST_INSTALL_ACTION)
 	$(TOUCH) $@
 
+ifeq ($(strip $(SINGLE_PYTHON_VERSION)),no)
 # Rename binaries in /usr/bin to contain version number
 COMPONENT_POST_INSTALL_ACTION += \
 	for f in $(PROTOUSRBINDIR)/* ; do \
@@ -114,6 +115,7 @@ COMPONENT_POST_INSTALL_ACTION += \
 		done ; \
 		$(MV) $$f $$f-$(PYTHON_VERSION) ; \
 	done ;
+endif
 
 # Define Python version specific filenames for tests.
 ifeq ($(strip $(USE_COMMON_TEST_MASTER)),no)
@@ -230,9 +232,11 @@ $(BUILD_DIR)/%/.tested:    $(COMPONENT_TEST_DEP)
 	$(TOUCH) $@
 
 
+ifeq ($(strip $(SINGLE_PYTHON_VERSION)),no)
 # We need to add -$(PYV) to package fmri
 GENERATE_EXTRA_CMD += | \
-	$(GSED) -e 's/^\(set name=pkg.fmri [^@]*\)\(.*\)$$/\1-$$(PYV)\2/' \
+	$(GSED) -e 's/^\(set name=pkg.fmri [^@]*\)\(.*\)$$/\1-$$(PYV)\2/'
+endif
 
 
 clean::


### PR DESCRIPTION
This introduces new `SINGLE_PERL_VERSION`/`SINGLE_PYTHON_VERSION` variables (I'm not sure the names are best, so if there is some suggestion I'm open to change them) defaulting to `no` for `makemaker`/`modulebuild`/`setup.py` builds respectively and `yes` otherwise.  The defaults could be overriden in component's `Makefile` if needed.

I added guards to `setup.py.mk` to allow immediate use of it (for components like `barman`).  I didn't add similar guards for perl builds (`makemaker`/`modulebuild`) because I'm not aware about any component that would use it.  If there is a need for them we can add later.

I tested this with `barman` with this change:
```
diff --git a/components/python/barman/Makefile b/components/python/barman/Makefile
index 72b47afe5..505b6e8d6 100644
--- a/components/python/barman/Makefile
+++ b/components/python/barman/Makefile
@@ -31,18 +31,13 @@ COMPONENT_CLASSIFICATION=   System/Databases
 COMPONENT_FMRI=                database/postgres/barman
 COMPONENT_LICENSE=     GPLv3
 
-PYTHON_VERSIONS= $(PYTHON_VERSION)
+SINGLE_PYTHON_VERSION = yes
 
 PKG_MACROS += PYVER=$(PYTHON_VERSION)
 
 TEST_TARGET=   $(NO_TESTS)
 include $(WS_TOP)/make-rules/common.mk
 
-# Remove the default post install actions for python packages:
-COMPONENT_POST_INSTALL_ACTION=
-# Suppress the automatic addition of $(PYV) to the package fmri:
-GENERATE_EXTRA_CMD=
-
 # Install example configuration files
 DOC_DIR=$(PROTO_DIR)/usr/share/barman
 
```
and confirmed that nothing changed.  Please note that I had to set `SINGLE_PYTHON_VERSION` to `yes` because `barman` is `setup.py` build defaulting to `SINGLE_PYTHON_VERSION = no`.