### PR TITLE
system-config-printer - fix opening Print Settings

### DIFF
--- a/components/print/system-config-printer/Makefile
+++ b/components/print/system-config-printer/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME =		system-config-printer
 HUMAN_VERSION =			1.5.18
 COMPONENT_VERSION =		2.30.0
-COMPONENT_REVISION =		6
+COMPONENT_REVISION =		7
 COMPONENT_FMRI =		print/cups/system-config-printer
 COMPONENT_SUMMARY =		Print Manager for CUPS
 COMPONENT_CLASSIFICATION =	System/Administration and Configuration

--- a/components/print/system-config-printer/system-config-printer.p5m
+++ b/components/print/system-config-printer/system-config-printer.p5m
@@ -23,6 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=.*/applet.py$ -> default mode 0555>
+<transform file path=usr/share/system-config-printer/system-config-printer.py -> default mode 0555>
 
 file path=etc/cupshelpers/preferreddrivers.xml
 file path=etc/dbus-1/system.d/com.redhat.NewPrinterNotification.conf


### PR DESCRIPTION
Fix /usr/bin/system-config-printer so Print Settings window opens.