### PR TITLE
prep-patch.mk: do not use shell call for PATCHES

### DIFF
--- a/make-rules/prep-patch.mk
+++ b/make-rules/prep-patch.mk
@@ -47,9 +47,7 @@ PATCH_PATTERN ?=	*.patch*
 
 PATCH_DIR ?=		patches
 
-PATCHES =	$(shell find $(PATCH_DIR) -type f \
-			 -name '$(PATCH_PATTERN)' 2>/dev/null | \
-				LC_COLLATE=C sort)
+PATCHES =	$(wildcard $(PATCH_DIR)/$(PATCH_PATTERN))
 
 PCH_SUFFIXES = $(patsubst .patch_%,%, $(filter-out .patch,$(suffix $(PATCHES))))
 


### PR DESCRIPTION
I measured speed improvement of this change.  I tried `time gmake print-value-PATCHES >/dev/null` in a component dir and here are typical results before the change:
```
real    0m0.165s
user    0m0.073s
sys     0m0.091s
```
and after the change:
```
real    0m0.135s
user    0m0.062s
sys     0m0.064s
```
Please note that the previous version of `PATCHES` allowed patches in subdirectories of the `patches` directory while the new version does not.  I checked all components and confirmed we do not have directories in `patches`.