### PR TITLE
Replacement for the method script gconf-cache

### DIFF
--- a/components/desktop/desktop-cache/Makefile
+++ b/components/desktop/desktop-cache/Makefile
@@ -12,13 +12,14 @@
 #
 # Copyright 2019 Alexander Pyhalov
 # Copyright 2023 Klaus Ziegler
+# Copyright 2023 Gary Mills
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= desktop-cache
 COMPONENT_VERSION= 0.2.2
-COMPONENT_REVISION= 8
+COMPONENT_REVISION= 9
 COMPONENT_SUMMARY= desktop-cache is a set of SMF services used to update the various GNOME desktop caches.
 COMPONENT_SRC= desktop-cache-smf-services-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2
@@ -35,5 +36,7 @@ CONFIGURE_OPTIONS += --sysconfdir=/lib
 
 CONFIGURE_ENV += PYTHON=$(PYTHON)
 
+# Auto-generated dependencies
 PYTHON_REQUIRED_PACKAGES += runtime/python
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += SUNWcs

--- a/components/desktop/desktop-cache/patches/03-gconf.patch
+++ b/components/desktop/desktop-cache/patches/03-gconf.patch
@@ -1,21 +1,41 @@
---- desktop-cache-smf-services-0.2.2/gconf-cache/gconf-cache.orig	Sat Mar 15 19:06:03 2014
-+++ desktop-cache-smf-services-0.2.2/gconf-cache/gconf-cache	Sat Mar 15 19:14:29 2014
-@@ -52,8 +52,25 @@
+This patch eliminates calls to the find_newer python script and adds
+messages to the redo_gsettings_schemas function of the method script.
+
+--- desktop-cache-smf-services-0.2.2/gconf-cache/gconf-cache-old	Wed Apr 29 05:00:07 2009
++++ desktop-cache-smf-services-0.2.2/gconf-cache/gconf-cache	Sat Mar 25 16:38:19 2023
+@@ -1,5 +1,6 @@
+ #!/bin/ksh -p
+ #
++# Copyright 2023 Gary Mills
+ # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+ # Use is subject to license terms.
+ #
+@@ -36,7 +37,6 @@
+ . /lib/svc/share/smf_include.sh
+ 
+ USAGE="Usage: $0 { start | refresh }"
+-FIND_NEWER=/usr/share/desktop-cache/find_newer
+ 
+ if [ $# -ne 1 ] ; then
+     echo $USAGE
+@@ -52,15 +52,32 @@
  # generate/merge schema files in the gconf cache
  #
  
 +redo_gsettings_schemas ()
 +{
 +if [ -a "/usr/share/glib-2.0/schemas/gschemas.compiled" ]; then
-+  SCHEMAS=`${FIND_NEWER} -f -m -c --name '*.xml' \
-+      --newer /usr/share/glib-2.0/schemas/gschemas.compiled \
-+      /usr/share/glib-2.0/schemas 2>/dev/null`
++  SCHEMAS=`/usr/bin/find /usr/share/glib-2.0/schemas -follow ! -type d \
++    -name '*.xml' -newer /usr/share/glib-2.0/schemas/gschemas.compiled`
 +else
 +  SCHEMAS="NEW"
 +fi
 +
 +if [ -n "$SCHEMAS" ]; then
-+  /usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas/ 2>/dev/null
++    echo "Doing rebuild of gschemas.compiled file"
++    /usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas/ 2>/dev/null
++else
++    echo "Skipping rebuild of gschemas.compiled file"
 +fi
 +}
 +
@@ -24,8 +44,39 @@
 +redo_gsettings_schemas
 +
  if [ -a "/etc/gconf/gconf.xml.defaults/%gconf-tree.xml" ]; then
-   SCHEMAS=`${FIND_NEWER} -f -m -c --name '*.schemas' \
-       --newer /etc/gconf/gconf.xml.defaults/%gconf-tree.xml \
+-  SCHEMAS=`${FIND_NEWER} -f -m -c --name '*.schemas' \
+-      --newer /etc/gconf/gconf.xml.defaults/%gconf-tree.xml \
+-      /etc/gconf/schemas 2>/dev/null`
+-  ENTRIES=`${FIND_NEWER} -f -m -c --name '*.entries' \
+-      --newer /etc/gconf/gconf.xml.defaults/%gconf-tree.xml \
+-      /etc/gconf/schemas 2>/dev/null`
++  SCHEMAS=`/usr/bin/find /etc/gconf/schemas -follow ! -type d \
++    -name '*.schemas' -newer /etc/gconf/gconf.xml.defaults/%gconf-tree.xml`
++  ENTRIES=`/usr/bin/find /etc/gconf/schemas -follow ! -type d \
++    -name '*.entries' -newer /etc/gconf/gconf.xml.defaults/%gconf-tree.xml`
+ else
+   SCHEMAS=`/usr/bin/find /etc/gconf/schemas -name '*.schemas' ! -type d`
+   ENTRIES=`/usr/bin/find /etc/gconf/schemas -name '*.entries' ! -type d`
+@@ -75,8 +92,8 @@
+   echo "$SCHEMAS" | /bin/sed -e 's/^/    /'
+   # redirect stdout to /dev/null because gconftool is too verbose
+   # errors are printed to stderr
+-  GCONF_CONFIG_SOURCE=xml:merged:/etc/gconf/gconf.xml.defaults \
+-    /usr/bin/gconftool-2 --makefile-install-rule $SCHEMAS > /dev/null
++    GCONF_CONFIG_SOURCE=xml:merged:/etc/gconf/gconf.xml.defaults \
++      /usr/bin/gconftool-2 --makefile-install-rule $SCHEMAS > /dev/null
+   if [ $? -ne 0 ]; then
+     echo "gconftool-2 exited with an error while installing schemas"
+     exit $SMF_EXIT_ERR_FATAL
+@@ -94,7 +111,7 @@
+   echo "$ENTRIES" | /bin/sed -e 's/^/    /'
+   # redirect stdout to /dev/null because gconftool is too verbose
+   # errors are printed to stderr
+-  /usr/bin/gconftool-2 --direct \
++    /usr/bin/gconftool-2 --direct \
+       --config-source=xml:merged:/etc/gconf/gconf.xml.defaults \
+       --load $ENTRIES > /dev/null
+   if [ $? -ne 0 ]; then
 @@ -108,6 +125,8 @@
  
  refresh_gconf_cache ()
@@ -35,3 +86,23 @@
  if [ -a "/etc/gconf/gconf.xml.defaults/%gconf-tree.xml" ]; then
    SCHEMAS=`/usr/bin/find /etc/gconf/schemas ! -type d -follow \
      -name '*.schemas' 2>/dev/null`
+@@ -127,8 +146,8 @@
+   echo "$SCHEMAS" | /bin/sed -e 's/^/    /'
+   # redirect stdout to /dev/null because gconftool is too verbose
+   # errors are printed to stderr
+-  GCONF_CONFIG_SOURCE=xml:merged:/etc/gconf/gconf.xml.defaults \
+-    /usr/bin/gconftool-2 --makefile-install-rule $SCHEMAS > /dev/null
++    GCONF_CONFIG_SOURCE=xml:merged:/etc/gconf/gconf.xml.defaults \
++	/usr/bin/gconftool-2 --makefile-install-rule $SCHEMAS > /dev/null
+   if [ $? -ne 0 ]; then
+     echo "gconftool-2 exited with an error while installing schemas"
+     exit $SMF_EXIT_ERR_FATAL
+@@ -146,7 +165,7 @@
+   echo "$ENTRIES" | /bin/sed -e 's/^/    /'
+   # redirect stdout to /dev/null because gconftool is too verbose
+   # errors are printed to stderr
+-  /usr/bin/gconftool-2 --direct \
++    /usr/bin/gconftool-2 --direct \
+       --config-source=xml:merged:/etc/gconf/gconf.xml.defaults \
+       --load $ENTRIES > /dev/null
+   if [ $? -ne 0 ]; then

--- a/components/desktop/desktop-cache/pkg5
+++ b/components/desktop/desktop-cache/pkg5
@@ -2,8 +2,7 @@
     "dependencies": [
         "SUNWcs",
         "runtime/python-39",
-        "shell/ksh93",
-        "system/library"
+        "shell/ksh93"
     ],
     "fmris": [
         "service/gnome/desktop-cache"


### PR DESCRIPTION
This PR is the fix for OI bug report #15470 .  The enclosing package desktop-cache is a set of SMF services used to update the various MATE desktop caches.  Only the method script /lib/svc/method/gconf-cache is modified.  First, the changes eliminate calls to the python script /usr/share/desktop-cache/find_newer .  Second, they add explanatory messages to the redo_gsettings_schemas function.  These messages are logged to the service log file.  I did not test the other method scripts that call the find_newer python script.  Note that other illumos distros have dropped the python script completely.

The new method script is built in the usual way, with the build, install, and publish gmake targets.  I did testing on the new method script.  This included showing that it executes correctly, and that it behaved correctly during an OI upgrade.
