### PR TITLE
cog-spur: remove libxevie dependency

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -9,7 +9,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2022, 2023 David Stes
+# Copyright 2020, 2021, 2022, 2023, 2024 David Stes
 #
 
 
@@ -35,6 +35,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.3339
+COMPONENT_REVISION=	1
 GIT_TAG=		sun-v5.0.61
 PLUGIN_REV=		5.0-202312211904-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine
@@ -106,6 +107,10 @@ CONFIGURE_ENV    +=     LIBS="$(LIBS)"
 CONFIGURE_ENV.32 +=	TARGET_ARCH="-m32"
 CONFIGURE_ENV.64 +=	TARGET_ARCH="-m64"
 
+# for pkgsend generate (sample-manifest)
+# the actual manifest uses a mediator mediated hardlink for the squeak manpage
+PKG_HARDLINKS    += usr/share/man/man1/squeak.1
+
 # the opensmalltalk Makefile does not use DESTDIR
 COMPONENT_INSTALL_ARGS=  	ROOT=$(PROTO_DIR)
 COMPONENT_BUILD_TARGETS= 	getversion squeak plugins ckformat
@@ -136,7 +141,6 @@ REQUIRED_PACKAGES += system/library/dbus
 REQUIRED_PACKAGES += library/audio/gstreamer
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += system/library/freetype-2
-REQUIRED_PACKAGES += x11/library/libxevie
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/audio/pulseaudio

--- a/components/runtime/smalltalk/cog-spur/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/cog-spur/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/runtime/smalltalk/cog-spur/pkg5
+++ b/components/runtime/smalltalk/cog-spur/pkg5
@@ -13,17 +13,16 @@
         "system/library/freetype-2",
         "system/library/math",
         "x11/library/libx11",
-        "x11/library/libxevie",
         "x11/library/libxext",
         "x11/library/libxrender",
         "x11/library/mesa"
     ],
     "fmris": [
+        "runtime/smalltalk/cog-spur",
         "runtime/smalltalk/cog-spur-display-X11",
         "runtime/smalltalk/cog-spur-nodisplay",
         "runtime/smalltalk/cog-spur-ssl",
-        "runtime/smalltalk/cog-spur-vep",
-        "runtime/smalltalk/cog-spur"
+        "runtime/smalltalk/cog-spur-vep"
     ],
     "name": "cog-spur"
 }


### PR DESCRIPTION
I think there is no real dependency on libxevie in opensmalltalk but the Makefile had a manual required package of libxevie .