### PR TITLE
ngtcp2 - new package to support QUIC protocol

### DIFF
--- a/components/library/ngtcp2/Makefile
+++ b/components/library/ngtcp2/Makefile
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 Friedrich Kink
+#
+USE_DEFAULT_TEST_TRANSFORMS= yes
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		ngtcp2
+COMPONENT_VERSION=	0.13.0
+COMPONENT_SUMMARY=	ngtcp2 project is an effort to implement RFC9000 QUIC protocol.
+COMPONENT_PROJECT_URL=	https://ngtcp2.org/
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH= sha256:2e25642b9a6305890124cfc3f2ba45ef826f7cd69292418c0bf45ae1ee5c3238
+COMPONENT_ARCHIVE_URL=	https://github.com/ngtcp2/ngtcp2/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=		library/ngtcp2
+COMPONENT_CLASSIFICATION= System/Libraries
+COMPONENT_LICENSE=	MIT
+COMPONENT_LICENSE_FILE=	COPYING
+
+include $(WS_MAKE_RULES)/common.mk
+
+CONFIGURE_OPTIONS+=	--disable-static
+CONFIGURE_OPTIONS+=	--with-gnutls
+
+# Build dependencies
+REQUIRED_PACKAGES += developer/cunit
+REQUIRED_PACKAGES += library/nghttp3
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/gnutls-3
+REQUIRED_PACKAGES += system/library

--- a/components/library/ngtcp2/manifests/sample-manifest.p5m
+++ b/components/library/ngtcp2/manifests/sample-manifest.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/ngtcp2/ngtcp2.h
+file path=usr/include/ngtcp2/ngtcp2_crypto.h
+file path=usr/include/ngtcp2/ngtcp2_crypto_gnutls.h
+file path=usr/include/ngtcp2/version.h
+link path=usr/lib/$(MACH64)/libngtcp2.so target=libngtcp2.so.10.0.0
+link path=usr/lib/$(MACH64)/libngtcp2.so.10 target=libngtcp2.so.10.0.0
+file path=usr/lib/$(MACH64)/libngtcp2.so.10.0.0
+link path=usr/lib/$(MACH64)/libngtcp2_crypto_gnutls.so \
+    target=libngtcp2_crypto_gnutls.so.4.0.0
+link path=usr/lib/$(MACH64)/libngtcp2_crypto_gnutls.so.4 \
+    target=libngtcp2_crypto_gnutls.so.4.0.0
+file path=usr/lib/$(MACH64)/libngtcp2_crypto_gnutls.so.4.0.0
+file path=usr/lib/$(MACH64)/pkgconfig/libngtcp2.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libngtcp2_crypto_gnutls.pc
+file path=usr/share/doc/ngtcp2/README.rst

--- a/components/library/ngtcp2/ngtcp2.p5m
+++ b/components/library/ngtcp2/ngtcp2.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 Friedrich Kink
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/ngtcp2/ngtcp2.h
+file path=usr/include/ngtcp2/ngtcp2_crypto.h
+file path=usr/include/ngtcp2/ngtcp2_crypto_gnutls.h
+file path=usr/include/ngtcp2/version.h
+link path=usr/lib/$(MACH64)/libngtcp2.so target=libngtcp2.so.10.0.0
+link path=usr/lib/$(MACH64)/libngtcp2.so.10 target=libngtcp2.so.10.0.0
+file path=usr/lib/$(MACH64)/libngtcp2.so.10.0.0
+link path=usr/lib/$(MACH64)/libngtcp2_crypto_gnutls.so \
+    target=libngtcp2_crypto_gnutls.so.4.0.0
+link path=usr/lib/$(MACH64)/libngtcp2_crypto_gnutls.so.4 \
+    target=libngtcp2_crypto_gnutls.so.4.0.0
+file path=usr/lib/$(MACH64)/libngtcp2_crypto_gnutls.so.4.0.0
+file path=usr/lib/$(MACH64)/pkgconfig/libngtcp2.pc
+file path=usr/lib/$(MACH64)/pkgconfig/libngtcp2_crypto_gnutls.pc
+file path=usr/share/doc/ngtcp2/README.rst

--- a/components/library/ngtcp2/pkg5
+++ b/components/library/ngtcp2/pkg5
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "developer/cunit",
+        "library/gnutls-3",
+        "library/nghttp3",
+        "shell/ksh93",
+        "system/library"
+    ],
+    "fmris": [
+        "library/ngtcp2"
+    ],
+    "name": "ngtcp2"
+}

--- a/components/library/ngtcp2/test/results-all.master
+++ b/components/library/ngtcp2/test/results-all.master
@@ -1,0 +1,8 @@
+PASS: main
+# TOTAL: 1
+# PASS:  1
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0


### PR DESCRIPTION
also needed for curl http3 support