### PR TITLE
add SPARC support in hylafax - fpic to fPIC.

### DIFF
--- a/components/network/hylafax/Makefile
+++ b/components/network/hylafax/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		hylafax
 COMPONENT_VERSION=	6.0.7
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_FMRI=		network/hylafax
 COMPONENT_SUMMARY=	HylaFAX Open Source is an enterprise-class system for sending and \
 	receiving facsimiles as well as for sending alpha-numeric pages.

--- a/components/network/hylafax/patches/01_configure_Tiff.patch
+++ b/components/network/hylafax/patches/01_configure_Tiff.patch
@@ -1,5 +1,9 @@
---- hylafax-6.0.7/configure	2018-09-18 20:51:17.000000000 +0000
-+++ hylafax-6.0.7/configure.new	2022-12-11 14:48:53.248406453 +0000
+inhouse - not valid for upstream.
+
+SPARC needs fPIC instead of fpic.
+
+--- hylafax-6.0.7/configure.~1~	2018-09-18 20:51:17.000000000 +0200
++++ hylafax-6.0.7/configure	2023-02-06 18:50:54.173063804 +0100
 @@ -2563,7 +2563,7 @@
  				tiff_offset_t="uint32"
  				tiff_bytecount_t="uint32"
@@ -9,3 +13,14 @@
  				tiff_offset_t="uint64"
  				tiff_bytecount_t="uint64"
  				echo '#define TIFFHeader	TIFFHeaderClassic'
+@@ -3498,8 +3498,8 @@
+ 	if [ ${ISGCC} = "yes" ] ; then
+ 	    DSOOPTS='-shared -Wl,-G,-h,$@'
+ 	    LLDOPTS="$USE_RPATH -lstdc++"
+-	    GCOPTS="${GCOPTS} -fpic"
+-	    GCXXOPTS="${GCXXOPTS} -fpic"
++	    GCOPTS="${GCOPTS} -fPIC"
++	    GCXXOPTS="${GCXXOPTS} -fPIC"
+ 	else
+ 	    DSOOPTS='-G -h $@'
+ 	    LLDOPTS='-L${UTIL} -R${LIBDIR} -lhylafax-${ABI_VERSION} -lCrun'


### PR DESCRIPTION
this is needed for SPARC to increase position independent code size, it does not affect any x86/amd64 build.
without this you'll get:
ld: fatal: too many symbols require 'small' PIC references:
	have 1065, maximum 1024 -- recompile some modules -K PIC.
collect2: error: ld returned 1 exit status
