### PR TITLE
build gvfs using. 64bit progs from glib-2.74.5

### DIFF
--- a/components/library/gvfs/Makefile
+++ b/components/library/gvfs/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         gvfs
 COMPONENT_VERSION=      1.26.0
-COMPONENT_REVISION=     6
+COMPONENT_REVISION=     7
 COMPONENT_SUMMARY=      GNOME virtual file system framework
 COMPONENT_PROJECT_URL=  https://www.gnome.org
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -37,12 +37,8 @@ PATH= $(PATH.gnu)
 COMPONENT_PREP_ACTION= ( cd $(@D) && \
 	autoreconf -if)
 
-CFLAGS += -D_XPG4_2
-CFLAGS += -D__EXTENSIONS__
-CFLAGS.32 += -I/usr/include/libsmbclient
-LDFLAGS += -lxml2
-LDFLAGS.32 = -L/usr/lib/libsmbclient -R/usr/lib/libsmbclient
-LDFLAGS += $(LDFLAGS.$(BITS))
+CPPFLAGS += -D_XPG4_2 -D__EXTENSIONS__
+LDFLAGS += -lxml2 -L/usr/lib/libsmbclient/$(MACH64) -R/usr/lib/libsmbclient/$(MACH64)
 
 CONFIGURE_OPTIONS += --sysconfdir=/etc
 CONFIGURE_OPTIONS += --disable-fuse
@@ -60,11 +56,15 @@ CONFIGURE_OPTIONS += --enable-http
 CONFIGURE_OPTIONS += --enable-keyring
 CONFIGURE_OPTIONS += --enable-shared
 CONFIGURE_OPTIONS += --with-pic
+CONFIGURE_OPTIONS += --with-samba-includes=/usr/include/libsmbclient
 
-CONFIGURE_OPTIONS.32 += --with-samba-includes=/usr/include/libsmbclient
-CONFIGURE_OPTIONS.32 += --with-samba-libs=/usr/lib/libsmbclient
+CONFIGURE_OPTIONS.32 += --without-samba
+CONFIGURE_OPTIONS.64 += --with-samba
+#CONFIGURE_OPTIONS.64 += --with-samba-libs=/usr/lib/libsmbclient/$(MACH64)
+CONFIGURE_OPTIONS += $(CONFIGURE_OPTIONS.$(BITS))
 
 CONFIGURE_ENV+= PERL=$(PERL)
+CONFIGURE_ENV+= GLIB_COMPILE_SCHEMAS=/usr/bin/glib-compile-schemas
 
 # Build dependencies
 REQUIRED_PACKAGES += developer/documentation-tool/gtk-doc

--- a/components/library/gvfs/gvfs.p5m
+++ b/components/library/gvfs/gvfs.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2016 Alexander Pyhalov
+# Copyright 2023 Klaus Ziegler
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -30,24 +30,6 @@ depend fmri=pkg:/gnome/gnome-mount type=require
 
 <transform path=.*/bin/$(MACH32) -> drop>
 
-file path=usr/bin/$(MACH32)/gvfs-cat
-file path=usr/bin/$(MACH32)/gvfs-copy
-file path=usr/bin/$(MACH32)/gvfs-info
-file path=usr/bin/$(MACH32)/gvfs-less
-file path=usr/bin/$(MACH32)/gvfs-ls
-file path=usr/bin/$(MACH32)/gvfs-mime
-file path=usr/bin/$(MACH32)/gvfs-mkdir
-file path=usr/bin/$(MACH32)/gvfs-monitor-dir
-file path=usr/bin/$(MACH32)/gvfs-monitor-file
-file path=usr/bin/$(MACH32)/gvfs-mount
-file path=usr/bin/$(MACH32)/gvfs-move
-file path=usr/bin/$(MACH32)/gvfs-open
-file path=usr/bin/$(MACH32)/gvfs-rename
-file path=usr/bin/$(MACH32)/gvfs-rm
-file path=usr/bin/$(MACH32)/gvfs-save
-file path=usr/bin/$(MACH32)/gvfs-set-attribute
-file path=usr/bin/$(MACH32)/gvfs-trash
-file path=usr/bin/$(MACH32)/gvfs-tree
 file path=usr/bin/gvfs-cat
 file path=usr/bin/gvfs-copy
 file path=usr/bin/gvfs-info
@@ -88,6 +70,8 @@ file path=usr/lib/$(MACH64)/gvfsd-metadata
 file path=usr/lib/$(MACH64)/gvfsd-network
 file path=usr/lib/$(MACH64)/gvfsd-recent
 file path=usr/lib/$(MACH64)/gvfsd-sftp
+file path=usr/lib/$(MACH64)/gvfsd-smb
+file path=usr/lib/$(MACH64)/gvfsd-smb-browse
 file path=usr/lib/$(MACH64)/gvfsd-trash
 file path=usr/lib/gio/modules/libgioremote-volume-monitor.so
 file path=usr/lib/gio/modules/libgvfsdbus.so
@@ -109,8 +93,6 @@ file path=usr/lib/gvfsd-metadata
 file path=usr/lib/gvfsd-network
 file path=usr/lib/gvfsd-recent
 file path=usr/lib/gvfsd-sftp
-file path=usr/lib/gvfsd-smb
-file path=usr/lib/gvfsd-smb-browse
 file path=usr/lib/gvfsd-trash
 file path=usr/share/GConf/gsettings/gvfs-dns-sd.convert
 file path=usr/share/GConf/gsettings/gvfs-smb.convert

--- a/components/library/gvfs/manifests/sample-manifest.p5m
+++ b/components/library/gvfs/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -81,6 +81,8 @@ file path=usr/lib/$(MACH64)/gvfsd-metadata
 file path=usr/lib/$(MACH64)/gvfsd-network
 file path=usr/lib/$(MACH64)/gvfsd-recent
 file path=usr/lib/$(MACH64)/gvfsd-sftp
+file path=usr/lib/$(MACH64)/gvfsd-smb
+file path=usr/lib/$(MACH64)/gvfsd-smb-browse
 file path=usr/lib/$(MACH64)/gvfsd-trash
 file path=usr/lib/gio/modules/libgioremote-volume-monitor.so
 file path=usr/lib/gio/modules/libgvfsdbus.so
@@ -102,8 +104,6 @@ file path=usr/lib/gvfsd-metadata
 file path=usr/lib/gvfsd-network
 file path=usr/lib/gvfsd-recent
 file path=usr/lib/gvfsd-sftp
-file path=usr/lib/gvfsd-smb
-file path=usr/lib/gvfsd-smb-browse
 file path=usr/lib/gvfsd-trash
 file path=usr/share/GConf/gsettings/gvfs-dns-sd.convert
 file path=usr/share/GConf/gsettings/gvfs-smb.convert


### PR DESCRIPTION
This fxes building library/gnome/gvfs using the new 64 bit binaries of library/glib2@2.74.5-2023.0.0.2
