### PR TITLE
build-essential: really drop dependency on developer/gnome/gettext

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
-COMPONENT_VERSION =	12
+COMPONENT_VERSION =	13
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -73,7 +73,6 @@ depend fmri=text/groff type=require
 depend fmri=text/intltool type=require
 depend fmri=text/texinfo type=require
 depend fmri=data/docbook type=require
-depend fmri=developer/gnome/gettext type=require
 
 # Source control tools
 depend fmri=developer/versioning/git type=require


### PR DESCRIPTION
Damn, it was listed there twice.