### PR TITLE
python/backports.ssl_match_hostname: rebuild to remove backports/__init__.py

### DIFF
--- a/components/python/backports.ssl_match_hostname/Makefile
+++ b/components/python/backports.ssl_match_hostname/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		backports.ssl_match_hostname
 COMPONENT_VERSION =		3.7.0.1
-COMPONENT_REVISION =		1
+COMPONENT_REVISION =		2
 COMPONENT_SUMMARY =		backports.ssl_match_hostname - The ssl.match_hostname() function from Python 3.5
 COMPONENT_PROJECT_URL =		http://bitbucket.org/brandon/backports.ssl_match_hostname
 COMPONENT_ARCHIVE_URL =		\

--- a/components/python/backports.ssl_match_hostname/backports.ssl_match_hostname-PYVER.p5m
+++ b/components/python/backports.ssl_match_hostname/backports.ssl_match_hostname-PYVER.p5m
@@ -24,5 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/python$(PYVER)/vendor-packages/backports.ssl_match_hostname-$(COMPONENT_VERSION)-py$(PYVER).egg-info
-file path=usr/lib/python$(PYVER)/vendor-packages/backports/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/backports/ssl_match_hostname/__init__.py

--- a/components/python/backports.ssl_match_hostname/manifests/sample-manifest.p5m
+++ b/components/python/backports.ssl_match_hostname/manifests/sample-manifest.p5m
@@ -24,5 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/python$(PYVER)/vendor-packages/backports.ssl_match_hostname-$(COMPONENT_VERSION)-py$(PYVER).egg-info
-file path=usr/lib/python$(PYVER)/vendor-packages/backports/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/backports/ssl_match_hostname/__init__.py


### PR DESCRIPTION
This should be merged immediately after PR #9687.  Thanks.