### PR TITLE
thunderbird: add patch from solaris userland to stop mixing EGL and

### DIFF
--- a/components/mail/thunderbird/Makefile
+++ b/components/mail/thunderbird/Makefile
@@ -31,7 +31,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =	thunderbird
 COMPONENT_VERSION =	115.3.1
-COMPONENT_REVISION =	1
+COMPONENT_REVISION =	2
 COMPONENT_SUMMARY = Mozilla Thunderbird Email Application
 COMPONENT_PROJECT_URL =	https://www.thunderbird.net/
 COMPONENT_SRC = $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/mail/thunderbird/patches/firefox-115-glx-only.patch
+++ b/components/mail/thunderbird/patches/firefox-115-glx-only.patch
@@ -1,0 +1,18 @@
+The 115.x version of Firefox & Thunderbird are mixing OpenGL & EGL calls in a way
+that works with Mesa but not the Nvidia drivers
+--- firefox-115.2.0.orig/toolkit/xre/glxtest/glxtest.cpp	2023-09-18 15:31:54.579296247 -0400
++++ firefox-115.2.0/toolkit/xre/glxtest/glxtest.cpp	2023-09-18 15:12:11.836077440 -0400
+@@ -956,9 +956,13 @@
+ #ifdef MOZ_X11
+   if (!aWayland) {
+     // TODO: --display command line argument is not properly handled
++#ifdef __sun
++    glxtest();
++#else
+     if (!x11_egltest()) {
+       glxtest();
+     }
++#endif
+   }
+ #endif
+   // Finally write buffered data to the pipe.


### PR DESCRIPTION
OpenGL