### PR TITLE
FIX: 14481 - UIManager.getSystemLookAndFeelClassName() returns Motif not GTK

### DIFF
--- a/components/runtime/openjdk-11/Makefile
+++ b/components/runtime/openjdk-11/Makefile
@@ -14,6 +14,7 @@
 # Copyright 2019 Michal Nowak
 # Copyright 2021 Andreas Grueninger, Grueninger GmbH, (grueni). All rights reserved.
 # Copyright 2023 Niklas Poslovski
+# Copyright 2023 Franklin Ronald <franklin@wiselabs.com.br>
 #
 
 include ../../../make-rules/shared-macros.mk
@@ -23,6 +24,7 @@ OPENJDK_UPDATE=	0
 OPENJDK_BUILD=	20
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)
+COMPONENT_REVISION = 1
 COMPONENT_FMRI=	runtime/java/$(COMPONENT_NAME)$(OPENJDK_VERSION)
 COMPONENT_SUMMARY=	Open-source implementation of the Java Platform, Standard Edition
 COMPONENT_SRC=	jdk$(OPENJDK_VERSION)u-jdk-$(COMPONENT_VERSION)-ga

--- a/components/runtime/openjdk-11/patches/src_java.desktop_share_classes_javax_swing_UIManager.java.patch
+++ b/components/runtime/openjdk-11/patches/src_java.desktop_share_classes_javax_swing_UIManager.java.patch
@@ -1,0 +1,16 @@
+--- a/src/java.desktop/share/classes/javax/swing/UIManager.java.orig	Mon Nov 27 19:15:37 2023
++++ b/src/java.desktop/share/classes/javax/swing/UIManager.java	Mon Nov 27 19:45:00 2023
+@@ -657,9 +657,12 @@
+         if (osType == OSInfo.OSType.WINDOWS) {
+             return "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
+         } else {
++            String xdgCurrentDesktop = System.getenv("XDG_CURRENT_DESKTOP");
+             String desktop = AccessController.doPrivileged(new GetPropertyAction("sun.desktop"));
+             Toolkit toolkit = Toolkit.getDefaultToolkit();
+-            if ("gnome".equals(desktop) &&
++            if (("mate".equalsIgnoreCase(xdgCurrentDesktop) || 
++                    "gnome".equalsIgnoreCase(xdgCurrentDesktop) || 
++                    "gnome".equals(desktop)) &&
+                     toolkit instanceof SunToolkit &&
+                     ((SunToolkit) toolkit).isNativeGTKAvailable()) {
+                 // May be set on Linux and Solaris boxs.


### PR DESCRIPTION
Fix for the issue https://www.illumos.org/issues/14481

The official OpenJDK repository only distinguishes whether it is Gnome or not. But it really doesn't make sense that the Java distribution present in OpenIndiana returns Motif as the look and feel of the system, when running Mate DE. And so a simple contribution follows.

About the change in the JDK8 Makefile: On my first attempt, I was unable to compile due to lack of dependencies, I ran "gmake REQUIRED_PACKAGES" and it added the GCC_RUNTIME_PKG dependency to the Makefile and then compiled normally. Please check whether I should keep this change or not.