### PR TITLE
runtime/perl: switch to Perl 5.38

### DIFF
--- a/components/meta-packages/perl/Makefile
+++ b/components/meta-packages/perl/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		perl
 COMPONENT_VERSION =		$(PERL_VERSION)
-COMPONENT_REVISION =		4
+COMPONENT_REVISION =		5
 COMPONENT_SUMMARY =		Perl - Highly capable, feature-rich programming language
 COMPONENT_PROJECT_URL =		https://www.perl.org/
 COMPONENT_FMRI =		runtime/perl

--- a/components/meta-packages/perl/history
+++ b/components/meta-packages/perl/history
@@ -1,0 +1,1 @@
+runtime/perl-536/module/sun-solaris@0.5.11,5.11-2023.0.0.21809


### PR DESCRIPTION
This is second step of switching to Perl 5.38.  I suggest to merge this as first PR after the illumos-gate is built with #13762 in place.