### PR TITLE
make-rules: cleanup REQUIRED_PACKAGES

### DIFF
--- a/make-rules/font.mk
+++ b/make-rules/font.mk
@@ -195,7 +195,7 @@ $(MANIFEST_BASE)-%.font-transforms: %.p5m
 	-p $(PROTO_DIR) -m $< > $@ || ( rm $@ ; exit 1 )
 
 # Package containing fc-scan used in generate_font_metadata.pl
-REQUIRED_PACKAGES	+= system/library/fontconfig
+USERLAND_REQUIRED_PACKAGES += system/library/fontconfig
 # Package containing $(MKFONTSCALE) & $(MKFONTDIR)
-REQUIRED_PACKAGES	+= x11/font-utilities
+USERLAND_REQUIRED_PACKAGES += x11/font-utilities
 

--- a/make-rules/gcc-component.mk
+++ b/make-rules/gcc-component.mk
@@ -193,11 +193,6 @@ COMPONENT_TEST_TARGETS = mail-report.log
 COMPONENT_TEST_MASTER = \
 	$(COMPONENT_TEST_RESULTS_DIR)/results-$(MACH).master
 
-# Common dependencies
-REQUIRED_PACKAGES += SUNWcs
-REQUIRED_PACKAGES += system/library
-REQUIRED_PACKAGES += system/library/math
-
 # Required by the test suite
 TEST_REQUIRED_PACKAGES += developer/test/dejagnu
 TEST_REQUIRED_PACKAGES += developer/build/autoconf-archive

--- a/make-rules/mate.mk
+++ b/make-rules/mate.mk
@@ -59,8 +59,8 @@ endif
 
 # Default build dependencies
 ifeq   ($(strip $(BUILD_STYLE)),configure)
-REQUIRED_PACKAGES += developer/build/autoconf
+USERLAND_REQUIRED_PACKAGES += developer/build/autoconf
 endif
-REQUIRED_PACKAGES += developer/build/pkg-config
-REQUIRED_PACKAGES += developer/documentation-tool/gtk-doc
-REQUIRED_PACKAGES += library/desktop/mate/mate-common
+USERLAND_REQUIRED_PACKAGES += developer/build/pkg-config
+USERLAND_REQUIRED_PACKAGES += developer/documentation-tool/gtk-doc
+USERLAND_REQUIRED_PACKAGES += library/desktop/mate/mate-common

--- a/make-rules/meson.mk
+++ b/make-rules/meson.mk
@@ -158,7 +158,7 @@ ifeq   ($(strip $(BUILD_STYLE)),meson)
 configure:	$(CONFIGURE_$(MK_BITS))
 endif
 
-REQUIRED_PACKAGES += developer/build/meson
+USERLAND_REQUIRED_PACKAGES += developer/build/meson
 
 # Meson generates build.ninja files for the ninja build tool to run,
 # so we include ninja.mk for the build/install/test rules

--- a/make-rules/ninja.mk
+++ b/make-rules/ninja.mk
@@ -112,4 +112,5 @@ $(BUILD_DIR)/%/.tested:    $(BUILD_DIR)/%/.built
 
 clean::
 	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
-REQUIRED_PACKAGES += developer/build/ninja
+
+USERLAND_REQUIRED_PACKAGES += developer/build/ninja

--- a/make-rules/prep-git.mk
+++ b/make-rules/prep-git.mk
@@ -112,7 +112,7 @@ $$(USERLAND_ARCHIVES)$$(COMPONENT_ARCHIVE$(1)):	$(MAKEFILE_PREREQ)
 		Makefile ))
 
 
-REQUIRED_PACKAGES += developer/versioning/git
+USERLAND_REQUIRED_PACKAGES += developer/versioning/git
 
 endif
 endef

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1314,21 +1314,13 @@ COMPONENT_HOOK ?=	echo $(COMPONENT_NAME) $(COMPONENT_VERSION)
 component-hook:
 	@$(COMPONENT_HOOK)
 
-# Add default dependency to SUNWcs
-REQUIRED_PACKAGES += SUNWcs
-
-# Add default dependency to shell/ksh93 which has been separated from SUNWcs
-REQUIRED_PACKAGES += shell/ksh93
+# We need shell/ksh93 to be able to run scripts in the tools directory
+USERLAND_REQUIRED_PACKAGES += shell/ksh93
 
 #
 # Packages with tools that are required to build Userland components
 #
 USERLAND_REQUIRED_PACKAGES += metapackages/build-essential
-
-# Only a default dependency if component being built produces binaries.
-ifneq ($(strip $(BUILD_BITS)),NO_ARCH)
-REQUIRED_PACKAGES += system/library
-endif
 
 # Define substitution rules for some packages.
 # Such package names may change and would be better defined with a macro to

--- a/make-rules/x11.mk
+++ b/make-rules/x11.mk
@@ -161,6 +161,6 @@ PKG_MACROS += X11PKGVERS=$(PKG_X11_VERSION)
 #
 # Default build dependencies
 #
-REQUIRED_PACKAGES += x11/header/x11-protocols
-REQUIRED_PACKAGES += developer/build/autoconf/xorg-macros
+USERLAND_REQUIRED_PACKAGES += x11/header/x11-protocols
+USERLAND_REQUIRED_PACKAGES += developer/build/autoconf/xorg-macros
 


### PR DESCRIPTION
There is no need to add anything to `REQUIRED_PACKAGES` in `make-rules`.  All default build-only dependencies should go to `USERLAND_REQUIRED_PACKAGES` in `make-rules` for now.  Runtime dependencies are already automatically detected by the `REQUIRED_PACKAGES` target and added to components' `Makefile`.

Anything added to `REQUIRED_PACKAGES` in `make-rules` just unnecessarily pollutes components' `pkg5` files.