### PR TITLE
history: temporarily add obsoleted megasync with noincorporate

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -1029,6 +1029,7 @@ network/dhcp/dhcpmgr/locale/sv@0.5.11,5.11-2018.0.0.0
 network/dhcp/dhcpmgr/locale/zh_cn@0.5.11-2013.0.0.0
 network/dhcp/dhcpmgr/locale/zh_hk_tw@0.5.11-2013.0.0.0
 network/dhcp/dhcpmgr@0.5.11,5.11-2022.0.1.0
+network/megasync@4.6.6,5.11-2022.0.0.1.1 noincorporate
 network/putty/putty-tools@0.76,5.11-2020.0.1.1 network/putty
 print/lp/filter/a2ps@4.14,5.11-2015.0.2.0 print/filter/a2ps@4.14,5.11-0.151.1.8.1
 print/lp/ipp/ipp-listener@0.5.11,5.11-2022.0.1.0


### PR DESCRIPTION
This is to fix the long standing issue when `userland-incorporation` prevents installation of `megasync` from the encumbered repo.  Once this is merged and successfully built I'll create another PR with removal of `megasync` from `history`.