### PR TITLE
prep-svn.mk : create WS_TOP/archives

### DIFF
--- a/make-rules/prep-svn.mk
+++ b/make-rules/prep-svn.mk
@@ -48,6 +48,7 @@ CLEAN_PATHS += $$(COMPONENT_SRC$(1))
 CLOBBER_PATHS += COMPONENT_ARCHIVE$(1)
 SOURCE_DIR$(1) = $$(COMPONENT_DIR)/$$(COMPONENT_SRC$(1))
 
+download::      $$(USERLAND_ARCHIVES)
 download::	$$(USERLAND_ARCHIVES)$$(COMPONENT_ARCHIVE$(1))
 
 # First attempt to download a cached archive of the SCM repo at the proper


### PR DESCRIPTION

squeak uses subversion and prep-svn.mk

the latest months I observe the following:   WS_TOP/archives is not automaitcally created on svn export

this PR tries to do the same thing as prep-download.mk  and to MKDIR WS_TOP/archives before svn export