### PR TITLE
Update nut-v2.8.1 packaging

### DIFF
--- a/components/sysutils/nut/Makefile
+++ b/components/sysutils/nut/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=	nut
 COMPONENT_VERSION=	2.8.1
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Network UPS Tools (NUT)
 COMPONENT_DESCRIPTION=	Network UPS Tools (NUT) is a versatile power-device monitoring toolkit to facilitate safe shutdowns
 COMPONENT_SRC=	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -146,23 +147,6 @@ CONFIGURE_OPTIONS +=	--enable-spellcheck
 CONFIGURE_OPTIONS +=	--disable-cppcheck
 
 CONFIGURE_OPTIONS +=	$(CONFIGURE_OPTIONS.$(BITS))
-
-# TOTHINK? variant.opensolaris.zone=global
-$(BUILD_DIR)/nut-usb-driver.p5m.include: $(BUILD_DIR)/$(MACH64)/scripts/udev/nut-usbups.rules
-	(echo "# NUT USB VID:PID pairs supported by some USB-capable driver"; \
-	 echo "# Parsed from $< during package build"; \
-	 echo "driver name=ugen \\" ; \
-	 grep -E 'ATTR.*idVendor.*idProduct' < "$<" | \
-	 $(GSED) 's/^.*ATTR{idVendor}=="0*\([a-fA-F0-9][a-fA-F0-9]*\)".*ATTR{idProduct}=="0*\([a-fA-F0-9][a-fA-F0-9]*\)".*$$/    alias="usb\1,\2.*" \\/' ; \
-	 echo '    perms="* 0664 root nut"' ; \
-	) > "$@"
-
-# Inject into build chain, to patch .mogrified file used to create .mangled and beyond
-$(BUILD_DIR)/.injected.nut-usb-driver.p5m.include: $(BUILD_DIR)/manifest-$(MACH)-nut-drivers-usb.mogrified $(BUILD_DIR)/nut-usb-driver.p5m.include
-	cat "$(BUILD_DIR)/nut-usb-driver.p5m.include" >> "$(BUILD_DIR)/manifest-$(MACH)-nut-drivers-usb.mogrified"
-	touch "$@"
-
-$(BUILD_DIR)/manifest-$(MACH)-nut-drivers-usb.mangled: $(BUILD_DIR)/nut-usb-driver.p5m.include $(BUILD_DIR)/.injected.nut-usb-driver.p5m.include
 
 # NUT-Monitor UI has two similar implementations, for py2gtk and py3qt5.
 # The PyNUT.py (general binding) module is written to work with both 2.x

--- a/components/sysutils/nut/history
+++ b/components/sysutils/nut/history
@@ -1,0 +1,1 @@
+system/management/nut-common@2.7.4,5.11-2022.0.0.6 system/management/nut/common

--- a/components/sysutils/nut/nut-bins.p5m
+++ b/components/sysutils/nut/nut-bins.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016-2023 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/bins@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) - Grouping of NUT command-line and daemon client and server sides"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend fmri=$(COMPONENT_FMRI)/clients@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) type=require
+depend fmri=$(COMPONENT_FMRI)/server@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) type=require

--- a/components/sysutils/nut/nut-clients.p5m
+++ b/components/sysutils/nut/nut-clients.p5m
@@ -25,6 +25,8 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr/lib/nut/bin/(.+) -> default mode 0555>
 <transform dir path=usr/lib/nut/bin -> set group bin>
+<transform file path=usr/share/nut/solaris-smf/method/(.+) -> default mode 0555>
+<transform dir path=usr/share/nut/solaris-smf/method -> set group bin>
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
 <transform file path=usr/share/man/man1/(.+) -> set action.hash usr/share/man/man1/%<1> >
 <transform file path=usr/share/man/man1m/(.+) -> set action.hash usr/share/man/man1m/%<1> >

--- a/components/sysutils/nut/nut-server.p5m
+++ b/components/sysutils/nut/nut-server.p5m
@@ -25,6 +25,8 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr/lib/nut/bin/(.+) -> default mode 0555>
 <transform dir path=usr/lib/nut/bin -> set group bin>
+<transform file path=usr/share/nut/solaris-smf/method/(.+) -> default mode 0555>
+<transform dir path=usr/share/nut/solaris-smf/method -> set group bin>
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
 <transform file path=usr/share/man/man1/(.+) -> set action.hash usr/share/man/man1/%<1> >
 <transform file path=usr/share/man/man1m/(.+) -> set action.hash usr/share/man/man1m/%<1> >

--- a/components/sysutils/nut/pkg5
+++ b/components/sysutils/nut/pkg5
@@ -21,6 +21,7 @@
     ],
     "fmris": [
         "system/management/nut/augeas",
+        "system/management/nut/bins",
         "system/management/nut/cgi",
         "system/management/nut/clients",
         "system/management/nut/common",


### PR DESCRIPTION
Lessons learned from #14630 :
* avoid delivering "driver" actions after all - they do not let NUT user get permissions to just the devices with wanted USB VID:PID, and it conflicts with ugen package overall :\ End-users with USB UPSes would probably have to set `user=root` in `ups.conf` sections, at least for now.
* make sure SMF method scripts are executable