### PR TITLE
python/ansible: skip collection dependency on ansible itself

### DIFF
--- a/components/python/ansible/Makefile
+++ b/components/python/ansible/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		ansible
 HUMAN_VERSION =			7.4.0
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		ansible - Radically simple IT automation
 COMPONENT_PROJECT_URL =		https://ansible.com/
 COMPONENT_ARCHIVE_URL =		\

--- a/components/python/ansible/ansible.p5m
+++ b/components/python/ansible/ansible.p5m
@@ -16284,7 +16284,7 @@ depend type=require fmri=pkg:/library/python/ansible-core-$(PYV)
 <transform file path=.*/vendor-packages/ansible_collections/cisco/aci/ -> drop>
 # Missing dependencies for cisco.asa: ansible-pylibssh
 <transform file path=.*/vendor-packages/ansible_collections/cisco/asa/ -> drop>
-# Missing dependencies for cisco.dnac: ansible-base antsibull dnacentersdk recommonmark
+# Missing dependencies for cisco.dnac: ansible-base antsibull recommonmark
 <transform file path=.*/vendor-packages/ansible_collections/cisco/dnac/ -> drop>
 # Missing dependencies for cisco.ios: ansible-pylibssh
 <transform file path=.*/vendor-packages/ansible_collections/cisco/ios/ -> drop>
@@ -16302,7 +16302,7 @@ depend type=require fmri=pkg:/library/python/ansible-core-$(PYV)
 <transform file path=.*/vendor-packages/ansible_collections/community/docker/ -> drop>
 # Missing dependencies for community.hashi_vault: ansible-pygments antsibull-docs azure-identity boto3 botocore hvac sphinx-ansible-theme
 <transform file path=.*/vendor-packages/ansible_collections/community/hashi_vault/ -> drop>
-# Missing dependencies for community.mongodb: ansible ansible-lint docker molecule python-vagrant
+# Missing dependencies for community.mongodb: ansible-lint docker molecule python-vagrant
 <transform file path=.*/vendor-packages/ansible_collections/community/mongodb/ -> drop>
 # Missing dependencies for community.okd: kubernetes requests-oauthlib
 <transform file path=.*/vendor-packages/ansible_collections/community/okd/ -> drop>
@@ -16310,14 +16310,10 @@ depend type=require fmri=pkg:/library/python/ansible-core-$(PYV)
 <transform file path=.*/vendor-packages/ansible_collections/community/postgresql/ -> drop>
 # Missing dependencies for community.routeros: librouteros
 <transform file path=.*/vendor-packages/ansible_collections/community/routeros/ -> drop>
-# Missing dependencies for community.skydive: ansible
-<transform file path=.*/vendor-packages/ansible_collections/community/skydive/ -> drop>
 # Missing dependencies for community.vmware: pyvmomi
 <transform file path=.*/vendor-packages/ansible_collections/community/vmware/ -> drop>
-# Missing dependencies for community.zabbix: ansible ansible-compat docker ipaddr molecule molecule-docker pytest-testinfra
+# Missing dependencies for community.zabbix: ansible-compat docker ipaddr molecule molecule-docker pytest-testinfra
 <transform file path=.*/vendor-packages/ansible_collections/community/zabbix/ -> drop>
-# Missing dependencies for cyberark.conjur: ansible
-<transform file path=.*/vendor-packages/ansible_collections/cyberark/conjur/ -> drop>
 # Missing dependencies for dellemc.openmanage: omsdk
 <transform file path=.*/vendor-packages/ansible_collections/dellemc/openmanage/ -> drop>
 # Missing dependencies for dellemc.powerflex: pypowerflex

--- a/components/python/ansible/python-integrate-project.conf
+++ b/components/python/ansible/python-integrate-project.conf
@@ -80,7 +80,8 @@ cat "$SOURCE_DIR/tags.yaml" | egrep -v '^(#| )' | sed -e 's/:$//' | tr '.' '/' |
 	    -name tests -prune \
 	    -o \( -name requirements-test.txt -o -name requirements-dev.txt \) -prune \
 	    -o \( -type f -name requirements*.txt -o -name ee-requirements.txt \) -exec cat {} \; \
-		| "$WS_TOP/tools/python-requires" - | sed -e 's|^|/library/python/|' | LC_ALL=C sort -u)
+		| "$WS_TOP/tools/python-requires" - | grep -v '^ansible$' \
+		| sed -e 's|^|/library/python/|' | LC_ALL=C sort -u)
 	[[ -n "$DEPS" ]] || continue
 
 	# Check requirements


### PR DESCRIPTION
This will add `community/skydive` and `cyberark/conjur` to the package.