### PR TITLE
fontconfig: work-arounds

### DIFF
--- a/components/library/fontconfig/Makefile
+++ b/components/library/fontconfig/Makefile
@@ -19,6 +19,7 @@ USE_DEFAULT_TEST_TRANSFORMS= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		fontconfig
+COMPONENT_REVISION=	1
 COMPONENT_VERSION=	2.14.2
 COMPONENT_SUMMARY=	Fontconfig - Font configuration and customization library
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/library/fontconfig/files/08-remap-pcf-xorg-fonts.conf
+++ b/components/library/fontconfig/files/08-remap-pcf-xorg-fonts.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+ <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+ <fontconfig>
+     <alias>
+         <family>Courier</family>
+         <prefer><family>Liberation Serif</family></prefer>
+     </alias>
+     <alias>
+         <family>Helvetica</family>
+         <prefer><family>Liberation Sans</family></prefer>
+     </alias>
+     <alias>
+         <family>Times</family>
+         <prefer><family>Liberation Mono</family></prefer>
+     </alias>
+ </fontconfig>

--- a/components/library/fontconfig/files/local.conf
+++ b/components/library/fontconfig/files/local.conf
@@ -15,8 +15,6 @@
 		<edit mode="assign" name="hintstyle"><const>hintslight</const></edit>
 		<edit mode="assign" name="antialias"><bool>true</bool></edit>
 		<edit mode="assign" name="lcdfilter"><const>lcddefault</const></edit>
-		<!-- Disable emmbedded bitmap for all fonts -->
-		<edit mode="assign" name="embeddedbitmap"><bool>false</bool></edit>
 		<!-- If the font is bold, turn off autohinting -->
 		<test name="weight" compare="more"><const>medium</const></test>
 		<edit mode="assign" name="autohint"><bool>true</bool></edit>

--- a/components/library/fontconfig/fontconfig.p5m
+++ b/components/library/fontconfig/fontconfig.p5m
@@ -23,10 +23,12 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file files/08-remap-pcf-xorg-fonts.conf path=etc/fonts/conf.avail/08-remap-pcf-xorg-fonts.conf
 file files/20-indic.conf path=etc/fonts/conf.avail/20-indic.conf
 file files/49-sun-preuser.conf path=etc/fonts/conf.avail/49-sun-preuser.conf
 file files/90-sun-prefer-bitmap.conf path=etc/fonts/conf.avail/90-sun-prefer-bitmap.conf
 
+link path=etc/fonts/conf.d/08-remap-pcf-xorg-fonts.conf target=../conf.avail/08-remap-pcf-xorg-fonts.conf
 link path=etc/fonts/conf.d/20-indic.conf target=../conf.avail/20-indic.conf
 link path=etc/fonts/conf.d/49-sun-preuser.conf target=../conf.avail/49-sun-preuser.conf
 link path=etc/fonts/conf.d/90-sun-prefer-bitmap.conf target=../conf.avail/90-sun-prefer-bitmap.conf


### PR DESCRIPTION
The 08 conf file remaps the most common xorg core bitmap fonts to metrically equivalent scaled liberation fonts.  Firefox 112/113 does not display text with Helvetica, Times, or Courier.  The scaled font also renders more pleasing looking characters.  mate font viewer still shows the bitmap fonts, The font list in LibreOffice and Gimp do not change.

local.conf is changed to allow support for the Noto Color Emoji font