### PR TITLE
add warning about 32bit build requirements for SunRay

### DIFF
--- a/components/library/dbus-glib/WARNING
+++ b/components/library/dbus-glib/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/library/dbus/WARNING
+++ b/components/library/dbus/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/library/glib/WARNING
+++ b/components/library/glib/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/library/libffi/WARNING
+++ b/components/library/libffi/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/library/mozilla-nspr/WARNING
+++ b/components/library/mozilla-nspr/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/library/pcre2/WARNING
+++ b/components/library/pcre2/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/library/zlib/WARNING
+++ b/components/library/zlib/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/x11/libX11/WARNING
+++ b/components/x11/libX11/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/x11/libXext/WARNING
+++ b/components/x11/libXext/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.

--- a/components/x11/libxcb/WARNING
+++ b/components/x11/libxcb/WARNING
@@ -1,0 +1,3 @@
+Attention
+
+GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.


### PR DESCRIPTION
add warnings that this package should still build in 32bit too, because GDM tool gdm-session-worker have to run in 32bit and requires this libraries.