### PR TITLE
build-essential: drop dependency on developer/gnome/gettext

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
-COMPONENT_VERSION =	11
+COMPONENT_VERSION =	12
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -55,7 +55,7 @@ depend fmri=developer/gnu-binutils type=require
 
 # Package Tools
 depend fmri=developer/build/pkg-config type=require
-depend fmri=developer/gnome/gettext type=require
+depend fmri=gnome/gnome-common type=require
 
 # Text and macro tools
 depend fmri=developer/macro/gnu-m4 type=require
@@ -70,6 +70,7 @@ depend fmri=text/gnu-grep type=require
 depend fmri=text/gnu-patch type=require
 depend fmri=text/gnu-sed type=require
 depend fmri=text/groff type=require
+depend fmri=text/intltool type=require
 depend fmri=text/texinfo type=require
 depend fmri=data/docbook type=require
 depend fmri=developer/gnome/gettext type=require


### PR DESCRIPTION
Since the `developer/gnome/gettext` package is just a meta-package that depends on:
```
developer/build/pkg-config
gnome/gnome-common
text/gnu-gettext
text/intltool
```
with no other added value then it would be good to slowly phase it out to cleanup the still complex set of meta-packages.

Since `build-essential` already depends on `pkg-config` and `gnu-gettext` this simply replaces the `developer/gnome/gettext` dependency by `gnome/gnome-common` and `text/intltool`.