### PR TITLE
userland-mapping: allow components without packages

### DIFF
--- a/tools/userland-mapping
+++ b/tools/userland-mapping
@@ -64,8 +64,6 @@ def generate_component_data(component_path, subdir='components'):
     if not component_name:
         raise ValueError('Component name is empty for path ' + component_path + '.')
     component_fmris = component.supplied_packages
-    if not component_fmris:
-        raise ValueError('Component FMRIs is empty for path ' + component_path + '.')
 
     component_relative_path = component_path.split(os.path.join(os.environ['WS_TOP'], subdir))[-1].replace('/', '', 1)
 


### PR DESCRIPTION
This is similar to #14166 but for different tool this time.