### PR TITLE
libmicrohttpd: removed unneeded old workarounds

### DIFF
--- a/components/library/libmicrohttpd/Makefile
+++ b/components/library/libmicrohttpd/Makefile
@@ -11,6 +11,7 @@
 #
 # Copyright 2014 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
 # Copyright 2019 Michal Nowak
+# Copyright 2023 Karlson2k (Evgeny Grin) <k2k@narod.ru>
 #
 
 BUILD_BITS= 64_and_32
@@ -19,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libmicrohttpd
 COMPONENT_VERSION=	0.9.77
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	GNU libmicrohttpd is a small HTTP server as a C library
 COMPONENT_PROJECT_URL=	https://www.gnu.org/software/libmicrohttpd/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -32,16 +34,9 @@ COMPONENT_LICENSE=	LGPL2.1+
 
 include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_PREP_ACTION += (cd $(@D) && autoreconf -fi)
-
-CONFIGURE_ENV += LIBS="-lnsl -lsocket"
-
-CONFIGURE_OPTIONS += --enable-epoll=no
-CONFIGURE_OPTIONS += --enable-itc=socketpair
 CONFIGURE_OPTIONS += --disable-static
-
-# Tests work properly only for curl with GnuTLS SSL backend (we use OpenSSL only),
-# see https://gnunet.org/bugs/view.php?id=5564.
+# Make sure that HTTPS is enabled
+CONFIGURE_OPTIONS += --enable-https
 
 # Needed for "gmake test" to work successfully.
 # If SHELLOPTS is exported (as it is by the userland makefiles),
@@ -51,9 +46,6 @@ CONFIGURE_OPTIONS += --disable-static
 unexport SHELLOPTS
 
 COMPONENT_TEST_ENV += LD_OPTIONS="$(LD_OPTIONS)"
-
-# Manually added build dependencies
-REQUIRED_PACKAGES += system/library/security/libgcrypt
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/gnutls-3

--- a/components/library/libmicrohttpd/pkg5
+++ b/components/library/libmicrohttpd/pkg5
@@ -1,8 +1,7 @@
 {
     "dependencies": [
         "library/gnutls-3",
-        "system/library",
-        "system/library/security/libgcrypt"
+        "system/library"
     ],
     "fmris": [
         "library/libmicrohttpd"


### PR DESCRIPTION
Several changes:
* Dropped unneeded rebuild of autotools files
* Removed enforcement of `-lnsl -lsocket` libs, they are detected automatically by configure
* Removed forced fallback to socketpair instead of EventFD. EventFD has long been fixed in the illumos kernel, fallback is not needed anymore.
* Removed disable of epoll functionality. epoll has long been fixed in the illumos kernel, disabling is not needed anymore.
* Added configure option to ensure that HTTPS is detected and built.
* Removed not needed libgcrypt library. It was required for proper initialisation of GnuTLS in early 2.x days.

Tests results file was updated, but it has no difference. This is an additional proof that workarounds are not needed.