### PR TITLE
Request support of 32bit for some libraries needed by Squeak

### DIFF
--- a/components/desktop/pulseaudio/WARNING
+++ b/components/desktop/pulseaudio/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/library/cairo/WARNING
+++ b/components/library/cairo/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/library/freetype/WARNING
+++ b/components/library/freetype/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/library/glib/WARNING
+++ b/components/library/glib/WARNING
@@ -1,3 +1,7 @@
 Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
+
+The package runtime/smalltalk/squeak depends on this library.
+A 32bit and 63bit version of this library is required for Squeak.
+

--- a/components/library/libffi/WARNING
+++ b/components/library/libffi/WARNING
@@ -1,3 +1,7 @@
 Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
+
+The package runtime/smalltalk/squeak depends on this library.
+A 32bit and 63bit version of this library is required for Squeak.
+

--- a/components/library/libjpeg-turbo/WARNING
+++ b/components/library/libjpeg-turbo/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/library/openssl/openssl-1.0.2/WARNING
+++ b/components/library/openssl/openssl-1.0.2/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/library/pango/WARNING
+++ b/components/library/pango/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/multimedia/gstreamer/WARNING
+++ b/components/multimedia/gstreamer/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/x11/libX11/WARNING
+++ b/components/x11/libX11/WARNING
@@ -1,3 +1,7 @@
 Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
+
+The package runtime/smalltalk/squeak depends on this library.
+A 32bit and 63bit version of this library is required for Squeak.
+

--- a/components/x11/libXext/WARNING
+++ b/components/x11/libXext/WARNING
@@ -1,3 +1,7 @@
 Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
+
+The package runtime/smalltalk/squeak depends on this library.
+A 32bit and 63bit version of this library is required for Squeak.
+

--- a/components/x11/libXrender/WARNING
+++ b/components/x11/libXrender/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.

--- a/components/x11/mesa/WARNING
+++ b/components/x11/mesa/WARNING
@@ -1,6 +1,3 @@
-Attention
-
-GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
 The package runtime/smalltalk/squeak depends on this library.
 A 32bit and 63bit version of this library is required for Squeak.


### PR DESCRIPTION

WARNING:  this will add WARNING files to critical libraries and I have no idea whether this will force a J JENKINGS rebuild or rebuild of critical system libraries.

Basically I am just requesting support for 332bit for the Squeak 32bit interpreter.
This interpreter is required to run 32bit Smalltalk images.

Given the enormous amount of work that solaris-userland and oi-userland did in the past to support both 32bit and 64bit, it would be nice to continue to support 32bit if possible.

I understand that if some of the upstream components like CAIRO or PANGO or FREETYPE would drop support for 32bit then obviously OpenIndiana cannot continue to support 32bit versions.