### PR TITLE
transforms: do not strip Python 3 ABI extensions

### DIFF
--- a/transforms/generate-cleanup
+++ b/transforms/generate-cleanup
@@ -78,12 +78,9 @@
 # PEP 627 made the RECORD file optional.  Since we do not need the file and it
 # could contain inaccurate info we simply drop it.
 <transform dir file link hardlink path=usr\/lib\/python3\.\d+\/vendor-packages\/[^/]+\.dist-info/RECORD$ -> drop>
-# Strip Python 3 cpython ABI extension
+# Replace Python version by $(PYV)
 <transform file -> \
-	edit path "^(usr/lib/python3\.\d+/vendor-packages/(.*/)?[^/]+)\.cpython-3\d+\.so$" "\1.so">
-# Strip Python 3 abi3 ABI extension
-<transform file -> \
-	edit path "^(usr/lib/python3\.\d+/vendor-packages/(.*/)?[^/]+)\.abi3\.so$" "\1.so">
+	edit path "^(usr/lib/python3\.\d+/vendor-packages/(.*/)?[^/]+\.cpython-)3\d+\.so$" "\1$!(PYV).so">
 # Replace Python version by $(PYVER)
 <transform file path=usr/bin/[^/]+-3\.\d+$ -> default tmp.fmri "$(COMPONENT_FMRI)">
 <transform file tmp.fmri=.*runtime/python -> edit path "^(usr/bin/[^/]+-)3\.\d+$" "\1$!(PYVER)">

--- a/transforms/python-3-soabi
+++ b/transforms/python-3-soabi
@@ -26,7 +26,7 @@
 # Python ABI for .so files is to append ".cpython-3#.so".
 # See http://legacy.python.org/dev/peps/pep-3149/ and
 # https://github.com/python/cpython/issues/80888 for details.
-$(PY3_CPYTHON_NAMING)<transform file -> edit path \
+$(PY3_CPYTHON_NAMING)<transform file path=(?!.*\.(cpython-3\d+|abi3)\.so$) -> edit path \
 $(PY3_CPYTHON_NAMING)      "(usr/lib/python3\.)(\d+)(/vendor-packages/(.*/)?(64/)?.*)\.so$" \
 $(PY3_CPYTHON_NAMING)      \\1\\2\\3.cpython-3\\2.so >
 
@@ -34,6 +34,6 @@ $(PY3_CPYTHON_NAMING)      \\1\\2\\3.cpython-3\\2.so >
 # all Python versions.  The compiled shared libraries have ".abi3.so" suffix to
 # indicate the usage of the limited API.
 # See https://www.python.org/dev/peps/pep-0384/ for more information.
-$(PY3_ABI3_NAMING)<transform file -> edit path \
+$(PY3_ABI3_NAMING)<transform file path=(?!.*\.(cpython-3\d+|abi3)\.so$) -> edit path \
 $(PY3_ABI3_NAMING)      "(usr/lib/python3\.\d+/vendor-packages/(.*/)?(64/)?.*)\.so$" \
 $(PY3_ABI3_NAMING)      \\1.abi3.so >


### PR DESCRIPTION
This feature brings more problems than it solves.  Does it solve anything these days?  I doubt.  Did it solve any issue in past?  Not sure.  So it is time to slowly phase it out.  The first step is to disable the manifest generation side of the feature.