### PR TITLE
make-rules: support for TEST_CONFLICTING_PACKAGES

### DIFF
--- a/make-rules/environment.mk
+++ b/make-rules/environment.mk
@@ -63,6 +63,11 @@ component-test-environment-check:: component-environment-check
 	$(call separator-line,Required Additional Packages Needed for Testing Only)
 	@[ -z "$(strip $(USERLAND_TEST_REQUIRED_PACKAGES))$(strip $(TEST_REQUIRED_PACKAGES))" ] || \
 		/usr/bin/pkg list -vH $(USERLAND_TEST_REQUIRED_PACKAGES:%=/%) $(TEST_REQUIRED_PACKAGES:%=/%)
+	@C=0 ; \
+		for p in $(TEST_CONFLICTING_PACKAGES) ; do \
+			/usr/bin/pkg list -q /$$p && echo "Conflicting package $$p found" && C=1 ; \
+		done ; \
+		exit $$C
 	$(call separator-line)
 
 component-test-environment-prep::

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1349,6 +1349,9 @@ TEST_REQUIRED_PACKAGES += $(foreach ver,$(PYTHON_VERSIONS),$(TEST_REQUIRED_PACKA
 REQUIRED_PACKAGES += $(foreach ver,$(PERL_VERSIONS),$(PERL_REQUIRED_PACKAGES:%=%-$(shell echo $(ver) | tr -d .)))
 TEST_REQUIRED_PACKAGES += $(foreach ver,$(PERL_VERSIONS),$(TEST_REQUIRED_PACKAGES.perl:%=%-$(shell echo $(ver) | tr -d .)))
 
+# Generate conflicting packages for all built python version variants for given package
+TEST_CONFLICTING_PACKAGES += $(foreach ver,$(PYTHON_VERSIONS),$(TEST_CONFLICTING_PACKAGES.python:%=%-$(shell echo $(ver) | tr -d .)))
+
 include $(WS_MAKE_RULES)/environment.mk
 include $(WS_MAKE_RULES)/depend.mk
 include $(WS_MAKE_RULES)/component.mk 


### PR DESCRIPTION
Tests for some Python components fails when there are some other packages installed.  For example tests for `pytest-xdist` fails when there is `teamcity-messages` or `pytest-randomly` installed.  Such packages are conflicting with `pytest-xdist` tests.  So far we just added a comment to the affected component (to its `Makefile`) describing the conflict.  But as time goes and number of packages with similar conflicts increases it would be great to have some support to report such conflicts.

This PR adds support for the `test-env-check` target to detect and report such conflicts.