### PR TITLE
tools/cloney: copy mode should copy symlinks and preserve attributes

### DIFF
--- a/tools/cloney
+++ b/tools/cloney
@@ -96,7 +96,7 @@ gfind . -type f -o -type l | \
     while read i;
 do
 	rm -f "${destdir}/$i"
-	cp "${srcdir}/$i" "${destdir}/$i"
+	cp -a "${srcdir}/$i" "${destdir}/$i"
 done
 else
 	echo "CLONEY_MODE=$CLONEY_MODE not supported"


### PR DESCRIPTION
This fixes the recent [python/identify build failure](https://hipster.openindiana.org/logs/oi-userland/10283/python.identify.publish.log).