### PR TITLE
jenkins-standalone.p5m: update baseline to JDK17

### DIFF
--- a/components/developer/jenkins/Makefile
+++ b/components/developer/jenkins/Makefile
@@ -21,6 +21,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		jenkins
 COMPONENT_VERSION=	2.364
+COMPONENT_REVISION=	1
 COMPONENT_FMRI=		developer/jenkins
 COMPONENT_CLASSIFICATION=	Web Services/Application and Web Servers
 COMPONENT_PROJECT_URL=	http://jenkins-ci.org/

--- a/components/developer/jenkins/jenkins-common.p5m
+++ b/components/developer/jenkins/jenkins-common.p5m
@@ -45,6 +45,8 @@ dir group=jenkins owner=jenkins mode=0755 path=var/lib/jenkins/build_workspace
 dir group=jenkins owner=jenkins mode=0755 path=var/lib/jenkins/syshome
 dir group=jenkins owner=jenkins mode=0700 path=var/lib/jenkins/syshome/.ssh
 
-# Note: java8+ is required since 2017
-# This may be JRE8 for the server, though JDK8 also suffices :)
+# Note: java8+ is required since 2017, not supported since 2022
+# java11/17 is required since 2022 (java21 is acceptable since Aug 2023)
+# https://www.jenkins.io/doc/book/platform-information/support-policy-java/
+# This may be JRE for the server, though JDK also suffices :)
 depend fmri=__TBD pkg.debug.depend.file=usr/bin/java type=require

--- a/components/developer/jenkins/jenkins-standalone.p5m
+++ b/components/developer/jenkins/jenkins-standalone.p5m
@@ -33,7 +33,7 @@ depend type=require-any \
     fmri=pkg:/developer/jenkins-core-weekly \
     fmri=pkg:/developer/jenkins-core-lts
 depend type=require \
-    fmri=pkg:/runtime/java/openjdk8
+    fmri=pkg:/runtime/java/openjdk17
 # The font is required by Jenkins Web-GUI to start up, see
 #   https://wiki.jenkins.io/display/JENKINS/Jenkins+got+java.awt.headless+problem
 depend type=require \


### PR DESCRIPTION
Core was updated long ago, but this one got missed :)
Also bumps comments that referred to JDK8+.