### PR TITLE
upowerd: update illumos code for use newer glib version

### DIFF
--- a/components/sysutils/upower/Makefile
+++ b/components/sysutils/upower/Makefile
@@ -14,13 +14,13 @@
 # Copyright 2020 Michal Nowak
 #
 
-BUILD_BITS=		32_and_64
+BUILD_BITS=		64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		upower
 COMPONENT_VERSION=	0.99.11
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_PROJECT_URL=	http://upower.freedesktop.org/
 COMPONENT_CLASSIFICATION= System/Libraries
 COMPONENT_FMRI=		system/upower

--- a/components/sysutils/upower/manifests/sample-manifest.p5m
+++ b/components/sysutils/upower/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -39,10 +40,6 @@ link path=usr/lib/$(MACH64)/libupower-glib.so target=libupower-glib.so.3.0.1
 link path=usr/lib/$(MACH64)/libupower-glib.so.3 target=libupower-glib.so.3.0.1
 file path=usr/lib/$(MACH64)/libupower-glib.so.3.0.1
 file path=usr/lib/$(MACH64)/pkgconfig/upower-glib.pc
-link path=usr/lib/libupower-glib.so target=libupower-glib.so.3.0.1
-link path=usr/lib/libupower-glib.so.3 target=libupower-glib.so.3.0.1
-file path=usr/lib/libupower-glib.so.3.0.1
-file path=usr/lib/pkgconfig/upower-glib.pc
 file path=usr/lib/upowerd
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.Device.xml
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.KbdBacklight.xml
@@ -60,7 +57,6 @@ file path=usr/share/gtk-doc/html/UPower/home.png
 file path=usr/share/gtk-doc/html/UPower/index.html
 file path=usr/share/gtk-doc/html/UPower/left-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/left.png
-file path=usr/share/gtk-doc/html/UPower/object-tree.html
 file path=usr/share/gtk-doc/html/UPower/right-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/right.png
 file path=usr/share/gtk-doc/html/UPower/style.css

--- a/components/sysutils/upower/patches/02-backend-illumos.patch
+++ b/components/sysutils/upower/patches/02-backend-illumos.patch
@@ -719,7 +719,7 @@ diff -urN upower-0.99.4-orig/src/illumos/up-backend.c upower-0.99.4/src/illumos/
 +
 +static gboolean
 +simulate_iochannel_data (gpointer data) {
-+	write(sysevent_pipe_fds[1],"\n", strlen("\n") + 1);
++	write(sysevent_pipe_fds[1],"\n", strlen("\n"));
 +
 +	return TRUE;
 +}
@@ -736,7 +736,7 @@ diff -urN upower-0.99.4-orig/src/illumos/up-backend.c upower-0.99.4/src/illumos/
 +		return;
 +	
 +	if (strcmp(class, EC_PWRCTL) == 0) {
-+		write(sysevent_pipe_fds[1],"\n", strlen("\n") + 1);
++		write(sysevent_pipe_fds[1],"\n", strlen("\n"));
 +	}
 +}
 +

--- a/components/sysutils/upower/upower.p5m
+++ b/components/sysutils/upower/upower.p5m
@@ -15,6 +15,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(COMPONENT_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -44,10 +45,6 @@ link path=usr/lib/$(MACH64)/libupower-glib.so target=libupower-glib.so.3.0.1
 link path=usr/lib/$(MACH64)/libupower-glib.so.3 target=libupower-glib.so.3.0.1
 file path=usr/lib/$(MACH64)/libupower-glib.so.3.0.1
 file path=usr/lib/$(MACH64)/pkgconfig/upower-glib.pc
-link path=usr/lib/libupower-glib.so target=libupower-glib.so.3.0.1
-link path=usr/lib/libupower-glib.so.3 target=libupower-glib.so.3.0.1
-file path=usr/lib/libupower-glib.so.3.0.1
-file path=usr/lib/pkgconfig/upower-glib.pc
 file path=usr/lib/upowerd mode=0555
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.Device.xml
 file path=usr/share/dbus-1/interfaces/org.freedesktop.UPower.KbdBacklight.xml
@@ -65,7 +62,6 @@ file path=usr/share/gtk-doc/html/UPower/home.png
 file path=usr/share/gtk-doc/html/UPower/index.html
 file path=usr/share/gtk-doc/html/UPower/left-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/left.png
-file path=usr/share/gtk-doc/html/UPower/object-tree.html
 file path=usr/share/gtk-doc/html/UPower/right-insensitive.png
 file path=usr/share/gtk-doc/html/UPower/right.png
 file path=usr/share/gtk-doc/html/UPower/style.css


### PR DESCRIPTION
it is necessary for use newer glib since PR#9857. The change is similar to https://www.illumos.org/issues/15025