### PR TITLE
hunspell-pt_br: rename package to fix version anachrony

### DIFF
--- a/components/text/hunspell-pt_br/Makefile
+++ b/components/text/hunspell-pt_br/Makefile
@@ -21,7 +21,7 @@ COMPONENT_PROJECT_URL=	https://pt-br.libreoffice.org/projetos/vero
 COMPONENT_SUMMARY=	Myspell and Hunspell spell dictionary files for Portugese Brazilian
 COMPONENT_LICENSE=	MPL1.1
 COMPONENT_LICENSE_FILE=	$(COMPONENT_NAME).license
-COMPONENT_FMRI=	library/myspell/dictionary/pt_br
+COMPONENT_FMRI=	library/myspell/dictionary/pt-br
 COMPONENT_CLASSIFICATION	= System/Localizations
 
 COMPONENT_SRC=            VeroptBR3215AOC
@@ -59,3 +59,5 @@ install: $(SOURCE_DIR)/.installed
 
 clean::
 	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
+
+# Auto-generated dependencies

--- a/components/text/hunspell-pt_br/history
+++ b/components/text/hunspell-pt_br/history
@@ -1,0 +1,1 @@
+library/myspell/dictionary/pt_br@2013.10.30,5.11-2020.0.1.1 library/myspell/dictionary/pt-br

--- a/components/text/hunspell-pt_br/pkg5
+++ b/components/text/hunspell-pt_br/pkg5
@@ -1,7 +1,7 @@
 {
     "dependencies": [],
     "fmris": [
-        "library/myspell/dictionary/pt_br"
+        "library/myspell/dictionary/pt-br"
     ],
     "name": "hunspell-pt_br"
 }


### PR DESCRIPTION
This should fix the following version anachrony:
```
pkg://openindiana.org/library/myspell/dictionary/pt_br@2013.10.30-2020.0.1.0:20200330T162525Z i--
pkg://openindiana.org/library/myspell/dictionary/pt_br@3.2.15-2023.0.0.0:20230614T172623Z ---
```