### PR TITLE
illumos-gate: dhcpagent should ask for Rootpath too

### DIFF
--- a/components/openindiana/illumos-gate/overlay/etc/default/dhcpagent
+++ b/components/openindiana/illumos-gate/overlay/etc/default/dhcpagent
@@ -1,0 +1,188 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+# Copyright (c) 2016-2017, Chris Fraire <cfraire@me.com>.
+#
+
+#
+# This file contains tunable parameters for dhcpagent(8).
+#
+
+# All parameters can be tuned for a specific interface by prepending
+# the interface name to the parameter name.  For example, to make
+# VERIFIED_LEASE_ONLY happen on all interfaces except hme0, specify:
+#
+# hme0.VERIFIED_LEASE_ONLY=no
+# VERIFIED_LEASE_ONLY=yes
+#
+# An interface name alone specifies IPv4 DHCP.  For DHCPv6, append ".v6".
+# Some examples:
+#
+# hme0.VERIFIED_LEASE_ONLY=no		specify hme0 v4 behavior
+# hme0.v6.VERIFIED_LEASE_ONLY=no	specify hme0 v6 behavior
+# VERIFIED_LEASE_ONLY=no		match all v4 interfaces
+# .v6.VERIFIED_LEASE_ONLY=no		match all v6 interfaces
+
+# By default, when the DHCP agent is sent a SIGTERM (typically when
+# the system is shut down), all managed addresses are dropped rather
+# than released.  Dropping an address does not notify the DHCP server
+# that the address is no longer in use, leaving it possibly available
+# for subsequent use by the same client.  If DHCP is later restarted
+# on the interface, the client will ask the server if it can continue
+# to use the address.  If the server either grants the request, or
+# does not answer (and the lease has not yet expired), then the client
+# will use the original address.
+#
+# Similarly, when the system is suspended and then woken up or when
+# the link status transitions from down to up, DHCP will ask the server
+# to continue to use the managed address, in case the lease has changed.
+#
+# By uncommenting the following parameter-value pairs, all managed
+# addresses are released on SIGTERM instead, and any that may have been
+# saved but cannot be verified will not be used.  When SIGTERM is
+# received, the DHCP server is notified that the address is available
+# for use, and the address will not be saved for a later restart.  If
+# DHCP receives SIGTHAW or a link-up event, DHCP will attempt to verify
+# the previous lease, but if unable to do so, it will not attempt to
+# use that lease.  This behavior is often preferred for roaming systems.
+#
+# VERIFIED_LEASE_ONLY=yes
+# .v6.VERIFIED_LEASE_ONLY=yes
+
+# By default, the DHCP agent waits 3 seconds to collect OFFER
+# responses to a DISCOVER.  If it receives no OFFERs in this time, it
+# then waits for another 3 seconds, and so forth.  To change this
+# behavior, set and uncomment the following parameter-value pair.
+# Note: this does not control the retransmission strategy for
+# DISCOVERs, which is formally specified in RFC 2131.  This parameter
+# is specified in seconds.
+#
+# OFFER_WAIT=
+
+# By default, the DHCP agent does not send out a client identifier
+# (and hence, the chaddr field is used by the DHCP server as the
+# client identifier.)  To make the DHCP agent send a client
+# identifier, set and uncomment the following parameter-value pair.
+# Note that by default this is treated as an NVT ASCII string.  To
+# specify a binary value, prepend "0x" to a sequence of hexadecimal
+# digits (for example, the value 0xAABBCC11 would set the client
+# identifier to the 4-byte binary sequence 0xAA 0xBB 0xCC 0x11).
+#
+# CLIENT_ID=
+
+# By default, for an IPv4 interface that is not in an IP network
+# multipathing (IPMP) group, that is not IP over InfiniBand (IPoIB), and
+# that is not a logical interface, the DHCP agent will forgo sending a
+# client identifier unless CLIENT_ID is defined.
+#
+# To use a system-managed, RFC 3315-style (i.e., DHCPv6-style) binding
+# identifier as documented in RFC 4361, "Node-specific Client Identifiers
+# for DHCPv4," for all IPv4 interfaces (unless CLIENT_ID is defined),
+# uncomment the following line.
+#
+# V4_DEFAULT_IAID_DUID=yes
+
+# By default, the DHCP agent will try to request the Fully Qualified Domain
+# Name (FQDN) currently associated with the interface performing DHCP.  The
+# hostname is defined by using the -h,--reqhost option of ipadm(8) or the
+# ncu ip-reqhost property of nwamcfg(8) or by flagging the interface as
+# primary so that nodename(5) is used as the hostname.
+#
+# A defined hostname will be used as the FQDN if it is "rooted" (i.e., if
+# it ends with a '.') or if it consists of at least three DNS labels (e.g.,
+# srv.example.com).  If the hostname is not an FQDN, then DNS_DOMAINNAME
+# will be appended if defined or ADOPT_DOMAINNAME discernment will be used
+# if active.  If no FQDN can be determined, the option will not be used.
+#
+# If this REQUEST_FQDN option is enabled, an FQDN will be sent in messages
+# to the DHCP server along with RFC 4702 options to request that a
+# collaborating DNS server perform DNS updates for A and PTR resource
+# records.  To prevent sending FQDN and DNS options, uncomment the line
+# below.
+#
+# If an FQDN is sent, REQUEST_HOSTNAME processing will not be done, per RFC
+# 4702 (3.1):  "clients that send the Client FQDN option in their messages
+# MUST NOT also send the Host Name."
+#
+# REQUEST_FQDN=no
+
+# By default, the DHCP agent will not attempt to construct an FQDN from a
+# PQDN specified by the -h,--reqhost option of ipadm(8), by the ncu
+# ip-reqhost property of nwamcfg(8), or by nodename(5).  Set and
+# uncomment the following parameter to indicate a domain name to be used by
+# the DHCP agent to construct if necessary an FQDN.
+#
+# DNS_DOMAINNAME=
+
+# By default, the DHCP agent will not attempt to use a domain name returned
+# by the DHCP server or the domain in resolv.conf(5) to construct an FQDN
+# from a PQDN specified by the -h,--reqhost option of ipadm(8), by the ncu
+# ip-reqhost property of nwamcfg(8), or by nodename(5).  Set and uncomment
+# the following parameter to indicate that a returned DHCPv4 DNSdmain or the
+# domain from resolv.conf(5) should be adopted by the DHCP agent to
+# construct if necessary an FQDN.
+#
+# ADOPT_DOMAINNAME=yes
+
+# By default, the DHCP agent will try to request the hostname currently
+# associated with the interface performing DHCP.  If this option is
+# enabled, the agent will attempt to use an -h,--reqhost option saved with
+# ipadm(8) or an ncu ip-reqhost property set with nwamcfg(8); or else
+# attempt to find a host name in /etc/hostname.<if>, which must contain a
+# line of the form
+#
+#	inet name
+#
+# where "name" is a single RFC 1101-compliant token; or else use
+# nodename(5) for a DHCP interface flagged as primary.  If found in any of
+# these configurations, the token will be used to request that host name
+# from the DHCP server.  To prevent this, uncomment the following line.
+#
+# REQUEST_HOSTNAME=no
+
+# By default, a parameter request list requesting a subnet mask (1),
+# router (3), DNS server (6), hostname (12), DNS domain (15), root path (17),
+# broadcast address (28), and encapsulated vendor options (43), is sent to the
+# DHCP server when the DHCP agent sends requests.  However, if desired, this
+# can be changed by altering the following parameter-value pair.  The
+# numbers correspond to the values defined in the IANA bootp-dhcp-parameters
+# registry at the time of this writing.  Site and standard option names from
+# /etc/dhcp/inittab are also accepted.
+#
+PARAM_REQUEST_LIST=1,3,6,12,15,17,28,43
+
+# The default DHCPv6 parameter request list has preference (7), unicast (12),
+# DNS addresses (23), DNS search list (24), NIS addresses (27), and
+# NIS domain (29).  This may be changed by altering the following parameter-
+# value pair.  The numbers correspond to the values defined in the IANA
+# dhcpv6-parameters registry at the time of this writing.  Site and standard
+# option names from /etc/dhcp/inittab6 are also accepted.
+.v6.PARAM_REQUEST_LIST=7,12,23,24,27,29
+
+# The parameter ignore list allows you to instruct the DHCP client to discard
+# optional parameters received from the DHCP server.  The format is the same
+# as the request list above.  When discarded, a parameter will not be acted
+# on by the DHCP client or returned to users via the dhcpinfo(1) command.
+PARAM_IGNORE_LIST=
+.v6.PARAM_IGNORE_LIST=


### PR DESCRIPTION
This adds 17 (Rootpath) to `PARAM_REQUEST_LIST` for `dhcpagent`.  This is needed to make the installation over network (PXE + NFS) fully working automatically.  The related change in slim_source is [here](https://github.com/OpenIndiana/slim_source/pull/71).