### PR TITLE
shared-macros.mk: support for parallel builds opt-in

### DIFF
--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -181,7 +181,7 @@ $(foreach pyver,$(filter-out $(PYTHON_VERSION),$(PYTHON_VERSIONS)),$(eval $(call
 # where egg-info is re-generated
 CLONEY_ARGS = CLONEY_MODE="copy"
 
-COMPONENT_BUILD_CMD = $(PYTHON) setup.py --no-user-cfg build
+COMPONENT_BUILD_CMD = $(PYTHON) setup.py --no-user-cfg build $(COMPONENT_BUILD_SETUP_PY_ARGS)
 
 # build the configured source
 $(BUILD_DIR)/%/.built:	$(SOURCE_DIR)/.prep

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -418,6 +418,16 @@ CONFIGURE_NO_ARCH =	$(BUILD_DIR_NO_ARCH)/.configured
 CONFIGURE_32 =		$(BUILD_DIR_32)/.configured
 CONFIGURE_64 =		$(BUILD_DIR_64)/.configured
 
+# In ideal world all components should support parallel build but it is often
+# not the case.  So by default we do not run parallel build and allow
+# components to opt-in for parallel build by setting USE_PARALLEL_BUILD = yes
+# before the shared-macros.mk file is included.
+PARALLEL_JOBS ?= 8
+ifeq ($(strip $(USE_PARALLEL_BUILD)),yes)
+COMPONENT_BUILD_GMAKE_ARGS += -j$(PARALLEL_JOBS)
+COMPONENT_BUILD_SETUP_PY_ARGS += -j$(PARALLEL_JOBS)
+endif
+
 BUILD_DIR_NO_ARCH =	$(BUILD_DIR)/$(MACH)
 BUILD_DIR_32 =		$(BUILD_DIR)/$(MACH32)
 BUILD_DIR_64 =		$(BUILD_DIR)/$(MACH64)


### PR DESCRIPTION
If you want different number of parallel jobs than 8, just set PARALLEL_JOBS in you environment.