### PR TITLE
bind: fix link-local addresses scoped with interface names

### DIFF
--- a/components/network/bind/Makefile
+++ b/components/network/bind/Makefile
@@ -30,6 +30,7 @@ COMPONENT_TEST_DIR = $(@D)/tests
 
 COMPONENT_NAME=		bind
 COMPONENT_VERSION=	9.18.21
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	BIND DNS name server and configuration tools.
 COMPONENT_DESCRIPTION=	BIND is open source software that implements the Domain Name System \
                         (DNS) protocols for the Internet.  This package contains the DNS \
@@ -60,6 +61,10 @@ CFLAGS += $(CPP_XPG6MODE)
 # FYI, The configure options are displayed by 'named -V'.  Previously
 # that was overriden by setting CONFIGARGS to hide build server
 # pathnames.
+
+# default LD_OPTION $(LD_B_DIRECT) causes problems with tests which
+# interpose on functions in shared libraries
+LD_B_DIRECT=
 
 # DNS libraries are in usr/lib/dns - Override settings from configure.mk
 CONFIGURE_LIBDIR.64= $(CONFIGURE_PREFIX)/lib/dns/$(MACH64)
@@ -101,6 +106,13 @@ COMPONENT_TEST_ENV += LC_ALL=C.UTF-8
 # The user running the test needs an profiles=Network Management entry in /etc/user_attr in order to successfully run the following ifconfig.sh up script:
 COMPONENT_PRE_TEST_ACTION= ( cd $(BUILD_DIR_64)/bin/tests/system && pfexec sh ./ifconfig.sh up )
 COMPONENT_POST_TEST_ACTION= ( cd $(BUILD_DIR_64)/bin/tests/system && pfexec sh ./ifconfig.sh down )
+
+# If SHELLOPTS is exported (as it is by the userland makefiles),
+# then all shell options get exported to child invocations of bash,
+# which results in test failures due to nounset and xtrace being
+# set unexpectedly, and errors such as "$1: unbound variable" and
+# diffs failing due to script tracing in output files.
+unexport SHELLOPTS
 
 # Manually added build dependencies
 REQUIRED_PACKAGES += library/cmocka

--- a/components/network/bind/patches/03-fix-netmask.patch
+++ b/components/network/bind/patches/03-fix-netmask.patch
@@ -1,0 +1,11 @@
+--- bind-9.18.21/bin/tests/system/ifconfig.sh.in.~1~	Fri Dec  8 04:09:37 2023
++++ bind-9.18.21/bin/tests/system/ifconfig.sh.in	Wed Jan 24 09:57:02 2024
+@@ -69,7 +69,7 @@
+     *-*-solaris2.1[1-9])
+       [ "$a" ] && {
+         /sbin/ipadm create-addr -t -T static \
+-          -a $a lo0/bind9v4$int \
++          -a $a/32 lo0/bind9v4$int \
+           || echo failed lo0/bind9v4$int
+       }
+       [ "$aaaa" ] && {

--- a/components/network/bind/patches/04-fix-update-test.patch
+++ b/components/network/bind/patches/04-fix-update-test.patch
@@ -1,0 +1,11 @@
+--- bind-9.18.21/tests/dns/update_test.c.~1~	Fri Dec  8 04:09:37 2023
++++ bind-9.18.21/tests/dns/update_test.c	Wed Jan 24 14:18:57 2024
+@@ -49,7 +49,7 @@
+ setup_test(void **state) {
+ 	UNUSED(state);
+ 
+-	setenv("TZ", "", 1);
++	setenv("TZ", "GMT0", 1);
+ 
+ 	return (0);
+ }

--- a/components/network/bind/patches/05-if-nametoindex.patch
+++ b/components/network/bind/patches/05-if-nametoindex.patch
@@ -1,0 +1,10 @@
+--- bind-9.18.21/configure.ac.~2~	Wed Jan 24 14:54:35 2024
++++ bind-9.18.21/configure.ac	Wed Jan 24 16:16:14 2024
+@@ -1025,6 +1025,7 @@
+ #
+ # Check for if_nametoindex() for IPv6 scoped addresses support
+ #
++AC_SEARCH_LIBS([if_nametoindex], [socket])
+ AC_CHECK_FUNCS([if_nametoindex])
+ 
+ ISC_ATOMIC_LIBS=""

--- a/components/network/bind/test/results-all.master
+++ b/components/network/bind/test/results-all.master
@@ -1,102 +1,109 @@
-FAIL: serve-stale
-PASS: doth
-PASS: acl
-PASS: additional
-PASS: addzone
-PASS: allow-query
-PASS: auth
-PASS: autosign
-PASS: builtin
-PASS: cacheclean
-PASS: case
-PASS: catz
-FAIL: cds
-PASS: checkconf
-PASS: checknames
-PASS: checkzone
-PASS: database
-PASS: dialup
-PASS: dlzexternal
-PASS: dns64
-PASS: dsdigest
-PASS: dupsigs
-PASS: dyndb
-PASS: ecdsa
-PASS: eddsa
-PASS: ednscompliance
-PASS: emptyzones
-SKIP: enginepkcs11
-PASS: filter-aaaa
-PASS: formerr
-SKIP: geoip2
-PASS: glue
-PASS: idna
-PASS: include-multiplecfg
-PASS: inline
-PASS: integrity
-PASS: hooks
-PASS: host
-PASS: journal
-PASS: keepalive
-SKIP: keyfromlabel
-PASS: legacy
-PASS: limits
-PASS: logfileconfig
-PASS: masterfile
-PASS: masterformat
-PASS: metadata
-PASS: mirror
-PASS: mkeys
-PASS: names
-PASS: notify
-PASS: nsec3
-PASS: nslookup
-PASS: padding
-PASS: pending
-PASS: redirect
-PASS: rndc
-PASS: rootkeysentinel
-PASS: rpz
-PASS: rrchecker
-PASS: rrl
-PASS: rrsetorder
-PASS: rsabigexponent
-FAIL: runtime
-PASS: sfcache
-PASS: smartsign
-PASS: sortlist
-PASS: spf
-PASS: staticstub
-PASS: stub
-PASS: synthfromdnssec
-PASS: tkey
-PASS: tools
-PASS: transport-acl
-FAIL: tsig
-FAIL: tsiggss
-PASS: ttl
-PASS: unknown
-PASS: verify
-PASS: views
-PASS: wildcard
-PASS: xferquota
-PASS: zonechecks
-PASS: nzd2nzf
-PASS: kasp
-PASS: keymgr2kasp
-PASS: tcp
-PASS: pipelined
-PASS: checkds
-PASS: dispatch
-PASS: rpzextra
-PASS: shutdown
-PASS: timeouts
-PASS: qmin
-PASS: cookie
-# TOTAL: 95
-# PASS:  87
-# SKIP:  3
+# TOTAL: 0
+# PASS:  0
+# SKIP:  0
 # XFAIL: 0
-# FAIL:  5
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+PASS: aes_test
+PASS: buffer_test
+PASS: counter_test
+PASS: crc64_test
+PASS: errno_test
+PASS: file_test
+PASS: hash_test
+PASS: heap_test
+PASS: hmac_test
+PASS: ht_test
+PASS: lex_test
+PASS: md_test
+PASS: mem_test
+PASS: netaddr_test
+PASS: netmgr_test
+PASS: parse_test
+PASS: pool_test
+PASS: quota_test
+PASS: radix_test
+PASS: random_test
+PASS: regex_test
+PASS: result_test
+PASS: safe_test
+PASS: siphash_test
+PASS: sockaddr_test
+PASS: stats_test
+PASS: symtab_test
+PASS: task_test
+PASS: taskpool_test
+PASS: time_test
+PASS: timer_test
+PASS: doh_test
+# TOTAL: 32
+# PASS:  32
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+PASS: acl_test
+PASS: db_test
+PASS: dbdiff_test
+PASS: dbiterator_test
+PASS: dbversion_test
+PASS: dh_test
+PASS: dispatch_test
+PASS: dns64_test
+PASS: dst_test
+PASS: keytable_test
+PASS: name_test
+PASS: nsec3_test
+PASS: nsec3param_test
+PASS: private_test
+PASS: rbt_test
+PASS: rbtdb_test
+PASS: rdata_test
+PASS: rdataset_test
+PASS: rdatasetstats_test
+PASS: resolver_test
+PASS: rsa_test
+PASS: sigs_test
+PASS: time_test
+PASS: tsig_test
+PASS: update_test
+PASS: zonemgr_test
+PASS: zt_test
+PASS: master_test
+# TOTAL: 28
+# PASS:  28
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+PASS: listenlist_test
+PASS: notify_test
+PASS: plugin_test
+PASS: query_test
+# TOTAL: 4
+# PASS:  4
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+PASS: duration_test
+PASS: parser_test
+# TOTAL: 2
+# PASS:  2
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+PASS: resconf_test
+# TOTAL: 1
+# PASS:  1
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
 # XPASS: 0
 # ERROR: 0


### PR DESCRIPTION
If bind's configure can't find if_nametoindex(), it only lets you use interface ids (fe80::1%5) instead of interface names (like fe80::1%wan0); pass LIBS=-lsocket to configure and it will find the function in -lsocket.