### PR TITLE
Change group for pkgconfig directrories to bin.

### DIFF
--- a/transforms/defaults
+++ b/transforms/defaults
@@ -32,8 +32,8 @@
 <transform dir path=etc/profile.d/.* -> default group sys>
 <transform dir path=etc/skel$ -> default group sys>
 <transform dir path=usr$ -> default group sys>
-<transform dir path=usr/lib/pkgconfig$ -> default group other>
-<transform dir path=usr/lib/.*/pkgconfig$ -> default group other>
+<transform dir path=usr/lib/pkgconfig$ -> default group bin>
+<transform dir path=usr/lib/.*/pkgconfig$ -> default group bin>
 <transform dir path=usr/share$ -> default group sys>
 <transform dir path=usr/share/application-registry$ -> default group other>
 <transform dir path=usr/share/aclocal$ -> default group other>


### PR DESCRIPTION
This change has to be merged after integration of illumos ticket #14639 / Gerrit #2115:
Add pkg-config support for libuuid - provide uuid.pc files