### PR TITLE
hexchat: disable direct binding to fix Python plugin

### DIFF
--- a/components/desktop/hexchat/Makefile
+++ b/components/desktop/hexchat/Makefile
@@ -21,7 +21,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		hexchat
 COMPONENT_VERSION=	2.16.1
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	https://hexchat.github.io/
 COMPONENT_SUMMARY=	HexChat IRC client
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -43,15 +43,18 @@ TEST_TARGET=           $(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 PATH=$(PATH.gnu)
 
+# Disable direct binding to allow the Python plugin to load.
+# Without this, you get:
+# ld.so.1: hexchat: fatal: relocation error: file .../python.so:
+#   symbol __iob: referenced symbol not found
+LD_B_DIRECT=
+
 PERL5_LIBDIR=/usr/perl5/$(PERL_VERSION)/lib/$(PERL_ARCH)/CORE/
 COMPONENT_POST_INSTALL_ACTION = ( \
-	for file in `find $(PROTOUSRDIR) -name "*.so"`; do \
         /usr/bin/elfedit -e 'dyn:value -s  RUNPATH "$(PERL5_LIBDIR)"' $(PROTOUSRDIR)/lib/$(MACH64)/hexchat/plugins/perl.so; \
         /usr/bin/elfedit -e 'dyn:value -s  RPATH "$(PERL5_LIBDIR)"' $(PROTOUSRDIR)/lib/$(MACH64)/hexchat/plugins/perl.so; \
-	/usr/bin/elfedit -e 'dyn:value -s NEEDED "libpython3.9.so.1.0"' $(PROTOUSRDIR)/lib/$(MACH64)/hexchat/plugins/python.so; \
-	done; )
-
-
+	/usr/bin/elfedit -e 'dyn:value -add -s NEEDED "libpython3.9.so.1.0"' \
+			$(PROTOUSRDIR)/lib/$(MACH64)/hexchat/plugins/python.so)
 
 CONFIGURE_OPTIONS += -Dwith-python=python-3.9
 CONFIGURE_OPTIONS += -Dwith-lua=false


### PR DESCRIPTION
Without this change if you attempt to load the plugin, it fails to find __iob from libc:

/load /usr/lib/amd64/hexchat/plugins/python.so
ld.so.1: hexchat: fatal: relocation error: file /usr/lib/amd64/hexchat/plugins/python.so: symbol __iob: referenced symbol not found

Also, in COMPONENT_POST_INSTALL ACTION:
 - remove unnecessary loop around elfedit commands
 - use 'dyn:value -add' so python.so retains a dependency on libc.so.1