### PR TITLE
remove or modify WARNING files about squeak

### DIFF
--- a/components/library/cairo/WARNING
+++ b/components/library/cairo/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/library/freetype/WARNING
+++ b/components/library/freetype/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/library/glib/WARNING
+++ b/components/library/glib/WARNING
@@ -2,6 +2,3 @@ Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/library/libffi/WARNING
+++ b/components/library/libffi/WARNING
@@ -2,6 +2,3 @@ Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/library/libjpeg-turbo/WARNING
+++ b/components/library/libjpeg-turbo/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/library/openssl/openssl-1.0.2/WARNING
+++ b/components/library/openssl/openssl-1.0.2/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/library/pango/WARNING
+++ b/components/library/pango/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/multimedia/gstreamer/WARNING
+++ b/components/multimedia/gstreamer/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/x11/libX11/WARNING
+++ b/components/x11/libX11/WARNING
@@ -2,6 +2,3 @@ Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/x11/libXext/WARNING
+++ b/components/x11/libXext/WARNING
@@ -2,6 +2,3 @@ Attention
 
 GDM for SunRay (http://pkg.toc.de/sunray) depends on this package. There are 32-bit and 64-bit builds required.
 
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/x11/libXrender/WARNING
+++ b/components/x11/libXrender/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-

--- a/components/x11/mesa/WARNING
+++ b/components/x11/mesa/WARNING
@@ -1,4 +1,0 @@
-
-The package runtime/smalltalk/squeak depends on this library.
-A 32bit and 63bit version of this library is required for Squeak.
-


### PR DESCRIPTION
This commit changes multiple WARNING files in multiple locations.   The 32bit squeak interpreter is now built as an ELF64 binary and is able to run 32bit smalltalk images so there is no real dependency on 32bit OpenIndiana libraries.