### PR TITLE
remove automake-111 from libgtop dependencies.

### DIFF
--- a/components/library/libgtop/Makefile
+++ b/components/library/libgtop/Makefile
@@ -49,9 +49,6 @@ CONFIGURE_ENV    += PYTHON=$(PYTHON)
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
-# Build dependencies
-REQUIRED_PACKAGES += developer/build/automake-111
-
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/glib2
 REQUIRED_PACKAGES += system/library

--- a/components/library/libgtop/pkg5
+++ b/components/library/libgtop/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
         "SUNWcs",
-        "developer/build/automake-111",
         "library/glib2",
         "shell/ksh93",
         "system/library",


### PR DESCRIPTION
isn't needed anymore more for libgtop.