### PR TITLE
Fix obsoletion of gnome-user-docs

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -401,6 +401,7 @@ diagnostic/bwm-ng@0.6,5.11-2016.1.1.0
 diagnostics/arcstat@0.5,5.11-2014.0.1.0 system/monitoring/arcstat@0.5.11,5.11-2014.0.0.0
 documentation/diveintopython@5.4,5.11-2018.0.0.2
 documentation/gnome/gnome-devel-docs@2.32.0,5.11-2018.0.0.0
+documentation/gnome/gnome-user-docs@2.32.0,5.11-2018.0.0.1
 driver/audio/audiovia97@0.5.11,5.11-2022.0.1.0
 driver/graphics/nvidia-460@0.460.91,5.11-2020.0.1.1 driver/graphics/nvidia-470
 driver/graphics/nvidia-495@0.495.46,5.11-2021.0.0.1 driver/graphics/nvidia
@@ -480,7 +481,6 @@ gnome/gnome-screenshot@2.32.0,5.11-2017.0.0.3
 gnome/gnome-search-tool@2.32.0,5.11-2017.0.0.3
 gnome/gnome-session@2.32.1,5.11-2018.0.0.2
 gnome/gnome-settings-daemon@2.32.1,5.11-2017.0.0.5
-gnome/gnome-user-docs@2.32.0,5.11-2018.0.0.1
 gnome/locale/cs@0.5.11,5.11-2015.0.2.0
 gnome/locale/de@0.5.11,5.11-2015.0.2.0
 gnome/locale/es@0.5.11,5.11-2015.0.2.0


### PR DESCRIPTION
The package was removed in commit cd712ab4cc54f0fcdc99aff22fc57d29853e8f5a, but the obsoletion was incorrect, so the package is still installable.