### PR TITLE
jenkinshelper.ksh: gmake clean before publish

### DIFF
--- a/tools/jenkinshelper.ksh
+++ b/tools/jenkinshelper.ksh
@@ -59,7 +59,7 @@ stage_build_changed() {
 	for f in $(git diff --name-only HEAD..origin/oi/hipster | grep Makefile; exit 0); do
 		echo "jenkinshelper: building for ${f%/*}..."
 		curpwd=$(pwd)
-		cd "${f%/*}" && COMPONENT_BUILD_ARGS=-j$(psrinfo -t -c) gmake publish
+		cd "${f%/*}" && gmake clean && COMPONENT_BUILD_ARGS=-j$(psrinfo -t -c) gmake publish
 		rc=$?
 		cd "${curpwd}"
 		echo "jenkinshelper: done with ${f%/*} return code ${rc}"


### PR DESCRIPTION
I've seen several of my pull requests fail to build in jenkins because I've updated existing patches and this causes `gmake publish` to attempt to apply them again (which fails).   We could attempt to restructure the patching make macros to figure out when a `make clean` is necessary, but just always rerunning `make clean` on changed components is going to be more robust and easier to do in the short term, albeit a bit slower.

Let me know if I'm missing something.
