### PR TITLE
squeak: add results-32.master

### DIFF
--- a/components/runtime/smalltalk/squeak/Makefile
+++ b/components/runtime/smalltalk/squeak/Makefile
@@ -55,7 +55,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.19.15
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -71,7 +71,10 @@ SVN_HASH=  sha256:5b8cbf212bc6913c25699cd4e22dbd1ee8778deb5130b07c99033ede1b46ad
 COMPONENT_LICENSE=      Squeak4
 COMPONENT_LICENSE_FILE= squeak4.license
 
-TEST_TARGET= $(NO_TESTS)
+# the tests are ran only on 32bit for Squeak classical VM
+# because inisqueak downloads a 32 bit image (provided by squeak.org)
+# for OpenSmalltalk (see cog-spur and stack-spur) 32bit + 64bit
+COMPONENT_TEST_CMD=	$(COMPONENT_TEST_RESULTS_DIR)/testrunner.sh $(BITS) $(COMPONENT_DIR) $(BUILD_DIR_32)
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/runtime/smalltalk/squeak/test/results-all.master
+++ b/components/runtime/smalltalk/squeak/test/results-all.master
@@ -1,0 +1,22 @@
+SUnit Results
+Squeak4.6
+solaris2.11
+Squeak4.6 of 21 July 2021 [latest update: #15118]
+Failed Tests
+'BrowserTest>>#testSelectClassNamedPreservesPlace'
+'ClosureCompilerTest>>#testSourceRangeAccessForBlueBookInjectInto'
+'DecompilerTests>>#testDecompilerInClassesPNtoPZ'
+'ExceptionTests>>#testHandlerFromAction'
+'FontTest>>#testParagraph'
+'FontTest>>#testParagraphFallback'
+'PackageDependencyTest>>#testMonticello'
+'PackageDependencyTest>>#testNetwork'
+'PackageDependencyTest>>#testPreferenceBrowser'
+'SocketTest>>#testSocketReuse'
+'SocketTest>>#testUDP'
+'TestVMStatistics>>#testVmStatisticsReportString'
+'TestValueWithinFix>>#testValueWithinTimingRepeat'
+Errors
+Total Number of Passed Tests: 3750
+Total Number of Failures: 13
+Total Number of Errors: 0

--- a/components/runtime/smalltalk/squeak/test/testrunner.sh
+++ b/components/runtime/smalltalk/squeak/test/testrunner.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+BITS=$1
+COMPONENT_DIR=$2
+BUILD_DIR=$3
+TEST_TARGET=$4
+
+LOGFILE=testrunner-log.$BITS
+
+# the tests could be ran after pkg install as:
+#       inisqueak -n;squeak squeak.image testrunner.st
+# or interactively simply by opening a Squeak image and going to TestRunner
+
+# however here we want to do this on the newly built 32bit VM
+# so we start squeak from the BUILD_DIR directory
+# we only test the 32bit VM because inisqueak downloads a 32bit image
+
+# WARNING HACK : fake 64bit results because we don't want to run 64bit test
+case $BITS in
+ 32) ;;
+ 64) cat $COMPONENT_DIR/test/results-all.master ;exit 0;;
+  *) echo "Unknown BITS $BITS";exit 1;;
+esac
+
+# unlike OpenSmalltalk libtool/configure plugins are not found in build dir
+# make sure that the newly built VM loads plugins fro the build dir
+
+for plugin in vm-display-X11 vm-display-null vm-sound-pulse vm-sound-null UUIDPlugin SqueakSSL
+do
+  SQUEAK_PLUGINS=$SQUEAK_PLUGINS:$BUILD_DIR/$plugin
+# LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BUILD_DIR/$plugin
+done
+#echo "Setting LD_LIBRARY_PATH to $LD_LIBRARY_PATH" >> $LOGFILE
+#export LD_LIBRARY_PATH
+echo "Setting SQUEAK_PLUGINS to $SQUEAK_PLUGINS" >> $LOGFILE
+export SQUEAK_PLUGINS
+
+# download squeak.image to current directory
+$COMPONENT_DIR/inisqueak4 -n >> $LOGFILE 2>&1
+
+# start squeak binary from the build dir
+$BUILD_DIR/squeakvm squeak.image $COMPONENT_DIR/test/testrunner.st >> $LOGFILE 2>&1
+
+# testrunner.st saves output in a file , dump that file as output
+cat results-32.vm
+

--- a/components/runtime/smalltalk/squeak/test/testrunner.st
+++ b/components/runtime/smalltalk/squeak/test/testrunner.st
@@ -1,0 +1,27 @@
+| file result testRunner |
+Utilities setAuthorInitials:'hipster'.
+testRunner _ TestRunner new runAll.
+result _ testRunner result.
+file _ StandardFileStream fileNamed:'results-32.vm'.
+file nextPutAll: 'SUnit Results'; lf.
+file nextPutAll: Smalltalk version; lf.
+file nextPutAll: Smalltalk osVersion; lf.
+file nextPutAll: Smalltalk vmVersion; lf.
+file nextPutAll: 'Failed Tests'; lf.
+testRunner failedList do:
+		[ : each | each printOn:file.  file lf ].
+file nextPutAll: 'Errors'; lf.
+testRunner errorList do:
+		[ : each | each printOn:file.  file lf ].
+file nextPutAll: 'Total Number of Passed Tests: '.
+result passedCount printOn:file.
+file lf.
+file nextPutAll: 'Total Number of Failures: '.
+result failureCount printOn:file.
+file lf.
+file nextPutAll: 'Total Number of Errors: '.
+result errorCount printOn:file.
+file lf.
+file close.
+Smalltalk quitPrimitive.
+


### PR DESCRIPTION
add tests results for the classical squeak vm / interpreter

when running gmake test,  this requires a little user input : you have to type in your initials for the TestRunner in squeak 4.6

this is no longer the case in Squeak 5 and 6 images
