### PR TITLE
network/moosefs: added package

### DIFF
--- a/components/network/moosefs/Makefile
+++ b/components/network/moosefs/Makefile
@@ -1,0 +1,60 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		moosefs
+COMPONENT_VERSION=	3.0.116
+COMPONENT_SUMMARY=	Open Source, Petabyte, Fault-Tolerant, Highly Performing, Scalable Network Distributed File System (Software-Defined Storage)
+COMPONENT_PROJECT_URL=	https://moosefs.com/
+COMPONENT_FMRI=		network/${COMPONENT_NAME}
+COMPONENT_CLASSIFICATION=System/File System
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=	https://codeload.github.com/moosefs/moosefs/tar.gz/refs/tags/v$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE_HASH=	sha256:3b70dd4551db282e6e9b9c8ecdb5f2ec5ed98b644dc06e2006cd0deaa84f6c9c
+COMPONENT_LICENSE=	GPLv3
+COMPONENT_LICENSE_FILE=	COPYING
+
+TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
+include $(WS_MAKE_RULES)/common.mk
+
+# needs a buildnumer
+COMPONENT_PRE_CONFIGURE_ACTION	+= (echo "0" > $(@D)/buildno.txt) ;
+
+# we need to generate the makefiles because we patches Makefile.am 
+COMPONENT_PREP_ACTION= ( cd $(@D) && \
+		       aclocal -I. && \
+		       automake -a -f -c && \
+		       autoconf )
+
+# pkgdepend does not like only the major version, replace with a specific python versien 
+COMPONENT_POST_INSTALL_ACTION += $(GSED) -i -e 's?env python3?python$(PYTHON_VERSION)?' $(PROTOUSRBINDIR)/mfscli ;
+COMPONENT_POST_INSTALL_ACTION += $(GSED) -i -e 's?env python3?python$(PYTHON_VERSION)?' $(PROTOUSRSBINDIR)/mfscgiserv ;
+COMPONENT_POST_INSTALL_ACTION += $(GSED) -i -e 's?env python3?python$(PYTHON_VERSION)?' $(PROTOUSRSHAREDIR)/mfscgi/mfs.cgi ;
+
+CONFIGURE_OPTIONS+= --localstatedir=/var
+CONFIGURE_OPTIONS+= --sysconfdir=/etc
+
+# Build dependencies
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += runtime/python
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += library/libfuse
+REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/libpcap
+REQUIRED_PACKAGES += system/library/math

--- a/components/network/moosefs/files/moosefs-cgiserv.xml
+++ b/components/network/moosefs/files/moosefs-cgiserv.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='moosefs-cgiserv'>
+	<service name='network/moosefs-cgiserv' type='service' version='0'>
+		<single_instance/>
+		<dependency name='fs' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/system/filesystem/local'/>
+		</dependency>
+		<dependency name='network' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/milestone/multi-user-server'/>
+		</dependency>
+		<instance name='default' enabled='false'>
+			<exec_method type='method' name='start' exec='/usr/sbin/mfscgiserv' timeout_seconds='240'></exec_method>
+			<exec_method type='method' name='stop' exec=':kill' timeout_seconds='60'></exec_method>
+			<template>
+				<common_name>
+					<loctext xml:lang='C'>MooseFS CGI webserver</loctext>
+				</common_name>
+			</template>
+		</instance>
+	</service>
+</service_bundle>
+

--- a/components/network/moosefs/files/moosefs-chunkserver.xml
+++ b/components/network/moosefs/files/moosefs-chunkserver.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='moosefs-chunkserver'>
+	<service name='network/moosefs-chunkserver' type='service' version='0'>
+		<single_instance/>
+		<dependency name='fs' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/system/filesystem/local'/>
+		</dependency>
+		<dependency name='network' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/milestone/multi-user-server'/>
+		</dependency>
+		<instance name='default' enabled='false'>
+			<exec_method type='method' name='start' exec='/usr/sbin/mfschunkserver' timeout_seconds='240'></exec_method>
+			<exec_method type='method' name='stop' exec=':kill' timeout_seconds='60'></exec_method>
+			<template>
+				<common_name>
+					<loctext xml:lang='C'>MooseFS data storage and synchronization component</loctext>
+				</common_name>
+			</template>
+		</instance>
+	</service>
+</service_bundle>

--- a/components/network/moosefs/files/moosefs-master.xml
+++ b/components/network/moosefs/files/moosefs-master.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='moosefs-master'>
+	<service name='network/moosefs-master' type='service' version='0'>
+		<single_instance/>
+		<dependency name='fs' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/system/filesystem/local'/>
+		</dependency>
+		<dependency name='network' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/milestone/multi-user-server'/>
+		</dependency>
+		<instance name='default' enabled='false'>
+			<exec_method type='method' name='start' exec='/usr/sbin/mfsmaster' timeout_seconds='240'></exec_method>
+			<exec_method type='method' name='stop' exec=':kill' timeout_seconds='60'></exec_method>
+			<template>
+				<common_name>
+					<loctext xml:lang='C'>MooseFS master server</loctext>
+				</common_name>
+			</template>
+		</instance>
+	</service>
+</service_bundle>
+

--- a/components/network/moosefs/files/moosefs-metalogger.xml
+++ b/components/network/moosefs/files/moosefs-metalogger.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='moosefs-metalogger'>
+	<service name='network/moosefs-metalogger' type='service' version='0'>
+		<single_instance/>
+		<dependency name='fs' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/system/filesystem/local'/>
+		</dependency>
+		<dependency name='network' grouping='require_all' restart_on='none' type='service'>
+			<service_fmri value='svc:/milestone/multi-user-server'/>
+		</dependency>
+		<instance name='default' enabled='false'>
+			<exec_method type='method' name='start' exec='/usr/sbin/mfsmetalogger' timeout_seconds='240'></exec_method>
+			<exec_method type='method' name='stop' exec=':kill' timeout_seconds='60'></exec_method>
+			<template>
+				<common_name>
+					<loctext xml:lang='C'>MooseFS metadata backup server</loctext>
+				</common_name>
+			</template>
+		</instance>
+	</service>
+</service_bundle>
+

--- a/components/network/moosefs/manifests/sample-manifest.p5m
+++ b/components/network/moosefs/manifests/sample-manifest.p5m
@@ -1,0 +1,156 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/mfs/mfschunkserver.cfg.sample
+file path=etc/mfs/mfshdd.cfg.sample
+file path=etc/mfs/mfsmaster.cfg.sample
+file path=etc/mfs/mfsmetalogger.cfg.sample
+file path=etc/mfs/mfsmount.cfg.sample
+link path=usr/bin/mfsappendchunks target=mfstools
+link path=usr/bin/mfscheckfile target=mfstools
+link path=usr/bin/mfschkarchive target=mfstools
+file path=usr/bin/mfscli
+link path=usr/bin/mfsclrarchive target=mfstools
+link path=usr/bin/mfscopyeattr target=mfstools
+link path=usr/bin/mfscopygoal target=mfstools
+link path=usr/bin/mfscopyquota target=mfstools
+link path=usr/bin/mfscopysclass target=mfstools
+link path=usr/bin/mfscopytrashtime target=mfstools
+link path=usr/bin/mfsdeleattr target=mfstools
+link path=usr/bin/mfsdelquota target=mfstools
+link path=usr/bin/mfsdirinfo target=mfstools
+link path=usr/bin/mfsfileinfo target=mfstools
+link path=usr/bin/mfsfilepaths target=mfstools
+link path=usr/bin/mfsfilerepair target=mfstools
+link path=usr/bin/mfsgeteattr target=mfstools
+link path=usr/bin/mfsgetgoal target=mfstools
+link path=usr/bin/mfsgetquota target=mfstools
+link path=usr/bin/mfsgetsclass target=mfstools
+link path=usr/bin/mfsgettrashtime target=mfstools
+link path=usr/bin/mfslistsclass target=mfstools
+link path=usr/bin/mfsmakesnapshot target=mfstools
+file path=usr/bin/mfsmount
+link path=usr/bin/mfsrgetgoal target=mfstools
+link path=usr/bin/mfsrgettrashtime target=mfstools
+link path=usr/bin/mfsrmsnapshot target=mfstools
+link path=usr/bin/mfsrsetgoal target=mfstools
+link path=usr/bin/mfsrsettrashtime target=mfstools
+link path=usr/bin/mfsscadmin target=mfstools
+link path=usr/bin/mfssetarchive target=mfstools
+link path=usr/bin/mfsseteattr target=mfstools
+link path=usr/bin/mfssetgoal target=mfstools
+link path=usr/bin/mfssetquota target=mfstools
+link path=usr/bin/mfssetsclass target=mfstools
+link path=usr/bin/mfssettrashtime target=mfstools
+file path=usr/bin/mfstools
+link path=usr/bin/mfsxchgsclass target=mfstools
+file path=usr/include/mfsio.h
+file path=usr/lib/$(MACH64)/libmfsio.a
+link path=usr/lib/$(MACH64)/libmfsio.so target=libmfsio.so.1.0.0
+link path=usr/lib/$(MACH64)/libmfsio.so.1 target=libmfsio.so.1.0.0
+file path=usr/lib/$(MACH64)/libmfsio.so.1.0.0
+file path=usr/sbin/mfscgiserv
+file path=usr/sbin/mfschunkserver
+file path=usr/sbin/mfschunktool
+file path=usr/sbin/mfscsstatsdump
+file path=usr/sbin/mfsmaster
+file path=usr/sbin/mfsmetadirinfo
+file path=usr/sbin/mfsmetadump
+file path=usr/sbin/mfsmetalogger
+file path=usr/sbin/mfsmetarestore
+file path=usr/sbin/mfsnetdump
+file path=usr/sbin/mfsstatsdump
+file path=usr/share/man/man1/mfsappendchunks.1
+file path=usr/share/man/man1/mfsarchive.1
+file path=usr/share/man/man1/mfscheckfile.1
+file path=usr/share/man/man1/mfschkarchive.1
+file path=usr/share/man/man1/mfscli.1
+file path=usr/share/man/man1/mfsclrarchive.1
+file path=usr/share/man/man1/mfscopyeattr.1
+file path=usr/share/man/man1/mfscopygoal.1
+file path=usr/share/man/man1/mfscopyquota.1
+file path=usr/share/man/man1/mfscopysclass.1
+file path=usr/share/man/man1/mfscopytrashtime.1
+file path=usr/share/man/man1/mfsdeleattr.1
+file path=usr/share/man/man1/mfsdelquota.1
+file path=usr/share/man/man1/mfsdiagtools.1
+file path=usr/share/man/man1/mfsdirinfo.1
+file path=usr/share/man/man1/mfseattr.1
+file path=usr/share/man/man1/mfsfileinfo.1
+file path=usr/share/man/man1/mfsfilepaths.1
+file path=usr/share/man/man1/mfsfilerepair.1
+file path=usr/share/man/man1/mfsgeteattr.1
+file path=usr/share/man/man1/mfsgetgoal.1
+file path=usr/share/man/man1/mfsgetquota.1
+file path=usr/share/man/man1/mfsgetsclass.1
+file path=usr/share/man/man1/mfsgettrashtime.1
+file path=usr/share/man/man1/mfsgoal.1
+file path=usr/share/man/man1/mfslistsclass.1
+file path=usr/share/man/man1/mfsmakesnapshot.1
+file path=usr/share/man/man1/mfsquota.1
+file path=usr/share/man/man1/mfsrgetgoal.1
+file path=usr/share/man/man1/mfsrgettrashtime.1
+file path=usr/share/man/man1/mfsrmsnapshot.1
+file path=usr/share/man/man1/mfsrsetgoal.1
+file path=usr/share/man/man1/mfsrsettrashtime.1
+file path=usr/share/man/man1/mfsscadmin.1
+file path=usr/share/man/man1/mfssclass.1
+file path=usr/share/man/man1/mfssetarchive.1
+file path=usr/share/man/man1/mfsseteattr.1
+file path=usr/share/man/man1/mfssetgoal.1
+file path=usr/share/man/man1/mfssetquota.1
+file path=usr/share/man/man1/mfssetsclass.1
+file path=usr/share/man/man1/mfssettrashtime.1
+file path=usr/share/man/man1/mfssnapshots.1
+file path=usr/share/man/man1/mfstools.1
+file path=usr/share/man/man1/mfstrashtime.1
+file path=usr/share/man/man1/mfsxchgsclass.1
+file path=usr/share/man/man5/mfschunkserver.cfg.5
+file path=usr/share/man/man5/mfsexports.cfg.5
+file path=usr/share/man/man5/mfshdd.cfg.5
+file path=usr/share/man/man5/mfsmaster.cfg.5
+file path=usr/share/man/man5/mfsmetalogger.cfg.5
+file path=usr/share/man/man5/mfstopology.cfg.5
+file path=usr/share/man/man8/mfscgiserv.8
+file path=usr/share/man/man8/mfschunkserver.8
+file path=usr/share/man/man8/mfschunktool.8
+file path=usr/share/man/man8/mfscsstatsdump.8
+file path=usr/share/man/man8/mfsmaster.8
+file path=usr/share/man/man8/mfsmetadirinfo.8
+file path=usr/share/man/man8/mfsmetadump.8
+file path=usr/share/man/man8/mfsmetalogger.8
+file path=usr/share/man/man8/mfsmetarestore.8
+file path=usr/share/man/man8/mfsmount.8
+file path=usr/share/man/man8/mfsnetdump.8
+file path=usr/share/man/man8/mfsstatsdump.8
+file path=usr/share/mfscgi/acidtab.js
+file path=usr/share/mfscgi/chart.cgi
+file path=usr/share/mfscgi/err.gif
+file path=usr/share/mfscgi/favicon.ico
+file path=usr/share/mfscgi/index.html
+file path=usr/share/mfscgi/logomini.png
+file path=usr/share/mfscgi/mfs.cgi
+file path=usr/share/mfscgi/mfs.css
+file path=var/mfs/metadata.mfs.empty

--- a/components/network/moosefs/moosefs-cgi.p5m
+++ b/components/network/moosefs/moosefs-cgi.p5m
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-cgi@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS CGI files"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/share/mfscgi/acidtab.js
+file path=usr/share/mfscgi/chart.cgi
+file path=usr/share/mfscgi/err.gif
+file path=usr/share/mfscgi/favicon.ico
+file path=usr/share/mfscgi/index.html
+file path=usr/share/mfscgi/logomini.png
+file path=usr/share/mfscgi/mfs.cgi mode=0755 preserve=false
+file path=usr/share/mfscgi/mfs.css

--- a/components/network/moosefs/moosefs-cgiserv.p5m
+++ b/components/network/moosefs/moosefs-cgiserv.p5m
@@ -1,0 +1,30 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-cgiserv@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS CGI webserver"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file files/moosefs-cgiserv.xml path=lib/svc/manifest/network/moosefs-cgiserv.xml restart_fmri=svc:/system/manifest-import:default
+
+file path=usr/sbin/mfscgiserv
+file path=usr/share/man/man8/mfscgiserv.8
+dir path=var/mfs owner=nobody group=nobody

--- a/components/network/moosefs/moosefs-chunkserver.p5m
+++ b/components/network/moosefs/moosefs-chunkserver.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-chunkserver@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS data storage and synchronization component"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file files/moosefs-chunkserver.xml path=lib/svc/manifest/network/moosefs-chunkserver.xml restart_fmri=svc:/system/manifest-import:default
+
+file path=etc/mfs/mfschunkserver.cfg.sample
+file path=etc/mfs/mfshdd.cfg.sample
+file path=usr/sbin/mfschunkserver
+file path=usr/sbin/mfschunktool
+file path=usr/sbin/mfscsstatsdump
+file path=usr/share/man/man5/mfschunkserver.cfg.5
+file path=usr/share/man/man5/mfshdd.cfg.5
+file path=usr/share/man/man8/mfschunkserver.8
+file path=usr/share/man/man8/mfschunktool.8
+file path=usr/share/man/man8/mfscsstatsdump.8
+dir path=var/mfs owner=nobody group=nobody

--- a/components/network/moosefs/moosefs-cli.p5m
+++ b/components/network/moosefs/moosefs-cli.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-cli@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS command line interface"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/mfscli
+file path=usr/share/man/man1/mfscli.1

--- a/components/network/moosefs/moosefs-client.p5m
+++ b/components/network/moosefs/moosefs-client.p5m
@@ -1,0 +1,113 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-client@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS client tools"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=etc/mfs/mfsmount.cfg.sample
+link path=usr/bin/mfsappendchunks target=mfstools
+link path=usr/bin/mfscheckfile target=mfstools
+link path=usr/bin/mfschkarchive target=mfstools
+link path=usr/bin/mfsclrarchive target=mfstools
+link path=usr/bin/mfscopyeattr target=mfstools
+link path=usr/bin/mfscopygoal target=mfstools
+link path=usr/bin/mfscopyquota target=mfstools
+link path=usr/bin/mfscopysclass target=mfstools
+link path=usr/bin/mfscopytrashtime target=mfstools
+link path=usr/bin/mfsdeleattr target=mfstools
+link path=usr/bin/mfsdelquota target=mfstools
+link path=usr/bin/mfsdirinfo target=mfstools
+link path=usr/bin/mfsfileinfo target=mfstools
+link path=usr/bin/mfsfilepaths target=mfstools
+link path=usr/bin/mfsfilerepair target=mfstools
+link path=usr/bin/mfsgeteattr target=mfstools
+link path=usr/bin/mfsgetgoal target=mfstools
+link path=usr/bin/mfsgetquota target=mfstools
+link path=usr/bin/mfsgetsclass target=mfstools
+link path=usr/bin/mfsgettrashtime target=mfstools
+link path=usr/bin/mfslistsclass target=mfstools
+link path=usr/bin/mfsmakesnapshot target=mfstools
+file path=usr/bin/mfsmount
+link path=usr/bin/mfsrgetgoal target=mfstools
+link path=usr/bin/mfsrgettrashtime target=mfstools
+link path=usr/bin/mfsrmsnapshot target=mfstools
+link path=usr/bin/mfsrsetgoal target=mfstools
+link path=usr/bin/mfsrsettrashtime target=mfstools
+link path=usr/bin/mfsscadmin target=mfstools
+link path=usr/bin/mfssetarchive target=mfstools
+link path=usr/bin/mfsseteattr target=mfstools
+link path=usr/bin/mfssetgoal target=mfstools
+link path=usr/bin/mfssetquota target=mfstools
+link path=usr/bin/mfssetsclass target=mfstools
+link path=usr/bin/mfssettrashtime target=mfstools
+file path=usr/bin/mfstools
+link path=usr/bin/mfsxchgsclass target=mfstools
+file path=usr/include/mfsio.h
+file path=usr/lib/$(MACH64)/libmfsio.a
+link path=usr/lib/$(MACH64)/libmfsio.so target=libmfsio.so.1.0.0
+link path=usr/lib/$(MACH64)/libmfsio.so.1 target=libmfsio.so.1.0.0
+file path=usr/lib/$(MACH64)/libmfsio.so.1.0.0
+file path=usr/share/man/man1/mfsappendchunks.1
+file path=usr/share/man/man1/mfsarchive.1
+file path=usr/share/man/man1/mfscheckfile.1
+file path=usr/share/man/man1/mfschkarchive.1
+file path=usr/share/man/man1/mfsclrarchive.1
+file path=usr/share/man/man1/mfscopyeattr.1
+file path=usr/share/man/man1/mfscopygoal.1
+file path=usr/share/man/man1/mfscopyquota.1
+file path=usr/share/man/man1/mfscopysclass.1
+file path=usr/share/man/man1/mfscopytrashtime.1
+file path=usr/share/man/man1/mfsdeleattr.1
+file path=usr/share/man/man1/mfsdelquota.1
+file path=usr/share/man/man1/mfsdiagtools.1
+file path=usr/share/man/man1/mfsdirinfo.1
+file path=usr/share/man/man1/mfseattr.1
+file path=usr/share/man/man1/mfsfileinfo.1
+file path=usr/share/man/man1/mfsfilepaths.1
+file path=usr/share/man/man1/mfsfilerepair.1
+file path=usr/share/man/man1/mfsgeteattr.1
+file path=usr/share/man/man1/mfsgetgoal.1
+file path=usr/share/man/man1/mfsgetquota.1
+file path=usr/share/man/man1/mfsgetsclass.1
+file path=usr/share/man/man1/mfsgettrashtime.1
+file path=usr/share/man/man1/mfsgoal.1
+file path=usr/share/man/man1/mfslistsclass.1
+file path=usr/share/man/man1/mfsmakesnapshot.1
+file path=usr/share/man/man1/mfsquota.1
+file path=usr/share/man/man1/mfsrgetgoal.1
+file path=usr/share/man/man1/mfsrgettrashtime.1
+file path=usr/share/man/man1/mfsrmsnapshot.1
+file path=usr/share/man/man1/mfsrsetgoal.1
+file path=usr/share/man/man1/mfsrsettrashtime.1
+file path=usr/share/man/man1/mfsscadmin.1
+file path=usr/share/man/man1/mfssclass.1
+file path=usr/share/man/man1/mfssetarchive.1
+file path=usr/share/man/man1/mfsseteattr.1
+file path=usr/share/man/man1/mfssetgoal.1
+file path=usr/share/man/man1/mfssetquota.1
+file path=usr/share/man/man1/mfssetsclass.1
+file path=usr/share/man/man1/mfssettrashtime.1
+file path=usr/share/man/man1/mfssnapshots.1
+file path=usr/share/man/man1/mfstools.1
+file path=usr/share/man/man1/mfstrashtime.1
+file path=usr/share/man/man1/mfsxchgsclass.1
+file path=usr/share/man/man8/mfsmount.8

--- a/components/network/moosefs/moosefs-master.p5m
+++ b/components/network/moosefs/moosefs-master.p5m
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-master@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS master server"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file files/moosefs-master.xml path=lib/svc/manifest/network/moosefs-master.xml restart_fmri=svc:/system/manifest-import:default
+
+file path=etc/mfs/mfsmaster.cfg.sample
+file path=usr/sbin/mfsmaster
+file path=usr/sbin/mfsmetadump
+file path=usr/sbin/mfsmetadirinfo
+file path=usr/sbin/mfsmetarestore
+file path=usr/sbin/mfsstatsdump
+file path=usr/share/man/man5/mfstopology.cfg.5
+file path=usr/share/man/man5/mfsexports.cfg.5
+file path=usr/share/man/man5/mfsmaster.cfg.5
+file path=usr/share/man/man8/mfsmaster.8
+file path=usr/share/man/man8/mfsmetarestore.8
+file path=usr/share/man/man8/mfsmetadump.8
+file path=usr/share/man/man8/mfsmetadirinfo.8
+file path=usr/share/man/man8/mfsstatsdump.8
+file path=var/mfs/metadata.mfs.empty

--- a/components/network/moosefs/moosefs-metalogger.p5m
+++ b/components/network/moosefs/moosefs-metalogger.p5m
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-metalogger@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS metadata backup server"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file files/moosefs-metalogger.xml path=lib/svc/manifest/network/moosefs-metalogger.xml restart_fmri=svc:/system/manifest-import:default
+
+file path=etc/mfs/mfsmetalogger.cfg.sample
+file path=usr/sbin/mfsmetalogger
+file path=usr/share/man/man5/mfsmetalogger.cfg.5
+file path=usr/share/man/man8/mfsmetalogger.8
+dir path=var/mfs owner=nobody group=nobody

--- a/components/network/moosefs/moosefs-netdump.p5m
+++ b/components/network/moosefs/moosefs-netdump.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 erwinlem
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-netdump@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="MooseFS network packet dump utility"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/sbin/mfsnetdump
+file path=usr/share/man/man8/mfsnetdump.8

--- a/components/network/moosefs/patches/001-mfsio.c.patch
+++ b/components/network/moosefs/patches/001-mfsio.c.patch
@@ -1,0 +1,10 @@
+--- moosefs-3.0.116/mfsclient/mfsio.c.bak	Thu Jan  5 04:19:20 2023
++++ moosefs-3.0.116/mfsclient/mfsio.c	Thu Jan  5 04:19:34 2023
+@@ -22,6 +22,7 @@
+ #include "config.h"
+ #endif
+ 
++#include <limits.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stdarg.h>

--- a/components/network/moosefs/patches/002-Makefile.am.patch
+++ b/components/network/moosefs/patches/002-Makefile.am.patch
@@ -1,0 +1,11 @@
+--- moosefs-3.0.116/mfsdata/Makefile.am.bak	Sun Jan  8 11:41:35 2023
++++ moosefs-3.0.116/mfsdata/Makefile.am	Sun Jan  8 11:49:58 2023
+@@ -24,8 +24,6 @@
+ endif
+ if BUILD_MASTER
+ 	$(INSTALL_DATA) $(builddir)/mfsmaster.cfg $(DESTDIR)$(sysconfdir)/mfs/mfsmaster.cfg.sample
+-	$(INSTALL_DATA) $(builddir)/mfsexports.cfg $(DESTDIR)$(sysconfdir)/mfs/mfsexports.cfg.sample
+-	$(INSTALL_DATA) $(builddir)/mfstopology.cfg $(DESTDIR)$(sysconfdir)/mfs/mfstopology.cfg.sample
+ 	$(INSTALL_DATA) $(srcdir)/metadata.mfs $(DESTDIR)$(DATA_PATH)/metadata.mfs.empty
+ 	if [ "`id -u`" = "0" ]; then \
+ 		if id -u $(DEFAULT_USER) 2> /dev/null > /dev/null ; then \

--- a/components/network/moosefs/patches/003-mfscgiserv.py.in.patch
+++ b/components/network/moosefs/patches/003-mfscgiserv.py.in.patch
@@ -1,0 +1,17 @@
+--- moosefs-3.0.116/mfsscripts/mfscgiserv.py.in.bak	Mon Jan  9 10:53:27 2023
++++ moosefs-3.0.116/mfsscripts/mfscgiserv.py.in	Mon Jan  9 10:53:40 2023
+@@ -12,12 +12,8 @@
+ import traceback
+ import datetime
+ import mimetypes
+-try:
+-	from urllib.parse import urlparse
+-	from urllib.parse import urlunparse
+-except ImportError:
+-	from urlparse import urlparse
+-	from urlparse import urlunparse
++from urllib.parse import urlparse
++from urllib.parse import urlunparse
+ import socket
+ import select
+ import subprocess

--- a/components/network/moosefs/pkg5
+++ b/components/network/moosefs/pkg5
@@ -1,0 +1,23 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "library/libfuse",
+        "library/zlib",
+        "runtime/python-39",
+        "shell/ksh93",
+        "system/library",
+        "system/library/libpcap",
+        "system/library/math"
+    ],
+    "fmris": [
+        "network/moosefs-cgi",
+        "network/moosefs-cgiserv",
+        "network/moosefs-chunkserver",
+        "network/moosefs-cli",
+        "network/moosefs-client",
+        "network/moosefs-master",
+        "network/moosefs-metalogger",
+        "network/moosefs-netdump"
+    ],
+    "name": "moosefs"
+}


### PR DESCRIPTION
The package has been split the same as the official packages, that way the documentation matches. I was tempted to put it in one package for simplicity sake but I think this is better.

I've been running moosefs on a 2 node cluster, so far it runs without problems. But I would like it if some other people field test this as well before I put important data on it.