### PR TITLE
Fix gnome-keyring build using 64bit glib commands.

### DIFF
--- a/components/desktop/gnome3/gnome-keyring/Makefile
+++ b/components/desktop/gnome3/gnome-keyring/Makefile
@@ -13,15 +13,16 @@
 # Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2018 Michal Nowak
 # Copyright (c) 2021 Andreas Wacknitz
+# Copyright (c) 2023 Klaus Ziegler
 #
-BUILD_BITS= 32_and_64
+BUILD_BITS= 64_and_32
 include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		gnome-keyring
 COMPONENT_MJR_VERSION=	3.28
 COMPONENT_MNR_VERSION=	2
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_PROJECT_URL=	https://www.gnome.org
 COMPONENT_SUMMARY=	GNOME Keyring
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -43,10 +44,7 @@ PAM_MODULE_DIR.32 = $(USRLIBDIR)/security
 PAM_MODULE_DIR.64 = $(PAM_MODULE_DIR.32)/$(MACH64)
 PAM_MODULE_DIR = $(PAM_MODULE_DIR.$(BITS))
 
-CONFIGURE_BINDIR.64 = $(CONFIGURE_PREFIX)/bin
-
-# Overwrite files in /usr/bin
-$(INSTALL_64):	$(INSTALL_32)
+CONFIGURE_ENV =	GLIB_COMPILE_SCHEMAS=/usr/bin/glib-compile-schemas
 
 CONFIGURE_OPTIONS += --sysconfdir=/etc
 CONFIGURE_OPTIONS += --libexecdir=$(CONFIGURE_LIBDIR.$(BITS))

--- a/components/desktop/gnome3/gnome-keyring/gnome-keyring.p5m
+++ b/components/desktop/gnome3/gnome-keyring/gnome-keyring.p5m
@@ -12,10 +12,12 @@
 #
 # Copyright 2017 Alexander Pyhalov
 # Copyright 2018 Michal Nowak
+# Copyright 2023 Klaus Ziegler
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)

--- a/components/desktop/gnome3/gnome-keyring/manifests/sample-manifest.p5m
+++ b/components/desktop/gnome3/gnome-keyring/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -25,6 +26,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 file path=etc/xdg/autostart/gnome-keyring-pkcs11.desktop
 file path=etc/xdg/autostart/gnome-keyring-secrets.desktop
 file path=etc/xdg/autostart/gnome-keyring-ssh.desktop
+link path=usr/bin/$(MACH32)/gnome-keyring target=gnome-keyring-3
+file path=usr/bin/$(MACH32)/gnome-keyring-3
+file path=usr/bin/$(MACH32)/gnome-keyring-daemon
 link path=usr/bin/gnome-keyring target=gnome-keyring-3
 file path=usr/bin/gnome-keyring-3
 file path=usr/bin/gnome-keyring-daemon


### PR DESCRIPTION
Another one which can use the 64 Bit commands from new glib now.