### PR TITLE
openssl-3.1: add SPARC support, fix pkgdepend.

### DIFF
--- a/components/library/openssl/openssl-3.1/Makefile
+++ b/components/library/openssl/openssl-3.1/Makefile
@@ -28,6 +28,7 @@ COMPONENT_VERSION_SHORT= 3.1
 COMPONENT_NAME=	openssl-$(COMPONENT_VERSION_SHORT)
 
 COMPONENT_VERSION=	3.1.0
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		library/security/openssl-31
 COMPONENT_CLASSIFICATION=System/Security
 COMPONENT_SUMMARY=	OpenSSL - a Toolkit for Transport Layer (TLS v1+) protocols and general purpose cryptographic library
@@ -58,10 +59,8 @@ CONFIGURE_OPTIONS += --libdir=lib/$(ARCHLIBSUBDIR)
 # comply with API 1.0 for now
 CONFIGURE_OPTIONS += --api=1.1.1
 CONFIGURE_OPTIONS += shared threads zlib
-# explicitly enabled
-ifeq ($(strip $(MACH)),i386)
+
 CONFIGURE_OPTIONS.64 += enable-ec_nistp_64_gcc_128
-endif
 
 # We define our own compiler and linker option sets for Solaris. See Configure
 # for more information.

--- a/components/library/openssl/openssl-3.1/openssl-3.1.p5m
+++ b/components/library/openssl/openssl-3.1/openssl-3.1.p5m
@@ -26,24 +26,9 @@
 <transform link mediator=openssl -> default mediator-implementation openssl>
 <transform link mediator=openssl -> default mediator-version 3.1>
 
-set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/usr/openssl/3.1/lib:/usr/openssl/3.1/lib/$(MACH64)
+set name=pkg.depend.runpath value=$PKGDEPEND_RUNPATH:/usr/openssl/3.1/lib:/usr/lib:/usr/openssl/3.1/lib/$(MACH64):/usr/lib/64
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
-
-# Fix Dependency detection not working for zlib for whatever reason
-# probalb pkgdepend being a princess again
-<transform file path=usr/openssl/3.1/lib/$(MACH64)/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/lib/64/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/$(MACH64)/libcrypto.so.* -> add pkg.depend.bypass-generate "lib/64/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/$(MACH64)/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/openssl/3.1/lib/amd64/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/$(MACH64)/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/openssl/3.1/lib/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/$(MACH64)/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/gcc/10/lib/amd64/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/lib/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/libcrypto.so.* -> add pkg.depend.bypass-generate "lib/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/openssl/3.1/lib/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/openssl/3.1/lib/amd64/libz.so.1">
-<transform file path=usr/openssl/3.1/lib/libcrypto.so.* -> add pkg.depend.bypass-generate "usr/gcc/10/lib/libz.so.1">
-
-depend fmri=library/zlib type=require
 
 ### Basic directories, links, and a configuration file.
 link path=etc/openssl/3.1/certs target=../certs pkg.linted.userland.action002.0=true


### PR DESCRIPTION
Just one line up in the manifest was the pkgdepend hassel with libz.so.1