### PR TITLE
python/pip-run: remove misplaced docs and tests files

### DIFF
--- a/components/python/pip-run/Makefile
+++ b/components/python/pip-run/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		pip-run
 HUMAN_VERSION =			12.6.0
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		pip-run - install packages and run Python with them
 COMPONENT_PROJECT_URL =		https://github.com/jaraco/pip-run
 COMPONENT_ARCHIVE_HASH =	\
@@ -28,6 +29,12 @@ COMPONENT_LICENSE =		MIT
 COMPONENT_LICENSE_FILE =	LICENSE
 
 include $(WS_MAKE_RULES)/common.mk
+
+# Remove misplaced docs and tests files
+# https://github.com/jaraco/pip-run/issues/98
+COMPONENT_POST_INSTALL_ACTION += \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/docs ; \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/tests ;
 
 # Revert back unneeded PYV normalizations
 COMPONENT_TEST_TRANSFORMS += "-e 's/py\$$(PYV)compat/py$(subst .,,$(PYTHON_VERSION))compat/'"

--- a/components/python/pip-run/manifests/sample-manifest.p5m
+++ b/components/python/pip-run/manifests/sample-manifest.p5m
@@ -24,10 +24,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/pip-run-$(PYVER)
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/conf.py
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/cowsay.svg
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/history.rst
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/index.rst
 file path=usr/lib/python$(PYVER)/vendor-packages/pip-run.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run-$(HUMAN_VERSION).dist-info/LICENSE
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run-$(HUMAN_VERSION).dist-info/METADATA
@@ -47,10 +43,6 @@ file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/retention/destroy.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/retention/persist.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/scripts.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/usage.txt
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_commands.py
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_deps.py
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_launch.py
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_scripts.py
 
 # python modules are unusable without python runtime binary
 depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \

--- a/components/python/pip-run/pip-run-PYVER.p5m
+++ b/components/python/pip-run/pip-run-PYVER.p5m
@@ -24,10 +24,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/pip-run-$(PYVER)
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/conf.py
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/cowsay.svg
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/history.rst
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/index.rst
 file path=usr/lib/python$(PYVER)/vendor-packages/pip-run.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run-$(HUMAN_VERSION).dist-info/LICENSE
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run-$(HUMAN_VERSION).dist-info/METADATA
@@ -47,10 +43,6 @@ file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/retention/destroy.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/retention/persist.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/scripts.py
 file path=usr/lib/python$(PYVER)/vendor-packages/pip_run/usage.txt
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_commands.py
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_deps.py
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_launch.py
-file path=usr/lib/python$(PYVER)/vendor-packages/tests/test_scripts.py
 
 # python modules are unusable without python runtime binary
 depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \

--- a/components/python/pip-run/python-integrate-project.conf
+++ b/components/python/pip-run/python-integrate-project.conf
@@ -16,5 +16,11 @@
 %patch% 01-no-ruff.patch
 
 %include-3%
+# Remove misplaced docs and tests files
+# https://github.com/jaraco/pip-run/issues/98
+COMPONENT_POST_INSTALL_ACTION += \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/docs ; \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/tests ;
+
 # Revert back unneeded PYV normalizations
 COMPONENT_TEST_TRANSFORMS += "-e 's/py\$$(PYV)compat/py$(subst .,,$(PYTHON_VERSION))compat/'"


### PR DESCRIPTION
Fix for https://github.com/jaraco/pip-run/issues/98