### PR TITLE
perl-536: drop vendor mediator priority for system-perl

### DIFF
--- a/components/perl/perl-536/Makefile
+++ b/components/perl/perl-536/Makefile
@@ -26,6 +26,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		perl
 COMPONENT_VERSION =		5.36.1
+COMPONENT_REVISION =		1
 COMPONENT_VERSION_MAJOR =	$(shell echo $(COMPONENT_VERSION) | $(GSED) -e 's/\(5\.[0-9]\{1,\}\)\..*/\1/g')
 COMPONENT_SUMMARY =		Perl $(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL =		https://www.perl.org/

--- a/transforms/defaults
+++ b/transforms/defaults
@@ -133,11 +133,6 @@ set name=variant.arch value=$(MACH)
 <transform link tmp.fmri=.* -> delete tmp.fmri .* >
 
 #
-# Set the default Perl for mediated links
-#
-<transform link mediator=system-perl mediator-version=5.36 -> default mediator-priority vendor>
-
-#
 # Set the default Apache for mediated links
 #
 <transform link mediator=apache mediator-version=2.2 -> default mediator-priority vendor>


### PR DESCRIPTION
Another cleanup before Perl 5.38 release.