### PR TITLE
smf-cacert; correct dependent REQUIRED_PACKAGES.

### DIFF
--- a/components/openindiana/smf-cacert/Makefile
+++ b/components/openindiana/smf-cacert/Makefile
@@ -16,6 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		smf-cacert
 COMPONENT_VERSION=	fd7e03f15c6db18ff48df400331e9a3c968d6cc9
+COMPONENT_REVISION=	1
 IPS_COMPONENT_VERSION=	0.0.1.20170919
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_VERSION).zip
@@ -43,4 +44,5 @@ build: $(BUILD_32)
 install: $(INSTALL_32)
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += SUNWcs

--- a/components/openindiana/smf-cacert/pkg5
+++ b/components/openindiana/smf-cacert/pkg5
@@ -1,7 +1,7 @@
 {
     "dependencies": [
         "SUNWcs",
-        "system/library"
+        "shell/ksh93"
     ],
     "fmris": [
         "system/ca-certificates"


### PR DESCRIPTION
correct dependencies for the upcoming 2023/04 release.