### PR TITLE
Jenkins recipe helpers - detect UPSTREAM_VERSION again

### DIFF
--- a/components/developer/jenkins-core-lts/check-version.sh
+++ b/components/developer/jenkins-core-lts/check-version.sh
@@ -2,14 +2,14 @@
 
 # Find the latest (tarball) release under original site
 #
-# Copyright 2016-2020 Jim Klimov
+# Copyright 2016-2023 Jim Klimov
 #
 
 BASE_URL="https://get.jenkins.io/war-stable/"
 DL_PAGE_URL="https://www.jenkins.io/download/"
 
 echo "=== Checking latest numbered release under $BASE_URL..."
-UPSTREAM_VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'DIR.*[0-9]*\.[0-9]*' | grep -vw latest | tail -1 | sed 's,^.*a href="\([0-9]*\.[0-9]*\.[0-9]*\)/*".*,\1,'`" \
+UPSTREAM_VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'href="[0-9]*\.[0-9]*\.[0-9]*/"' | grep -vw latest | sed 's,^.*a href="\([0-9]*\.[0-9]*\.[0-9]*\)/*".*,\1,' | sort -t. -k1n,1n -k2n,2n -k3n,3n | tail -1`" \
     && [ -n "$UPSTREAM_VERSION" ] && echo "Latest UPSTREAM_VERSION   = $UPSTREAM_VERSION" \
     || echo "WARNING: Could not fetch an UPSTREAM_VERSION, check manually at $DL_PAGE_URL " >&2
 

--- a/components/developer/jenkins-core-lts/check-version.sh
+++ b/components/developer/jenkins-core-lts/check-version.sh
@@ -26,5 +26,5 @@ if [ "$MAKEFILE_CHECKSUM" = "$UPSTREAM_CHECKSUM" ] ; then
     echo "=== MAKEFILE_CHECKSUM matches the UPSTREAM_CHECKSUM currently"
 fi
 
-echo "=== Please edit the Makefile and commit like this:"
+echo "=== Please edit the Makefile and commit like this (if needed):"
 echo "    git add -p Makefile; git commit -m 'Bump jenkins-core-lts to v${UPSTREAM_VERSION}'"

--- a/components/developer/jenkins-core-weekly/check-version.sh
+++ b/components/developer/jenkins-core-weekly/check-version.sh
@@ -26,5 +26,5 @@ if [ "$MAKEFILE_CHECKSUM" = "$UPSTREAM_CHECKSUM" ] ; then
     echo "=== MAKEFILE_CHECKSUM matches the UPSTREAM_CHECKSUM currently"
 fi
 
-echo "=== Please edit the Makefile and commit like this:"
+echo "=== Please edit the Makefile and commit like this (if needed):"
 echo "    git add -p Makefile; git commit -m 'Bump jenkins-core-weekly to v${UPSTREAM_VERSION}'"

--- a/components/developer/jenkins-core-weekly/check-version.sh
+++ b/components/developer/jenkins-core-weekly/check-version.sh
@@ -2,14 +2,14 @@
 
 # Find the latest (tarball) release under original site
 #
-# Copyright 2016-2020 Jim Klimov
+# Copyright 2016-2023 Jim Klimov
 #
 
 BASE_URL="https://get.jenkins.io/war/"
 DL_PAGE_URL="https://www.jenkins.io/download/"
 
 echo "=== Checking latest numbered release under $BASE_URL..."
-UPSTREAM_VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'DIR.*[0-9]*\.[0-9]*' | grep -vw latest | tail -1 | sed 's,^.*a href="\([0-9]*\.[0-9]*\)/*".*,\1,'`" \
+UPSTREAM_VERSION="`wget -q -O - "$BASE_URL" 2>/dev/null | egrep 'href="[0-9]*\.[0-9]*/"' | grep -vw latest | sed 's,^.*a href="\([0-9]*\.[0-9]*\)/*".*,\1,' | sort -t. -k1n,1n -k2n,2n | tail -1`" \
     && [ -n "$UPSTREAM_VERSION" ] && echo "Latest UPSTREAM_VERSION   = $UPSTREAM_VERSION" \
     || echo "WARNING: Could not fetch an UPSTREAM_VERSION, check manually at $DL_PAGE_URL " >&2
 


### PR DESCRIPTION
Relies on HTML markup of remote site, so subject to bit-rot and such maintenance from time to time.
Not part of automated workflows however, so not a critically big deal.

FWIW, also note that we detect separately a newest set of numbers from a list, and a checksum per their "latest" symlink, and assume the two resolve to the same version and set of files. It is theoretically feasible that some release is retracted etc. so "latest" does not point to newest numbers... but then the package build attempt would fail checksum tests so also not critical.