### PR TITLE
Switch meson option b_pie from false to true.

### DIFF
--- a/make-rules/meson.mk
+++ b/make-rules/meson.mk
@@ -47,7 +47,7 @@ else
 MESON_OPTIMIZATION ?=	3
 endif
 
-MESON_BUILDPIE ?=	false
+MESON_BUILDPIE ?=	true
 
 # If the component prefers 64-bit binaries, then ensure builds deliver 64-bit
 # binaries to the standard directories and 32-bit binaries to the non-standard


### PR DESCRIPTION
This should turn on gcc options fpic/fPIC for component build done by meson.