### PR TITLE
runtime/perl: make transition of default Perl version even more easier

### DIFF
--- a/components/meta-packages/perl/Makefile
+++ b/components/meta-packages/perl/Makefile
@@ -18,14 +18,23 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		perl
 COMPONENT_VERSION =		$(PERL_VERSION)
-COMPONENT_REVISION =		1
+COMPONENT_REVISION =		2
 COMPONENT_SUMMARY =		Perl - Highly capable, feature-rich programming language
 COMPONENT_PROJECT_URL =		https://www.perl.org/
 COMPONENT_FMRI =		runtime/perl
 COMPONENT_CLASSIFICATION =	Development/Perl
 
+SINGLE_PERL_VERSION = no
+
 include $(WS_MAKE_RULES)/common.mk
 
+PKG_MACROS += PERLVER=$(PERL_VERSION)
 PKG_MACROS += PLV=$(shell echo $(PERL_VERSION) | tr -d .)
+
+ifeq ($(PERL_VERSION),$(lastword $(PERL_VERSIONS)))
+PKG_MACROS += VENDOR_MEDIATOR=\#
+else
+PKG_MACROS += VENDOR_MEDIATOR=
+endif
 
 # Auto-generated dependencies

--- a/components/meta-packages/perl/manifests/sample-manifest.p5m
+++ b/components/meta-packages/perl/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/meta-packages/perl/perl.p5m
+++ b/components/meta-packages/perl/perl.p5m
@@ -21,3 +21,9 @@ set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 depend fmri=runtime/perl-$(PLV) type=require
+
+# These are temporary fake dir and vendor mediated symlinks used during
+# transition between Perl versions
+$(VENDOR_MEDIATOR)dir path=usr/perl5/$(PERLVER)
+$(VENDOR_MEDIATOR)link path=usr/perl5/transition-perl target=$(PERLVER) mediator=perl mediator-version=$(PERLVER) mediator-priority=vendor
+$(VENDOR_MEDIATOR)link path=usr/perl5/transition-system-perl target=$(PERLVER) mediator=system-perl mediator-version=$(PERLVER) mediator-priority=vendor

--- a/components/meta-packages/perl/pkg5
+++ b/components/meta-packages/perl/pkg5
@@ -1,9 +1,5 @@
 {
-    "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
-        "system/library"
-    ],
+    "dependencies": [],
     "fmris": [
         "runtime/perl"
     ],

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -794,10 +794,11 @@ QT6_BINDIR = $(QT6_BASEDIR)/bin/$(MACH64)
 QT6_LIBDIR = $(QT6_BASEDIR)/lib/$(MACH64)
 QT6_PKG_CONFIG_PATH = $(QT6_LIBDIR)/pkgconfig
 
-# This is the default BUILD version of perl
-# Not necessarily the system's default version, i.e. /usr/bin/perl
+# This is the default version of Perl
 PERL_VERSION =  5.36
 
+# The PERL_VERSIONS list should always be in ascending order (newest version
+# last)
 PERL_VERSIONS = 5.34 5.36
 # Perl up to 5.22 was built 32-bit only.  Starting with 5.24 the perl package
 # is built 64-bit only.  So now all PERL_VERSIONS are 64-bit only.


### PR DESCRIPTION
Perl 5.38 release is [close](https://www.nntp.perl.org/group/perl.perl5.porters/2023/06/msg266559.html) so prepare for it.