### PR TITLE
xorg-video: cleanup build dependencies

### DIFF
--- a/components/meta-packages/xorg-video/Makefile
+++ b/components/meta-packages/xorg-video/Makefile
@@ -12,40 +12,16 @@
 # Copyright 2011 EveryCity Ltd. All rights reserved.
 #
 
+BUILD_STYLE = pkg
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		xorg-video
-COMPONENT_VERSION=	0.5.11
-COMPONENT_REVISION= 3
+COMPONENT_VERSION=	1
 COMPONENT_SUMMARY=	Xorg server video drivers group
+COMPONENT_CLASSIFICATION=	System/X11
+COMPONENT_FMRI=			x11/server/xorg/driver/xorg-video
 
-include ../../../make-rules/ips.mk
-
-download:
-
-prep:
-
-build:
-
-install:
-	[ -d $(PROTO_DIR) ] || mkdir -p $(PROTO_DIR)
-
-clean:
-	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
+include $(WS_MAKE_RULES)/common.mk
 
 # Auto-generated dependencies
-REQUIRED_PACKAGES += consolidation/X/X-incorporation
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-ast
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-ati
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-cirrus
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-intel
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-mach64
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-mga
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-nv
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-openchrome
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-r128
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-savage
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-trident
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-vboxvideo
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-vesa
-REQUIRED_PACKAGES += x11/server/xorg/driver/xorg-video-vmware

--- a/components/meta-packages/xorg-video/manifests/sample-manifest.p5m
+++ b/components/meta-packages/xorg-video/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/meta-packages/xorg-video/pkg5
+++ b/components/meta-packages/xorg-video/pkg5
@@ -1,21 +1,5 @@
 {
-    "dependencies": [
-        "consolidation/X/X-incorporation",
-        "x11/server/xorg/driver/xorg-video-ast",
-        "x11/server/xorg/driver/xorg-video-ati",
-        "x11/server/xorg/driver/xorg-video-cirrus",
-        "x11/server/xorg/driver/xorg-video-intel",
-        "x11/server/xorg/driver/xorg-video-mach64",
-        "x11/server/xorg/driver/xorg-video-mga",
-        "x11/server/xorg/driver/xorg-video-nv",
-        "x11/server/xorg/driver/xorg-video-openchrome",
-        "x11/server/xorg/driver/xorg-video-r128",
-        "x11/server/xorg/driver/xorg-video-savage",
-        "x11/server/xorg/driver/xorg-video-trident",
-        "x11/server/xorg/driver/xorg-video-vboxvideo",
-        "x11/server/xorg/driver/xorg-video-vesa",
-        "x11/server/xorg/driver/xorg-video-vmware"
-    ],
+    "dependencies": [],
     "fmris": [
         "x11/server/xorg/driver/xorg-video"
     ],

--- a/components/meta-packages/xorg-video/xorg-video.p5m
+++ b/components/meta-packages/xorg-video/xorg-video.p5m
@@ -13,26 +13,24 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
-set name=pkg.fmri value=pkg:/x11/server/xorg/driver/xorg-video@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
-set name=pkg.description value="A group package that provides all of the available Xorg video drivers for a given platform"
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
-set name=info.classification value=org.opensolaris.category.2008:System/X11
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-depend fmri=pkg:/consolidation/X/X-incorporation type=require
 depend fmri=driver/graphics/nvidia fmri=driver/graphics/nvidia-340 fmri=driver/graphics/nvidia-390 fmri=driver/graphics/nvidia-470 type=require-any
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-ast type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-ati type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-cirrus type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-intel type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-mach64 type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-mga type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-nv type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-openchrome type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-r128 type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-savage type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-trident type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-vesa type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-vboxvideo type=require
-depend fmri=pkg:/x11/server/xorg/driver/xorg-video-vmware type=require
+depend fmri=x11/server/xorg/driver/xorg-video-ast type=require
+depend fmri=x11/server/xorg/driver/xorg-video-ati type=require
+depend fmri=x11/server/xorg/driver/xorg-video-cirrus type=require
+depend fmri=x11/server/xorg/driver/xorg-video-intel type=require
+depend fmri=x11/server/xorg/driver/xorg-video-mach64 type=require
+depend fmri=x11/server/xorg/driver/xorg-video-mga type=require
+depend fmri=x11/server/xorg/driver/xorg-video-nv type=require
+depend fmri=x11/server/xorg/driver/xorg-video-openchrome type=require
+depend fmri=x11/server/xorg/driver/xorg-video-r128 type=require
+depend fmri=x11/server/xorg/driver/xorg-video-savage type=require
+depend fmri=x11/server/xorg/driver/xorg-video-trident type=require
+depend fmri=x11/server/xorg/driver/xorg-video-vesa type=require
+depend fmri=x11/server/xorg/driver/xorg-video-vboxvideo type=require
+depend fmri=x11/server/xorg/driver/xorg-video-vmware type=require


### PR DESCRIPTION
This also removes dependency on `X-incorporation` because the incorporation have zero added value for `xorg-video`.