### PR TITLE
cups: update to 2.4.5

### DIFF
--- a/components/print/cups/Makefile
+++ b/components/print/cups/Makefile
@@ -27,12 +27,11 @@ BUILD_BITS= 64_and_32
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cups
-COMPONENT_VERSION=	2.4.4
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	2.4.5
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_PROJECT_URL=	https://openprinting.github.io/cups/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC)-source.tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:5fa783c2afca330cdb03579046fd489bcf8e90d6a81afb141adfd67e4758b242
+COMPONENT_ARCHIVE_HASH=	sha256:acd5bb2eb4ca7abebb7387182fd010ccc0d6f30c8589e20f707edc831d80bf09
 COMPONENT_ARCHIVE_URL=  https://github.com/OpenPrinting/cups/archive/refs/tags/v$(HUMAN_VERSION).tar.gz
 COMPONENT_LICENSE=	Apache 2.0 with an exception to allow linking against GNU GPL2-only software
 

--- a/components/print/cups/manifests/sample-manifest.p5m
+++ b/components/print/cups/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)


### PR DESCRIPTION
sample-manifest didn't change