### PR TITLE
libmediainfo: update to 23.03

### DIFF
--- a/components/library/MediaInfoLib/Makefile
+++ b/components/library/MediaInfoLib/Makefile
@@ -17,13 +17,14 @@ USE_DEFAULT_TEST_TRANSFORMS= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		MediaInfoLib
-COMPONENT_VERSION=	22.12
+COMPONENT_VERSION=	23.3
+HUMAN_VERSION=		23.03
 COMPONENT_SUMMARY=	MediaInfo(Lib) is a convenient unified display of the most relevant technical and tag data for video and audio files.
 COMPONENT_PROJECT_URL=	https://github.com/MediaArea/$(COMPONENT_NAME)
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/archive/refs/tags/v$(HUMAN_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:d585866b48e6eb1ec6a913b9d21b282ca93b2643a2d26e8af9576c6c160f00dd
+COMPONENT_ARCHIVE_HASH=	sha256:547716cb4e77b6ba0eee73c000d661ea68bccf5b18e82c5ecb0407e0a153aa46
 COMPONENT_FMRI=		library/libmediainfo
 COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_LICENSE=	BSD 2-Clause

--- a/components/library/MediaInfoLib/pkg5
+++ b/components/library/MediaInfoLib/pkg5
@@ -1,11 +1,9 @@
 {
     "dependencies": [
-        "SUNWcs",
         "image/graphviz",
         "library/libzen",
         "library/video/libmms",
         "library/zlib",
-        "shell/ksh93",
         "system/library",
         "system/library/g++-10-runtime",
         "system/library/gcc-10-runtime",


### PR DESCRIPTION
- sample-manifest didn't change
- gmake test run fine