### PR TITLE
gnupg: fix gpg2 mode settings and preserve attribute

### DIFF
--- a/components/sysutils/gnupg/Makefile
+++ b/components/sysutils/gnupg/Makefile
@@ -30,7 +30,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         gnupg
 COMPONENT_VERSION=      2.3.8
-COMPONENT_REVISION=		1
+COMPONENT_REVISION=		2
 COMPONENT_SUMMARY=      GNU Privacy Guard
 COMPONENT_DESCRIPTION=	A complete and free implementation of the OpenPGP Standard as defined by RFC4880
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/sysutils/gnupg/gnupg.p5m
+++ b/components/sysutils/gnupg/gnupg.p5m
@@ -45,7 +45,7 @@ depend fmri=__TBD pkg.debug.depend.file=usr/lib/pinentry type=require
 # privilege by making it setuid root and installing an exec_attr entry
 # to add just the necessary privilege. See files/exec_attr.
 <transform path=usr/bin/gpg2 -> set owner root>
-<transform path=usr/bin/gpg2 -> set mode 04755>
+<transform path=usr/bin/gpg2 -> set mode 04555>
 
 file files/exec_attr.gnupg path=etc/security/exec_attr.d/gnupg
 
@@ -62,7 +62,7 @@ file path=usr/bin/gpg-preset-passphrase
 file path=usr/bin/gpg-protect-tool
 file path=usr/bin/gpg-wks-client
 file path=usr/bin/gpg-wks-server
-file path=usr/bin/gpg2 preserve=false
+file path=usr/bin/gpg2
 file path=usr/bin/gpgconf
 file path=usr/bin/gpgparsemail
 file path=usr/bin/gpgscm


### PR DESCRIPTION
The old combination let the gpg2 binary untouched during updates.