### PR TITLE
package typo system/kernel/cpu-sun4v == cpu/sun4v

### DIFF
--- a/components/meta-packages/install-types/includes/minimal_sparcv9
+++ b/components/meta-packages/install-types/includes/minimal_sparcv9
@@ -152,7 +152,7 @@ depend type=require fmri=system/install
 depend type=require fmri=system/ipc
 depend type=require fmri=system/kernel
 depend type=require fmri=system/kernel/cpu-counters
-depend type=require fmri=system/kernel/cpu-sun4v
+depend type=require fmri=system/kernel/cpu/sun4v
 depend type=require fmri=system/kernel/dtrace/providers
 depend type=require fmri=system/kernel/platform
 depend type=require fmri=system/kernel/power


### PR DESCRIPTION
CPU packages for sun4v systems should have been named:

system/kernel/cpu/sun4v

instead of

system/kernel/cpu-sun4v

Sorry for the typo.