### PR TITLE
libwnck: rebuild with patch for core in _wnck_get_pid()

### DIFF
--- a/components/library/libwnck/Makefile
+++ b/components/library/libwnck/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		libwnck
 COMPONENT_MJR_VERSION=	43
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).0
+COMPONENT_REVISION = 	1
 COMPONENT_SUMMARY=	Window Navigator Construction Kit Library
 COMPONENT_PROJECT_URL=	https://www.gnome.org
 COMPONENT_SRC=		libwnck-$(COMPONENT_VERSION)

--- a/components/library/libwnck/patches/02-Revert-xutils-Get-the-correct-PID-for-clients-inside.patch
+++ b/components/library/libwnck/patches/02-Revert-xutils-Get-the-correct-PID-for-clients-inside.patch
@@ -1,0 +1,76 @@
+From 9c4551c67d6fe854f7d37970398f5d5c9d17c28e Mon Sep 17 00:00:00 2001
+From: raveit65 <mate@raveit.de>
+Date: Thu, 29 Sep 2022 10:31:16 +0200
+Subject: [PATCH] Revert "xutils: Get the correct PID for clients inside PID
+ namespaces"
+
+This reverts commit 07694559cc0c65ce1cca9ac33b165cef84c34d5e.
+
+- fixing https://gitlab.gnome.org/GNOME/libwnck/-/issues/154#note_1562760
+---
+ libwnck/xutils.c | 36 +++---------------------------------
+ 1 file changed, 3 insertions(+), 33 deletions(-)
+
+diff --git a/libwnck/xutils.c b/libwnck/xutils.c
+index 60ae7b2..f2a2d3c 100644
+--- a/libwnck/xutils.c
++++ b/libwnck/xutils.c
+@@ -27,9 +27,6 @@
+ #if HAVE_CAIRO_XLIB_XRENDER
+ #include <cairo-xlib-xrender.h>
+ #endif
+-#ifdef HAVE_XRES
+-#include <X11/extensions/XRes.h>
+-#endif
+ #include "screen.h"
+ #include "window.h"
+ #include "private.h"
+@@ -1149,41 +1146,14 @@ int
+ _wnck_get_pid (Screen *screen,
+                Window  xwindow)
+ {
+-  int pid = -1;
+-
+-#ifdef HAVE_XRES
+-  XResClientIdSpec client_spec;
+-  long client_id_count = 0;
+-  XResClientIdValue *client_ids = NULL;
+-
+-  client_spec.client = xwindow;
+-  client_spec.mask = XRES_CLIENT_ID_PID_MASK;
+-
+-  if (XResQueryClientIds (DisplayOfScreen (screen), 1, &client_spec,
+-                          &client_id_count, &client_ids) == Success)
+-    {
+-      long i;
+-
+-      for (i = 0; i < client_id_count; i++)
+-        {
+-          pid = XResGetClientPid (&client_ids[i]);
+-          if (pid != -1)
+-            break;
+-        }
+-
+-      XResClientIdsDestroy (client_id_count, client_ids);
+-
+-      if (pid != -1)
+-        return pid;
+-    }
+-#endif
++  int val;
+ 
+   if (!_wnck_get_cardinal (screen, xwindow,
+                            _wnck_atom_get ("_NET_WM_PID"),
+-                           &pid))
++                           &val))
+     return 0;
+   else
+-    return pid;
++    return val;
+ }
+ 
+ char*
+-- 
+2.37.3
+
+


### PR DESCRIPTION
I got core dumps of wnck-applet with this stack trace:
00007fffbfffe9e0 libglib-2.0.so.0.7400.7`g_log_writer_default+0x227()
00007fffbfffea30 libglib-2.0.so.0.7400.7`g_log_structured_array+0x84()
00007fffbfffefd0 libglib-2.0.so.0.7400.7`g_log_structured_standard+0x19a()
00007fffbffff070 libgdk-3.so.0.2404.30`_gdk_x11_display_error_event+0x142()
00007fffbffff0a0 libgdk-3.so.0.2404.30`gdk_x_error+0xab()
00007fffbffff1a0 libX11.so.4.0.0`_XError+0x12a()
00007fffbffff210 libX11.so.4.0.0`_XReply+0x40f()
00007fffbffff290 libXRes.so.1.0.0`XResQueryClientIds+0xde()
00007fffbffff2f0 libwnck-3.so.0.3.0`_wnck_get_pid+0x4f()
00007fffbffff340 libwnck-3.so.0.3.0`_wnck_window_create+0xb4()
00007fffbffff3f0 libwnck-3.so.0.3.0`do_update_now+0xa32()
00007fffbffff400 libwnck-3.so.0.3.0`update_idle+0x14()
00007fffbffff480 libglib-2.0.so.0.7400.7`g_main_context_dispatch+0xe6()
00007fffbffff4e0 libglib-2.0.so.0.7400.7`g_main_context_iterate.isra.0+0x1e8()
00007fffbffff510 libglib-2.0.so.0.7400.7`g_main_loop_run+0x77()
00007fffbffff530 libgtk-3.so.0.2404.30`gtk_main+0x7d()
00007fffbffff570 libmate-panel-applet-4.so.1.0.1`mate_panel_applet_factory_main+0x117()
00007fffbffff5b0 main+0xe4()
00007fffbffff5e0 _start_crt+0x87()
00007fffbffff5f0 _start+0x18()

The patch found on fedora build recipe helps.