### PR TITLE
shared-macros.mk: openssl should default to 1.1

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -999,7 +999,7 @@ INS.dir=        $(INSTALL) -d $@
 INS.file=       $(INSTALL) -m 444 $< $(@D)
 
 # OpenSSL macros
-OPENSSL_DEFAULT= 1.0
+OPENSSL_DEFAULT= 1.1
 ifeq ($(strip $(USE_OPENSSL11)),yes)
 OPENSSL_VERSION= 1.1
 PATH.prepend+=$(OPENSSL_BINDIR)


### PR DESCRIPTION
Currently ca half of components that use openssl already (explicitly) switched to openssl 1.1.  I think most components just do not care and use userland's defaults.  We should encourage them to upgrade by changing default openssl to 1.1.  A component that needs to stay with openssl 1.0 could easily opt out using `USE_OPENSSL10 = yes`.