### PR TITLE
add SPARC GCC>=7 option -mfsmuld to optimization

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1144,8 +1144,8 @@ XPG5MODE =		$(CPP_XPG5MODE)
 #
 
 # Control the GCC optimization level.
-gcc_OPT.sparc.32 =	-O3 -mcpu=ultrasparc -mvis
-gcc_OPT.sparc.64 =	-O3 -mcpu=ultrasparc -mvis
+gcc_OPT.sparc.32 =	-O3 -mcpu=ultrasparc -mvis -mfsmuld
+gcc_OPT.sparc.64 =	-O3 -mcpu=ultrasparc -mvis -mfsmuld
 gcc_OPT.i386.32 =	-O3
 gcc_OPT.i386.64 =	-O3
 gcc_OPT =		$(gcc_OPT.$(MACH).$(BITS))


### PR DESCRIPTION
All packages for SPARC are compiled using this tuning option.