### PR TITLE
at-spi2-core: fix dbus-daemon path

### DIFF
--- a/components/desktop/gnome2/at-spi2-core/Makefile
+++ b/components/desktop/gnome2/at-spi2-core/Makefile
@@ -19,7 +19,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         at-spi2-core
 COMPONENT_VERSION=      2.24.1
-COMPONENT_REVISION=     2
+COMPONENT_REVISION=     3
 COMPONENT_SUMMARY=      Assistive Technology Service Provider Interface
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
@@ -40,7 +40,7 @@ PATH=$(PATH.gnu)
 
 CONFIGURE_OPTIONS += --sysconfdir=/etc
 CONFIGURE_OPTIONS += --libexecdir=$(CONFIGURE_LIBDIR.$(BITS))
-CONFIGURE_OPTIONS += --with-dbus_daemondir=/usr/lib
+CONFIGURE_OPTIONS += --with-dbus_daemondir=/usr/libexec
 CONFIGURE_OPTIONS += --enable-xevie=no
 CONFIGURE_OPTIONS.32 += --enable-introspection=no
 

--- a/components/desktop/gnome2/at-spi2-core/manifests/sample-manifest.p5m
+++ b/components/desktop/gnome2/at-spi2-core/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/desktop/gnome2/at-spi2-core/pkg5
+++ b/components/desktop/gnome2/at-spi2-core/pkg5
@@ -1,9 +1,7 @@
 {
     "dependencies": [
-        "SUNWcs",
         "library/glib2",
         "library/perl-5/xml-parser",
-        "shell/ksh93",
         "system/library",
         "system/library/libdbus",
         "x11/library/libx11",


### PR DESCRIPTION
apps which use gnome accessibility toolkit no longer give error trying to execute /usr/lib/dbus-daemion