### PR TITLE
shared-macros.mk: set default Perl version to 5.38

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -836,7 +836,7 @@ QT6_PKG_CONFIG_PATH = $(QT6_LIBDIR)/pkgconfig
 #
 
 # This is the default version of Perl
-PERL_VERSION =  5.36
+PERL_VERSION =  5.38
 
 # The PERL_VERSIONS list should always be in ascending order (newest version
 # last)


### PR DESCRIPTION
This is first step of two to fully switch the default Perl to 5.38.  This is internal oi-userland switch and it will cause that the illumos-gate overnight build produce modules for Perl 5.38 instead of Perl 5.36.  The next step will be the actual Perl version switch via mediators and it will follow later.

I suggest to merge this as the last and single PR of a day, right before the illumos-gate is built.