### PR TITLE
gexiv2: update to 0.14.1 and drop 32 bit

### DIFF
--- a/components/library/gexiv2/Makefile
+++ b/components/library/gexiv2/Makefile
@@ -14,17 +14,17 @@
 # Copyright 2021 Andreas Wacknitz
 #
 
-BUILD_BITS= 32_and_64
+BUILD_BITS= 64
 BUILD_STYLE= meson
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gexiv2
 COMPONENT_MJR_VERSION=	0.14
-COMPONENT_VERSION= $(COMPONENT_MJR_VERSION).0
+COMPONENT_VERSION= $(COMPONENT_MJR_VERSION).1
 COMPONENT_SUMMARY= GObject wrapper around the Exiv2 photo metadata library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH=	sha256:e58279a6ff20b6f64fa499615da5e9b57cf65ba7850b72fafdf17221a9d6d69e
+COMPONENT_ARCHIVE_HASH=	sha256:ec3ee3ec3860b9c78958a55da89cf76ae2305848e12f41945b7b52124d8f6cf9
 COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/gexiv2/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://wiki.gnome.org/Projects/gexiv2
 COMPONENT_FMRI= image/library/gexiv2
@@ -36,19 +36,22 @@ include $(WS_MAKE_RULES)/common.mk
 
 PKG_MACROS += PYVER=$(PYTHON_VERSION)
 
-CONFIGURE_OPTIONS.32 += -Dintrospection=false
-CONFIGURE_OPTIONS.32 += -Dvapi=false
-CONFIGURE_OPTIONS.32 += -Dpython3=false
+CONFIGURE_OPTIONS    += -Dtests=true
 
 # gobject-introspection requires this
 COMPONENT_BUILD_ENV += CC="$(CC)"
 COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
 
+COMPONENT_POST_INSTALL_ACTION += \
+	$(MKDIR) $(PROTOUSRLIBDIR)/python$(PYTHON_VERSION)/vendor-packages; \
+	$(MV) $(PROTOUSRLIBDIR)/python$(PYTHON_VERSION)/site-packages/* $(PROTOUSRLIBDIR)/python$(PYTHON_VERSION)/vendor-packages/; \
+	$(PYTHON) -m compileall $(PROTOUSRLIBDIR)/python$(PYTHON_VERSION)/vendor-packages;
+
 COMPONENT_TEST_TRANSFORMS += \
 	'-n ' \
 	'-e "/Ok:/p" ' \
 	'-e "/Expected Fail:/p" ' \
-	'-e "/Fail:/p" ' \
+	'-e "/^Fail:/p" ' \
 	'-e "/Unexpected Pass:/p" ' \
 	'-e "/Skip:/p" ' \
 	'-e "/Timeout:/p" ' \

--- a/components/library/gexiv2/gexiv2.p5m
+++ b/components/library/gexiv2/gexiv2.p5m
@@ -36,13 +36,9 @@ file path=usr/include/gexiv2/gexiv2-version.h
 file path=usr/include/gexiv2/gexiv2.h
 file path=usr/lib/$(MACH64)/girepository-1.0/GExiv2-0.10.typelib
 link path=usr/lib/$(MACH64)/libgexiv2.so target=libgexiv2.so.2
-link path=usr/lib/$(MACH64)/libgexiv2.so.2 target=libgexiv2.so.2.14.0
-file path=usr/lib/$(MACH64)/libgexiv2.so.2.14.0
+link path=usr/lib/$(MACH64)/libgexiv2.so.2 target=libgexiv2.so.2.14.1
+file path=usr/lib/$(MACH64)/libgexiv2.so.2.14.1
 file path=usr/lib/$(MACH64)/pkgconfig/gexiv2.pc
-link path=usr/lib/libgexiv2.so target=libgexiv2.so.2
-link path=usr/lib/libgexiv2.so.2 target=libgexiv2.so.2.14.0
-file path=usr/lib/libgexiv2.so.2.14.0
-file path=usr/lib/pkgconfig/gexiv2.pc
 file path=usr/lib/python$(PYVER)/vendor-packages/gi/overrides/GExiv2.py
 file path=usr/share/gir-1.0/GExiv2-0.10.gir
 file path=usr/share/vala/vapi/gexiv2.deps

--- a/components/library/gexiv2/manifests/sample-manifest.p5m
+++ b/components/library/gexiv2/manifests/sample-manifest.p5m
@@ -34,13 +34,9 @@ file path=usr/include/gexiv2/gexiv2-version.h
 file path=usr/include/gexiv2/gexiv2.h
 file path=usr/lib/$(MACH64)/girepository-1.0/GExiv2-0.10.typelib
 link path=usr/lib/$(MACH64)/libgexiv2.so target=libgexiv2.so.2
-link path=usr/lib/$(MACH64)/libgexiv2.so.2 target=libgexiv2.so.2.14.0
-file path=usr/lib/$(MACH64)/libgexiv2.so.2.14.0
+link path=usr/lib/$(MACH64)/libgexiv2.so.2 target=libgexiv2.so.2.14.1
+file path=usr/lib/$(MACH64)/libgexiv2.so.2.14.1
 file path=usr/lib/$(MACH64)/pkgconfig/gexiv2.pc
-link path=usr/lib/libgexiv2.so target=libgexiv2.so.2
-link path=usr/lib/libgexiv2.so.2 target=libgexiv2.so.2.14.0
-file path=usr/lib/libgexiv2.so.2.14.0
-file path=usr/lib/pkgconfig/gexiv2.pc
 file path=usr/lib/python$(PYVER)/vendor-packages/gi/overrides/GExiv2.py
 file path=usr/share/gir-1.0/GExiv2-0.10.gir
 file path=usr/share/vala/vapi/gexiv2.deps

--- a/components/library/gexiv2/pkg5
+++ b/components/library/gexiv2/pkg5
@@ -1,11 +1,7 @@
 {
     "dependencies": [
-        "SUNWcs",
-        "developer/build/meson",
-        "developer/build/ninja",
         "image/library/exiv2",
         "library/glib2",
-        "shell/ksh93",
         "system/library",
         "system/library/g++-10-runtime",
         "system/library/gcc-10-runtime",

--- a/components/library/gexiv2/test/results-all.master
+++ b/components/library/gexiv2/test/results-all.master
@@ -1,5 +1,4 @@
-Ok:                 2   
-Expected Fail:      0   
+Ok:                 3   
 Expected Fail:      0   
 Fail:               0   
 Unexpected Pass:    0   


### PR DESCRIPTION
The only consumer is gimp which is 64 bit only