### PR TITLE
pkg: clobber in pkg subdir to force package publish

### DIFF
--- a/components/openindiana/pkg/Makefile
+++ b/components/openindiana/pkg/Makefile
@@ -56,6 +56,7 @@ $(BUILD_DIR)/$(MACH)/.built: $(SOURCE_DIR)/.downloaded
 	cd $(SOURCE_DIR)/src && \
 	PATH=$(PATH) $(MAKE) && PATH=$(PATH) $(MAKE) install && \
 	cd pkg && \
+	$(MAKE) clobber && \
 	$(MAKE) BUILD_VERSION=$(BUILD_VERSION) && \
 	$(MAKE) publish-pkgs BUILD_VERSION=$(BUILD_VERSION) && \
 	$(MAKE) repository-metadata && \


### PR DESCRIPTION
There are two distinct, but related problems with package publish:

1. I noticed that the package publish is sometimes not done at all when there is nothing changed.
2. In some other cases the publish is done but [silently fails](https://github.com/OpenIndiana/oi-userland/pull/15669#issuecomment-1895792424).

To solve both cases (the first one for sure, the second one hopefully) I propose to clobber packages before we try to publish them.