### PR TITLE
Fix SMF service gio-module-cache due to new glib2-2.74.5

### DIFF
--- a/components/desktop/desktop-cache/Makefile
+++ b/components/desktop/desktop-cache/Makefile
@@ -11,13 +11,14 @@
 
 #
 # Copyright 2019 Alexander Pyhalov
+# Copyright 2023 Klaus Ziegler
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= desktop-cache
 COMPONENT_VERSION= 0.2.2
-COMPONENT_REVISION= 7
+COMPONENT_REVISION= 8
 COMPONENT_SUMMARY= desktop-cache is a set of SMF services used to update the various GNOME desktop caches.
 COMPONENT_SRC= desktop-cache-smf-services-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -26,9 +27,7 @@ COMPONENT_ARCHIVE_HASH= \
 COMPONENT_ARCHIVE_URL= \
   http://dlc.openindiana.org/oi/jds/downloads/sources/$(COMPONENT_ARCHIVE)
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 CONFIGURE_OPTIONS = --libdir=/lib
 CONFIGURE_OPTIONS += --datadir=/usr/share
@@ -36,11 +35,5 @@ CONFIGURE_OPTIONS += --sysconfdir=/lib
 
 CONFIGURE_ENV += PYTHON=$(PYTHON)
 
-build: $(BUILD_32)
-
-install: $(INSTALL_32)
-
-test: $(NO_TESTS)
-
+PYTHON_REQUIRED_PACKAGES += runtime/python
 REQUIRED_PACKAGES += SUNWcs
-REQUIRED_PACKAGES += runtime/python-35

--- a/components/desktop/desktop-cache/patches/01-python.patch
+++ b/components/desktop/desktop-cache/patches/01-python.patch
@@ -2,7 +2,7 @@
 +++ desktop-cache-smf-services-0.2.2/find_newer	2019-08-01 16:27:59.118847968 +0000
 @@ -1,4 +1,4 @@
 -#!/usr/bin/python2.4
-+#!/usr/bin/python3.5
++#!/usr/bin/python3.9
  
  import os, sys
  import getopt

--- a/components/desktop/desktop-cache/pkg5
+++ b/components/desktop/desktop-cache/pkg5
@@ -1,7 +1,8 @@
 {
     "dependencies": [
         "SUNWcs",
-        "runtime/python-35",
+        "runtime/python-39",
+        "shell/ksh93",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
This fixes the maintenance problem  with SMF service:
svc:/application/desktop-cache/gio-module-cache:default
which is going into maintenance after update of glib-2.74.5, module cache directory:
/usr/lib/64/gio/modules will be changed to /usr/lib/gio/modules with a later change, when
all dependent modules which write to the cache directory have been converted to a single
cache 64bit directory: /usr/lib/gio/modules.