### PR TITLE
gcc-13: fix go crash, gcc bug 106813

### DIFF
--- a/components/developer/gcc-13/Makefile
+++ b/components/developer/gcc-13/Makefile
@@ -15,7 +15,7 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_VERSION= 13.2.0
-COMPONENT_REVISION= 0
+COMPONENT_REVISION= 1
 COMPONENT_SRC= gcc-releases-gcc-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_URL= https://github.com/gcc-mirror/gcc/archive/releases/$(COMPONENT_ARCHIVE)

--- a/components/developer/gcc-13/gcc-13.p5m
+++ b/components/developer/gcc-13/gcc-13.p5m
@@ -19,8 +19,11 @@
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/cc1$ -> default mode 0555>
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/cc1obj$ -> default mode 0555>
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/cc1plus$ -> default mode 0555>
+<transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/cgo$ -> default mode 0555>
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/collect2$ -> default mode 0555>
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/f951$ -> default mode 0555>
+<transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/go1$ -> default mode 0555>
+<transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/g\+\+-mapper-server$ -> default mode 0555>
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/install-tools/fixinc.sh$ -> default mode 0555>
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/install-tools/fixincl$ -> default mode 0555>
 <transform file path=usr/gcc/13/lib/gcc/$(GNU_TRIPLET)/$(HUMAN_VERSION)/install-tools/mkheaders$ -> default mode 0555>

--- a/components/developer/gcc-13/patches/Bug106813.patch
+++ b/components/developer/gcc-13/patches/Bug106813.patch
@@ -1,0 +1,18 @@
+
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106813
+
+diff --git a/libgo/runtime/go-signal.c b/libgo/runtime/go-signal.c
+index 528d9b6..865d652 100644
+--- a/libgo/runtime/go-signal.c
++++ b/libgo/runtime/go-signal.c
+@@ -244,6 +244,10 @@ getSiginfo(siginfo_t *info, void *context __attribute__((unused)))
+ 	ret.sigpc = ((ucontext_t*)(context))->uc_mcontext.pc;
+ #elif defined(__NetBSD__)
+ 	ret.sigpc = _UC_MACHINE_PC(((ucontext_t*)(context)));
++#elif defined(__x86_64__) && defined(__sun__)
++	ret.sigpc = ((ucontext_t*)(context))->uc_mcontext.gregs[REG_RIP];
++#elif defined(__i386__) && defined(__sun__)
++	ret.sigpc = ((ucontext_t*)(context))->uc_mcontext.gregs[REG_RIP];
+ #endif
+ 
+ 	if (ret.sigpc == 0) {


### PR DESCRIPTION
same as gcc-12.