### PR TITLE
bass-o-matic: add newline to end of pkg5 files

### DIFF
--- a/tools/bass/component.py
+++ b/tools/bass/component.py
@@ -63,6 +63,7 @@ class Component(object):
                          'dependencies' : self.required_packages }
                 with open(component_pkg5_file, 'w') as f:
                     f.write(json.dumps(data, sort_keys=True, indent=4))
+                    f.write('\n')
             else:
                 with open(component_pkg5_file, 'r') as f:
                     data = json.loads(f.read())


### PR DESCRIPTION
It is really annoying to see warnings about missing newline at end of pkg5 files.