### PR TITLE
python/compizconfig-python: do not incorporate recently obsoleted packages

### DIFF
--- a/components/python/compizconfig-python/Makefile
+++ b/components/python/compizconfig-python/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		compizconfig-python
 COMPONENT_VERSION=	0.8.18
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	compizconfig libraries - is an alternative configuration system for compiz
 COMPONENT_CLASSIFICATION=	Development/Python
 COMPONENT_PROJECT_URL=	http://www.northfield.ws

--- a/components/python/compizconfig-python/history
+++ b/components/python/compizconfig-python/history
@@ -1,5 +1,5 @@
 library/python-2/python-compizconfig-26@0.8.10,5.11-2016.0.1.5
 library/python-2/python-compizconfig@0.8.10,5.11-2016.0.1.5 library/python/python-compizconfig
 library/python/python-compizconfig-26@0.8.10,5.11-2016.0.1.5
-library/python/python-compizconfig-27@0.8.18,5.11-2020.0.1.1
-library/python/python-compizconfig-35@0.8.18,5.11-2020.0.1.1
+library/python/python-compizconfig-27@0.8.18,5.11-2020.0.1.2 noincorporate
+library/python/python-compizconfig-35@0.8.18,5.11-2020.0.1.2 noincorporate


### PR DESCRIPTION
Sorry, I forgot to add 'noincorporate' to `history` file.