### PR TITLE
named: "-u user" needs more privileges

### DIFF
--- a/components/network/bind/Makefile
+++ b/components/network/bind/Makefile
@@ -30,6 +30,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		bind
 COMPONENT_VERSION=	9.18.19
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	BIND DNS name server and configuration tools.
 COMPONENT_DESCRIPTION=	BIND is open source software that implements the Domain Name System \
                         (DNS) protocols for the Internet.  This package contains the DNS \

--- a/components/network/bind/patches/02-man-named.patch
+++ b/components/network/bind/patches/02-man-named.patch
@@ -1,6 +1,25 @@
---- bind-9.18.12/doc/man/named.8in	2023-02-03 12:27:09.125770285 +0100
-+++ bind-9.18.12/doc/man/named.8in.new	2023-02-25 18:46:41.520580373 +0100
-@@ -255,6 +255,100 @@
+--- bind-9.18.19/doc/man/named.8in-orig	Mon Sep 11 03:53:00 2023
++++ bind-9.18.19/doc/man/named.8in	Tue Oct 31 09:40:21 2023
+@@ -227,13 +227,11 @@
+ \fBNOTE:\fP
+ .INDENT 0.0
+ .INDENT 3.5
+-On Linux, \fBnamed\fP uses the kernel\(aqs capability mechanism to drop
+-all root privileges except the ability to \fBbind\fP to a
+-privileged port and set process resource limits. Unfortunately,
+-this means that the \fI\%\-u\fP option only works when \fBnamed\fP is run
+-on kernel 2.2.18 or later, or kernel 2.3.99\-pre3 or later, since
+-previous kernels did not allow privileges to be retained after
+-\fBsetuid\fP\&.
++On illumos-based distributions, including OpenIndiana, \fBnamed\fP
++uses the kernel\(aqs capability mechanism to drop
++all root privileges.
++The method script adds the privileges to \fBbind\fP to a privileged port.
++Basic privileges are still retained after \fBsetuid\fP\&.
+ .UNINDENT
+ .UNINDENT
+ .INDENT 0.0
+@@ -255,6 +253,100 @@
  Use of this option overrides the \fBlock\-file\fP option in
  \fI\%named.conf\fP\&. If set to \fBnone\fP, the lock file check is disabled.
  .UNINDENT
@@ -101,7 +120,7 @@
  .SH SIGNALS
  .sp
  In routine operation, signals should not be used to control the
-@@ -290,7 +384,8 @@
+@@ -290,7 +382,8 @@
  .UNINDENT
  .SH SEE ALSO
  .sp

--- a/components/network/bind/pkg5
+++ b/components/network/bind/pkg5
@@ -16,8 +16,8 @@
         "system/library/security/gss"
     ],
     "fmris": [
-        "network/dns/bind",
-        "service/network/dns/bind"
+        "service/network/dns/bind",
+        "network/dns/bind"
     ],
     "name": "bind"
 }


### PR DESCRIPTION
This product is the ISC Domain Name System (DNS) server.  Only the method script /lib/svc/method/dns-server is modified in this PR.  The change is only active when the "-u user" option is used.  It supplies the necessary process privileges to make the "-u user" option work without needing kernel modifications.  The new man page for "named" describes the privileges in more detail.

The steps build, install, and publish were all successful.

In testing, the "named -u user" process had the expected privileges.  The method script also worked correctly during a service restart and a system reboot.
