### PR TITLE
tools/license-detector: remove extra "GNU LESSER GENERAL PUBLIC LICENSE" from LGPL-2.1-only

### DIFF
--- a/tools/licenses/license.LGPL-2.1-only
+++ b/tools/licenses/license.LGPL-2.1-only
@@ -112,7 +112,6 @@ modification follow.  Pay close attention to the difference between a
 former contains code derived from the library, whereas the latter must
 be combined with the library in order to run.
 
-                  GNU LESSER GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License Agreement applies to any software library or other


### PR DESCRIPTION
This is to align the wording with https://spdx.org/licenses/LGPL-2.1-only.html and https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.  Please note the https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt uses the extra "GNU LESSER GENERAL PUBLIC LICENSE".  I reported the inconsistency to webmasters@gnu.org on 2023-07-14 (no response so far).