### PR TITLE
illumos-gate: add patch for preintegration of 16085_use_modern_libxml…

### DIFF
--- a/components/openindiana/illumos-gate/patches/0004-16085_use_modern_libxml2_API.patch
+++ b/components/openindiana/illumos-gate/patches/0004-16085_use_modern_libxml2_API.patch
@@ -1,0 +1,237 @@
+From 36420a9cba8e1b3c536b23e7dd3ac8ebdf4226b5 Mon Sep 17 00:00:00 2001
+From: Andy Fiddaman <illumos@fiddaman.net>
+Date: Tue, 28 Nov 2023 11:16:55 +0000
+Subject: [PATCH] 16085 use modern libxml2 API
+
+Change-ID: Ib291eee72c927f69221e6e80323f9461e1b08ea9
+---
+ .../common/fabric-xlate/fabric-xlate.c        |  2 ++
+ usr/src/cmd/isns/isnsd/door.c                 |  1 +
+ usr/src/cmd/isns/isnsd/xml/data.c             |  3 ---
+ usr/src/cmd/svc/svccfg/svccfg_xml.c           | 14 ++++++--------
+ usr/src/lib/fm/topo/libtopo/common/topo_xml.c |  2 --
+ usr/src/lib/libbrand/common/libbrand.c        | 19 +++----------------
+ usr/src/lib/libpool/common/pool_kernel.c      |  1 +
+ usr/src/lib/libpool/common/pool_xml.c         | 12 ++++--------
+ usr/src/lib/libzonecfg/common/libzonecfg.c    | 15 +++++++--------
+ 9 files changed, 24 insertions(+), 45 deletions(-)
+
+diff --git a/usr/src/cmd/fm/modules/common/fabric-xlate/fabric-xlate.c b/usr/src/cmd/fm/modules/common/fabric-xlate/fabric-xlate.c
+index 89a74e84b1..c75799a2c7 100644
+--- a/usr/src/cmd/fm/modules/common/fabric-xlate/fabric-xlate.c
++++ b/usr/src/cmd/fm/modules/common/fabric-xlate/fabric-xlate.c
+@@ -31,6 +31,8 @@
+ #include <unistd.h>
+ #include <pthread.h>
+ 
++#include <libxml/tree.h>
++#include <libxml/parser.h>
+ #include <libxml/xpathInternals.h>
+ 
+ #include "fabric-xlate.h"
+diff --git a/usr/src/cmd/isns/isnsd/door.c b/usr/src/cmd/isns/isnsd/door.c
+index ef4995532d..bc9cbbdafe 100644
+--- a/usr/src/cmd/isns/isnsd/door.c
++++ b/usr/src/cmd/isns/isnsd/door.c
+@@ -44,6 +44,7 @@
+ #include    <alloca.h>
+ #include    <pthread.h>
+ #include    <ucred.h>
++#include    <stdlib.h>
+ #include    "isns_server.h"
+ #include    "admintf.h"
+ #include    "isns_mgmt.h"
+diff --git a/usr/src/cmd/isns/isnsd/xml/data.c b/usr/src/cmd/isns/isnsd/xml/data.c
+index 3d5b17c762..7fa426516f 100644
+--- a/usr/src/cmd/isns/isnsd/xml/data.c
++++ b/usr/src/cmd/isns/isnsd/xml/data.c
+@@ -843,9 +843,6 @@ xml_init_data(
+ 	free(cwd);
+ 	free(p);
+ 
+-	/* do not keep blank spaces */
+-	(void) xmlKeepBlanksDefault(0);
+-
+ 	/* remove the tmp file if it exists */
+ 	if (access(xml_tmp_file, F_OK) == 0) {
+ 		(void) remove(xml_tmp_file);
+diff --git a/usr/src/cmd/svc/svccfg/svccfg_xml.c b/usr/src/cmd/svc/svccfg/svccfg_xml.c
+index 70e62a83bd..582ad9fdc4 100644
+--- a/usr/src/cmd/svc/svccfg/svccfg_xml.c
++++ b/usr/src/cmd/svc/svccfg/svccfg_xml.c
+@@ -242,16 +242,16 @@ static const char *lxml_prop_types[] = {
+ 	""				/* SC_XI_INCLUDE */
+ };
+ 
++static int xml_read_options = 0;
++
+ int
+ lxml_init()
+ {
+ 	if (getenv("SVCCFG_NOVALIDATE") == NULL) {
+ 		/*
+-		 * DTD validation, with line numbers.
++		 * DTD validation.
+ 		 */
+-		(void) xmlLineNumbersDefault(1);
+-		xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
+-		xmlLoadExtDtdDefaultValue |= XML_COMPLETE_ATTRS;
++		xml_read_options |= XML_PARSE_DTDLOAD | XML_PARSE_DTDATTR;
+ 	}
+ 
+ 	return (0);
+@@ -3720,10 +3720,8 @@ lxml_get_bundle_file(bundle_t *bundle, const char *filename, svccfg_op_t op)
+ 	if (do_validate)
+ 		dtdpath = getenv("SVCCFG_DTD");
+ 
+-	if (dtdpath != NULL)
+-		xmlLoadExtDtdDefaultValue = 0;
+-
+-	if ((document = xmlReadFile(filename, NULL, 0)) == NULL) {
++	document = xmlReadFile(filename, NULL, xml_read_options);
++	if (document == NULL) {
+ 		semerr(gettext("couldn't parse document\n"));
+ 		return (-1);
+ 	}
+diff --git a/usr/src/lib/fm/topo/libtopo/common/topo_xml.c b/usr/src/lib/fm/topo/libtopo/common/topo_xml.c
+index 2b843135c5..987c088b14 100644
+--- a/usr/src/lib/fm/topo/libtopo/common/topo_xml.c
++++ b/usr/src/lib/fm/topo/libtopo/common/topo_xml.c
+@@ -2010,8 +2010,6 @@ txml_file_parse(topo_mod_t *tmp,
+ 	 */
+ 	if (getenv("TOPOXML_VALIDATE") != NULL) {
+ 		dtdpath = getenv("TOPO_DTD");
+-		if (dtdpath != NULL)
+-			xmlLoadExtDtdDefaultValue = 0;
+ 		validate = 1;
+ 	}
+ 
+diff --git a/usr/src/lib/libbrand/common/libbrand.c b/usr/src/lib/libbrand/common/libbrand.c
+index 3112e31771..d81c92b763 100644
+--- a/usr/src/lib/libbrand/common/libbrand.c
++++ b/usr/src/lib/libbrand/common/libbrand.c
+@@ -139,21 +139,6 @@ libbrand_initialize()
+ 		return (B_FALSE);
+ 	}
+ 
+-	/*
+-	 * Note that here we're initializing per-process libxml2
+-	 * state.  By doing so we're implicitly assuming that
+-	 * no other code in this process is also trying to
+-	 * use libxml2.  But in most case we know this not to
+-	 * be true since we're almost always used in conjunction
+-	 * with libzonecfg, which also uses libxml2.  Lucky for
+-	 * us, libzonecfg initializes libxml2 to essentially
+-	 * the same defaults as we're using below.
+-	 */
+-	(void) xmlLineNumbersDefault(1);
+-	xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
+-	xmlDoValidityCheckingDefaultValue = 1;
+-	(void) xmlKeepBlanksDefault(0);
+-	xmlGetWarningsDefaultValue = 0;
+ 	xmlSetGenericErrorFunc(NULL, brand_error_func);
+ 
+ 	libbrand_initialized = B_TRUE;
+@@ -198,7 +183,9 @@ open_xml_file(const char *file)
+ 	/*
+ 	 * Parse the file
+ 	 */
+-	if ((doc = xmlParseFile(file)) == NULL)
++	doc = xmlReadFile(file, NULL, XML_PARSE_DTDLOAD |
++	    XML_PARSE_DTDVALID | XML_PARSE_NOBLANKS | XML_PARSE_NOWARNING);
++	if (doc == NULL)
+ 		return (NULL);
+ 
+ 	/*
+diff --git a/usr/src/lib/libpool/common/pool_kernel.c b/usr/src/lib/libpool/common/pool_kernel.c
+index 2179a7f0ea..4d1666f0db 100644
+--- a/usr/src/lib/libpool/common/pool_kernel.c
++++ b/usr/src/lib/libpool/common/pool_kernel.c
+@@ -43,6 +43,7 @@
+ #include <unistd.h>
+ 
+ #include <libxml/tree.h>
++#include <libxml/valid.h>
+ 
+ #include <sys/mman.h>
+ #include <sys/pool.h>
+diff --git a/usr/src/lib/libpool/common/pool_xml.c b/usr/src/lib/libpool/common/pool_xml.c
+index 4f0b6df116..e6b211ac5c 100644
+--- a/usr/src/lib/libpool/common/pool_xml.c
++++ b/usr/src/lib/libpool/common/pool_xml.c
+@@ -262,14 +262,6 @@ xml_init()
+ 	}
+ 	xmlInitParser();
+ 
+-	/*
+-	 * DTD validation, with line numbers.
+-	 */
+-	(void) xmlLineNumbersDefault(1);
+-	xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
+-	xmlDoValidityCheckingDefaultValue = 1;
+-	/* Try to improve indentation and readability */
+-	(void) xmlKeepBlanksDefault(0);
+ 	/* Send all XML errors to our debug handler */
+ 	xmlSetGenericErrorFunc(NULL, pool_error_func);
+ 	/* Load up DTD element a-dtype data to improve performance */
+@@ -2704,6 +2696,10 @@ pool_xml_parse_document(pool_conf_t *conf)
+ 			return (PO_FAIL);
+ 		}
+ 
++		xmlCtxtUseOptions(ctxt,
++		    XML_PARSE_DTDLOAD | XML_PARSE_DTDVALID |
++		    XML_PARSE_NOBLANKS);
++
+ 		while ((res = fread(chars, 1, size, prov->pxc_file)) > 0) {
+ 			if (xmlParseChunk(ctxt, chars, res, 0) != 0) {
+ 				xmlFreeParserCtxt(ctxt);
+diff --git a/usr/src/lib/libzonecfg/common/libzonecfg.c b/usr/src/lib/libzonecfg/common/libzonecfg.c
+index c1500aa184..0af2c1af36 100644
+--- a/usr/src/lib/libzonecfg/common/libzonecfg.c
++++ b/usr/src/lib/libzonecfg/common/libzonecfg.c
+@@ -162,6 +162,9 @@
+ #define	RCAP_SERVICE	"system/rcap:default"
+ #define	POOLD_SERVICE	"system/pools/dynamic:default"
+ 
++#define	XML_PARSER_OPTIONS	(XML_PARSE_DTDLOAD | XML_PARSE_DTDVALID | \
++				XML_PARSE_NOBLANKS | XML_PARSE_NOWARNING)
++
+ /*
+  * rctl alias definitions
+  *
+@@ -309,12 +312,6 @@ zonecfg_init_handle(void)
+ 		return (NULL);
+ 	}
+ 
+-	/* generic libxml initialization */
+-	(void) xmlLineNumbersDefault(1);
+-	xmlLoadExtDtdDefaultValue |= XML_DETECT_IDS;
+-	xmlDoValidityCheckingDefaultValue = 1;
+-	(void) xmlKeepBlanksDefault(0);
+-	xmlGetWarningsDefaultValue = 0;
+ 	xmlSetGenericErrorFunc(NULL, zonecfg_error_func);
+ 
+ 	return (handle);
+@@ -589,7 +586,8 @@ zonecfg_get_handle_impl(const char *zonename, const char *filename,
+ 	if (zonename == NULL)
+ 		return (Z_NO_ZONE);
+ 
+-	if ((handle->zone_dh_doc = xmlParseFile(filename)) == NULL) {
++	handle->zone_dh_doc = xmlReadFile(filename, NULL, XML_PARSER_OPTIONS);
++	if (handle->zone_dh_doc == NULL) {
+ 		/* distinguish file not found vs. found but not parsed */
+ 		if (stat(filename, &statbuf) == 0)
+ 			return (Z_INVALID_DOCUMENT);
+@@ -709,7 +707,8 @@ zonecfg_attach_manifest(int fd, zone_dochandle_t local_handle,
+ 	int valid;
+ 
+ 	/* load the manifest into the handle for the remote system */
+-	if ((rem_handle->zone_dh_doc = xmlReadFd(fd, NULL, NULL, 0)) == NULL) {
++	rem_handle->zone_dh_doc = xmlReadFd(fd, NULL, NULL, XML_PARSER_OPTIONS);
++	if (rem_handle->zone_dh_doc == NULL) {
+ 		return (Z_INVALID_DOCUMENT);
+ 	}
+ 	if ((cvp = xmlNewValidCtxt()) == NULL)
+-- 
+2.42.1
+


### PR DESCRIPTION
This patch corresponds to https://code.illumos.org/c/illumos-gate/+/3163 and delivers a preintergration of this change to openindiana. So we can keep the update of libxml 2.12.1.
It has to remove if CR3163 is integrated in illumos-gate.