### PR TITLE
rebuild libofa with gcc-10

### DIFF
--- a/components/library/libofa/Makefile
+++ b/components/library/libofa/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		libofa
 COMPONENT_VERSION=	222128881c792c99055fa0b9cf05e07ae9b5d818
 IPS_COMPONENT_VERSION=	0.9.3
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 # Project was initially at http://code.google.com/p/musicip-libofa/,
 # but as Google Code is closing we refer to more up-to-date mirror
 COMPONENT_PROJECT_URL=	https://github.com/tanob/libofa


### PR DESCRIPTION
one more leftover tiny lib with gcc-7 dependencies

after:
$ ldd /usr/lib/libofa.so.0.0.0 
        libfftw3.so.3 =>         /usr/lib/libfftw3.so.3
        libstdc++.so.6 =>        /usr/gcc/10/lib/libstdc++.so.6
        libm.so.2 =>     /lib/libm.so.2
        libc.so.1 =>     /lib/libc.so.1
        libgcc_s.so.1 =>         /usr/gcc/10/lib/libgcc_s.so.1
