### PR TITLE
history: remove library/audio/libmikmod

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -606,7 +606,6 @@ lang-support-vietnamese@0.1,5.11-2015.0.2.0
 library/apr-util/dbd-freetds@1.5.4,5.11-2020.0.1.6
 library/arcus@2.7.0,5.11-2023.0.0.3
 library/audio/audiofile@0.2.7,5.11-2022.1.0.3
-library/audio/libmikmod@3.2.0,5.11-2015.0.2.0
 library/c++/net6@1.3.14,5.11-2014.1.3.0
 library/c++/obby@0.4.7,5.11-2014.1.3.0
 library/c++/stdcxx@4.2.1,5.11-2014.1.3.0


### PR DESCRIPTION
... because it is not obsolete.  It is build in `library/libmikmod`.