### PR TITLE
python/pipenv: remove misplaced docs and examples files

### DIFF
--- a/components/python/pipenv/Makefile
+++ b/components/python/pipenv/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		pipenv
 HUMAN_VERSION =			2023.12.1
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		pipenv - Python Development Workflow for Humans.
 COMPONENT_PROJECT_URL =		https://github.com/pypa/pipenv
 COMPONENT_ARCHIVE_HASH =	\
@@ -30,6 +31,12 @@ COMPONENT_LICENSE_FILE =	LICENSE
 TEST_STYLE = none
 
 include $(WS_MAKE_RULES)/common.mk
+
+# Remove misplaced docs and examples files
+# https://github.com/pypa/pipenv/issues/5937
+COMPONENT_POST_INSTALL_ACTION += \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/docs ; \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/examples ;
 
 # Auto-generated dependencies
 PYTHON_REQUIRED_PACKAGES += library/python/certifi

--- a/components/python/pipenv/manifests/sample-manifest.p5m
+++ b/components/python/pipenv/manifests/sample-manifest.p5m
@@ -25,16 +25,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/pipenv-$(PYVER)
 file path=usr/bin/pipenv-resolver-$(PYVER)
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/Makefile
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_static/custom.css
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_static/konami.js
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_static/pipenv.png
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_templates/hacks.html
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_templates/sidebarlogo.html
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/conf.py
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/make.bat
-file path=usr/lib/python$(PYVER)/vendor-packages/examples/Pipfile
-file path=usr/lib/python$(PYVER)/vendor-packages/examples/Pipfile.lock
 file path=usr/lib/python$(PYVER)/vendor-packages/pipenv-$(HUMAN_VERSION).dist-info/LICENSE
 file path=usr/lib/python$(PYVER)/vendor-packages/pipenv-$(HUMAN_VERSION).dist-info/METADATA
 file path=usr/lib/python$(PYVER)/vendor-packages/pipenv-$(HUMAN_VERSION).dist-info/NOTICES

--- a/components/python/pipenv/pipenv-PYVER.p5m
+++ b/components/python/pipenv/pipenv-PYVER.p5m
@@ -25,16 +25,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/pipenv-$(PYVER)
 file path=usr/bin/pipenv-resolver-$(PYVER)
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/Makefile
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_static/custom.css
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_static/konami.js
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_static/pipenv.png
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_templates/hacks.html
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/_templates/sidebarlogo.html
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/conf.py
-file path=usr/lib/python$(PYVER)/vendor-packages/docs/make.bat
-file path=usr/lib/python$(PYVER)/vendor-packages/examples/Pipfile
-file path=usr/lib/python$(PYVER)/vendor-packages/examples/Pipfile.lock
 file path=usr/lib/python$(PYVER)/vendor-packages/pipenv-$(HUMAN_VERSION).dist-info/LICENSE
 file path=usr/lib/python$(PYVER)/vendor-packages/pipenv-$(HUMAN_VERSION).dist-info/METADATA
 file path=usr/lib/python$(PYVER)/vendor-packages/pipenv-$(HUMAN_VERSION).dist-info/NOTICES

--- a/components/python/pipenv/python-integrate-project.conf
+++ b/components/python/pipenv/python-integrate-project.conf
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Marcel Telka
+#
+
+%include-3%
+# Remove misplaced docs and examples files
+# https://github.com/pypa/pipenv/issues/5937
+COMPONENT_POST_INSTALL_ACTION += \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/docs ; \
+	$(RM) -r $(PROTO_DIR)/$(PYTHON_LIB)/examples ;


### PR DESCRIPTION
Fix for https://github.com/pypa/pipenv/issues/5937