### PR TITLE
cmake: Fix CMAKE_HOST_SYSTEM_PROCESSOR

### DIFF
--- a/components/developer/cmake/Makefile
+++ b/components/developer/cmake/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=         cmake
 COMPONENT_MAJOR_VERSION= 3.28
 COMPONENT_VERSION=      $(COMPONENT_MAJOR_VERSION).1
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=      A cross-platform, open-source make system
 COMPONENT_DESCRIPTION= \
 CMake is a family of tools designed to build, test and package software. \

--- a/components/developer/cmake/patches/04-determine-system-processor.patch
+++ b/components/developer/cmake/patches/04-determine-system-processor.patch
@@ -1,0 +1,15 @@
+--- cmake-3.27/Modules/CMakeDetermineSystem.cmake.orig	2023-07-21 17:20:23.384825842 +0900
++++ cmake-3.27/Modules/CMakeDetermineSystem.cmake	2023-12-14 09:37:37.809515837 +0900
+@@ -103,6 +103,12 @@
+         RESULT_VARIABLE val
+         OUTPUT_STRIP_TRAILING_WHITESPACE
+         ERROR_QUIET)
++    elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "SunOS")
++      execute_process(COMMAND isainfo -n
++        OUTPUT_VARIABLE CMAKE_HOST_SYSTEM_PROCESSOR
++        RESULT_VARIABLE val
++        OUTPUT_STRIP_TRAILING_WHITESPACE
++        ERROR_QUIET)
+     else()
+       execute_process(COMMAND ${CMAKE_UNAME} -p
+         OUTPUT_VARIABLE CMAKE_HOST_SYSTEM_PROCESSOR


### PR DESCRIPTION
On OpenIndiana on x86-64, `CMAKE_HOST_SYSTEM_PROCESSOR` (also `CMAKE_SYSTEM_PROCESSOR` when host == target archs) is `i386`; buit I think it should be `amd64` (or `x86_64`).

## Repro:

CMakeLists.txt
```cmake
message(STATUS "CMAKE_HOST_SYSTEM_PROCESSOR: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
```

```
$ cmake .
...(snip)
-- CMAKE_HOST_SYSTEM_PROCESSOR: i386
...(snip)
```

## Solution Proposal:

CMake should set `CMAKE_HOST_SYSTEM_PROCESSOR` by `isainfo -n` rather than `uname -p`.