### PR TITLE
Fix geany-plugins to be build using autoconf-2.71

### DIFF
--- a/components/editor/geany-plugins/Makefile
+++ b/components/editor/geany-plugins/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         geany-plugins
 COMPONENT_VERSION=      1.38
-COMPONENT_REVISION=     4
+COMPONENT_REVISION=     5
 COMPONENT_CLASSIFICATION=System/Text Tools
 COMPONENT_FMRI=         editor/geany/plugins
 COMPONENT_SUMMARY=      Plugins for Geany editor
@@ -33,7 +33,7 @@ COMPONENT_LICENSE=      GPLv2
 
 PYTHON_VERSION= 3.9
 
-COMPONENT_PREP_ACTION += ( cd $(@D) && autoreconf -f)
+COMPONENT_PREP_ACTION += ( cd $(@D) && rm ltmain.sh; autoreconf -fi )
 
 TEST_TARGET=		$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk


### PR DESCRIPTION
This fixes the following error during build after configure has taken place:
libtool: Version mismatch error.  This is libtool 2.4.6 Debian-2.4.6-15, but the
libtool: definition of this LT_INIT comes from libtool 2.4.7.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6 Debian-2.4.6-15
libtool: and run autoconf again.
