### PR TITLE
sbcl: fix build dependencies

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -28,6 +28,6 @@
 /^desktop\/libayatana-appindicator$/d
 /^runtime\/openjdk-11$/d
 /^runtime\/smalltalk\/squeak$/d
-# We cannot build sbcl on our build server because it lacks SIMD support.
+# We cannot build sbcl on our build server because it lacks AVX2 support.
 # Instead we need to provide pre-published files and publish it manually.
 /^runtime\/sbcl$/d

--- a/components/runtime/sbcl/Makefile
+++ b/components/runtime/sbcl/Makefile
@@ -32,10 +32,10 @@ COMPONENT_LICENSE_FILE=	COPYING
 TEST_TARGET= $(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 
-COMPONENT_ENV  =	PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/gnu/bin
+COMPONENT_ENV  =	PATH="$(PATH)"
 COMPONENT_ENV +=	GNUMAKE=$(GMAKE)
 COMPONENT_ENV +=	CC="$(CC)"
-COMPONENT_BUILD_ARGS  =	--prefix=/usr
+COMPONENT_BUILD_ARGS  =	--prefix=$(USRDIR)
 COMPONENT_BUILD_ARGS +=	--arch=x86-64
 # This is currently --with-sb-thread --with-sb-core-compression
 # --with-sb-xref-internals and :sb-after-xc-core as a build feature.
@@ -55,8 +55,8 @@ $(BUILD_DIR)/%/.installed:	$(BUILD_DIR)/%/.built
 $(BUILD_DIR)/%/.tested:		$(BUILD_DIR)/%/.installed
 	(cd $(@D)/tests; $(ENV) $(COMPONENT_ENV) BUILD_ROOT=$(PROTO_DIR) /usr/gnu/bin/sh run-tests.sh)
 
-clean::
-	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
+# Pre-installed sbcl is needed to build sbcl
+REQUIRED_PACKAGES += runtime/sbcl
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += compress/zstd

--- a/components/runtime/sbcl/patches/01-Config.x86-sunos.patch
+++ b/components/runtime/sbcl/patches/01-Config.x86-sunos.patch
@@ -1,5 +1,5 @@
---- sbcl-2.3.3/src/runtime/Config.x86-sunos.orig	2023-03-28 21:42:53.000000000 +0200
-+++ sbcl-2.3.3/src/runtime/Config.x86-sunos	2023-03-29 21:06:08.872366454 +0200
+--- sbcl-2.4.1/src/runtime/Config.x86-sunos.orig
++++ sbcl-2.4.1/src/runtime/Config.x86-sunos
 @@ -10,7 +10,7 @@
  # files for more information.
  

--- a/components/runtime/sbcl/patches/02-asdf-module.mk.patch
+++ b/components/runtime/sbcl/patches/02-asdf-module.mk.patch
@@ -1,6 +1,6 @@
---- sbcl-1.4.7/contrib/asdf-module.mk.1	2018-05-16 19:28:03.099397952 +0000
-+++ sbcl-1.4.7/contrib/asdf-module.mk	2018-05-16 19:28:18.335701315 +0000
-@@ -11,7 +11,7 @@
+--- sbcl-2.4.1/contrib/asdf-module.mk.orig
++++ sbcl-2.4.1/contrib/asdf-module.mk
+@@ -12,7 +12,7 @@
  ASD=$(DEST)/$(SYSTEM).asd
  
  ifeq (SunOS,$(UNAME))

--- a/components/runtime/sbcl/patches/03-Config.x86-64-sunos.patch
+++ b/components/runtime/sbcl/patches/03-Config.x86-64-sunos.patch
@@ -1,5 +1,5 @@
---- sbcl-2.3.3/src/runtime/Config.x86-64-sunos.orig	2023-03-28 21:42:53.000000000 +0200
-+++ sbcl-2.3.3/src/runtime/Config.x86-64-sunos	2023-03-29 21:09:15.948629755 +0200
+--- sbcl-2.4.1/src/runtime/Config.x86-64-sunos.orig
++++ sbcl-2.4.1/src/runtime/Config.x86-64-sunos
 @@ -1,5 +1,5 @@
  CC=gcc
 -CFLAGS += -m64 -g -Wall -std=gnu89 -D__EXTENSIONS__ -DSVR4 -D_REENTRANT -fno-omit-frame-pointer

--- a/components/runtime/sbcl/pkg5
+++ b/components/runtime/sbcl/pkg5
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "compress/zstd",
+        "runtime/sbcl",
         "system/library",
         "system/library/math"
     ],

--- a/components/runtime/sbcl/sbcl.p5m
+++ b/components/runtime/sbcl/sbcl.p5m
@@ -17,10 +17,10 @@
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
-set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
@@ -60,8 +60,8 @@ file path=usr/lib/sbcl/contrib/sb-rotate-byte.asd
 file path=usr/lib/sbcl/contrib/sb-rotate-byte.fasl
 file path=usr/lib/sbcl/contrib/sb-rt.asd
 file path=usr/lib/sbcl/contrib/sb-rt.fasl
-file path=usr/lib/sbcl/contrib/sb-simd.asd                                                                                                                                  
-file path=usr/lib/sbcl/contrib/sb-simd.fasl                                                                                          
+file path=usr/lib/sbcl/contrib/sb-simd.asd
+file path=usr/lib/sbcl/contrib/sb-simd.fasl
 file path=usr/lib/sbcl/contrib/sb-simple-streams.asd
 file path=usr/lib/sbcl/contrib/sb-simple-streams.fasl
 file path=usr/lib/sbcl/contrib/sb-sprof.asd


### PR DESCRIPTION
Please note that `COMPONENT_REVISION` is not incremented here because build of this component is disabled and we do not need its rebuild.