### PR TITLE
cups: update to 2.4.6

### DIFF
--- a/components/print/cups/Makefile
+++ b/components/print/cups/Makefile
@@ -27,12 +27,11 @@ BUILD_BITS= 64_and_32
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cups
-COMPONENT_VERSION=	2.4.5
-COMPONENT_REVSION=	1
+COMPONENT_VERSION=	2.4.6
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_PROJECT_URL=	https://openprinting.github.io/cups/
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC)-source.tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:acd5bb2eb4ca7abebb7387182fd010ccc0d6f30c8589e20f707edc831d80bf09
+COMPONENT_ARCHIVE_HASH=	sha256:7d89f684aace50e17100c78812069168f1bdc06f95623117094f8c47ef867aef
 COMPONENT_ARCHIVE_URL=  https://github.com/OpenPrinting/cups/archive/refs/tags/v$(HUMAN_VERSION).tar.gz
 COMPONENT_LICENSE=	Apache 2.0 with an exception to allow linking against GNU GPL2-only software
 


### PR DESCRIPTION
sample-manifest didn't change