### PR TITLE
docbook: fix docbook-catalog-install.sh again…

### DIFF
--- a/components/docbook/docbook/Makefile
+++ b/components/docbook/docbook/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= docbook
 COMPONENT_VERSION= 2.30.0
-COMPONENT_REVISION= 4
+COMPONENT_REVISION= 5
 COMPONENT_SUMMARY= docbook SGML and XML stylesheets
 COMPONENT_FMRI= data/docbook
 COMPONENT_CLASSIFICATION= Desktop (GNOME)/Documentation

--- a/components/docbook/docbook/files/docbook-catalog-install.sh
+++ b/components/docbook/docbook/files/docbook-catalog-install.sh
@@ -748,6 +748,13 @@ Version=1.79.2
 Release=5.1
 
 CATALOG=/etc/xml/catalog
+
+if [ ! -s $CATALOG ]
+then
+	# Empty or missing file confuses further "add" operations
+	/usr/bin/xmlcatalog --create > $CATALOG
+fi
+
 /usr/bin/xmlcatalog --noout --add "rewriteSystem" \
  "http://docbook.sourceforge.net/release/xsl/${Version}" \
  "file:///usr/share/sgml/docbook/xsl-stylesheets-${Version}-${Release}" $CATALOG


### PR DESCRIPTION
… (used in svc:/application/desktop-cache/docbook-catalog-update:default) for edge case of zero-sized lost catalog file: /etc/xml/catalog

Similar to a fix I did years ago for another catalog file - now happened to be needed locally for this one.