### PR TITLE
Switching mate-install to allow older installs to update

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
 COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	56
+COMPONENT_REVISION=	57
 COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
 
 include $(WS_MAKE_RULES)/ips.mk

--- a/components/meta-packages/install-types/includes/server_desktop_aarch64
+++ b/components/meta-packages/install-types/includes/server_desktop_aarch64
@@ -10,7 +10,7 @@ depend type=require fmri=diagnostic/top
 depend type=require fmri=driver/graphics/agpgart
 depend type=require fmri=driver/graphics/atiatom
 depend type=require fmri=driver/graphics/drm
-depend type=require fmri=driver/graphics/nvidia-470
+depend type=require-any fmri=driver/graphics/nvidia fmri=driver/graphics/nvidia-515 fmri=driver/graphics/nvidia-470 fmri=driver/graphics/nvidia-390 fmri=driver/graphics/nvidia-340
 depend type=require fmri=editor/nano
 depend type=require fmri=editor/vim
 depend type=require fmri=file/gnu-coreutils

--- a/components/meta-packages/install-types/includes/server_desktop_amd64
+++ b/components/meta-packages/install-types/includes/server_desktop_amd64
@@ -10,7 +10,7 @@ depend type=require fmri=diagnostic/top
 depend type=require fmri=driver/graphics/agpgart
 depend type=require fmri=driver/graphics/atiatom
 depend type=require fmri=driver/graphics/drm
-depend type=require fmri=driver/graphics/nvidia-470
+depend type=require-any fmri=driver/graphics/nvidia fmri=driver/graphics/nvidia-515 fmri=driver/graphics/nvidia-470 fmri=driver/graphics/nvidia-390 fmri=driver/graphics/nvidia-340
 depend type=require fmri=editor/nano
 depend type=require fmri=editor/vim
 depend type=require fmri=file/gnu-coreutils

--- a/components/meta-packages/install-types/pkg5
+++ b/components/meta-packages/install-types/pkg5
@@ -1,9 +1,5 @@
 {
-    "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
-        "system/library"
-    ],
+    "dependencies": [],
     "fmris": [
         "auto_install",
         "mate_install",


### PR DESCRIPTION
and make nvidia the default driver.

This got reported by @hrosenfeld today as it was blocking upgrading.