### PR TITLE
firefox: update to 122.0.1

### DIFF
--- a/components/web/firefox/Makefile
+++ b/components/web/firefox/Makefile
@@ -20,6 +20,7 @@
 
 USE_PARALLEL_BUILD = yes
 include ../../../make-rules/shared-macros.mk
+ENV = /usr/bin/env
 
 # ESR should be set to esr for esr build, or an empty string for other builds
 ESR = 
@@ -27,11 +28,11 @@ ESR =
 # CANDIDATE_BUILD is the build number found in the candidates directory.
 # CANDIDATE_BETA is the beta version found in the candidates directory.
 # Do not define either for final release build.
-# CANDIDATE_BUILD=2
+# CANDIDATE_BUILD=1
 # CANDIDATE_BETA=9
 
 COMPONENT_NAME =	firefox
-COMPONENT_VERSION =	122.0
+COMPONENT_VERSION =	122.0.1
 COMPONENT_SUMMARY=      Mozilla Firefox Web browser
 COMPONENT_PROJECT_URL =	https://www.mozilla.com/firefox
 COMPONENT_SRC_NAME =	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -41,7 +42,7 @@ COMPONENT_ARCHIVE =	$(COMPONENT_NAME)-$(COMPONENT_VERSION)b$(CANDIDATE_BETA)$(ES
 else
 COMPONENT_ARCHIVE =	$(COMPONENT_SRC_NAME)$(ESR).source.tar.xz
 endif
-COMPONENT_ARCHIVE_HASH= sha256:b84815a90e147965e4c0b50599c85b1022ab0fce42105e5ef45c630dcca5dec3
+COMPONENT_ARCHIVE_HASH= sha256:36f19c9a748eec2fd6d3a1594d0f1d7b715eaa1d9ed6d7eeda9db8478dcf36d6
 ifndef CANDIDATE_BUILD
 MOZILLA_FTP =		https://ftp.mozilla.org/pub/$(COMPONENT_NAME)/releases/$(COMPONENT_VERSION)$(ESR)
 else

--- a/components/web/firefox/pkg5
+++ b/components/web/firefox/pkg5
@@ -32,8 +32,8 @@
         "x11/library/libxrandr"
     ],
     "fmris": [
-        "web/data/firefox-bookmarks",
-        "web/browser/firefox"
+        "web/browser/firefox",
+        "web/data/firefox-bookmarks"
     ],
     "name": "firefox"
 }


### PR DESCRIPTION
This does not have a fix for firefox crashing on the ebay signin page. I have only confirmed the patch for subprocess_shared_unix.js (firefox-02-environ-revised.patch) introduced in 122 is not at fault.