### PR TITLE
tools/license-detector: add Apache-2.0

### DIFF
--- a/tools/license-detector
+++ b/tools/license-detector
@@ -84,7 +84,7 @@ fi
 TMPFILE=$(mktemp -q)
 [[ -z "$TMPFILE" ]] && printf "ERROR: Temporary file creation failed\n" >&2 && exit 1
 
-for l in "$WS_TOOLS"/licenses/* ; do
+for l in "$WS_TOOLS"/{licenses,license-headers}/* ; do
 	[[ -f "$l" ]] || continue
 
 	LICCMD="$(grep '^# ' "$l" | sed -e 's/^# //' | tr '\n' ' ')"

--- a/tools/license-headers/Apache-2.0
+++ b/tools/license-headers/Apache-2.0
@@ -1,0 +1,15 @@
+# sed -E -n
+# -e '/^Licensed under the Apache License/,/^limitations under the License./p'
+Copyright <year> <copyright holders>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Bleach uses the short version of the Apache license. 