### PR TITLE
switch default gcc to version 10

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -596,7 +596,7 @@ export CCACHE := $(shell \
         fi; \
     fi)
 
-GCC_VERSION =	7
+GCC_VERSION =	10
 GCC_ROOT =	/usr/gcc/$(GCC_VERSION)
 
 GCC_LIBDIR.32 =	$(GCC_ROOT)/lib

--- a/transforms/defaults
+++ b/transforms/defaults
@@ -123,7 +123,7 @@ set name=variant.arch value=$(MACH)
 #
 # Set the default GCC for mediated links
 #
-<transform link mediator=gcc mediator-version=7 -> default mediator-priority vendor>
+<transform link mediator=gcc mediator-version=10 -> default mediator-priority vendor>
 
 #
 # Set the default Python for mediated links


### PR DESCRIPTION
In the past we prepared such a change by mass builds of (almost) all packages. This time we want to take a smoother and less tedious route. We switch and re-publish packages later, e.g. when they got a fix or an update. According to alarcher this should be possible: "Only C++ can cause issues really.
As long as you make sure that all g++-runtime dependent packages are republished at once it should be fine.
This can help reduce the set of packages to take care of.
For the C++ components that do not build with gcc-10 and have no dependent libraries or binaries it is enough to set GCC_VERSION=7 in the Makefile."