### PR TITLE
libxml2: correct vendor_packages install bug.

### DIFF
--- a/components/library/libxml2/Makefile
+++ b/components/library/libxml2/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libxml2
 COMPONENT_VERSION=	2.10.4
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Libxml2 is the XML C parser and toolkit developed for the Gnome project
 COMPONENT_PROJECT_URL=	https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -63,7 +64,6 @@ CONFIGURE_OPTIONS += --sysconfdir=$(ETCDIR)
 CONFIGURE_OPTIONS += --localstatedir="$(VARDIR)"
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --with-pic
-CONFIGURE_OPTIONS += --with-icu
 CONFIGURE_OPTIONS += --with-ftp
 CONFIGURE_OPTIONS += --with-xptr-locs
 CONFIGURE_OPTIONS += --with-history
@@ -71,10 +71,8 @@ CONFIGURE_OPTIONS += --with-legacy
 CONFIGURE_OPTIONS.32 += --with-python=no
 
 CONFIGURE_ENV.64     += PYTHON=$(PYTHON.$(PYTHON_VERSION))
-COMPONENT_INSTALL_ARGS.64 += pythondir=$(PYTHON_VENDOR_PACKAGES)
-COMPONENT_INSTALL_ARGS.64 += pyexecdir=$(PYTHON_VENDOR_PACKAGES)
-COMPONENT_BUILD_ARGS.64 += pythondir=$(PYTHON_VENDOR_PACKAGES)
-COMPONENT_BUILD_ARGS.64 += pyexecdir=$(PYTHON_VENDOR_PACKAGES)
+CONFIGURE_ENV.64     += am_cv_python_pythondir=$(PYTHON_VENDOR_PACKAGES)
+CONFIGURE_ENV.64     += am_cv_python_pyexecdir=$(PYTHON_VENDOR_PACKAGES)
 
 COMPONENT_PREP_ACTION += (cd $(@D) ; cp ../mapfile libxml2.syms ; PATH="$(PATH)" autoreconf -if )
 

--- a/components/library/libxml2/history
+++ b/components/library/libxml2/history
@@ -1,5 +1,0 @@
-library/python/libxml2-27@2.9.9-2020.0.1.6
-library/python/libxml2-35@2.9.9-2020.0.1.5
-library/python/libxml2-34@2.9.9-2020.0.1.1
-library/python-2/libxml2-26@2.9.4,5.11-2016.0.1.0
-library/python-2/libxml2-27@2.9.4,5.11-2016.0.1.0

--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -749,6 +749,8 @@ library/python-2/lcms-27@1.19,5.11-2016.0.1.0
 library/python-2/libbe-27@0.5.11,5.11-2016.0.1.0
 library/python-2/libbe@0.5.11,5.11-2016.0.1.0
 library/python-2/libxml2-24@2.7.6,5.11-2015.0.2.0
+library/python-2/libxml2-26@2.9.4,5.11-2016.0.1.0
+library/python-2/libxml2-27@2.9.4,5.11-2016.0.1.0
 library/python-2/libxsl-24@1.1.26,5.11-2015.0.2.0
 library/python-2/logilab-astng-26@0.24.0,5.11-2016.0.1.0
 library/python-2/logilab-astng-27@0.24.0,5.11-2016.0.1.0
@@ -886,6 +888,9 @@ library/python/kafka-python-27@2.0.1,5.11-2020.0.1.1
 library/python/kafka-python-35@2.0.1,5.11-2020.0.1.1
 library/python/kafka-python@2.0.1,5.11-2020.0.1.1
 library/python/lcms-27@1.19,5.11-2020.0.1.4
+library/python/libxml2-27@2.9.9-2020.0.1.6
+library/python/libxml2-35@2.9.9-2020.0.1.5
+library/python/libxml2-34@2.9.9-2020.0.1.1
 library/python/livereload-27@2.6.1,5.11-2020.0.1.1
 library/python/livereload@2.6.1,5.11-2020.0.1.1
 library/python/logilab-astng-27@0.24.3,5.11-2020.0.1.2


### PR DESCRIPTION
Move old python-libxml versions to history file. Remove --with-icu conigure option to get rid of C++ dependencies, causes too much trouble with other software which is needed by libxml2. Oracle also doesn't use this option at all.
