### PR TITLE
Upgrade fuse to version 1.5

### DIFF
--- a/components/openindiana/fuse/Makefile
+++ b/components/openindiana/fuse/Makefile
@@ -14,17 +14,16 @@
 #
 
 BUILD_STYLE = justmake
-BUILD_BITS = NO_ARCH
+BUILD_BITS = 64
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		illumos-fusefs
-COMPONENT_VERSION=	ef9a33d4a18131a8c0e50002b138b0431e5db616
-IPS_COMPONENT_VERSION=	1.4
-COMPONENT_REVISION=	4
+COMPONENT_VERSION=	f7c3e8c785091774d75d4f11ac12f2309a3f2dbd
+IPS_COMPONENT_VERSION=	1.5
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).zip
-COMPONENT_ARCHIVE_HASH=	sha256:c050307b9364266a06b83b19c288763b1e9173ac8121431d026ccf5cdb1203b4
+COMPONENT_ARCHIVE_HASH=	sha256:06551185d2709b4ce043d98e97fccb0a375f5c4161550e594449ce09f09e8aab
 COMPONENT_ARCHIVE_URL=	https://github.com/jurikm/illumos-fusefs/archive/$(COMPONENT_VERSION).zip
 
 TEST_TARGET = $(NO_TESTS)
@@ -33,7 +32,8 @@ include $(WS_MAKE_RULES)/common.mk
 
 # Force gcc 7 for a case we would switch our default gcc to something else.
 # This should match the compiler used to build illumos-gate.
-GCC_VERSION = 7
+# Now switched to gcc 10
+GCC_VERSION = 10
 
 PATH=/opt/onbld/bin/i386:$(PATH.illumos)
 
@@ -45,12 +45,10 @@ $(BUILD_$(MK_BITS)):	$(SOURCE_DIR)/.prep
 
 $(INSTALL_$(MK_BITS)):	$(BUILD_$(MK_BITS))
 	$(MKDIR) $(PROTO_DIR)
-
 	(cd $(@D)/kernel && dmake install)
 
 	$(MKDIR) $(PROTOUSRKERNELDRVDIR) $(PROTOUSRKERNELDRVDIR64)
 
-	$(INSTALL) $(@D)/kernel/proto/$(USRKERNELDRVDIR)/fuse $(PROTOUSRKERNELDRVDIR)
 	$(INSTALL) $(@D)/kernel/proto/$(USRKERNELDRVDIR64)/fuse $(PROTOUSRKERNELDRVDIR64)
 	$(INSTALL) $(@D)/kernel/proto/$(USRKERNELDRVDIR)/fuse.conf $(PROTOUSRKERNELDRVDIR)
 

--- a/components/openindiana/fuse/Makefile
+++ b/components/openindiana/fuse/Makefile
@@ -45,6 +45,7 @@ $(BUILD_$(MK_BITS)):	$(SOURCE_DIR)/.prep
 
 $(INSTALL_$(MK_BITS)):	$(BUILD_$(MK_BITS))
 	$(MKDIR) $(PROTO_DIR)
+
 	(cd $(@D)/kernel && dmake install)
 
 	$(MKDIR) $(PROTOUSRKERNELDRVDIR) $(PROTOUSRKERNELDRVDIR64)

--- a/components/openindiana/fuse/fuse.p5m
+++ b/components/openindiana/fuse/fuse.p5m
@@ -35,5 +35,4 @@ set name=variant.opensolaris.zone value="global"
 
 driver devlink=type=ddi_pseudo;name=fuse\t\D name=fuse
 file path=usr/kernel/drv/$(MACH64)/fuse
-file path=usr/kernel/drv/fuse
 file path=usr/kernel/drv/fuse.conf preserve=true

--- a/components/openindiana/fuse/manifests/sample-manifest.p5m
+++ b/components/openindiana/fuse/manifests/sample-manifest.p5m
@@ -24,5 +24,4 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/kernel/drv/$(MACH64)/fuse
-file path=usr/kernel/drv/fuse
 file path=usr/kernel/drv/fuse.conf


### PR DESCRIPTION
For some reason it is still compiled both as 32 and 64 bits, but only the 64 bit variant is now installed