### PR TITLE
jenkinshelper*.ksh: stage_build_changed(): do not lose track of failures

### DIFF
--- a/tools/jenkinshelper-main.ksh
+++ b/tools/jenkinshelper-main.ksh
@@ -56,6 +56,7 @@ stage_setup() {
 # the components Makefile also (to update COMPONENT_REVISION, etc)
 stage_build_changed() {
 	echo "Last successful commit $1"
+	worst=0
 	for f in $(git diff --name-only HEAD^1 | grep Makefile; exit 0); do
 		echo "jenkinshelper: building for ${f%/*}..."
 		curpwd=$(pwd)
@@ -63,7 +64,11 @@ stage_build_changed() {
 		rc=$?
 		cd "${curpwd}"
 		echo "jenkinshelper: done with ${f%/*} return code ${rc}"
+		if [ rc -ne 0 ] ; then
+			worst=$rc
+		fi
 	done
+	return $worst
 }
 
 # prepare the pkg.depotd server instance, if an instance already

--- a/tools/jenkinshelper.ksh
+++ b/tools/jenkinshelper.ksh
@@ -55,6 +55,7 @@ stage_setup() {
 # we try to be smart and assume that all updates will always touch
 # the components Makefile also (to update COMPONENT_REVISION, etc)
 stage_build_changed() {
+	worst=0
 	for f in $(git diff --name-only HEAD..origin/oi/hipster | grep Makefile; exit 0); do
 		echo "jenkinshelper: building for ${f%/*}..."
 		curpwd=$(pwd)
@@ -62,7 +63,11 @@ stage_build_changed() {
 		rc=$?
 		cd "${curpwd}"
 		echo "jenkinshelper: done with ${f%/*} return code ${rc}"
+		if [ rc -ne 0 ] ; then
+			worst=$rc
+		fi
 	done
+	return $worst
 }
 
 # prepare the pkg.depotd server instance, if an instance already


### PR DESCRIPTION
As seen in https://github.com/OpenIndiana/oi-userland/pull/14630#issuecomment-1794306345 the current helper scripts hide failed stages from their exit-code.

This PR allows all selected stages to be tried and then returns the worst result. An alternative may be reasonable to fail fast, on the first fault - up to you :)