### PR TITLE
openmpi - fix duplicate man pages

### DIFF
--- a/components/library/openmpi/Makefile
+++ b/components/library/openmpi/Makefile
@@ -20,6 +20,7 @@ include $(WS_MAKE_RULES)/mpi-macros.mk
 COMPONENT_NAME =            openmpi/$(COMPILER)
 OPENMPI_VERSION_MAJOR =     4.1
 COMPONENT_VERSION =         $(OPENMPI_VERSION_MAJOR).5
+COMPONENT_REVISION =        1
 COMPONENT_FMRI =            library/openmpi/$(COMPILER)
 COMPONENT_CLASSIFICATION =  Development/High Performance Computing
 COMPONENT_PROJECT_URL =     https://www.open-mpi.org

--- a/components/library/openmpi/openmpi.p5m
+++ b/components/library/openmpi/openmpi.p5m
@@ -291,12 +291,8 @@ file path=usr/lib/$(MACH64)/openmpi/gcc/lib/pmix/mca_ptl_usock.so
 #file path=usr/share/Modules/modulefiles/openmpi/gcc/64/$(HUMAN_VERSION)
 link path=usr/share/man/man1/mpiCC.1 target=mpic++.1
 file path=usr/share/man/man1/mpic++.1
-file path=usr/share/man/man1/mpicc.1
-file path=usr/share/man/man1/mpicxx.1
-file path=usr/share/man/man1/mpiexec.1
 file path=usr/share/man/man1/mpif77.1
 file path=usr/share/man/man1/mpif90.1
-file path=usr/share/man/man1/mpifort.1
 file path=usr/share/man/man1/mpirun.1
 file path=usr/share/man/man1/ompi-clean.1
 file path=usr/share/man/man1/ompi-server.1


### PR DESCRIPTION
remove man pages which are already provided by the /library/mpich/gcc| package.