### PR TITLE
rebuild geany, dosbox, mosh for gcc-10-deps

### DIFF
--- a/components/editor/geany/Makefile
+++ b/components/editor/geany/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         geany
 COMPONENT_VERSION=      1.38
-COMPONENT_REVISION=     3
+COMPONENT_REVISION=     4
 COMPONENT_CLASSIFICATION=System/Text Tools
 COMPONENT_FMRI=         editor/geany
 COMPONENT_SUMMARY=      A fast and lightweight IDE
@@ -54,10 +54,8 @@ REQUIRED_PACKAGES += library/expat
 REQUIRED_PACKAGES += library/graphics/pixman
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += library/zlib
-REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/fontconfig
 REQUIRED_PACKAGES += system/library/freetype-2
-REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libx11
 REQUIRED_PACKAGES += x11/library/libxau
 REQUIRED_PACKAGES += x11/library/libxcb

--- a/components/editor/geany/pkg5
+++ b/components/editor/geany/pkg5
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "SUNWcs",
         "compress/bzip2",
         "developer/documentation-tool/doxygen",
         "image/library/libpng16",
@@ -16,12 +15,11 @@
         "library/graphics/pixman",
         "library/libffi",
         "library/zlib",
-        "shell/ksh93",
         "system/library",
         "system/library/fontconfig",
         "system/library/freetype-2",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime",
+        "system/library/g++-10-runtime",
+        "system/library/gcc-10-runtime",
         "system/library/math",
         "x11/library/libx11",
         "x11/library/libxau",

--- a/components/runtime/dosbox/Makefile
+++ b/components/runtime/dosbox/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		dosbox
 COMPONENT_VERSION=	0.74-3
+COMPONENT_REVISION= 1
 IPS_COMPONENT_VERSION=	0.74.3
 COMPONENT_PROJECT_URL=	https://www.dosbox.com/
 COMPONENT_SUMMARY=	DosBox - DOS Emulator

--- a/components/runtime/dosbox/dosbox.p5m
+++ b/components/runtime/dosbox/dosbox.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/runtime/dosbox/manifests/sample-manifest.p5m
+++ b/components/runtime/dosbox/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/runtime/dosbox/pkg5
+++ b/components/runtime/dosbox/pkg5
@@ -1,13 +1,12 @@
 {
     "dependencies": [
-        "SUNWcs",
         "image/library/libpng16",
         "library/audio/sdl-sound",
         "library/sdl",
         "library/zlib",
         "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime",
+        "system/library/g++-10-runtime",
+        "system/library/gcc-10-runtime",
         "system/library/math",
         "x11/library/libx11"
     ],

--- a/components/shell/mosh/Makefile
+++ b/components/shell/mosh/Makefile
@@ -26,6 +26,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		mosh
 COMPONENT_VERSION=	1.4.0
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY=	Mosh (mobile shell) - Remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line editing of user keystrokes (replacement for SSH).
 COMPONENT_PROJECT_URL=	https://mosh.org
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/shell/mosh/pkg5
+++ b/components/shell/mosh/pkg5
@@ -5,10 +5,9 @@
         "library/ncurses",
         "library/security/openssl-11",
         "library/zlib",
-        "shell/ksh93",
         "system/library",
-        "system/library/g++-7-runtime",
-        "system/library/gcc-7-runtime",
+        "system/library/g++-10-runtime",
+        "system/library/gcc-10-runtime",
         "system/library/libutempter",
         "system/library/math",
         "utility/bash-completion"


### PR DESCRIPTION
searched fpr packages in editors, runtime, encumbered and shell,
but alas these did not build:
components/encumbered/fs-uae
components/encumbered/x265
components/encumbered/audacity
components/runtime/erlang

no tests available for the succellfully packages,
sample-manifest did change only for the dosbox