### PR TITLE
rebuild tk

### DIFF
--- a/components/tcl/tk/Makefile
+++ b/components/tcl/tk/Makefile
@@ -29,9 +29,9 @@ include ../../../make-rules/shared-macros.mk
 
 USE_COMMON_TEST_MASTER=		yes
 COMPONENT_NAME=			tk
-COMPONENT_MAJOR_VERSION=	8.6
-COMPONENT_VERSION=		$(COMPONENT_MAJOR_VERSION).13
-COMPONENT_REVISION=		1
+COMPONENT_MJR_VERSION=	8.6
+COMPONENT_VERSION=		$(COMPONENT_MJR_VERSION).13
+COMPONENT_REVISION=		2
 COMPONENT_SUMMARY=		Tk - TCL GUI Toolkit
 COMPONENT_DESCRIPTION=	Tk is an open source, cross-platform widget toolkit that provides a library of basic elements for building a graphical user interface
 COMPONENT_PROJECT_URL=	https://www.tcl-lang.org/
@@ -46,7 +46,7 @@ COMPONENT_LICENSE_FILE=	license.terms
 
 include $(WS_MAKE_RULES)/common.mk
 
-PKG_MACROS += COMPONENT_MAJOR_VERSION=$(COMPONENT_MAJOR_VERSION)
+PKG_MACROS += COMPONENT_MAJOR_VERSION=$(COMPONENT_MJR_VERSION)
 
 COMPONENT_PREP_ACTION= \
 	(cd $(@D)/unix ; autoreconf -f)

--- a/components/tcl/tk/pkg5
+++ b/components/tcl/tk/pkg5
@@ -1,8 +1,6 @@
 {
     "dependencies": [
-        "SUNWcs",
         "runtime/tcl-8",
-        "shell/ksh93",
         "system/library",
         "system/library/fontconfig",
         "system/library/math",

--- a/components/tcl/tk/test/results-all.master
+++ b/components/tcl/tk/test/results-all.master
@@ -1,6 +1,6 @@
-all.tcl:	Total	9681	Passed	8834	Skipped	789	Failed	58
+all.tcl:	Total	9681	Passed	8960	Skipped	663	Failed	58
 Sourced 92 Test Files.
-Files with failing tests: canvText.test clrpick.test focus.test font.test pack.test place.test scrollbar.test unixEmbed.test unixFont.test unixWm.test winWm.test winfo.test wm.test
-all.tcl:	Total	496	Passed	474	Skipped	17	Failed	5
+Files with failing tests: canvText.test clrpick.test focus.test font.test pack.test place.test scrollbar.test text.test textImage.test unixEmbed.test unixFont.test unixWm.test winWm.test winfo.test wm.test
+all.tcl:	Total	496	Passed	478	Skipped	17	Failed	1
 Sourced 17 Test Files.
 Files with failing tests: entry.test


### PR DESCRIPTION
We seem to have a problem with our pythons. If I run gmake sample-manifest on either python-39 or python-37 the result doesn't include tkinter.so anymore, eg. python-39:
@@ -886,7 +886,6 @@ file path=usr/lib/python3.9/lib-dynload/_testcapi.cpython-39.so
 file path=usr/lib/python3.9/lib-dynload/_testimportmultiple.cpython-39.so
 file path=usr/lib/python3.9/lib-dynload/_testinternalcapi.cpython-39.so
 file path=usr/lib/python3.9/lib-dynload/_testmultiphase.cpython-39.so
-file path=usr/lib/python3.9/lib-dynload/_tkinter.cpython-39.so
 file path=usr/lib/python3.9/lib-dynload/_uuid.cpython-39.so
 file path=usr/lib/python3.9/lib-dynload/_xxsubinterpreters.cpython-39.so
 file path=usr/lib/python3.9/lib-dynload/_xxtestfuzz.cpython-39.so
