### PR TITLE
minimal_install: remove sdcard/real-mode on SPARC.

### DIFF
--- a/components/meta-packages/install-types/includes/minimal_sparcv9
+++ b/components/meta-packages/install-types/includes/minimal_sparcv9
@@ -96,7 +96,6 @@ depend type=require fmri=driver/storage/pmcs
 depend type=require fmri=driver/storage/qus
 depend type=require fmri=driver/storage/sbp2
 depend type=require fmri=driver/storage/scsa1394
-depend type=require fmri=driver/storage/sdcard
 depend type=require fmri=driver/storage/ses
 depend type=require fmri=driver/storage/sf
 depend type=require fmri=driver/storage/smp
@@ -136,7 +135,6 @@ depend type=require fmri=storage/mpathadm
 depend type=require fmri=storage/stmf
 depend type=require fmri=system/accounting/legacy
 depend type=require fmri=system/boot/grub
-depend type=require fmri=system/boot/real-mode
 depend type=require fmri=system/data/hardware-registry
 depend type=require fmri=system/data/keyboard/keytables
 depend type=require fmri=system/data/terminfo


### PR DESCRIPTION
driver/storage/sdcard used to deliver nothing on SPARC empty package, has been removed from the distribution, the corresponding package in x86 is now i386 only, because of the ongoing SPARC removal.
Of course system/boot/real-mode was a mistake by me - sorry for that.
