### PR TITLE
gtk-doc: fix dependencies

### DIFF
--- a/components/developer/gtk-doc/Makefile
+++ b/components/developer/gtk-doc/Makefile
@@ -19,7 +19,7 @@ COMPONENT_NAME=		gtk-doc
 COMPONENT_MAJOR_VERSION=        1.33
 COMPONENT_MINOR_VERSION=        2
 COMPONENT_VERSION=      $(COMPONENT_MAJOR_VERSION).$(COMPONENT_MINOR_VERSION)
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_PROJECT_URL=	https://gitlab.gnome.org/GNOME/gtk-doc
 COMPONENT_SUMMARY=	GTK+ DocBook Documentation Generator
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -27,6 +27,9 @@ COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=	\
     sha256:cc1b709a20eb030a278a1f9842a362e00402b7f834ae1df4c1998a723152bf43
 COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/$(COMPONENT_NAME)/$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=		developer/documentation-tool/gtk-doc
+COMPONENT_CLASSIFICATION=	Desktop (GNOME)/Libraries
+COMPONENT_LICENSE=	GPLv3, FDLv1.1
 
 # The built-in tests assume the package has already been installed
 TEST_TARGET=		$(NO_TESTS)
@@ -38,25 +41,15 @@ PATH=$(PATH.gnu)
 # Build configure script
 COMPONENT_PREP_ACTION += (cd $(@D); PATH="$(PATH)" autoreconf -fiv)
 
-# pkgdepend doesn't like the first line of a Python script to be:
-# '#!/usr/bin/env python3' so turn it into '#!/usr/bin/python$(PYTHON_VERSION)'
-#
-COMPONENT_POST_INSTALL_ACTION += \
-	$(GSED) -i -e 's?env python3?python$(PYTHON_VERSION)?' \
-		$(PROTOUSRSHAREDIR)/gtk-doc/python/gtkdoc/highlight.py;
-COMPONENT_POST_INSTALL_ACTION += \
-	$(GSED) -i -e 's?env python3?python$(PYTHON_VERSION)?' \
-		$(PROTOUSRSHAREDIR)/gtk-doc/python/gtkdoc/mkhtml2.py;
-
 CONFIGURE_OPTIONS+=	--bindir=$(USRBINDIR)
 CONFIGURE_OPTIONS+=	--sbindir=$(USRSBINDIR)
 CONFIGURE_OPTIONS+=	--sysconfdir=$(ETCDIR)
 CONFIGURE_ENV+=		PYTHON=$(PYTHON)
 
-# Manually added dependencies
-REQUIRED_PACKAGES += SUNWcs
+# Manually added build and runtime dependencies
 REQUIRED_PACKAGES += text/itstool
-PYTHON_REQUIRED_PACKAGES += runtime/python
 PYTHON_REQUIRED_PACKAGES += library/python/pygments
 
 # Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += runtime/python
+REQUIRED_PACKAGES += shell/ksh93

--- a/components/developer/gtk-doc/gtk-doc.p5m
+++ b/components/developer/gtk-doc/gtk-doc.p5m
@@ -12,38 +12,40 @@
 # Copyright 2014 Alexander Pyhalov. All rights reserved.
 #
 
-set name=pkg.fmri value=pkg:/developer/documentation-tool/gtk-doc@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
-set name=info.classification value="org.opensolaris.category.2008:Desktop (GNOME)/Libraries"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-license gtk-doc.license license='GPLv3, FDLv1.1'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-# Python scripts are broken
-<transform file path=usr/bin/ -> set pkg.depend.bypass-generate .*>
+# Do not generate dependencies on gtkdoc_uninstalled.  Such module does not exist intentionally.
+<transform file path=usr/bin/ -> add pkg.depend.bypass-generate .*/gtkdoc_uninstalled.*>
+# Do not generate dependencies on own gtkdoc module.
+<transform file path=usr/bin/ -> add pkg.depend.bypass-generate .*/gtkdoc.*>
 
-# Add a runtime dependency on pygments and as we are using python-3.7 depend on pygments-37:
-depend fmri=library/python/pygments-37 type=require
+# Add a runtime dependency on pygments
+depend fmri=library/python/pygments type=require
 
 file path=usr/bin/gtkdoc-check
 file path=usr/bin/gtkdoc-depscan
 file path=usr/bin/gtkdoc-fixxref
 file path=usr/bin/gtkdoc-mkdb
 file path=usr/bin/gtkdoc-mkhtml
+file path=usr/bin/gtkdoc-mkhtml2
 file path=usr/bin/gtkdoc-mkman
 file path=usr/bin/gtkdoc-mkpdf
-file path=usr/bin/gtkdoc-mkhtml2
 file path=usr/bin/gtkdoc-rebase
 file path=usr/bin/gtkdoc-scan
 file path=usr/bin/gtkdoc-scangobj
 file path=usr/bin/gtkdocize
+file path=usr/share/aclocal/gtk-doc.m4
 file path=usr/share/cmake/GtkDoc/GtkDocConfig.cmake
 file path=usr/share/cmake/GtkDoc/GtkDocConfigVersion.cmake
 file path=usr/share/cmake/GtkDoc/GtkDocScanGObjWrapper.cmake
-file path=usr/share/aclocal/gtk-doc.m4
 file path=usr/share/gtk-doc/data/devhelp2.xsd
 file path=usr/share/gtk-doc/data/devhelp2.xsl
 file path=usr/share/gtk-doc/data/gtk-doc.flat.make

--- a/components/developer/gtk-doc/pkg5
+++ b/components/developer/gtk-doc/pkg5
@@ -1,8 +1,8 @@
 {
     "dependencies": [
-        "SUNWcs",
         "library/python/pygments-39",
         "runtime/python-39",
+        "shell/ksh93",
         "text/itstool"
     ],
     "fmris": [


### PR DESCRIPTION
This is follow-up for #11542.  I forgot to check the p5m file previously and I left dependency on `pygments-37` there.