### PR TITLE
modulebuild.mk: Module::Build is not needed to bootstrap Module::Build

### DIFF
--- a/make-rules/modulebuild.mk
+++ b/make-rules/modulebuild.mk
@@ -85,5 +85,11 @@ $(BUILD_DIR)/%/.tested:	$(BUILD_DIR)/%/.built
 		$(COMPONENT_TEST_CLEANUP)
 		$(TOUCH) $@
 
-# Build.PL needs Module::Build
+# Workaround for https://github.com/Perl-Toolchain-Gang/Module-Build/issues/91.
+# Without the workaround we would need to add library/perl-5/module-build as a
+# required package manually to all Perl components with the modulebuild build
+# style.  We do not need the library/perl-5/module-build package to bootstrap
+# the Module::Build module itself.
+ifneq ($(strip $(COMPONENT_PERL_MODULE)),Module::Build)
 USERLAND_REQUIRED_PACKAGES.perl += library/perl-5/module-build
+endif


### PR DESCRIPTION
This fixes [the recent build failure](https://hipster.openindiana.org/jenkins/job/oi-userland/9746/).