### PR TITLE
libsecret: update to 0.20.4, drop 32 bit apps and provide test results

### DIFF
--- a/components/library/libsecret/Makefile
+++ b/components/library/libsecret/Makefile
@@ -13,33 +13,48 @@
 # Copyright 2016 Alexander Pyhalov
 #
 
-BUILD_STYLE=configure
-BUILD_BITS=32_and_64
+BUILD_BITS= 64_and_32
+USE_DEFAULT_TEST_TRANSFORMS= yes
+USE_COMMON_TEST_MASTER= no
+SINGLE_PYTHON_VERSION= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         libsecret
-COMPONENT_VERSION=      0.18.5
-COMPONENT_REVISION=     2
+COMPONENT_MAJOR_VERSION= 0.20
+COMPONENT_VERSION=		$(COMPONENT_MAJOR_VERSION).4
 COMPONENT_SUMMARY=      GObject based library for accessing the Secret Service API
+COMPONENT_PROJECT_URL=  https://www.gnome.org
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= \
-	sha256:9ce7bd8dd5831f2786c935d82638ac428fa085057cc6780aba0e39375887ccb3
-COMPONENT_ARCHIVE_URL=  \
-	https://download.gnome.org/sources/$(COMPONENT_NAME)/0.18/$(COMPONENT_ARCHIVE)
-COMPONENT_PROJECT_URL=  http://www.gnome.org
-COMPONENT_FMRI=         library/libsecret
+COMPONENT_ARCHIVE_HASH= sha256:325a4c54db320c406711bf2b55e5cb5b6c29823426aa82596a907595abb39d28
+COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/$(COMPONENT_NAME)/$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=         library/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=System/Security
 COMPONENT_LICENSE=      LGPLv2.1
 COMPONENT_LICENSE_FILE= COPYING
 
-TEST_TARGET=$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 
-PATH=/usr/gnu/bin:/usr/bin
+# If we use gcc-7 vala tests cannot be build because of a 32/64 bit ELFCLASS mismatch.
+GCC_VERSION= 10
+
+PATH= $(PATH.gnu)
+
+CONFIGURE_OPTIONS += --disable-static
+CONFIGURE_OPTIONS.32 += --disable-introspection
+CONFIGURE_OPTIONS.64 += --enable-introspection
+CONFIGURE_OPTIONS.32 += --disable-vala
+CONFIGURE_OPTIONS.64 += --enable-vala
 
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
+
+COMPONENT_TEST_ENV += CC="$(CC)"
+COMPONENT_TEST_ENV += CFLAGS="$(CFLAGS)"
+
+# Manually added dependencies
+REQUIRED_PACKAGES += developer/vala
+REQUIRED_PACKAGES += library/desktop/gobject/gobject-introspection
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/glib2

--- a/components/library/libsecret/libsecret.p5m
+++ b/components/library/libsecret/libsecret.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2016 Alexander Pyhalov
+# Copyright 2022 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,20 +23,25 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/secret-tool
+<transform file path=.*/bin/$(MACH32)/.+ -> drop>
+
+file path=usr/bin/$(MACH32)/secret-tool
 file path=usr/bin/secret-tool
 file path=usr/include/libsecret-1/libsecret/secret-attributes.h
+file path=usr/include/libsecret-1/libsecret/secret-backend.h
 file path=usr/include/libsecret-1/libsecret/secret-collection.h
 file path=usr/include/libsecret-1/libsecret/secret-enum-types.h
 file path=usr/include/libsecret-1/libsecret/secret-item.h
 file path=usr/include/libsecret-1/libsecret/secret-password.h
 file path=usr/include/libsecret-1/libsecret/secret-paths.h
 file path=usr/include/libsecret-1/libsecret/secret-prompt.h
+file path=usr/include/libsecret-1/libsecret/secret-retrievable.h
 file path=usr/include/libsecret-1/libsecret/secret-schema.h
 file path=usr/include/libsecret-1/libsecret/secret-schemas.h
 file path=usr/include/libsecret-1/libsecret/secret-service.h
 file path=usr/include/libsecret-1/libsecret/secret-types.h
 file path=usr/include/libsecret-1/libsecret/secret-value.h
+file path=usr/include/libsecret-1/libsecret/secret-version.h
 file path=usr/include/libsecret-1/libsecret/secret.h
 file path=usr/lib/$(MACH64)/girepository-1.0/Secret-1.typelib
 link path=usr/lib/$(MACH64)/libsecret-1.so target=libsecret-1.so.0.0.0
@@ -53,13 +59,16 @@ file path=usr/share/locale/an/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ar/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/as/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/be/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/bg/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/bs/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ca/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ca@valencia/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/ckb/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/cs/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/da/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/de/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/el/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/eo/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/es/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/eu/LC_MESSAGES/libsecret.mo
@@ -68,6 +77,7 @@ file path=usr/share/locale/fr/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/fur/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/gl/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/he/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/hr/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/hu/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/id/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/it/LC_MESSAGES/libsecret.mo
@@ -77,7 +87,9 @@ file path=usr/share/locale/ko/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/lt/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/lv/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ml/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/ms/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/nb/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/ne/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/nl/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/oc/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/pa/LC_MESSAGES/libsecret.mo

--- a/components/library/libsecret/manifests/sample-manifest.p5m
+++ b/components/library/libsecret/manifests/sample-manifest.p5m
@@ -23,29 +23,30 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/secret-tool
+file path=usr/bin/$(MACH32)/secret-tool
 file path=usr/bin/secret-tool
 file path=usr/include/libsecret-1/libsecret/secret-attributes.h
+file path=usr/include/libsecret-1/libsecret/secret-backend.h
 file path=usr/include/libsecret-1/libsecret/secret-collection.h
 file path=usr/include/libsecret-1/libsecret/secret-enum-types.h
 file path=usr/include/libsecret-1/libsecret/secret-item.h
 file path=usr/include/libsecret-1/libsecret/secret-password.h
 file path=usr/include/libsecret-1/libsecret/secret-paths.h
 file path=usr/include/libsecret-1/libsecret/secret-prompt.h
+file path=usr/include/libsecret-1/libsecret/secret-retrievable.h
 file path=usr/include/libsecret-1/libsecret/secret-schema.h
 file path=usr/include/libsecret-1/libsecret/secret-schemas.h
 file path=usr/include/libsecret-1/libsecret/secret-service.h
 file path=usr/include/libsecret-1/libsecret/secret-types.h
 file path=usr/include/libsecret-1/libsecret/secret-value.h
+file path=usr/include/libsecret-1/libsecret/secret-version.h
 file path=usr/include/libsecret-1/libsecret/secret.h
 file path=usr/lib/$(MACH64)/girepository-1.0/Secret-1.typelib
-file path=usr/lib/$(MACH64)/libsecret-1.a
 link path=usr/lib/$(MACH64)/libsecret-1.so target=libsecret-1.so.0.0.0
 link path=usr/lib/$(MACH64)/libsecret-1.so.0 target=libsecret-1.so.0.0.0
 file path=usr/lib/$(MACH64)/libsecret-1.so.0.0.0
 file path=usr/lib/$(MACH64)/pkgconfig/libsecret-1.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libsecret-unstable.pc
-file path=usr/lib/libsecret-1.a
 link path=usr/lib/libsecret-1.so target=libsecret-1.so.0.0.0
 link path=usr/lib/libsecret-1.so.0 target=libsecret-1.so.0.0.0
 file path=usr/lib/libsecret-1.so.0.0.0
@@ -56,13 +57,16 @@ file path=usr/share/locale/an/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ar/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/as/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/be/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/bg/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/bs/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ca/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ca@valencia/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/ckb/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/cs/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/da/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/de/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/el/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/en_GB/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/eo/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/es/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/eu/LC_MESSAGES/libsecret.mo
@@ -71,6 +75,7 @@ file path=usr/share/locale/fr/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/fur/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/gl/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/he/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/hr/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/hu/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/id/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/it/LC_MESSAGES/libsecret.mo
@@ -80,7 +85,9 @@ file path=usr/share/locale/ko/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/lt/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/lv/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/ml/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/ms/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/nb/LC_MESSAGES/libsecret.mo
+file path=usr/share/locale/ne/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/nl/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/oc/LC_MESSAGES/libsecret.mo
 file path=usr/share/locale/pa/LC_MESSAGES/libsecret.mo

--- a/components/library/libsecret/patches/01-getpass.patch
+++ b/components/library/libsecret/patches/01-getpass.patch
@@ -1,0 +1,23 @@
+Replace getpass() with getpassphrase(), to avoid sctrict password length
+limitation. The former one, as provided in Solaris libc, only accepts 8
+characters, while latter one accepts 256 characters. See getpass(3C) manual
+page.
+
+On Linux, the problem doesn't exist, the glibc version of getpass() is
+unlimited. To match it on Solaris, we would have to provide own function, but
+then the secret-tool internally doesn't care too much about long passwords too,
+e.g. the function that reads password from standard input (read_password_stdin)
+limits the input by reading into single 8k buffer.
+
+diff -ur libsecret-0.20.4.orig/tool/secret-tool.c libsecret-0.20.4/tool/secret-tool.c
+--- libsecret-0.20.4.orig/tool/secret-tool.c	2019-10-12 02:46:23.000000000 +0000
++++ libsecret-0.20.4/tool/secret-tool.c	2021-11-16 08:21:18.880630279 +0000
+@@ -267,7 +267,7 @@
+ {
+ 	gchar *password;
+ 
+-	password = getpass ("Password: ");
++	password = getpassphrase ("Password: ");
+ 	return secret_value_new_full (password, -1, "text/plain",
+ 	                              (GDestroyNotify)secret_password_wipe);
+ }

--- a/components/library/libsecret/pkg5
+++ b/components/library/libsecret/pkg5
@@ -1,6 +1,8 @@
 {
     "dependencies": [
         "SUNWcs",
+        "developer/vala",
+        "library/desktop/gobject/gobject-introspection",
         "library/glib2",
         "shell/ksh93",
         "system/library",

--- a/components/library/libsecret/test/results-32.master
+++ b/components/library/libsecret/test/results-32.master
@@ -1,0 +1,45 @@
+PASS: test-hex 1 /hex/encode
+PASS: test-hex 2 /hex/encode_spaces
+PASS: test-hex 3 /hex/decode
+PASS: test-hex 4 /hex/decode_fail
+ERROR: test-secmem - Bail out! ERROR:$(SOURCE_DIR)/egg/test-secmem.c:76:test_alloc_free: 'p' should not be NULL
+PASS: test-hkdf 1 /hkdf/test-case-1
+PASS: test-hkdf 2 /hkdf/test-case-2
+PASS: test-hkdf 3 /hkdf/test-case-3
+PASS: test-hkdf 4 /hkdf/test-case-4
+PASS: test-hkdf 5 /hkdf/test-case-5
+PASS: test-hkdf 6 /hkdf/test-case-6
+PASS: test-hkdf 7 /hkdf/test-case-7
+PASS: test-dh 1 /dh/default_768
+PASS: test-dh 2 /dh/default_1024
+PASS: test-dh 3 /dh/default_1536
+PASS: test-dh 4 /dh/default_2048
+PASS: test-dh 5 /dh/default_3072
+PASS: test-dh 6 /dh/default_4096
+PASS: test-dh 7 /dh/default_8192
+PASS: test-dh 8 /dh/default_bad
+ERROR: test-attributes - missing test plan
+ERROR: test-value - missing test plan
+ERROR: test-prompt - missing test plan
+ERROR: test-service - missing test plan
+ERROR: test-session - missing test plan
+ERROR: test-paths - missing test plan
+ERROR: test-methods - missing test plan
+ERROR: test-password - missing test plan
+ERROR: test-item - missing test plan
+ERROR: test-collection - missing test plan
+ERROR: test-file-collection - missing test plan
+FAIL: libsecret/test-py-lookup.py
+FAIL: libsecret/test-py-clear.py
+FAIL: libsecret/test-py-store.py
+FAIL: libsecret/test-js-lookup.js
+FAIL: libsecret/test-js-clear.js
+FAIL: libsecret/test-js-store.js
+ERROR: tool/test-secret-tool.sh - too few tests run (expected 6, got 0)
+# TOTAL: 38
+# PASS:  19
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  6
+# XPASS: 0
+# ERROR: 13

--- a/components/library/libsecret/test/results-64.master
+++ b/components/library/libsecret/test/results-64.master
@@ -1,0 +1,47 @@
+PASS: test-hex 1 /hex/encode
+PASS: test-hex 2 /hex/encode_spaces
+PASS: test-hex 3 /hex/decode
+PASS: test-hex 4 /hex/decode_fail
+ERROR: test-secmem - Bail out! ERROR:$(SOURCE_DIR)/egg/test-secmem.c:76:test_alloc_free: 'p' should not be NULL
+PASS: test-hkdf 1 /hkdf/test-case-1
+PASS: test-hkdf 2 /hkdf/test-case-2
+PASS: test-hkdf 3 /hkdf/test-case-3
+PASS: test-hkdf 4 /hkdf/test-case-4
+PASS: test-hkdf 5 /hkdf/test-case-5
+PASS: test-hkdf 6 /hkdf/test-case-6
+PASS: test-hkdf 7 /hkdf/test-case-7
+PASS: test-dh 1 /dh/default_768
+PASS: test-dh 2 /dh/default_1024
+PASS: test-dh 3 /dh/default_1536
+PASS: test-dh 4 /dh/default_2048
+PASS: test-dh 5 /dh/default_3072
+PASS: test-dh 6 /dh/default_4096
+PASS: test-dh 7 /dh/default_8192
+PASS: test-dh 8 /dh/default_bad
+ERROR: test-attributes - missing test plan
+ERROR: test-value - missing test plan
+ERROR: test-prompt - missing test plan
+ERROR: test-service - missing test plan
+ERROR: test-session - missing test plan
+ERROR: test-paths - missing test plan
+ERROR: test-methods - missing test plan
+ERROR: test-password - missing test plan
+ERROR: test-item - missing test plan
+ERROR: test-collection - missing test plan
+ERROR: test-file-collection - missing test plan
+PASS: libsecret/test-py-lookup.py
+PASS: libsecret/test-py-clear.py
+PASS: libsecret/test-py-store.py
+FAIL: libsecret/test-js-lookup.js
+FAIL: libsecret/test-js-clear.js
+FAIL: libsecret/test-js-store.js
+ERROR: test-vala-lang - missing test plan
+ERROR: test-vala-unstable - missing test plan
+ERROR: tool/test-secret-tool.sh - too few tests run (expected 6, got 0)
+# TOTAL: 40
+# PASS:  22
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  3
+# XPASS: 0
+# ERROR: 15


### PR DESCRIPTION
We cannot upgrade to the latest version because it's meson build style only and we are at least missing typogrify packages for python3.