### PR TITLE
postgresql-common: remove dependency on postgres library and move var/postgres dir

### DIFF
--- a/components/database/postgresql-12/postgresql12-service.p5m
+++ b/components/database/postgresql-12/postgresql12-service.p5m
@@ -33,7 +33,6 @@ file files/user_attr path=etc/user_attr.d/postgres-12
 file files/postgresql_12.xml path=lib/svc/manifest/application/database/postgresql_12.xml   restart_fmri=svc:/system/manifest-import:default
 file files/postgres_12 mode=0555 path=lib/svc/method/postgres_12
 
-dir group=postgres mode=0755 owner=postgres path=var/postgres
 dir group=postgres mode=0755 owner=postgres path=var/postgres/12
 dir group=postgres mode=0700 owner=postgres path=var/postgres/12/backups
 dir group=postgres mode=0700 owner=postgres path=var/postgres/12/data

--- a/components/database/postgresql-14/postgresql14-service.p5m
+++ b/components/database/postgresql-14/postgresql14-service.p5m
@@ -35,7 +35,6 @@ file files/user_attr path=etc/user_attr.d/postgres-14
 file files/postgresql_14.xml path=lib/svc/manifest/application/database/postgresql_14.xml   restart_fmri=svc:/system/manifest-import:default
 file files/postgres_14 mode=0555 path=lib/svc/method/postgres_14
 
-dir group=postgres mode=0755 owner=postgres path=var/postgres
 dir group=postgres mode=0755 owner=postgres path=var/postgres/14
 dir group=postgres mode=0700 owner=postgres path=var/postgres/14/backups
 dir group=postgres mode=0700 owner=postgres path=var/postgres/14/data

--- a/components/database/postgresql-common/Makefile
+++ b/components/database/postgresql-common/Makefile
@@ -16,10 +16,10 @@
 include ../../../make-rules/shared-macros.mk
 
 # Beside the p5m file, there is really nothing to this component which just
-# delivers a user and group actions as a common ground for PostGreSQL database servers.
-# Originally this has been deployed by the oldest PostGreSQL version we provide.
+# delivers a user and group actions as a common ground for PostgreSQL database servers.
+# Version number of this component is not related to PostgreSQL version.
 COMPONENT_NAME=				postgres-common
-COMPONENT_VERSION=			9.6
+COMPONENT_VERSION=			10
 COMPONENT_SUMMARY=			PostgreSQL common version independent files
 COMPONENT_FMRI=				database/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	Development/Databases

--- a/components/database/postgresql-common/manifests/sample-manifest.p5m
+++ b/components/database/postgresql-common/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/database/postgresql-common/pkg5
+++ b/components/database/postgresql-common/pkg5
@@ -1,9 +1,5 @@
 {
-    "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
-        "system/library"
-    ],
+    "dependencies": [],
     "fmris": [
         "database/postgres-common"
     ],

--- a/components/database/postgresql-common/postgresql-common.p5m
+++ b/components/database/postgresql-common/postgresql-common.p5m
@@ -15,6 +15,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
@@ -24,8 +25,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 group gid=90 groupname=postgres
 user ftpuser=false gcos-field="PostgreSQL Reserved UID" group=postgres login-shell=/usr/bin/pfksh password=NP uid=90 username=postgres home-dir="/var/postgres"
 
-depend type=require-any \
-  fmri=pkg:/database/postgres-96/library \
-  fmri=pkg:/database/postgres-10/library \
-  fmri=pkg:/database/postgres-11/library \
-  fmri=pkg:/database/postgres-12/library
+dir group=postgres mode=0755 owner=postgres path=var/postgres


### PR DESCRIPTION
`postgres-common` is a helper package for actual postgres services packages only so there is no need to depend on `database/postgres-XX/library`.  In addition, such dependency tend to become outdated.