### PR TITLE
php-imagick add ini file

### DIFF
--- a/components/web/php/php-8_1-ext-imagick/Makefile
+++ b/components/web/php/php-8_1-ext-imagick/Makefile
@@ -18,7 +18,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		php-8.1-ext-imagick
 COMPONENT_VERSION=	3.7.0
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	ImageMagick for PHP
 COMPONENT_PROJECT_URL=	https://pecl.php.net/package/imagick
 COMPONENT_SRC=		imagick-$(COMPONENT_VERSION)

--- a/components/web/php/php-8_1-ext-imagick/imagick.ini
+++ b/components/web/php/php-8_1-ext-imagick/imagick.ini
@@ -1,0 +1,2 @@
+[imagick]
+extension=imagick.so

--- a/components/web/php/php-8_1-ext-imagick/php-8_1-ext-imagick.p5m
+++ b/components/web/php/php-8_1-ext-imagick/php-8_1-ext-imagick.p5m
@@ -28,3 +28,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/php/8.1/extensions/imagick.so
 file path=usr/php/8.1/include/php/ext/imagick/php_imagick_shared.h
+file imagick.ini path=etc/php/8.1/conf.d/imagick.ini preserve=true mode=0644


### PR DESCRIPTION


The ini file was missing, so apache did not use the extension.

From the manifest of the build:

file 8ea8f70f311c284128e43fe393a9edf6a6cfaa3f chash=741253f3feaeef85844b9bd9a6761b020263ba97 group=bin mode=0644 owner=root path=etc/php/8.1/conf.d/imagick.ini pkg.content-hash=file:sha512t_256:a87c22e9ed1d1796020650a591a5cf4032972d47715dc5b81a19668a0446b9c1 pkg.content-hash=gzip:sha512t_256:6c6b8d4fca61e20e98d18e73ba2831f4d2256cec64fa1c9d62c941537eb20709 pkg.csize=46 pkg.size=31 preserve=true
