### PR TITLE
samba - rebuild to fix linker dependency to liblmdb-0.9.30.so

### DIFF
--- a/components/network/samba/Makefile
+++ b/components/network/samba/Makefile
@@ -32,6 +32,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		samba
 COMPONENT_VERSION =		4.17.5
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		samba - A Windows SMB/CIFS fileserver for UNIX
 COMPONENT_SRC =			$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL =		https://www.samba.org/


### PR DESCRIPTION
former samba build had a fixed linker dependency to liblmdb-0.9.29.so. Due to the update of the lmdb package to library version *.30 samba was partly unhappy.