### PR TITLE
tools/python-integrate-project: fix the directory emptying

### DIFF
--- a/tools/python-integrate-project
+++ b/tools/python-integrate-project
@@ -96,7 +96,7 @@ function get_PKGINFO_entry
 # Prepare the directory
 [[ -z "$DIRECTORY" ]] && DIRECTORY="python/$DISTRIBUTION"
 DIR="$BASE_DIR/$DIRECTORY"
-rm -rf "$DIR/*"
+rm -rf "$DIR"/*
 mkdir -p "$DIR"
 cd "$DIR"
 git restore --staged . > /dev/null 2>&1


### PR DESCRIPTION
Third attempt to make this trivial thing done properly.