### PR TITLE
sed: update to 4.9

### DIFF
--- a/components/text/sed/Makefile
+++ b/components/text/sed/Makefile
@@ -23,6 +23,7 @@
 # Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2017, Aurelien Larcher.
 # Copyright (c) 2020, Michal Nowak
+# Copyright (c) 2022, Nona Hansel
 #
 
 BUILD_BITS=		64
@@ -30,7 +31,7 @@ BUILD_BITS=		64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		sed
-COMPONENT_VERSION=	4.8
+COMPONENT_VERSION=	4.9
 COMPONENT_FMRI=		text/gnu-sed
 COMPONENT_SUMMARY=	GNU implementation of sed, the Unix stream editor
 COMPONENT_CLASSIFICATION=	Applications/System Utilities
@@ -38,7 +39,7 @@ COMPONENT_PROJECT_URL=	https://www.gnu.org/software/sed/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
-	sha256:f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633
+	sha256:6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181
 COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/pub/gnu/sed/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	GPLv3, FDLv1.3
 

--- a/components/text/sed/manifests/sample-manifest.p5m
+++ b/components/text/sed/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -47,6 +48,7 @@ file path=usr/share/locale/hu/LC_MESSAGES/sed.mo
 file path=usr/share/locale/id/LC_MESSAGES/sed.mo
 file path=usr/share/locale/it/LC_MESSAGES/sed.mo
 file path=usr/share/locale/ja/LC_MESSAGES/sed.mo
+file path=usr/share/locale/ka/LC_MESSAGES/sed.mo
 file path=usr/share/locale/ko/LC_MESSAGES/sed.mo
 file path=usr/share/locale/nb/LC_MESSAGES/sed.mo
 file path=usr/share/locale/nl/LC_MESSAGES/sed.mo

--- a/components/text/sed/pkg5
+++ b/components/text/sed/pkg5
@@ -8,6 +8,7 @@
         "locale/fr",
         "locale/fr-extra",
         "locale/zh_cn-extra",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [

--- a/components/text/sed/sed.p5m
+++ b/components/text/sed/sed.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -47,6 +48,7 @@ file path=usr/share/locale/hu/LC_MESSAGES/sed.mo
 file path=usr/share/locale/id/LC_MESSAGES/sed.mo
 file path=usr/share/locale/it/LC_MESSAGES/sed.mo
 file path=usr/share/locale/ja/LC_MESSAGES/sed.mo
+file path=usr/share/locale/ka/LC_MESSAGES/sed.mo
 file path=usr/share/locale/ko/LC_MESSAGES/sed.mo
 file path=usr/share/locale/nb/LC_MESSAGES/sed.mo
 file path=usr/share/locale/nl/LC_MESSAGES/sed.mo

--- a/components/text/sed/test/results-all.master
+++ b/components/text/sed/test/results-all.master
@@ -3,6 +3,7 @@ PASS: testsuite/bug32082.sh
 PASS: testsuite/bug32271-1.sh
 PASS: testsuite/bug32271-2.sh
 PASS: testsuite/cmd-l.sh
+PASS: testsuite/cmd-0r.sh
 PASS: testsuite/cmd-R.sh
 PASS: testsuite/colon-with-no-label.sh
 PASS: testsuite/comment-n.sh
@@ -65,8 +66,8 @@ PASS: testsuite/utf8-ru.sh
 PASS: testsuite/uniq.sh
 PASS: testsuite/word-delim.sh
 PASS: testsuite/xemacs.sh
-# TOTAL: 67
-# PASS:  61
+# TOTAL: 68
+# PASS:  62
 # SKIP:  6
 # XFAIL: 0
 # FAIL:  0
@@ -82,24 +83,28 @@ PASS: test-copy-acl-2.sh
 PASS: test-alignof
 PASS: test-alloca-opt
 PASS: test-arpa_inet
+PASS: test-assert
 PASS: test-binary-io.sh
 PASS: test-bind
 PASS: test-btowc1.sh
 PASS: test-btowc2.sh
 PASS: test-c-ctype
 PASS: test-c-strcase.sh
+PASS: test-calloc-gnu
 PASS: test-canonicalize-lgpl
 PASS: test-chdir
 PASS: test-cloexec
 PASS: test-close
 PASS: test-connect
 PASS: test-ctype
-PASS: dfa-invalid-char-class.sh
-PASS: dfa-match.sh
+PASS: test-dfa-invalid-char-class.sh
+PASS: test-dfa-invalid-merge.sh
+PASS: test-dfa-match.sh
 PASS: test-dirent
 PASS: test-dup2
 PASS: test-environ
 PASS: test-errno
+PASS: test-explicit_bzero
 PASS: test-fcntl-h
 PASS: test-fcntl
 PASS: test-fdopen
@@ -109,11 +114,14 @@ PASS: test-fgetc
 PASS: test-file-has-acl.sh
 PASS: test-file-has-acl-1.sh
 PASS: test-file-has-acl-2.sh
+PASS: test-fopen-gnu
+PASS: test-fopen
 PASS: test-fpending.sh
 PASS: test-fpurge
 PASS: test-fputc
 PASS: test-fread
 PASS: test-freading
+PASS: test-free
 PASS: test-fseek.sh
 PASS: test-fseek2.sh
 PASS: test-fseeko.sh
@@ -134,10 +142,11 @@ PASS: test-fwriting
 PASS: test-getcwd-lgpl
 PASS: test-getdelim
 PASS: test-getdtablesize
-PASS: test-getopt-gnu
-PASS: test-getopt-posix
 PASS: test-getprogname
+PASS: test-getrandom
 PASS: test-gettimeofday
+PASS: test-dynarray
+PASS: test-scratch-buffer
 PASS: test-hard-locale
 PASS: test-ignore-value
 PASS: test-inet_pton
@@ -154,6 +163,7 @@ PASS: test-localeconv
 PASS: test-localename
 PASS: test-lseek.sh
 PASS: test-lstat
+PASS: test-malloc-gnu
 PASS: test-malloca
 PASS: test-mbrtowc1.sh
 PASS: test-mbrtowc2.sh
@@ -180,14 +190,18 @@ PASS: test-pathmax
 PASS: test-perror.sh
 PASS: test-perror2
 PASS: test-pipe
+PASS: test-pselect
 PASS: test-pthread
 PASS: test-pthread-thread
 PASS: test-pthread_sigmask1
 SKIP: test-pthread_sigmask2
 PASS: test-quotearg-simple
 PASS: test-raise
+PASS: test-rawmemchr
 PASS: test-read-file
 PASS: test-readlink
+PASS: test-realloc-gnu
+PASS: test-reallocarray
 PASS: test-regex
 PASS: test-rename
 PASS: test-rmdir
@@ -202,7 +216,6 @@ SKIP: test-setlocale_null-mt-all
 PASS: test-setlocale1.sh
 PASS: test-setlocale2.sh
 PASS: test-setsockopt
-PASS: test-sigaction
 PASS: test-signal-h
 PASS: test-sigprocmask
 PASS: test-sleep
@@ -211,6 +224,7 @@ PASS: test-stat
 PASS: test-stat-time
 PASS: test-stdalign
 PASS: test-stdbool
+PASS: test-stdckdint
 PASS: test-stddef
 PASS: test-stdint
 PASS: test-stdio
@@ -221,6 +235,7 @@ PASS: test-string
 PASS: test-strverscmp
 PASS: test-symlink
 PASS: test-sys_ioctl
+PASS: test-sys_random
 PASS: test-sys_select
 PASS: test-sys_socket
 PASS: test-sys_stat
@@ -250,8 +265,8 @@ SKIP: test-wcrtomb-w32-6.sh
 SKIP: test-wcrtomb-w32-7.sh
 PASS: test-wctype-h
 PASS: test-xalloc-die.sh
-# TOTAL: 178
-# PASS:  158
+# TOTAL: 192
+# PASS:  172
 # SKIP:  20
 # XFAIL: 0
 # FAIL:  0


### PR DESCRIPTION
It builds, installs and publishes fine. Tests run fine too. When installed locally I tested it with 
`sed 's/word1/word2/g' random_file` and it worked.

`pfexec pkg info gnu-sed` says the right version.