### PR TITLE
illumos-gate: made 64-bit libnwam compatible for 32-bit nwamd

### DIFF
--- a/components/openindiana/illumos-gate/patches/0003-want-64-bit-libnwam-32bit-compat.patch
+++ b/components/openindiana/illumos-gate/patches/0003-want-64-bit-libnwam-32bit-compat.patch
@@ -1,0 +1,51 @@
+Because the nwamd is still a 32bit binary the doorfs calls have to be compatible for 64bit and 32bit.
+If all runs in 64bit this patch is no longer necessary.
+
+diff --git a/usr/src/lib/libnwam/common/libnwam.h b/usr/src/lib/libnwam/common/libnwam.h
+index 7d9025a399..63c6271e46 100644
+--- a/usr/src/lib/libnwam/common/libnwam.h
++++ b/usr/src/lib/libnwam/common/libnwam.h
+@@ -966,6 +966,8 @@ typedef enum {
+        NWAM_OBJECT_TYPE_KNOWN_WLAN = 4
+ } nwam_object_type_t;
+ 
++#pragma pack(4)
++
+ typedef struct nwam_event *nwam_event_t;
+ struct nwam_event {
+        int nwe_type;
+@@ -1040,6 +1042,8 @@ struct nwam_event {
+        } nwe_data;
+ };
+ 
++#pragma pack()
++
+ /* NWAM client functions, used to register/unregister and receive events */
+ extern nwam_error_t nwam_events_init(void);
+ extern void nwam_events_fini(void);
+diff --git a/usr/src/lib/libnwam/common/libnwam_priv.h b/usr/src/lib/libnwam/common/libnwam_priv.h
+index 14b92b2c3a..40c029e4e3 100644
+--- a/usr/src/lib/libnwam/common/libnwam_priv.h
++++ b/usr/src/lib/libnwam/common/libnwam_priv.h
+@@ -73,6 +73,7 @@ typedef enum {
+ 
+ #define        NWAMD_MAX_NUM_WLANS     64
+ 
++#pragma pack(4)
+ typedef union {
+        /* Used for EVENT_[UN]REGISTER requests */
+        struct {
+@@ -133,10 +134,11 @@ typedef struct nwam_backend_door_arg {
+        nwam_backend_door_cmd_t nwbda_cmd;
+        char nwbda_dbname[MAXPATHLEN];                  /* config filename */
+        char nwbda_object[NWAM_MAX_NAME_LEN];           /* config object */
+-       size_t nwbda_datalen;                           /* data follows arg */
++       unsigned int nwbda_datalen;                             /* data follows arg */
+        nwam_error_t nwbda_result;                      /* return code */
+        uint64_t nwbda_flags;
+ } nwam_backend_door_arg_t;
++#pragma pack()
+ 
+ /*
+  * Functions needed to initialize/stop processing of libnwam backend data
+


### PR DESCRIPTION
The data structures used for the doorfs calls between nwam-manager (64-bit) and nwamd (32-bit) have to be compatible.