### PR TITLE
libXmu: do not override automatically detected dependencies

### DIFF
--- a/components/x11/libXmu/patches/01-solaris-abi.patch
+++ b/components/x11/libXmu/patches/01-solaris-abi.patch
@@ -37,7 +37,7 @@ $(libXmuu_la_SOURCES) removed from libXmu_la_SOURCES to avoid LD multiply define
  
 -libXmu_la_LIBADD = $(LTLIBOBJS) $(XMU_LIBS)
 -libXmuu_la_LIBADD = $(XMUU_LIBS)
-+libXmu_la_DEPENDENCIES = libXmuu.la
++EXTRA_libXmu_la_DEPENDENCIES = libXmuu.la
 +
 +libXmu_la_LIBADD = $(LTLIBOBJS) $(XMU_LIBS) libXmuu.la -lX11 -lc -lm
 +libXmuu_la_LIBADD = $(XMUU_LIBS) -lc


### PR DESCRIPTION
This is minor issue that manifests in some specific scenarios.  The change have no effect on current oi-userland build of `libXmu`, but it could be possibly needed in future.

Since I already had to deal with this issue in a private oi-userland fork it is better to have this integrated to avoid some possible future surprises.

Thanks.