### PR TITLE
docbook: fix docbook-catalog-install.sh again…

### DIFF
--- a/components/docbook/docbook/Makefile
+++ b/components/docbook/docbook/Makefile
@@ -17,7 +17,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= docbook
 COMPONENT_VERSION= 2.30.0
-COMPONENT_REVISION= 5
+COMPONENT_REVISION= 6
 COMPONENT_SUMMARY= docbook SGML and XML stylesheets
 COMPONENT_FMRI= data/docbook
 COMPONENT_CLASSIFICATION= Desktop (GNOME)/Documentation

--- a/components/docbook/docbook/files/docbook-catalog-install.sh
+++ b/components/docbook/docbook/files/docbook-catalog-install.sh
@@ -749,10 +749,31 @@ Release=5.1
 
 CATALOG=/etc/xml/catalog
 
+# Normally the baseline file is delivered by the package and
+# then grows according to updates with new docbook releases.
+# This logic repeats what the package recipe does, to "revive"
+# the file if it gets corrupted or deleted on a deployed system.
 if [ ! -s $CATALOG ]
 then
 	# Empty or missing file confuses further "add" operations
 	/usr/bin/xmlcatalog --create > $CATALOG
+
+	# Now put the common DocBook entries in it
+	/usr/bin/xmlcatalog --noout --add "delegatePublic" \
+		"-//OASIS//ENTITIES DocBook XML" \
+		"file:///usr/share/sgml/docbook/xmlcatalog" $CATALOG
+	/usr/bin/xmlcatalog --noout --add "delegatePublic" \
+		"-//OASIS//DTD DocBook XML" \
+		"file:///usr/share/sgml/docbook/xmlcatalog" $CATALOG
+	/usr/bin/xmlcatalog --noout --add "delegatePublic" \
+		"ISO 8879:1986" \
+		"file:///usr/share/sgml/docbook/xmlcatalog" $CATALOG
+	/usr/bin/xmlcatalog --noout --add "delegateSystem" \
+		"http://www.oasis-open.org/docbook/" \
+		"file:///usr/share/sgml/docbook/xmlcatalog" $CATALOG
+	/usr/bin/xmlcatalog --noout --add "delegateURI" \
+		"http://www.oasis-open.org/docbook/" \
+		"file:///usr/share/sgml/docbook/xmlcatalog" $CATALOG
 fi
 
 /usr/bin/xmlcatalog --noout --add "rewriteSystem" \


### PR DESCRIPTION
…(used in svc:/application/desktop-cache/docbook-catalog-update:default) for edge case of zero-sized lost catalog file: /etc/xml/catalog (add "delegate" rules)

Follow-up from #14559 as there is more to this edge case

Tested by nuking the local `/etc/xml/catalog` file and running the script. `a2x` was satisfied with what appeared.