### PR TITLE
make-rules: remove unused NUM_EXTRA_ARCHIVES

### DIFF
--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -456,9 +456,7 @@ endif
 clean::
 	$(RM) -r $(SOURCE_DIR) $(BUILD_DIR)
 
-# Make it easy to construct a URL for a pypi source download. This
-# construct supports an optional call to a number from
-# NUM_EXTRA_ARCHIVES for multiple archive downloads.
+# Make it easy to construct a URL for a pypi source download.
 pypi_url_multi = pypi:///$(COMPONENT_NAME_$(1))==$(COMPONENT_VERSION_$(1))
 pypi_url_single = pypi:///$(COMPONENT_NAME)==$(COMPONENT_VERSION)
 pypi_url = $(if $(COMPONENT_NAME_$(1)),$(pypi_url_multi),$(pypi_url_single))

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1219,9 +1219,6 @@ COMPONENT_INSTALL_ENV= \
 # PERL options which depend on C options should be placed here
 PERL_OPTIMIZE :=	$(shell $(PERL) -e 'use Config; print $$Config{optimize}')
 
-# Allow user to override default maximum number of archives
-NUM_EXTRA_ARCHIVES= 1 2 3 4 5 6 7 8 9 10
-
 # Rewrite absolute source-code paths into relative for ccache, so that any
 # workspace with a shared CCACHE_DIR can benefit when compiling a component
 ifneq ($(strip $(CCACHE)),)


### PR DESCRIPTION
The `NUM_EXTRA_ARCHIVES` usage was removed 7 years ago via e28f4f6a37d2e61c4fe651ca063efa94f8078edd...