### PR TITLE
gcc-7: install-strip should install libobjc

### DIFF
--- a/components/developer/gcc-7/patches/1006-install-strip-libobjc.patch
+++ b/components/developer/gcc-7/patches/1006-install-strip-libobjc.patch
@@ -1,0 +1,14 @@
+Without this we will miss libobjc in proto area.
+
+--- gcc-gcc-7.5.0-oi-0/libobjc/Makefile.in.orig
++++ gcc-gcc-7.5.0-oi-0/libobjc/Makefile.in
+@@ -324,7 +324,8 @@
+ 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
+ 	done
+ 
+-check uninstall install-strip dist installcheck installdirs:
++check uninstall dist installcheck installdirs:
++install-strip: install
+ 
+ mostlyclean:
+ 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo


### PR DESCRIPTION
This PR intentionally won't trigger rebuild of gcc-7 for two reasons:
1. We do not need the rebuild/republish of gcc-7 now because this PR just fixes the build and otherwise changes nothing in the final package.
2. gcc-7 is currently not buildable using (the default) gcc-10.  Possible solutions (untested):

- add `GCC_VERSION = 7`, or
- switch gcc-7 to 64-bit, or
- force to compile with `-m32` flag.