### PR TITLE
stack-spur: remove libxevie dependency

### DIFF
--- a/components/runtime/smalltalk/stack-spur/Makefile
+++ b/components/runtime/smalltalk/stack-spur/Makefile
@@ -9,7 +9,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2022, 2023 David Stes
+# Copyright 2020, 2021, 2022, 2023, 2024 David Stes
 #
 
 
@@ -41,6 +41,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		stack-spur
 COMPONENT_VERSION=	5.0.3339
+COMPONENT_REVISION=	1
 GIT_TAG=		sun-v5.0.61
 PLUGIN_REV=		5.0-202312211904
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
@@ -144,7 +145,6 @@ REQUIRED_PACKAGES += system/library/dbus
 REQUIRED_PACKAGES += library/audio/gstreamer
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += system/library/freetype-2
-REQUIRED_PACKAGES += x11/library/libxevie
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/audio/pulseaudio

--- a/components/runtime/smalltalk/stack-spur/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/runtime/smalltalk/stack-spur/pkg5
+++ b/components/runtime/smalltalk/stack-spur/pkg5
@@ -13,17 +13,16 @@
         "system/library/freetype-2",
         "system/library/math",
         "x11/library/libx11",
-        "x11/library/libxevie",
         "x11/library/libxext",
         "x11/library/libxrender",
         "x11/library/mesa"
     ],
     "fmris": [
+        "runtime/smalltalk/stack-spur",
         "runtime/smalltalk/stack-spur-display-X11",
         "runtime/smalltalk/stack-spur-nodisplay",
         "runtime/smalltalk/stack-spur-ssl",
-        "runtime/smalltalk/stack-spur-vep",
-        "runtime/smalltalk/stack-spur"
+        "runtime/smalltalk/stack-spur-vep"
     ],
     "name": "stack-spur"
 }


### PR DESCRIPTION
I think there is no real dependency on libxevie in opensmalltalk but the Makefile had a manual required package of libxevie .