### PR TITLE
build-essential: switch to unversioned runtime/perl

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -1,6 +1,6 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL)". You may
+# Common Development and Distribution License ("CDDL"). You may
 # only use this file in accordance with the terms of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
@@ -13,26 +13,16 @@
 # Copyright 2021 Andreas Wacknitz. All rights reserved.
 #
 
+BUILD_STYLE = pkg
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
-COMPONENT_VERSION =	4
+COMPONENT_VERSION =	5
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential
 
-include ../../../make-rules/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
-PKGLINT=/bin/true
-
-download:
-
-prep:
-
-build:
-
-install:
-	[ -d $(PROTO_DIR) ] || mkdir -p $(PROTO_DIR)
-
-clean:
-	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
+# Auto-generated dependencies

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -15,6 +15,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
@@ -106,8 +107,7 @@ depend fmri=developer/java/openjdk8 type=require
 depend fmri=developer/java/junit type=require
 
 # Runtimes
-depend fmri=runtime/perl-534 type=require
-depend fmri=runtime/perl-536 type=require
+depend fmri=runtime/perl type=require
 depend fmri=runtime/ruby type=require
 depend fmri=runtime/lua type=require
 depend fmri=library/apr-util type=require

--- a/components/meta-packages/build-essential/manifests/sample-manifest.p5m
+++ b/components/meta-packages/build-essential/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/meta-packages/build-essential/pkg5
+++ b/components/meta-packages/build-essential/pkg5
@@ -1,9 +1,5 @@
 {
-    "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
-        "system/library"
-    ],
+    "dependencies": [],
     "fmris": [
         "metapackages/build-essential"
     ],


### PR DESCRIPTION
I think this is the last preparation step before Perl 5.38 release and integration.