### PR TITLE
python/backports.functools_lru_cache: rename package to normalize it; update to 1.6.4;

### DIFF
--- a/components/python/backports.functools_lru_cache/Makefile
+++ b/components/python/backports.functools_lru_cache/Makefile
@@ -1,48 +1,45 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL)". You may
-# only use this file in accordance with the terms of the CDDL.
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 
 #
-# Copyright 2016 Alexander Pyhalov
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project backports.functools_lru_cache
 #
+
+BUILD_STYLE = pyproject
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=		backports.functools_lru_cache
-COMPONENT_VERSION=	1.5
-COMPONENT_SUMMARY=	'Backport of functools.lru_cache from Python 3.3'
-COMPONENT_PROJECT_URL=	https://pypi.org/project/backports.functools_lru_cache/
-COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	\
-    sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a
-COMPONENT_ARCHIVE_URL=	$(call pypi_url)
-COMPONENT_FMRI=	library/python/backports.functools_lru_cache
-COMPONENT_CLASSIFICATION=	Development/Python
-COMPONENT_LICENSE=	MIT
-COMPONENT_LICENSE_FILE=	LICENSE
+COMPONENT_NAME =		backports.functools_lru_cache
+HUMAN_VERSION =			1.6.4
+COMPONENT_SUMMARY =		backports.functools_lru_cache - Backport of functools.lru_cache
+COMPONENT_PROJECT_URL =		https://github.com/jaraco/backports.functools_lru_cache
+COMPONENT_ARCHIVE_URL =		\
+	https://files.pythonhosted.org/packages/95/9f/122a41912932c77d5b8e6cab6bd456e6270211a3ed7248a80c235179a012/backports.functools_lru_cache-1.6.4.tar.gz
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:d5ed2169378b67d3c545e5600d363a923b09c456dab1593914935a68ad478271
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE
 
-PYTHON_VERSIONS=	2.7
+include $(WS_MAKE_RULES)/common.mk
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/setup.py.mk
-include $(WS_MAKE_RULES)/ips.mk
-
-COMPONENT_BUILD_ENV += SETUPTOOLS_SCM_PRETEND_VERSION=$(COMPONENT_VERSION)
-COMPONENT_INSTALL_ENV += SETUPTOOLS_SCM_PRETEND_VERSION=$(COMPONENT_VERSION)
-
-# common targets
-build:		$(BUILD_NO_ARCH)
-
-install:	$(INSTALL_NO_ARCH)
-
-test:           $(NO_TESTS)
-
-# Build dependencies
-REQUIRED_PACKAGES += library/python/setuptools_scm-27
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools-scm
+PYTHON_REQUIRED_PACKAGES += library/python/wheel
+PYTHON_REQUIRED_PACKAGES += runtime/python
+TEST_REQUIRED_PACKAGES.python += library/python/pytest
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-black
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-checkdocs
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-cov
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-enabler
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-flake8
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-mypy

--- a/components/python/backports.functools_lru_cache/backports.functools_lru_cache-PYVER.p5m
+++ b/components/python/backports.functools_lru_cache/backports.functools_lru_cache-PYVER.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 Alexander Pyhalov
+# This file was automatically generated using python-integrate-project
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,12 +23,14 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend type=require fmri=library/python/backports/backports-common-$(PYV)
-
-file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py$(PYVER).egg-info/PKG-INFO
-file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py$(PYVER).egg-info/SOURCES.txt
-file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py$(PYVER).egg-info/dependency_links.txt
-file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py$(PYVER).egg-info/namespace_packages.txt
-file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py$(PYVER).egg-info/requires.txt
-file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py$(PYVER).egg-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/top_level.txt
 file path=usr/lib/python$(PYVER)/vendor-packages/backports/functools_lru_cache.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/backports.functools_lru_cache/history
+++ b/components/python/backports.functools_lru_cache/history
@@ -1,0 +1,2 @@
+library/python/backports.functools_lru_cache-27@1.5,5.11-2020.0.1.1 noincorporate
+library/python/backports.functools_lru_cache@1.5,5.11-2020.0.1.1 library/python/backports-functools-lru-cache

--- a/components/python/backports.functools_lru_cache/manifests/sample-manifest.p5m
+++ b/components/python/backports.functools_lru_cache/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
-set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,11 +23,14 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/lib/python2.7/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py2.7.egg-info/PKG-INFO
-file path=usr/lib/python2.7/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py2.7.egg-info/SOURCES.txt
-file path=usr/lib/python2.7/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py2.7.egg-info/dependency_links.txt
-file path=usr/lib/python2.7/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py2.7.egg-info/namespace_packages.txt
-file path=usr/lib/python2.7/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py2.7.egg-info/requires.txt
-file path=usr/lib/python2.7/vendor-packages/backports.functools_lru_cache-$(COMPONENT_VERSION)-py2.7.egg-info/top_level.txt
-file path=usr/lib/python2.7/vendor-packages/backports/__init__.py
-file path=usr/lib/python2.7/vendor-packages/backports/functools_lru_cache.py
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/backports.functools_lru_cache-$(HUMAN_VERSION).dist-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/functools_lru_cache.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/backports.functools_lru_cache/pkg5
+++ b/components/python/backports.functools_lru_cache/pkg5
@@ -1,12 +1,21 @@
 {
     "dependencies": [
         "SUNWcs",
-        "library/python/setuptools_scm-27",
+        "library/python/setuptools-37",
+        "library/python/setuptools-39",
+        "library/python/setuptools-scm-37",
+        "library/python/setuptools-scm-39",
+        "library/python/wheel-37",
+        "library/python/wheel-39",
+        "runtime/python-37",
+        "runtime/python-39",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [
-        "library/python/backports.functools_lru_cache-27",
-        "library/python/backports.functools_lru_cache"
+        "library/python/backports-functools-lru-cache-37",
+        "library/python/backports-functools-lru-cache-39",
+        "library/python/backports-functools-lru-cache"
     ],
     "name": "backports.functools_lru_cache"
 }


### PR DESCRIPTION
rebuild for python 3.7 and 3.9 and to get package for python 2.7 obsoleted