### PR TITLE
wxwidgets-3: fix 64 bit metadata information.

### DIFF
--- a/components/library/wxwidgets-3/Makefile
+++ b/components/library/wxwidgets-3/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         wxwidgets-3
 COMPONENT_VERSION=      3.1.5
-COMPONENT_REVISION=     5
+COMPONENT_REVISION=     6
 COMPONENT_SUMMARY=      wxWidgets - Cross-Platform GUI Library
 COMPONENT_PROJECT_URL=  https://www.wxwidgets.org/
 COMPONENT_SRC_NAME=     wxWidgets

--- a/components/library/wxwidgets-3/wxwidgets-3.p5m
+++ b/components/library/wxwidgets-3/wxwidgets-3.p5m
@@ -33,7 +33,7 @@ depend fmri=service/opengl/ogl-select type=require
 file usr/share/aclocal/wxwin.m4 path=usr/share/aclocal/wxwin-3.1.m4
 link path=usr/share/aclocal/wxwin.m4 target=wxwin-3.1.m4 mediator=wxwidgets mediator-version=3
 
-link path=usr/bin/wx-config-3.1 target=../lib/wx/config/gtk3-unicode-3.1
+link path=usr/bin/wx-config-3.1 target=../lib/$(MACH64)/wx/config/gtk3-unicode-3.1
 link path=usr/bin/wx-config-3 target=wx-config-3.1
 link path=usr/bin/wx-config target=wx-config-3.1 mediator=wxwidgets mediator-version=3
 file path=usr/bin/wxrc-3.1


### PR DESCRIPTION
Sorry, has been forgotten in the last #PR due to not being able to publish on oibuild.