### PR TITLE
cmake.mk: cmake needs PATH

### DIFF
--- a/make-rules/cmake.mk
+++ b/make-rules/cmake.mk
@@ -97,6 +97,7 @@ CMAKE_ENV += FFLAGS="$(F77FLAGS)"
 CMAKE_ENV += FCFLAGS="$(FCFLAGS)"
 CMAKE_ENV += LDFLAGS="$(LDFLAGS)"
 CMAKE_ENV += PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)"
+CMAKE_ENV += PATH="$(PATH)"
 
 # Rewrite absolute source-code paths into relative for ccache, so that any
 # workspace with a shared CCACHE_DIR can benefit when compiling a component


### PR DESCRIPTION
This is to avoid the following error when running in environment without `PATH` available (for example something like `env - gmake publish` would otherwise fail):
```
CMake Error: Could not find CMAKE_ROOT !!!
CMake has most likely not been installed correctly.
Modules directory not found in
```