### PR TITLE
replace nvidia with nvidia-470

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	54
+COMPONENT_REVISION=	55
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/server_desktop
+++ b/components/meta-packages/install-types/includes/server_desktop
@@ -10,7 +10,7 @@ depend type=require fmri=diagnostic/top
 depend type=require fmri=driver/graphics/agpgart
 depend type=require fmri=driver/graphics/atiatom
 depend type=require fmri=driver/graphics/drm
-depend type=require fmri=driver/graphics/nvidia
+depend type=require fmri=driver/graphics/nvidia-470
 depend type=require fmri=editor/nano
 depend type=require fmri=editor/vim
 depend type=require fmri=file/gnu-coreutils


### PR DESCRIPTION
This seems to be necessary because we have boot problems since today (probably due to the switch to gcc-10 for illumos-gate builds). Having install media with this problem is a receipt tor a disaster. nvidia-470 doesn't seem to have the same problems.