### PR TITLE
minidlna: Rebuild after libFLAC update

### DIFF
--- a/components/encumbered/minidlna/Makefile
+++ b/components/encumbered/minidlna/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= minidlna
 COMPONENT_VERSION= 1.3.2
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY=  MiniDLNA DLNA/UPnP-AV media server
 COMPONENT_PROJECT_URL= https://sourceforge.net/projects/minidlna/
 COMPONENT_FMRI= media/minidlna


### PR DESCRIPTION
minidlna uses the libFLAC library.
The version we deliver wants to use the lib-version

libFLAC.so.8 =>  /usr/lib/64/libFLAC.so.8

This libFLAC version doesn't exist anymore.

The new version for minidlna is

libFLAC.so.12 =>         /usr/lib/64/libFLAC.so.12

minidlna needs only to be recompiled.
=> 
minidlna version didn't changed.
No test exists.

Recompiled version works fine.
Tested with VLC-program on different clients (Linux, Windows, Android)




