### PR TITLE
webkitgtk: update to 2.42.5

### DIFF
--- a/components/library/webkitgtk/Makefile
+++ b/components/library/webkitgtk/Makefile
@@ -16,15 +16,16 @@
 # Copyright 2023 Friedrich Kink
 #
 
+USE_PARALLEL_BUILD = yes
 BUILD_STYLE=		cmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		webkitgtk
-COMPONENT_VERSION=	2.42.3
+COMPONENT_VERSION=	2.42.5
 COMPONENT_SUMMARY=	Web content engine library for GTK+
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:0a1a4630045628b3a6fe95da72dc47852cff20d66be1ac6fd0d669c88c13d8e2
+COMPONENT_ARCHIVE_HASH= sha256:b64278c1f20b8cfdbfb5ff573c37d871aba74a1db26d9b39f74e8953fe61e749
 COMPONENT_ARCHIVE_URL=	https://webkitgtk.org/releases/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://webkitgtk.org
 COMPONENT_FMRI=		library/desktop/webkitgtk2

--- a/components/library/webkitgtk/manifests/sample-manifest.p5m
+++ b/components/library/webkitgtk/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -243,26 +243,26 @@ file path=usr/include/webkitgtk-4.1/webkitdom/WebKitDOMXPathResult.h
 file path=usr/include/webkitgtk-4.1/webkitdom/webkitdom.h
 file path=usr/include/webkitgtk-4.1/webkitdom/webkitdomautocleanups.h
 file path=usr/include/webkitgtk-4.1/webkitdom/webkitdomdefines.h
-file path=usr/lib/$(MACH64)/MiniBrowser
 file path=usr/lib/$(MACH64)/girepository-1.0/JavaScriptCore-4.1.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/WebKit2-4.1.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/WebKit2WebExtension-4.1.typelib
 link path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so \
     target=libjavascriptcoregtk-4.1.so.0
 link path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so.0 \
-    target=libjavascriptcoregtk-4.1.so.0.4.12
-file path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so.0.4.12
+    target=libjavascriptcoregtk-4.1.so.0.4.14
+file path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so.0.4.14
 link path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so target=libwebkit2gtk-4.1.so.0
 link path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so.0 \
-    target=libwebkit2gtk-4.1.so.0.12.6
-file path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so.0.12.6
+    target=libwebkit2gtk-4.1.so.0.12.8
+file path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so.0.12.8
 file path=usr/lib/$(MACH64)/pkgconfig/javascriptcoregtk-4.1.pc
 file path=usr/lib/$(MACH64)/pkgconfig/webkit2gtk-4.1.pc
 file path=usr/lib/$(MACH64)/pkgconfig/webkit2gtk-web-extension-4.1.pc
-file path=usr/lib/$(MACH64)/webkit2gtk-4.1/WebKitNetworkProcess
-file path=usr/lib/$(MACH64)/webkit2gtk-4.1/WebKitWebProcess
 file path=usr/lib/$(MACH64)/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so
-file path=usr/lib/$(MACH64)/webkit2gtk-4.1/jsc
+file path=usr/libexec/MiniBrowser
+file path=usr/libexec/webkit2gtk-4.1/WebKitNetworkProcess
+file path=usr/libexec/webkit2gtk-4.1/WebKitWebProcess
+file path=usr/libexec/webkit2gtk-4.1/jsc
 file path=usr/share/gir-1.0/JavaScriptCore-4.1.gir
 file path=usr/share/gir-1.0/WebKit2-4.1.gir
 file path=usr/share/gir-1.0/WebKit2WebExtension-4.1.gir

--- a/components/library/webkitgtk/patches/06-wasm-section-parser.patch
+++ b/components/library/webkitgtk/patches/06-wasm-section-parser.patch
@@ -1,0 +1,38 @@
+--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp	2023-08-09 09:49:33.123924000 +0000
++++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp	2023-09-15 17:26:32.376874342 +0000
+@@ -93,7 +93,7 @@
+             break;
+         }
+         default:
+-            return fail(i, "th Type is non-Func, non-Struct, and non-Array ", typeKind);
++            return fail(i, "th Type is non-Func, non-Struct, and non-Array ", (signed char)typeKind);
+         }
+ 
+         WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for Type section's ", i, "th signature");
+@@ -812,7 +812,7 @@
+         packedType = static_cast<PackedType>(kind);
+         return { };
+     }
+-    return fail("expected a packed type but got ", kind);
++    return fail("expected a packed type but got ", (signed char)kind);
+ }
+ 
+ auto SectionParser::parseStorageType(StorageType& storageType) -> PartialResult
+@@ -915,7 +915,7 @@
+             break;
+         }
+         default:
+-            return fail(i, "th Type is non-Func, non-Struct, and non-Array ", typeKind);
++            return fail(i, "th Type is non-Func, non-Struct, and non-Array ", (signed char)typeKind);
+         }
+ 
+         WASM_PARSER_FAIL_IF(!signature, "can't allocate enough memory for recursion group's ", i, "th signature");
+@@ -1076,7 +1076,7 @@
+         break;
+     }
+     default:
+-        return fail("invalid structural type definition for subtype ", typeKind);
++        return fail("invalid structural type definition for subtype ", (signed char)typeKind);
+     }
+ 
+     // When no supertypes are specified, we will normalize type definitions to

--- a/components/library/webkitgtk/patches/13-solaris-support.patch
+++ b/components/library/webkitgtk/patches/13-solaris-support.patch
@@ -55,7 +55,27 @@ diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
 index 41afbb4..9e5d453 100644
 --- a/Source/WTF/wtf/PlatformHave.h
 +++ b/Source/WTF/wtf/PlatformHave.h
-@@ -328,7 +328,7 @@
+@@ -229,16 +229,16 @@
+ #define HAVE_HOSTED_CORE_ANIMATION 1
+ #endif
+ 
+-#if OS(DARWIN) || OS(FUCHSIA) || ((OS(FREEBSD) || OS(NETBSD) || OS(OPENBSD) || OS(LINUX)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS) || CPU(RISCV64)))
++#if OS(DARWIN) || OS(FUCHSIA) || OS(SOLARIS) || ((OS(FREEBSD) || OS(NETBSD) || OS(OPENBSD) || OS(LINUX)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS) || CPU(RISCV64)))
+ #define HAVE_MACHINE_CONTEXT 1
+ #endif
+ 
+-#if OS(DARWIN) || (OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__) && !CPU(MIPS))
++#if OS(DARWIN) || OS(SOLARIS) || (OS(LINUX) && defined(__GLIBC__) && !defined(__UCLIBC__) && !CPU(MIPS))
+ #define HAVE_BACKTRACE 1
+ #define HAVE_BACKTRACE_SYMBOLS 1
+ #endif
+ 
+-#if OS(DARWIN) || OS(LINUX)
++#if OS(DARWIN) || OS(LINUX) || OS(SOLARIS)
+ #define HAVE_DLADDR 1
+ #endif
+ 
+@@ -376,7 +376,7 @@
  #define HAVE_URL_FORMATTING 1
  #endif
  
@@ -134,3 +154,58 @@ index 6577423..b882b9e 100644
  #else
      return "unknown"_s;
  #endif
+--- webkitgtk-2.42.5/Source/JavaScriptCore/runtime/MachineContext.h.~1~	2023-09-19 04:27:45.475782200 -0400
++++ webkitgtk-2.42.5/Source/JavaScriptCore/runtime/MachineContext.h	2024-02-18 01:24:47.690986457 -0500
+@@ -33,6 +33,7 @@
+ #include <wtf/PlatformRegisters.h>
+ #include <wtf/PointerPreparations.h>
+ #include <wtf/StdLibExtras.h>
++#include <sys/regset.h>
+ 
+ namespace JSC {
+ namespace MachineContext {
+@@ -193,7 +194,7 @@
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(SOLARIS)
+ 
+ #if CPU(X86)
+     return reinterpret_cast<void*&>((uintptr_t&) machineContext.gregs[REG_ESP]);
+@@ -338,7 +339,7 @@
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(SOLARIS)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -496,7 +497,7 @@
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(SOLARIS)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -652,7 +653,7 @@
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(SOLARIS)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -787,7 +788,7 @@
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(SOLARIS)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)

--- a/components/library/webkitgtk/pkg5
+++ b/components/library/webkitgtk/pkg5
@@ -16,7 +16,7 @@
         "library/desktop/pango",
         "library/glib2",
         "library/gnutls-3",
-        "library/icu",
+        "library/icu-74",
         "library/lcms2",
         "library/libsecret",
         "library/libsoup3",

--- a/components/library/webkitgtk/webkitgtk2.p5m
+++ b/components/library/webkitgtk/webkitgtk2.p5m
@@ -27,24 +27,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr/lib/$(MACH64)/webkit2gtk-4.1/[^/]* -> default mode 0555>
+<transform file path=usr/libexec/MiniBrowser -> default mode 0555>
 
-file path=usr/lib/$(MACH64)/MiniBrowser mode=0555
-link path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so \
-    target=libjavascriptcoregtk-4.1.so.0
-link path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so.0 \
-    target=libjavascriptcoregtk-4.1.so.0.4.12
-file path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so.0.4.12
-link path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so target=libwebkit2gtk-4.1.so.0
-link path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so.0 \
-    target=libwebkit2gtk-4.1.so.0.12.6
-file path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so.0.12.6
-file path=usr/lib/$(MACH64)/pkgconfig/javascriptcoregtk-4.1.pc
-file path=usr/lib/$(MACH64)/pkgconfig/webkit2gtk-4.1.pc
-file path=usr/lib/$(MACH64)/pkgconfig/webkit2gtk-web-extension-4.1.pc
-file path=usr/lib/$(MACH64)/webkit2gtk-4.1/WebKitNetworkProcess
-file path=usr/lib/$(MACH64)/webkit2gtk-4.1/WebKitWebProcess
-file path=usr/lib/$(MACH64)/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so
-file path=usr/lib/$(MACH64)/webkit2gtk-4.1/jsc
 file path=usr/bin/WebKitWebDriver
 file path=usr/include/webkitgtk-4.1/JavaScriptCore/JSBase.h
 file path=usr/include/webkitgtk-4.1/JavaScriptCore/JSContextRef.h
@@ -268,6 +252,23 @@ file path=usr/include/webkitgtk-4.1/webkitdom/webkitdomdefines.h
 file path=usr/lib/$(MACH64)/girepository-1.0/JavaScriptCore-4.1.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/WebKit2-4.1.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/WebKit2WebExtension-4.1.typelib
+link path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so \
+    target=libjavascriptcoregtk-4.1.so.0
+link path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so.0 \
+    target=libjavascriptcoregtk-4.1.so.0.4.14
+file path=usr/lib/$(MACH64)/libjavascriptcoregtk-4.1.so.0.4.14
+link path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so target=libwebkit2gtk-4.1.so.0
+link path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so.0 \
+    target=libwebkit2gtk-4.1.so.0.12.8
+file path=usr/lib/$(MACH64)/libwebkit2gtk-4.1.so.0.12.8
+file path=usr/lib/$(MACH64)/pkgconfig/javascriptcoregtk-4.1.pc
+file path=usr/lib/$(MACH64)/pkgconfig/webkit2gtk-4.1.pc
+file path=usr/lib/$(MACH64)/pkgconfig/webkit2gtk-web-extension-4.1.pc
+file path=usr/lib/$(MACH64)/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so
+file path=usr/libexec/MiniBrowser
+file path=usr/libexec/webkit2gtk-4.1/WebKitNetworkProcess
+file path=usr/libexec/webkit2gtk-4.1/WebKitWebProcess
+file path=usr/libexec/webkit2gtk-4.1/jsc
 file path=usr/share/gir-1.0/JavaScriptCore-4.1.gir
 file path=usr/share/gir-1.0/WebKit2-4.1.gir
 file path=usr/share/gir-1.0/WebKit2WebExtension-4.1.gir


### PR DESCRIPTION
Add patches to support compiling with a correctly detected host cpu

Like 2.42.3, it crashes (WebProcess CRASHED) when trying to render content, such as trying load a page with MiniBrowser.  Is there a known good version of webkitgtk on OI?  Or a known date when webkitgtk worked without crashing?