### PR TITLE
firefox: add patch to support binutils >= 2.41

### DIFF
--- a/components/web/firefox/patches/05-libavcodec-binutil2.41.patch
+++ b/components/web/firefox/patches/05-libavcodec-binutil2.41.patch
@@ -1,0 +1,77 @@
+/<<PKGBUILDDIR>>/media/ffvpx/libavcodec/x86/mathops.h: Assembler messages:
+/<<PKGBUILDDIR>>/media/ffvpx/libavcodec/x86/mathops.h:125: Error: operand type mismatch for `shr'
+
+Port ffmpeg patch to Firefox for binutil >= 2.41
+
+From: Rémi Denis-Courmont <remi@remlab.net>
+Date: Sun, 16 Jul 2023 15:18:02 +0000 (+0300)
+Subject: avcodec/x86/mathops: clip constants used with shift instructions within inline assembly
+X-Git-Url: http://git.videolan.org/?p=ffmpeg.git;a=commitdiff_plain;h=effadce6c756247ea8bae32dc13bb3e6f464f0eb
+
+avcodec/x86/mathops: clip constants used with shift instructions within inline assembly
+
+Fixes assembling with binutil as >= 2.41
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed19..ca7e2dffc1 100644
+--- a/media/ffvpx/libavcodec/x86/mathops.h
++++ b/media/ffvpx/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 


### PR DESCRIPTION
vp8 and vp9 videos still play