### PR TITLE
iaxmodem - fix segmentation fault and change initial SMF to disabled

### DIFF
--- a/components/network/iaxmodem/Makefile
+++ b/components/network/iaxmodem/Makefile
@@ -16,6 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		iaxmodem
 COMPONENT_VERSION=	1.3.3
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		network/iaxmodem
 COMPONENT_SUMMARY=	IAXmodem is a software modem written in C that uses an IAX channel
 COMPONENT_DESCRIPTION=	IAXmodem is a software modem written in C that uses an IAX channel \
@@ -48,7 +49,6 @@ COMPONENT_POST_CONFIGURE_ACTION += ( \
 	 $(GSED) -i -e 's/-DSTATICLIBS -DUSE_UNIX98_PTY/-DSTATICLIBS -D__EXTENSIONS__ -DSOLARIS -DUSE_UNIX98_PTY/' $(@D)/Makefile; \
 	 $(GSED) -i -e 's/-DMODEMVER/-m64 -DMODEMVER/' $(@D)/Makefile; \
 	 $(GSED) -i -e 's:Ilib/libiax2/src:I/usr/include/iax:' $(@D)/Makefile; \
-	 $(GSED) -i -e 's: lib/spandsp/src/.libs/libspandsp.a: -lspandsp:' $(@D)/Makefile; \
 	 $(GSED) -i -e 's: lib/libiax2/src/.libs/libiax.a: -liax:' $(@D)/Makefile; \
 	 $(GSED) -i -e 's/-lm -lutil -ltiff/-m64 -lm -lnsl -lsocket -ltiff/' $(@D)/Makefile; \
 	 );
@@ -72,5 +72,5 @@ COMPONENT_POST_INSTALL_ACTION= ( \
 # Auto-generated dependencies
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/libiax2
-REQUIRED_PACKAGES += library/spandsp
 REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/network/iaxmodem/files/iaxmodem.xml
+++ b/components/network/iaxmodem/files/iaxmodem.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
 <service_bundle type='manifest' name='export'>
   <service name='network/iaxmodem' type='service' version='0'>
-    <create_default_instance enabled='true'/>
+    <create_default_instance enabled='false'/>
     <single_instance/>
     <dependency name='fs-local' grouping='require_all' restart_on='none' type='service'>
       <service_fmri value='svc:/system/filesystem/local'/>

--- a/components/network/iaxmodem/pkg5
+++ b/components/network/iaxmodem/pkg5
@@ -2,9 +2,9 @@
     "dependencies": [
         "SUNWcs",
         "library/libiax2",
-        "library/spandsp",
         "shell/ksh93",
-        "system/library"
+        "system/library",
+        "system/library/math"
     ],
     "fmris": [
         "network/iaxmodem"


### PR DESCRIPTION
seems some incompatibility with extra provided spandsp library (which is version3.0), so switched back to included one.