### PR TITLE
python39: patch 64-bit system_lib_dirs for illumos

### DIFF
--- a/components/python/python39/Makefile
+++ b/components/python/python39/Makefile
@@ -30,7 +30,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=	        Python
 COMPONENT_VERSION=      3.9.16
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=      The Python interpreter, libraries and utilities
 COMPONENT_PROJECT_URL=  https://python.org/
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/python/python39/patches/45-system-64-libs.patch
+++ b/components/python/python39/patches/45-system-64-libs.patch
@@ -1,0 +1,11 @@
+--- Python-3.9.16/setup.py.~7~	Thu Jan 25 12:06:42 2024
++++ Python-3.9.16/setup.py	Thu Jan 25 12:20:40 2024
+@@ -759,7 +759,7 @@
+             add_dir_to_list(self.compiler.include_dirs,
+                             sysconfig.get_config_var("INCLUDEDIR"))
+ 
+-        system_lib_dirs = ['/lib64', '/usr/lib64', '/lib', '/usr/lib']
++        system_lib_dirs = ['/lib/64', '/usr/lib/64', '/lib', '/usr/lib']
+         system_include_dirs = ['/usr/include']
+         # lib_dirs and inc_dirs are used to search for files;
+         # if a file is found in one of those directories, it can


### PR DESCRIPTION
Fixes missing _tkinter module; tcl/tk libraries are now only in /usr/lib/64