### PR TITLE
components/Makefile: we do not need to clean depends.mk

### DIFF
--- a/components/Makefile
+++ b/components/Makefile
@@ -105,7 +105,6 @@ component-hook:	$(COMPONENT_DIRS.nosetup)
 
 clean:		$(COMPONENT_DIRS.nosetup)
 	$(RM) $(WS_TOP)/components/$(ENCUMBERED)components.mk \
-	$(WS_TOP)/components/$(ENCUMBERED)depends.mk \
 	$(WS_TOP)/components/mapping.json \
 	.profile
 


### PR DESCRIPTION
... because it is no longer generated.