### PR TITLE
Newer autoconf puts manpages (correctly) in section 4 instead of 7.

### DIFF
--- a/components/x11/xf86-input-acecad/Makefile
+++ b/components/x11/xf86-input-acecad/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-input-acecad
 COMPONENT_VERSION= 1.5.0
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-input-acecad
 COMPONENT_SUMMARY= xf86-input-acecad - Acecad Flair input driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-input-acecad/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-input-acecad/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/$(MACH64)/xorg/modules/input/acecad_drv.so
-file path=usr/share/man/man7/acecad.7
+file path=usr/share/man/man4/acecad.4

--- a/components/x11/xf86-input-acecad/pkg5
+++ b/components/x11/xf86-input-acecad/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
+        "shell/ksh93",
         "system/library",
         "x11/header/x11-protocols",
         "x11/server/xorg"

--- a/components/x11/xf86-input-acecad/xorg-input-acecad.p5m
+++ b/components/x11/xf86-input-acecad/xorg-input-acecad.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=usr/lib/xorg/modules/input/$(MACH64)/(.+)$ -> set action.hash usr/lib/$(MACH64)/xorg/modules/input/%<\1> >
 
 file path=usr/lib/xorg/modules/input/$(MACH64)/acecad_drv.so
-file path=usr/share/man/man7/acecad.7
+file path=usr/share/man/man4/acecad.4

--- a/components/x11/xf86-input-keyboard/Makefile
+++ b/components/x11/xf86-input-keyboard/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-input-keyboard
 COMPONENT_VERSION= 1.9.0
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-input-keyboard
 COMPONENT_SUMMARY= \
   xf86-input-keyboard - Keyboard input driver for the Xorg X server

--- a/components/x11/xf86-input-keyboard/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-input-keyboard/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/$(MACH64)/xorg/modules/input/kbd_drv.so
-file path=usr/share/man/man7/kbd.7
+file path=usr/share/man/man4/kbd.4

--- a/components/x11/xf86-input-keyboard/pkg5
+++ b/components/x11/xf86-input-keyboard/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
+        "shell/ksh93",
         "system/header/header-usb",
         "system/library",
         "x11/header/x11-protocols",

--- a/components/x11/xf86-input-keyboard/xorg-input-keyboard.p5m
+++ b/components/x11/xf86-input-keyboard/xorg-input-keyboard.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=usr/lib/xorg/modules/input/$(MACH64)/(.+)$ -> set action.hash usr/lib/$(MACH64)/xorg/modules/input/%<\1> >
 
 file path=usr/lib/xorg/modules/input/$(MACH64)/kbd_drv.so
-file path=usr/share/man/man7/kbd.7
+file path=usr/share/man/man4/kbd.4

--- a/components/x11/xf86-input-mouse/Makefile
+++ b/components/x11/xf86-input-mouse/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-input-mouse
 COMPONENT_VERSION= 1.9.3
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-input-mouse
 COMPONENT_SUMMARY= xf86-input-mouse - Mouse input driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-input-mouse/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-input-mouse/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/include/xorg/xf86-mouse-properties.h
 file path=usr/lib/$(MACH64)/pkgconfig/xorg-mouse.pc
 file path=usr/lib/$(MACH64)/xorg/modules/input/mouse_drv.so
-file path=usr/share/man/man7/mousedrv.7
+file path=usr/share/man/man4/mousedrv.4

--- a/components/x11/xf86-input-mouse/pkg5
+++ b/components/x11/xf86-input-mouse/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
+        "shell/ksh93",
         "system/library",
         "x11/header/x11-protocols"
     ],

--- a/components/x11/xf86-input-mouse/xorg-input-mouse.p5m
+++ b/components/x11/xf86-input-mouse/xorg-input-mouse.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -29,4 +30,4 @@ file README path=usr/share/doc/X11/README.mouse
 file path=usr/include/xorg/xf86-mouse-properties.h
 file path=usr/lib/$(MACH64)/pkgconfig/xorg-mouse.pc
 file path=usr/lib/xorg/modules/input/$(MACH64)/mouse_drv.so
-file path=usr/share/man/man7/mousedrv.7
+file path=usr/share/man/man4/mousedrv.4

--- a/components/x11/xf86-input-synaptics/Makefile
+++ b/components/x11/xf86-input-synaptics/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-input-synaptics
 COMPONENT_VERSION= 1.9.1
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-input-synaptics
 COMPONENT_SUMMARY= xf86-input-synaptics - Synaptics touchpad driver for X.Org
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-input-synaptics/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-input-synaptics/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -30,4 +31,4 @@ file path=usr/lib/$(MACH64)/xorg/modules/input/synaptics_drv.so
 file path=usr/share/X11/xorg.conf.d/70-synaptics.conf
 file path=usr/share/man/man1/synclient.1
 file path=usr/share/man/man1/syndaemon.1
-file path=usr/share/man/man7/synaptics.7
+file path=usr/share/man/man4/synaptics.4

--- a/components/x11/xf86-input-synaptics/pkg5
+++ b/components/x11/xf86-input-synaptics/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
+        "shell/ksh93",
         "system/library",
         "system/library/math",
         "x11/header/x11-protocols",

--- a/components/x11/xf86-input-synaptics/xorg-input-synaptics.p5m
+++ b/components/x11/xf86-input-synaptics/xorg-input-synaptics.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -34,4 +35,4 @@ file path=usr/lib/xorg/modules/input/$(MACH64)/synaptics_drv.so
 file path=usr/share/X11/xorg.conf.d/70-synaptics.conf
 file path=usr/share/man/man1/synclient.1
 file path=usr/share/man/man1/syndaemon.1
-file path=usr/share/man/man7/synaptics.7
+file path=usr/share/man/man4/synaptics.4

--- a/components/x11/xf86-input-vmmouse/Makefile
+++ b/components/x11/xf86-input-vmmouse/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-input-vmmouse
 COMPONENT_VERSION= 13.1.0
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-input-vmmouse
 COMPONENT_SUMMARY= xf86-input-vmmouse - VMWare guest mouse input driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-input-vmmouse/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-input-vmmouse/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -28,4 +29,4 @@ file path=usr/lib/hal/hal-probe-vmmouse
 file path=usr/lib/xorg/$(MACH64)/vmmouse_detect
 file path=usr/share/X11/xorg.conf.d/50-vmmouse.conf
 file path=usr/share/man/man1/vmmouse_detect.1
-file path=usr/share/man/man7/vmmouse.7
+file path=usr/share/man/man4/vmmouse.4

--- a/components/x11/xf86-input-vmmouse/pkg5
+++ b/components/x11/xf86-input-vmmouse/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
+        "shell/ksh93",
         "system/library",
         "x11/header/x11-protocols",
         "x11/library/libpthread-stubs",

--- a/components/x11/xf86-input-vmmouse/xorg-input-vmmouse.p5m
+++ b/components/x11/xf86-input-vmmouse/xorg-input-vmmouse.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -30,4 +31,4 @@ file path=usr/lib/hal/hal-probe-vmmouse mode=0555
 file path=usr/lib/xorg/modules/input/$(MACH64)/vmmouse_drv.so
 file path=usr/share/X11/xorg.conf.d/50-vmmouse.conf
 file path=usr/share/man/man1/vmmouse_detect.1
-file path=usr/share/man/man7/vmmouse.7
+file path=usr/share/man/man4/vmmouse.4

--- a/components/x11/xf86-input-void/Makefile
+++ b/components/x11/xf86-input-void/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-input-void
 COMPONENT_VERSION= 1.4.1
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-input-void
 COMPONENT_SUMMARY= xf86-input-void - null input driver for Xorg server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-input-void/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-input-void/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/$(MACH64)/xorg/modules/input/void_drv.so
-file path=usr/share/man/man7/void.7
+file path=usr/share/man/man4/void.4

--- a/components/x11/xf86-input-void/pkg5
+++ b/components/x11/xf86-input-void/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
+        "shell/ksh93",
         "system/library",
         "x11/header/x11-protocols"
     ],

--- a/components/x11/xf86-input-void/xorg-input-void.p5m
+++ b/components/x11/xf86-input-void/xorg-input-void.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/input/$(MACH64)/void_drv.so
-file path=usr/share/man/man7/void.7
+file path=usr/share/man/man4/void.4

--- a/components/x11/xf86-video-ati/Makefile
+++ b/components/x11/xf86-video-ati/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-ati
 COMPONENT_VERSION= 6.14.6
-COMPONENT_REVISION= 4
+COMPONENT_REVISION= 5
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-ati
 COMPONENT_SUMMARY= xf86-video-ati - ATI Radeon video driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-ati/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-ati/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -27,5 +28,5 @@ file path=usr/lib/xorg/modules/drivers/$(MACH64)/radeon_drv.so
 file path=usr/lib/xorg/modules/multimedia/$(MACH64)/theatre200_drv.so
 file path=usr/lib/xorg/modules/multimedia/$(MACH64)/theatre_detect_drv.so
 file path=usr/lib/xorg/modules/multimedia/$(MACH64)/theatre_drv.so
-file path=usr/share/man/man7/ati.7
-file path=usr/share/man/man7/radeon.7
+file path=usr/share/man/man4/ati.4
+file path=usr/share/man/man4/radeon.4

--- a/components/x11/xf86-video-ati/pkg5
+++ b/components/x11/xf86-video-ati/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "system/library/math",

--- a/components/x11/xf86-video-ati/xorg-video-ati.p5m
+++ b/components/x11/xf86-video-ati/xorg-video-ati.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -27,5 +28,5 @@ file path=usr/lib/xorg/modules/drivers/$(MACH64)/radeon_drv.so
 file path=usr/lib/xorg/modules/multimedia/$(MACH64)/theatre200_drv.so
 file path=usr/lib/xorg/modules/multimedia/$(MACH64)/theatre_detect_drv.so
 file path=usr/lib/xorg/modules/multimedia/$(MACH64)/theatre_drv.so
-file path=usr/share/man/man7/ati.7
-file path=usr/share/man/man7/radeon.7
+file path=usr/share/man/man4/ati.4
+file path=usr/share/man/man4/radeon.4

--- a/components/x11/xf86-video-cirrus/Makefile
+++ b/components/x11/xf86-video-cirrus/Makefile
@@ -20,7 +20,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-cirrus
 COMPONENT_VERSION= 1.5.3
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-cirrus
 COMPONENT_SUMMARY= xf86-video-cirrus - Cirrus Logic video driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-cirrus/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-cirrus/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/lib/$(MACH64)/xorg/modules/drivers/cirrus_alpine.so
 file path=usr/lib/$(MACH64)/xorg/modules/drivers/cirrus_drv.so
 file path=usr/lib/$(MACH64)/xorg/modules/drivers/cirrus_laguna.so
-file path=usr/share/man/man7/cirrus.7
+file path=usr/share/man/man4/cirrus.4

--- a/components/x11/xf86-video-cirrus/pkg5
+++ b/components/x11/xf86-video-cirrus/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "developer/build/pkg-config",
         "diagnostic/scanpci",
+        "shell/ksh93",
         "system/library",
         "x11/header/x11-protocols",
         "x11/server/xorg"

--- a/components/x11/xf86-video-cirrus/xorg-video-cirrus.p5m
+++ b/components/x11/xf86-video-cirrus/xorg-video-cirrus.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -27,4 +28,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/cirrus_alpine.so
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/cirrus_drv.so
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/cirrus_laguna.so
-file path=usr/share/man/man7/cirrus.7
+file path=usr/share/man/man4/cirrus.4

--- a/components/x11/xf86-video-intel/Makefile
+++ b/components/x11/xf86-video-intel/Makefile
@@ -20,7 +20,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-intel
 COMPONENT_VERSION= 2.99.917
-COMPONENT_REVISION= 10
+COMPONENT_REVISION= 11
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-intel
 COMPONENT_SUMMARY= xf86-video-intel - Intel integrated graphics chipset driver for the Xorg X server
 COMPONENT_GIT_DATE= 20171018

--- a/components/x11/xf86-video-intel/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-intel/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -31,6 +32,6 @@ link path=usr/lib/$(MACH64)/libIntelXvMC.so.1 target=libIntelXvMC.so.1.0.0
 file path=usr/lib/$(MACH64)/libIntelXvMC.so.1.0.0
 file path=usr/lib/$(MACH64)/xf86-video-intel-backlight-helper
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/intel_drv.so
-file path=usr/share/man/man7/intel-virtual-output.7
-file path=usr/share/man/man7/intel.7
+file path=usr/share/man/man4/intel-virtual-output.4
+file path=usr/share/man/man4/intel.4
 file path=usr/share/polkit-1/actions/org.x.xf86-video-intel.backlight-helper.policy

--- a/components/x11/xf86-video-intel/pkg5
+++ b/components/x11/xf86-video-intel/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "system/library/math",

--- a/components/x11/xf86-video-intel/xorg-video-intel.p5m
+++ b/components/x11/xf86-video-intel/xorg-video-intel.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -31,6 +32,6 @@ link path=usr/lib/$(MACH64)/libIntelXvMC.so.1 target=libIntelXvMC.so.1.0.0
 file path=usr/lib/$(MACH64)/libIntelXvMC.so.1.0.0
 file path=usr/lib/$(MACH64)/xf86-video-intel-backlight-helper mode=0555
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/intel_drv.so
-file path=usr/share/man/man7/intel-virtual-output.7
-file path=usr/share/man/man7/intel.7
+file path=usr/share/man/man4/intel-virtual-output.4
+file path=usr/share/man/man4/intel.4
 file path=usr/share/polkit-1/actions/org.x.xf86-video-intel.backlight-helper.policy

--- a/components/x11/xf86-video-mga/Makefile
+++ b/components/x11/xf86-video-mga/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-mga
 COMPONENT_VERSION= 1.6.5
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-mga
 COMPONENT_SUMMARY= xf86-video-mga - Matrox MGA driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-mga/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-mga/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/mga_drv.so
-file path=usr/share/man/man7/mga.7
+file path=usr/share/man/man4/mga.4

--- a/components/x11/xf86-video-mga/pkg5
+++ b/components/x11/xf86-video-mga/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "x11/header/x11-protocols",

--- a/components/x11/xf86-video-mga/xorg-video-mga.p5m
+++ b/components/x11/xf86-video-mga/xorg-video-mga.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/mga_drv.so
-file path=usr/share/man/man7/mga.7
+file path=usr/share/man/man4/mga.4

--- a/components/x11/xf86-video-nv/Makefile
+++ b/components/x11/xf86-video-nv/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-nv
 COMPONENT_VERSION= 2.1.21
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-nv
 COMPONENT_SUMMARY= xf86-video-nv - NVIDIA video driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-nv/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-nv/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/$(MACH64)/xorg/modules/drivers/nv_drv.so
-file path=usr/share/man/man7/nv.7
+file path=usr/share/man/man4/nv.4

--- a/components/x11/xf86-video-nv/pkg5
+++ b/components/x11/xf86-video-nv/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/library",
         "system/library/math",
         "x11/header/x11-protocols",

--- a/components/x11/xf86-video-nv/xorg-video-nv.p5m
+++ b/components/x11/xf86-video-nv/xorg-video-nv.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/nv_drv.so
-file path=usr/share/man/man7/nv.7
+file path=usr/share/man/man4/nv.4

--- a/components/x11/xf86-video-openchrome/Makefile
+++ b/components/x11/xf86-video-openchrome/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-openchrome
 COMPONENT_VERSION= 0.6.0
-COMPONENT_REVISION= 4
+COMPONENT_REVISION= 5
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-openchrome
 COMPONENT_SUMMARY= xf86-video-openchrome - OpenChrome driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-openchrome/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-openchrome/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/openchrome_drv.so
-file path=usr/share/man/man7/openchrome.7
+file path=usr/share/man/man4/openchrome.4

--- a/components/x11/xf86-video-openchrome/pkg5
+++ b/components/x11/xf86-video-openchrome/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "system/library/math",

--- a/components/x11/xf86-video-openchrome/xorg-video-openchrome.p5m
+++ b/components/x11/xf86-video-openchrome/xorg-video-openchrome.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/openchrome_drv.so
-file path=usr/share/man/man7/openchrome.7
+file path=usr/share/man/man4/openchrome.4

--- a/components/x11/xf86-video-r128/Makefile
+++ b/components/x11/xf86-video-r128/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-r128
 COMPONENT_VERSION= 6.10.2
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-r128
 COMPONENT_SUMMARY= xf86-video-r128 - ATI Rage 128 video driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-r128/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-r128/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/r128_drv.so
-file path=usr/share/man/man7/r128.7
+file path=usr/share/man/man4/r128.4

--- a/components/x11/xf86-video-r128/pkg5
+++ b/components/x11/xf86-video-r128/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "x11/header/x11-protocols",

--- a/components/x11/xf86-video-r128/xorg-video-r128.p5m
+++ b/components/x11/xf86-video-r128/xorg-video-r128.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file README path=usr/share/doc/X11/README.r128
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/r128_drv.so
-file path=usr/share/man/man7/r128.7
+file path=usr/share/man/man4/r128.4

--- a/components/x11/xf86-video-savage/Makefile
+++ b/components/x11/xf86-video-savage/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-savage
 COMPONENT_VERSION= 2.3.9
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-savage
 COMPONENT_SUMMARY= xf86-video-savage - S3 Savage video driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-savage/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-savage/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/savage_drv.so
-file path=usr/share/man/man7/savage.7
+file path=usr/share/man/man4/savage.4

--- a/components/x11/xf86-video-savage/pkg5
+++ b/components/x11/xf86-video-savage/pkg5
@@ -3,6 +3,7 @@
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "system/library/math",

--- a/components/x11/xf86-video-savage/xorg-video-savage.p5m
+++ b/components/x11/xf86-video-savage/xorg-video-savage.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/savage_drv.so
-file path=usr/share/man/man7/savage.7
+file path=usr/share/man/man4/savage.4

--- a/components/x11/xf86-video-trident/Makefile
+++ b/components/x11/xf86-video-trident/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-trident
 COMPONENT_VERSION= 1.3.8
-COMPONENT_REVISION= 3
+COMPONENT_REVISION= 4
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-trident
 COMPONENT_SUMMARY= xf86-video-trident - Trident video driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-trident/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-trident/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/$(MACH64)/xorg/modules/drivers/trident_drv.so
-file path=usr/share/man/man7/trident.7
+file path=usr/share/man/man4/trident.4

--- a/components/x11/xf86-video-trident/pkg5
+++ b/components/x11/xf86-video-trident/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/library",
         "system/library/math",
         "x11/header/x11-protocols",

--- a/components/x11/xf86-video-trident/xorg-video-trident.p5m
+++ b/components/x11/xf86-video-trident/xorg-video-trident.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/trident_drv.so
-file path=usr/share/man/man7/trident.7
+file path=usr/share/man/man4/trident.4

--- a/components/x11/xf86-video-vboxvideo/Makefile
+++ b/components/x11/xf86-video-vboxvideo/Makefile
@@ -21,7 +21,7 @@ COMPONENT_NAME= xf86-video-vboxvideo
 COMPONENT_VERSION= 1.0.0
 # Use version string from Xorg module
 IPS_COMPONENT_VERSION= 1.0.1
-COMPONENT_REVISION= 4
+COMPONENT_REVISION= 5
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-vboxvideo
 COMPONENT_SUMMARY= xf86-video-vboxvideo - VirtualBox UMS driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-vboxvideo/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-vboxvideo/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/$(MACH64)/drivers/vboxvideo_drv.so
-file path=usr/share/man/man7/vboxvideo.7
+file path=usr/share/man/man4/vboxvideo.4

--- a/components/x11/xf86-video-vboxvideo/pkg5
+++ b/components/x11/xf86-video-vboxvideo/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "system/library/math",

--- a/components/x11/xf86-video-vboxvideo/xf86-video-vboxvideo.p5m
+++ b/components/x11/xf86-video-vboxvideo/xf86-video-vboxvideo.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,4 +26,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=usr/lib/xorg/modules/drivers/$(MACH64)/(.+)$ -> set action.hash usr/lib/xorg/modules/$(MACH64)/drivers/%<\1> >
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/vboxvideo_drv.so
-file path=usr/share/man/man7/vboxvideo.7
+file path=usr/share/man/man4/vboxvideo.4

--- a/components/x11/xf86-video-vesa/Makefile
+++ b/components/x11/xf86-video-vesa/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-vesa
 COMPONENT_VERSION= 2.4.0
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-vesa
 COMPONENT_SUMMARY= xf86-video-vesa - VESA driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-vesa/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-vesa/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/vesa_drv.so
-file path=usr/share/man/man7/vesa.7
+file path=usr/share/man/man4/vesa.4

--- a/components/x11/xf86-video-vesa/pkg5
+++ b/components/x11/xf86-video-vesa/pkg5
@@ -3,6 +3,7 @@
         "SUNWcs",
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
+        "shell/ksh93",
         "system/library",
         "x11/header/x11-protocols",
         "x11/server/xorg"

--- a/components/x11/xf86-video-vesa/xorg-video-vesa.p5m
+++ b/components/x11/xf86-video-vesa/xorg-video-vesa.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/vesa_drv.so
-file path=usr/share/man/man7/vesa.7
+file path=usr/share/man/man4/vesa.4

--- a/components/x11/xf86-video-vmware/Makefile
+++ b/components/x11/xf86-video-vmware/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME= xf86-video-vmware
 COMPONENT_VERSION= 13.3.0
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_FMRI= x11/server/xorg/driver/xorg-video-vmware
 COMPONENT_SUMMARY= xf86-video-vmware - VMWare driver for the Xorg X server
 COMPONENT_ARCHIVE_HASH= \

--- a/components/x11/xf86-video-vmware/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-vmware/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/vmware_drv.so
-file path=usr/share/man/man7/vmware.7
+file path=usr/share/man/man4/vmware.4

--- a/components/x11/xf86-video-vmware/pkg5
+++ b/components/x11/xf86-video-vmware/pkg5
@@ -4,6 +4,7 @@
         "developer/build/autoconf/xorg-macros",
         "diagnostic/scanpci",
         "library/graphics/pixman",
+        "shell/ksh93",
         "system/header/header-drm",
         "system/library",
         "x11/header/x11-protocols",

--- a/components/x11/xf86-video-vmware/xorg-video-vmware.p5m
+++ b/components/x11/xf86-video-vmware/xorg-video-vmware.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -23,4 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/xorg/modules/drivers/$(MACH64)/vmware_drv.so
-file path=usr/share/man/man7/vmware.7
+file path=usr/share/man/man4/vmware.4


### PR DESCRIPTION
Illumos (and nearly all other oses) put devices in section 4. Section 7 was used by older Solaris/System V for devices.