### PR TITLE
Mail::SPF - remove spfquery script as it conflicts with libspf2 binary

### DIFF
--- a/components/perl/Mail-SPF/Mail-SPF-PERLVER.p5m
+++ b/components/perl/Mail-SPF/Mail-SPF-PERLVER.p5m
@@ -23,8 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/perl5/$(PERLVER)/bin/spfquery
-file path=usr/perl5/$(PERLVER)/man/man1/spfquery.1
 file path=usr/perl5/$(PERLVER)/man/man3perl/Mail::SPF.3perl
 file path=usr/perl5/$(PERLVER)/man/man3perl/Mail::SPF::Base.3perl
 file path=usr/perl5/$(PERLVER)/man/man3perl/Mail::SPF::MacroString.3perl

--- a/components/perl/Mail-SPF/Makefile
+++ b/components/perl/Mail-SPF/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_PERL_MODULE =		Mail::SPF
 HUMAN_VERSION =			2.9.0
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		Mail::SPF - An object-oriented implementation of Sender Policy Framework
 COMPONENT_ARCHIVE_URL=		https://cpan.metacpan.org/authors/id/J/JM/JMEHNLE/mail-spf/Mail-SPF-v2.9.0.tar.gz
 COMPONENT_ARCHIVE_HASH =	\
@@ -34,8 +35,8 @@ include $(WS_MAKE_RULES)/common.mk
 
 # see https://rt.cpan.org/Ticket/Display.html?id=93241
 COMPONENT_PREP_ACTION =+ $(RM) -f $(SOURCE_DIR)/t/90-author-pod-validation.t
-GENERATE_EXTRA_CMD += | grep -v spfd
-
+GENERATE_EXTRA_CMD += | $(GNU_GREP) -v spfd
+GENERATE_EXTRA_CMD += | $(GNU_GREP) -v spfquery
 
 # Auto-generated dependencies
 PERL_REQUIRED_PACKAGES += library/perl-5/error

--- a/components/perl/Mail-SPF/manifests/sample-manifest.p5m
+++ b/components/perl/Mail-SPF/manifests/sample-manifest.p5m
@@ -23,8 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/perl5/$(PERLVER)/bin/spfquery
-file path=usr/perl5/$(PERLVER)/man/man1/spfquery.1
 file path=usr/perl5/$(PERLVER)/man/man3perl/Mail::SPF.3perl
 file path=usr/perl5/$(PERLVER)/man/man3perl/Mail::SPF::Base.3perl
 file path=usr/perl5/$(PERLVER)/man/man3perl/Mail::SPF::MacroString.3perl

--- a/components/perl/Mail-SPF/perl-integrate-module.conf
+++ b/components/perl/Mail-SPF/perl-integrate-module.conf
@@ -20,4 +20,4 @@ COMPONENT_SRC =                 $(COMPONENT_NAME)-v$(HUMAN_VERSION)
 # see https://rt.cpan.org/Ticket/Display.html?id=93241
 COMPONENT_PREP_ACTION =+ $(RM) -f $(SOURCE_DIR)/t/90-author-pod-validation.t
 GENERATE_EXTRA_CMD += | $(GNU_GREP) -v spfd
-
+GENERATE_EXTRA_CMD += | $(GNU_GREP) -v spfquery


### PR DESCRIPTION
Comparing both spfquery script/binary it makes more sense to keep the binary which comes with libspf2. It is a binary (usually faster) and slightly younger.