### PR TITLE
graphviz: remove graphviz-php from history

### DIFF
--- a/components/image/graphviz/history
+++ b/components/image/graphviz/history
@@ -1,6 +1,5 @@
 image/graphviz/graphviz-perl-534@7.10.0-2023.0.0.1
 image/graphviz/graphviz-python-26@2.38.0,5.11-2016.0.1.4
-image/graphviz/graphviz-php@2.40.1-2018.0.0.5
 image/graphviz/graphviz-perl-522@2.40.1-2020.0.1.6
 image/graphviz/graphviz-python-27@2.40.1-2020.0.1.6
 image/graphviz/graphviz-sharp@2.40.1-2020.0.1.6


### PR DESCRIPTION
... because it is not obsolete:
```
$ pkg list -afv image/graphviz/graphviz-php
FMRI                                                                         IFO
pkg://openindiana.org/image/graphviz/graphviz-php@9.0.0-2024.0.0.4:20240211T231638Z i--
pkg://openindiana.org/image/graphviz/graphviz-php@9.0.0-2023.0.0.3:20231104T134646Z ---
pkg://openindiana.org/image/graphviz/graphviz-php@9.0.0-2023.0.0.2:20231029T124052Z ---
pkg://openindiana.org/image/graphviz/graphviz-php@9.0.0-2023.0.0.2:20231029T123821Z ---
pkg://openindiana.org/image/graphviz/graphviz-php@9.0.0-2023.0.0.1:20231013T105754Z ---
pkg://openindiana.org/image/graphviz/graphviz-php@2.40.1-2018.0.0.5:20240211T231748Z --o
pkg://openindiana.org/image/graphviz/graphviz-php@2.40.1-2018.0.0.5:20231104T134703Z --o
pkg://openindiana.org/image/graphviz/graphviz-php@2.40.1-2018.0.0.5:20231029T124107Z --o
pkg://openindiana.org/image/graphviz/graphviz-php@2.40.1-2018.0.0.5:20231029T123833Z --o
pkg://openindiana.org/image/graphviz/graphviz-php@2.40.1-2018.0.0.5:20231029T122730Z --o
$
```