### PR TITLE
Add component gdk-pixbuf-xlib for newer gdk-pixbuf

### DIFF
--- a/components/library/gdk-pixbuf-xlib/Makefile
+++ b/components/library/gdk-pixbuf-xlib/Makefile
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 Klaus Ziegler
+#
+
+include ../../../make-rules/shared-macros.mk
+BUILD_STYLE= meson
+BUILD_BITS= 32_and_64
+
+COMPONENT_NAME= gdk-pixbuf-xlib
+COMPMAJOR= 2.40
+COMPMINOR= 2
+COMPONENT_VERSION= $(COMPMAJOR).$(COMPMINOR)
+COMPONENT_SUMMARY= GNOME gdk-pixbuf-xlib
+COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPMAJOR).$(COMPMINOR)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH= \
+  sha256:8b8e1c270ec16a06f665ea841f8e4e167eaa0118d0cbfeeade43745f09198ff7
+COMPONENT_ARCHIVE_URL= \
+  https://download.gnome.org/sources/$(COMPONENT_NAME)/$(COMPMAJOR)/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL = https://gitlab.gnome.org/Archive/gdk-pixbuf-xlib
+COMPONENT_FMRI=	library/desktop/gdk-pixbuf-xlib
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += x11/library/libx11

--- a/components/library/gdk-pixbuf-xlib/gdk-pixbuf-xlib.p5m
+++ b/components/library/gdk-pixbuf-xlib/gdk-pixbuf-xlib.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 Klaus Ziegler
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="org.opensolaris.category.2008:Desktop (GNOME)/Libraries"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license COPYING license='LGPLv2'
+
+file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf-xlib/gdk-pixbuf-xlib.h
+file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf-xlib/gdk-pixbuf-xlibrgb.h
+link path=usr/lib/$(MACH64)/libgdk_pixbuf_xlib-2.0.so \
+    target=libgdk_pixbuf_xlib-2.0.so.0
+link path=usr/lib/$(MACH64)/libgdk_pixbuf_xlib-2.0.so.0 \
+    target=libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/$(MACH64)/libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/$(MACH64)/pkgconfig/gdk-pixbuf-xlib-2.0.pc
+link path=usr/lib/libgdk_pixbuf_xlib-2.0.so target=libgdk_pixbuf_xlib-2.0.so.0
+link path=usr/lib/libgdk_pixbuf_xlib-2.0.so.0 \
+    target=libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/pkgconfig/gdk-pixbuf-xlib-2.0.pc

--- a/components/library/gdk-pixbuf-xlib/manifests/sample-manifest.p5m
+++ b/components/library/gdk-pixbuf-xlib/manifests/sample-manifest.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf-xlib/gdk-pixbuf-xlib.h
+file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf-xlib/gdk-pixbuf-xlibrgb.h
+link path=usr/lib/$(MACH64)/libgdk_pixbuf_xlib-2.0.so \
+    target=libgdk_pixbuf_xlib-2.0.so.0
+link path=usr/lib/$(MACH64)/libgdk_pixbuf_xlib-2.0.so.0 \
+    target=libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/$(MACH64)/libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/$(MACH64)/pkgconfig/gdk-pixbuf-xlib-2.0.pc
+link path=usr/lib/libgdk_pixbuf_xlib-2.0.so target=libgdk_pixbuf_xlib-2.0.so.0
+link path=usr/lib/libgdk_pixbuf_xlib-2.0.so.0 \
+    target=libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/libgdk_pixbuf_xlib-2.0.so.0.4000.2
+file path=usr/lib/pkgconfig/gdk-pixbuf-xlib-2.0.pc

--- a/components/library/gdk-pixbuf-xlib/pkg5
+++ b/components/library/gdk-pixbuf-xlib/pkg5
@@ -1,0 +1,16 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "developer/build/meson",
+        "developer/build/ninja",
+        "library/desktop/gdk-pixbuf",
+        "library/glib2",
+        "shell/ksh93",
+        "system/library",
+        "x11/library/libx11"
+    ],
+    "fmris": [
+        "library/desktop/gdk-pixbuf-xlib"
+    ],
+    "name": "gdk-pixbuf-xlib"
+}


### PR DESCRIPTION
This new component will be needed for a newer gdk-pixbuf, at least needed for components:
desktop/mate/mate-settings-daemon
desktop/xscreensaver/hacks
desktop/xscreensaver/hacks/hacks-gl
web/browser/w3m

components which compile without the xlib part of pixbuf are so far:
benchmark/gtkperf
communication/im/pidgin
communication/im/venom
desktop/administration/nwam-manager
desktop/archive-manager/engrampa
desktop/cd-burning/brasero
desktop/compiz
desktop/gnumeric
desktop/irc/hexchat
desktop/mate/caja
desktop/mate/caja/caja-extensions
desktop/mate/control-center
desktop/mate/marco
desktop/mate/mate-applets
desktop/mate/mate-dictionary
desktop/mate/mate-disk-usage-analyzer
desktop/mate/mate-media
desktop/mate/mate-notification-daemon
desktop/mate/mate-panel
desktop/mate/mate-power-manager
desktop/mate/mate-screensaver
desktop/mate/mate-screenshot
desktop/mate/mate-search-tool
desktop/mate/mate-session-manager
desktop/nntp/pan
desktop/office/abiword
desktop/pdf-viewer/atril
desktop/remote-desktop/remmina
desktop/remote-desktop/vinagre
desktop/system-monitor/gkrellm
desktop/system-monitor/mate-system-monitor
desktop/torrent/transmission
desktop/window-manager/awesome
desktop/window-manager/openbox
desktop/xcowsay
developer/ui-designer/glade
editor/blog/drivel
editor/diagram/dia
editor/geany
editor/geany/plugins
editor/gnu-emacs/gnu-emacs-gtk
editor/gnu-emacs/gnu-emacs-x11
editor/gvim
editor/pluma
games/freeciv
gnome/media/totem
gnome/security/seahorse
gnome/theme/blueprint
gnome/theme/gtk2-engines
gnome/theme/gtk2-engines-extra
gnome/theme/gtk2-engines-murrine
gnome/theme/gtk3-engines
gnome/theme/gtk3-engines-extra
gnome/zenity
image/editor/inkscape
image/gexif
image/graphviz
image/library/gegl
image/library/librsvg
image/viewer/eom
image/viewer/geeqie
image/viewer/gthumb
library/audio/gstreamer/plugin/good
library/audio/gstreamer1/plugin/good
library/desktop/c++/gtkmm
library/desktop/c++/gtkmm3
library/desktop/clutter
library/desktop/clutter/clutter-gtk
library/desktop/goffice
library/desktop/gtk-vnc
library/desktop/gtk2
library/desktop/gtk3
library/desktop/gtk3/gtk-backend-cups
library/desktop/gtkimageview
library/desktop/gtksourceview
library/desktop/gtksourceview3
library/desktop/gtksourceview4
library/desktop/libbonoboui
library/desktop/libchamplain
library/desktop/libexif-gtk
library/desktop/libgksu
library/desktop/libglade
library/desktop/libgnomecanvas
library/desktop/libgnomeui
library/desktop/libgsf
library/desktop/libsexy
library/desktop/libvisual/plugins
library/desktop/libwnck3
library/desktop/mate/libmatekbd
library/desktop/mate/libmateweather
library/desktop/mate/mate-desktop
library/desktop/search/tracker
library/desktop/vte
library/desktop/webkitgtk2
library/gnome/gcr
library/graphics/wxwidgets
library/graphics/wxwidgets-3
library/libgdl
library/libhandy
library/libnotify
library/libpoppler
mail/claws-mail
network/putty
print/filter/ghostscript
print/lp/print-manager
system/desktop/stardict
system/display-manager/lightdm/gtk-greeter
system/input-method/ibus
system/install/gui-install
system/media/gmtp
terminal/mate-terminal
terminal/urxvt

components which still need to be tested for with/without xlib part of pixbuf:
audio/audacity
desktop/file-manager/gnome-commander
desktop/gtkam
desktop/office/libreoffice
gnome/media/rhythmbox
gnome/theme/nimbus
image/editor/gimp
image/editor/gimp/plugin/gimp-gtkam
library/python/pygtk2-27
mail/thunderbird
media/vlc
web/browser/firefox
web/browser/w3m
driver/graphics/nvidia
driver/graphics/nvidia-340
driver/graphics/nvidia-390
driver/graphics/nvidia-470
