### PR TITLE
cppunit - rebuild to remove gcc 7 dependency

### DIFF
--- a/components/developer/cppunit/Makefile
+++ b/components/developer/cppunit/Makefile
@@ -13,11 +13,12 @@
 # Copyright (c) 2013, Igor Kozhukhov <ikozhukhov@gmail.com>.  All rights reserved.
 # Copyright (c) 2020, Andreas Wacknitz
 #
-BUILD_BITS=				32_and_64
+BUILD_BITS=				64_and_32
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=			cppunit
 COMPONENT_VERSION=		1.15.1
+COMPONENT_REVISION=		1
 COMPONENT_FMRI=			developer/cppunit
 COMPONENT_SUMMARY=		Unit Testing Library for C++
 COMPONENT_CLASSIFICATION=Development/C++

--- a/components/developer/cppunit/cppunit.p5m
+++ b/components/developer/cppunit/cppunit.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/developer/cppunit/manifests/sample-manifest.p5m
+++ b/components/developer/cppunit/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2020 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/developer/cppunit/pkg5
+++ b/components/developer/cppunit/pkg5
@@ -2,8 +2,8 @@
     "dependencies": [
         "SUNWcs",
         "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime"
+        "system/library/g++-10-runtime",
+        "system/library/gcc-10-runtime"
     ],
     "fmris": [
         "developer/cppunit"


### PR DESCRIPTION
due to a mix of libstdc++.so.6, one provided by gcc-7 path introduced by libcppunit-1.15.so.1 and one provided by gcc-10 used for the package build (i.e. squid) tests failed with strange segfault. 