### PR TITLE
shared-macros.mk: fix unset BITS for simple BUILD_BITS

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -134,6 +134,11 @@ LINKER =		gcc
 # Possible values are: '32', '64', '32_and_64', '64_and_32', and 'NO_ARCH' (the
 # orderings specify build preference).
 BUILD_BITS ?= 64
+ifeq ($(strip $(BUILD_BITS)),64)
+BITS ?=         64
+else
+BITS ?=         32
+endif
 
 # Based on BUILD_BITS, determine which binaries are preferred for a build.
 # This macro is for the convenience of other make-rules files and should not be


### PR DESCRIPTION
This fixes a problem where BITS is not correctly set (eg. for thunderbird).

We still have a problem with BUILD_BITS either 32_and_64 or 64_and_32 where BITS is not available (but needed) in configure phase.