### PR TITLE
Obsolete Catalan and Japanese man pages

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -1285,6 +1285,8 @@ system/management/wbem/sblim-cim-client@1.6.0,5.11-2013.0.0.1
 system/management/wbem/wbemcli@1.3.7,5.11-2013.0.0.1
 system/management/web/openwsman@2.1.0-2018.0.0.0
 system/management/webmin@1.510,5.11-2014.0.1.0
+system/manual/locale/ca@0.5.11,5.11-2013.0.0.1
+system/manual/locale/ja@0.5.11,5.11-2013.0.0.1
 system/network/http-cache-accelerator@0.5.11,5.11-2022.0.1.0
 system/network/routing/quagga@0.99.8,5.11-2018.0.0.0
 system/pciutils/pci.ids@2.2.20180208-2018.0.0.1 system/data/hardware-registry
@@ -1297,6 +1299,7 @@ system/xvm/header-xvm@3.4.2,5.11-2015.0.2.0
 system/xvm/xvm-gui@0.5.11,5.11-2015.0.2.0
 system/xvm@0.5.11,5.11-2015.0.2.0
 terminal/gnome-terminal@2.32.1,5.11-2017.0.0.2
+text/doctools/ja@0.5.11,5.11-2013.0.0.1
 text/o3read@0.0.4,5.11-2015.0.2.0
 web/browser/firefox/locale/de_de@0.5.11,5.11-2015.0.2.0
 web/browser/firefox/locale/es_es@0.5.11,5.11-2015.0.2.0

--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -1,6 +1,6 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL)". You may
+# Common Development and Distribution License ("CDDL"). You may
 # only use this file in accordance with the terms of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
@@ -13,27 +13,15 @@
 # Copyright 2013 Klaus Ziegler
 #
 
+BUILD_STYLE = pkg
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION=	0.1
-COMPONENT_REVISION=	57
-COMPONENT_SUMMARY=	A meta-packages that install common applications for ISOs
+COMPONENT_VERSION =	1
 
-include $(WS_MAKE_RULES)/ips.mk
+include $(WS_MAKE_RULES)/common.mk
 
 PKG_OPTIONS+= -I $(COMPONENT_DIR)/includes
-
-download:
-
-prep:
-
-build:
-
-install:
-	[ -d $(PROTO_DIR) ] || mkdir -p $(PROTO_DIR)
-
-clean:
-	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
 
 # Auto-generated dependencies

--- a/components/meta-packages/install-types/includes/server_desktop_aarch64
+++ b/components/meta-packages/install-types/includes/server_desktop_aarch64
@@ -140,8 +140,6 @@ depend type=require fmri=shell/zsh
 depend type=require fmri=system/install/locale
 depend type=require fmri=system/kernel/dynamic-reconfiguration/i86pc
 depend type=require fmri=system/management/ipmitool
-depend type=require fmri=system/manual/locale/ca
-depend type=require fmri=system/manual/locale/ja
 depend type=require fmri=system/network/ppp
 depend type=require fmri=system/network/ppp/pppdump
 depend type=require fmri=system/network/ppp/tunnel
@@ -150,7 +148,6 @@ depend type=require fmri=system/xvm/xvmstore
 depend type=require fmri=system/zones/brand/ipkg
 depend type=require fmri=terminal/screen
 depend type=require fmri=text/doctools
-depend type=require fmri=text/doctools/ja
 depend type=require fmri=text/gawk
 depend type=require fmri=text/gnu-diffutils
 depend type=require fmri=text/gnu-grep

--- a/components/meta-packages/install-types/includes/server_desktop_amd64
+++ b/components/meta-packages/install-types/includes/server_desktop_amd64
@@ -140,8 +140,6 @@ depend type=require fmri=shell/zsh
 depend type=require fmri=system/install/locale
 depend type=require fmri=system/kernel/dynamic-reconfiguration/i86pc
 depend type=require fmri=system/management/ipmitool
-depend type=require fmri=system/manual/locale/ca
-depend type=require fmri=system/manual/locale/ja
 depend type=require fmri=system/network/ppp
 depend type=require fmri=system/network/ppp/pppdump
 depend type=require fmri=system/network/ppp/tunnel
@@ -150,7 +148,6 @@ depend type=require fmri=system/xvm/xvmstore
 depend type=require fmri=system/zones/brand/ipkg
 depend type=require fmri=terminal/screen
 depend type=require fmri=text/doctools
-depend type=require fmri=text/doctools/ja
 depend type=require fmri=text/gawk
 depend type=require fmri=text/gnu-diffutils
 depend type=require fmri=text/gnu-grep

--- a/components/meta-packages/install-types/includes/server_desktop_sparcv9
+++ b/components/meta-packages/install-types/includes/server_desktop_sparcv9
@@ -134,7 +134,6 @@ depend type=require fmri=shell/tcsh
 depend type=require fmri=shell/which
 depend type=require fmri=shell/zsh
 depend type=require fmri=system/install/locale
-depend type=require fmri=system/manual/locale/ca
 depend type=require fmri=system/network/ppp
 depend type=require fmri=system/network/ppp/pppdump
 depend type=require fmri=system/network/ppp/tunnel

--- a/components/meta-packages/install-types/manifests/sample-manifest.p5m
+++ b/components/meta-packages/install-types/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2023 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)


### PR DESCRIPTION
There are several problems with these packages:

- We do not have build recipes for them in oi-userland
- Man pages are surely out of sync with their English counterparts
- We have nobody who can maintain these man pages
- The `text/doctools/ja` package contains dead symlinks
- The license of many files in `text/doctools/ja` is unclear