### PR TITLE
inconsolata: lowercase the package name

### DIFF
--- a/components/fonts/inconsolata/Makefile
+++ b/components/fonts/inconsolata/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=  		Inconsolata
 COMPONENT_VERSION=		3.0.0
 HUMAN_VERSION=			3.000
+COMPONENT_REVISION=		1
 COMPONENT_SUMMARY=		Open-source monospace font for code listings, originally by raphlinus
 COMPONENT_SRC_BASE=  	$(COMPONENT_NAME)
 COMPONENT_SRC=			$(COMPONENT_SRC_BASE)-v$(HUMAN_VERSION)
@@ -43,6 +44,7 @@ FONT_TYPE = TTF
 
 include $(WS_MAKE_RULES)/font.mk
 
+COMPONENT_FONT_PKG = inconsolata
 COMPONENT_FONT_SRC_DIR = fonts/ttf
 COMPONENT_FONT_FILES += *.ttf
 COMPONENT_FONTCONF_FILES =

--- a/components/fonts/inconsolata/history
+++ b/components/fonts/inconsolata/history
@@ -1,0 +1,1 @@
+system/font/truetype/Inconsolata@3.0.0,5.11-2022.0.0.1 system/font/truetype/inconsolata

--- a/components/fonts/inconsolata/inconsolata.p5m
+++ b/components/fonts/inconsolata/inconsolata.p5m
@@ -13,13 +13,12 @@
 # Copyright 2022 Andreas Wacknitz
 #
 
-set name=pkg.fmri \
-    value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
-set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'

--- a/components/fonts/inconsolata/manifests/sample-manifest.p5m
+++ b/components/fonts/inconsolata/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/fonts/inconsolata/pkg5
+++ b/components/fonts/inconsolata/pkg5
@@ -1,13 +1,7 @@
 {
-    "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
-        "system/library",
-        "system/library/fontconfig",
-        "x11/font-utilities"
-    ],
+    "dependencies": [],
     "fmris": [
-        "system/font/truetype/Inconsolata"
+        "system/font/truetype/inconsolata"
     ],
     "name": "Inconsolata"
 }


### PR DESCRIPTION
This is to align with other font packages and other packages in general.