### PR TITLE
gdb: fix python3.9 support

### DIFF
--- a/components/developer/gdb/Makefile
+++ b/components/developer/gdb/Makefile
@@ -33,17 +33,17 @@ BUILD_BITS= 64
 # good results, even on SPARC.
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=		gdb
-COMPONENT_VERSION=	8.0
-COMPONENT_REVISION=	1
-COMPONENT_SUMMARY=	GDB: The GNU Project Debugger
+COMPONENT_NAME=         gdb
+COMPONENT_VERSION=      8.0
+COMPONENT_REVISION=     2
+COMPONENT_SUMMARY=      GDB: The GNU Project Debugger
 COMPONENT_CLASSIFICATION=Development/System
-COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	\
-     sha256:8968a19e14e176ee026f0ca777657c43456514ad41bb2bc7273e8c4219555ac9
-COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/gnu/gdb/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=	https://www.gnu.org/software/gdb/
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= \
+	sha256:8968a19e14e176ee026f0ca777657c43456514ad41bb2bc7273e8c4219555ac9
+COMPONENT_ARCHIVE_URL=  https://ftp.gnu.org/gnu/gdb/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=  https://www.gnu.org/software/gdb/
 
 CONFIGURE_DEFAULT_DIRS=no
 
@@ -98,9 +98,10 @@ LDFLAGS += -L/usr/gnu/lib/$(MACH64) -R/usr/gnu/lib/$(MACH64)
 # inserted into configrue option strings during
 # nested configure invocations within the gdb build.
 
-CONFIGURE_ENV += CFLAGS="`echo $(CFLAGS)`"
-CONFIGURE_ENV += CPPFLAGS="`echo $(CPPFLAGS)`"
-CONFIGURE_ENV += LDFLAGS="`echo $(LDFLAGS)`"
+CONFIGURE_ENV += CFLAGS="$(CFLAGS)"
+CONFIGURE_ENV += CXXFLAGS="$(CXXFLAGS)"
+CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
+CONFIGURE_ENV += LDFLAGS="$(LDFLAGS)"
 
 CONFIGURE_DEFAULT_DIRS=no
 CONFIGURE_OPTIONS += --mandir=$(CONFIGURE_MANDIR)
@@ -130,13 +131,13 @@ COMPONENT_BUILD_ENV += PATH=$(PATH)
 # Generate the newly added Solaris instruction and
 # register tables which weren't there by default.
 COMPONENT_PRE_CONFIGURE_ACTION = \
-  ( cd  $(SOURCE_DIR)/gdb/features ; \
-    $(GMAKE) all; )
+  +( cd  $(SOURCE_DIR)/gdb/features ; \
+    $(ENV) $(COMPONENT_BUILD_ENV) $(GMAKE) all; )
 
 # build the manpages
 COMPONENT_POST_BUILD_ACTION = \
-	( cd $(BUILD_DIR_64)/gdb/doc ; \
-	$(GMAKE) man )
+	+( cd $(BUILD_DIR_64)/gdb/doc ; \
+    $(ENV) $(COMPONENT_BUILD_ENV) $(GMAKE) man; )
 
 # Two tests hangs up the test run, so skip them.
 COMPONENT_PRE_TEST_ACTION += \

--- a/components/developer/gdb/patches/30-python-3.9.patch
+++ b/components/developer/gdb/patches/30-python-3.9.patch
@@ -1,0 +1,162 @@
+diff -ru a/gdb/python/python-internal.h b/gdb/python/python-internal.h
+--- a/gdb/python/python-internal.h	2022-11-08 22:51:45.529953091 +0000
++++ b/gdb/python/python-internal.h	2022-11-08 17:54:26.449605233 +0000
+@@ -361,7 +361,7 @@
+ struct bpstats;
+ struct inferior;
+ 
+-extern int gdb_python_initialized;
++extern PyThreadState* gdb_python_initialized;
+ 
+ extern PyObject *gdb_module;
+ extern PyObject *gdb_python_module;
+diff -ru a/gdb/python/python.c b/gdb/python/python.c
+--- a/gdb/python/python.c	2022-11-08 22:51:45.530981476 +0000
++++ b/gdb/python/python.c	2022-11-08 22:54:58.542577932 +0000
+@@ -102,10 +102,9 @@
+ #include "py-ref.h"
+ #include "py-event.h"
+ 
+-/* True if Python has been successfully initialized, false
++/* Pointer to the main thread if Python has been successfully initialized, NULL
+    otherwise.  */
+-
+-int gdb_python_initialized;
++PyThreadState* gdb_python_initialized = NULL;
+ 
+ extern PyMethodDef python_GdbMethods[];
+ 
+@@ -209,11 +208,10 @@
+   m_language (python_language)
+ {
+   /* We should not ever enter Python unless initialized.  */
+-  if (!gdb_python_initialized)
++  if (!Py_IsInitialized())
+     error (_("Python not initialized"));
+ 
+   m_previous_active = set_active_ext_lang (&extension_language_python);
+-
+   m_state = PyGILState_Ensure ();
+ 
+   python_gdbarch = gdbarch;
+@@ -255,7 +253,11 @@
+ static int
+ gdbpy_check_quit_flag (const struct extension_language_defn *extlang)
+ {
+-  return PyOS_InterruptOccurred ();
++  if(!Py_IsInitialized()) return 0;
++  PyGILState_STATE gstate = PyGILState_Ensure();
++  int ret = PyOS_InterruptOccurred ();
++  PyGILState_Release(gstate);
++  return ret;
+ }
+ 
+ /* Evaluate a Python command like PyRun_SimpleString, but uses
+@@ -960,7 +962,7 @@
+ gdbpy_before_prompt_hook (const struct extension_language_defn *extlang,
+ 			  const char *current_gdb_prompt)
+ {
+-  if (!gdb_python_initialized)
++  if (!Py_IsInitialized())
+     return EXT_LANG_RC_NOP;
+ 
+   gdbpy_enter enter_py (get_current_arch (), current_language);
+@@ -1240,7 +1242,7 @@
+ 			     struct objfile *objfile, FILE *file,
+ 			     const char *filename)
+ {
+-  if (!gdb_python_initialized)
++  if (!Py_IsInitialized())
+     return;
+ 
+   gdbpy_enter enter_py (get_objfile_arch (objfile), current_language);
+@@ -1262,7 +1264,7 @@
+ 			      struct objfile *objfile, const char *name,
+ 			      const char *script)
+ {
+-  if (!gdb_python_initialized)
++  if (!Py_IsInitialized())
+     return;
+ 
+   gdbpy_enter enter_py (get_objfile_arch (objfile), current_language);
+@@ -1322,7 +1324,7 @@
+ {
+   PyObject *printers_obj = NULL;
+ 
+-  if (!gdb_python_initialized)
++  if (!Py_IsInitialized())
+     return;
+ 
+   gdbpy_enter enter_py (get_current_arch (), current_language);
+@@ -1367,7 +1369,7 @@
+   if (printers_obj == NULL)
+     return EXT_LANG_RC_NOP;
+ 
+-  if (!gdb_python_initialized)
++  if (!Py_IsInitialized())
+     return EXT_LANG_RC_NOP;
+ 
+   gdbpy_enter enter_py (get_current_arch (), current_language);
+@@ -1430,7 +1432,7 @@
+   if (printers == NULL)
+     return;
+ 
+-  if (!gdb_python_initialized)
++  if (!Py_IsInitialized())
+     return;
+ 
+   gdbpy_enter enter_py (get_current_arch (), current_language);
+@@ -1510,10 +1512,9 @@
+      SIGINT handler is gdb's.  We still need to tell it to notify Python.  */
+   previous_active = set_active_ext_lang (&extension_language_python);
+ 
+-  (void) PyGILState_Ensure ();
+   python_gdbarch = target_gdbarch ();
+   python_language = current_language;
+-
++  PyEval_RestoreThread (gdb_python_initialized);
+   Py_Finalize ();
+ 
+   restore_active_ext_lang (previous_active);
+@@ -1591,7 +1592,6 @@
+ #endif
+ 
+   Py_Initialize ();
+-  PyEval_InitThreads ();
+ 
+ #ifdef IS_PY3K
+   gdb_module = PyImport_ImportModule ("_gdb");
+@@ -1696,14 +1696,19 @@
+   if (gdbpy_value_cst == NULL)
+     return false;
+ 
+-  /* Release the GIL while gdb runs.  */
+-  PyThreadState_Swap (NULL);
+-  PyEval_ReleaseLock ();
++  /* Release the GIL while gdb runs. 
++    PyEval_SaveThread both NULLs the python thread state
++    and releases the GIL. We save the main thread info just
++    in case it's needed later, but it's probably the only
++    thread running. */
++
++  gdb_python_initialized = PyEval_SaveThread ();
++  // From this point forward any calls to PyThreadState_*
++  // will cause an exception, unless the thread is restored
++  // or a new one initialized.
+ 
+   make_final_cleanup (finalize_python, NULL);
+ 
+-  /* Only set this when initialization has succeeded.  */
+-  gdb_python_initialized = 1;
+   return true;
+ }
+ 
+@@ -1877,7 +1882,7 @@
+ static int
+ gdbpy_initialized (const struct extension_language_defn *extlang)
+ {
+-  return gdb_python_initialized;
++  return Py_IsInitialized();
+ }
+ 
+ #endif /* HAVE_PYTHON */

--- a/components/developer/gdb/patches/31-prompt-SyntaxWarning.patch
+++ b/components/developer/gdb/patches/31-prompt-SyntaxWarning.patch
@@ -1,0 +1,20 @@
+--- a/gdb/python/lib/gdb/command/prompt.py	Sun Jun  4 15:51:27 2017
++++ b/gdb/python/lib/gdb/command/prompt.py	Tue Nov  8 21:51:25 2022
+@@ -45,7 +45,7 @@
+         self.hook_set = False
+ 
+     def get_show_string (self, pvalue):
+-        if self.value is not '':
++        if self.value != '':
+            return "The extended prompt is: " + self.value
+         else:
+            return "The extended prompt is not set."
+@@ -57,7 +57,7 @@
+         return ""
+ 
+     def before_prompt_hook(self, current):
+-        if self.value is not '':
++        if self.value != '':
+             return gdb.prompt.substitute_prompt(self.value)
+         else:
+             return None


### PR DESCRIPTION
Tech info: [Python 3.9 Threading/Init/Finalization](https://docs.python.org/3.9/c-api/init.html)
Changes between the python3.7 and python3.9 C API required patching of gdb:
 - `PyEval_ReleaseLock` is deprecated since 3.2 & cannot be called when the thread state is NULL anymore.
 - Main thread state must be restored before calling `Py_Finalize`.
 - `PyOS_InterruptOccurred` now needs the current thread to have acquired the GIL.
 - `PyEval_InitThreads` is now a part of `Py_Initialize` and doesn't need to be called anymore.