### PR TITLE
nwam-manager: switch to 64 bit

### DIFF
--- a/components/openindiana/nwam-manager/Makefile
+++ b/components/openindiana/nwam-manager/Makefile
@@ -14,8 +14,7 @@
 # Copyright 2017 Gary Mills
 #
 
-BUILD_BITS = 32
-
+BUILD_BITS= 64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		nwam-manager


### PR DESCRIPTION
This needs an updated illumos-gate before being merged.