### PR TITLE
Rebuild all packages depending on libjpeg6 that cannot find their library in a non default location merge after libjpeg9 PR

### DIFF
--- a/components/desktop/freerdp/Makefile
+++ b/components/desktop/freerdp/Makefile
@@ -21,7 +21,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		freerdp
 COMPONENT_VERSION=	2.10.0
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	Remote Desktop Viewer Client
 COMPONENT_PROJECT_URL=	https://www.freerdp.com
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -99,12 +99,11 @@ COMPONENT_POST_INSTALL_ACTION  = \
     done ;
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += $(ICU_LIBRARY_PKG)
 REQUIRED_PACKAGES += audio/lame
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += library/audio/pulseaudio
 REQUIRED_PACKAGES += library/desktop/cairo
-REQUIRED_PACKAGES += library/icu
 REQUIRED_PACKAGES += library/libusb-1
 REQUIRED_PACKAGES += library/print/cups-libs
 REQUIRED_PACKAGES += library/security/openssl-11

--- a/components/desktop/freerdp/pkg5
+++ b/components/desktop/freerdp/pkg5
@@ -1,8 +1,7 @@
 {
     "dependencies": [
         "audio/lame",
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "library/audio/pulseaudio",
         "library/desktop/cairo",
         "library/icu",

--- a/components/perl/Tk/Makefile
+++ b/components/perl/Tk/Makefile
@@ -43,8 +43,7 @@ COMPONENT_TEST_TRANSFORMS += "-e '/^Stack moved/d'"
 
 # Auto-generated dependencies
 PERL_REQUIRED_PACKAGES += runtime/perl
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/fontconfig

--- a/components/perl/Tk/pkg5
+++ b/components/perl/Tk/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "runtime/perl-534",
         "runtime/perl-536",

--- a/components/runtime/openjdk-11/Makefile
+++ b/components/runtime/openjdk-11/Makefile
@@ -22,6 +22,7 @@ include ../../../make-rules/shared-macros.mk
 OPENJDK_VERSION=	11
 OPENJDK_UPDATE=	0
 OPENJDK_BUILD=	22
+COMPONENT_REVISION= 1
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)
 COMPONENT_FMRI=	runtime/java/$(COMPONENT_NAME)$(OPENJDK_VERSION)
@@ -134,8 +135,7 @@ REQUIRED_PACKAGES += system/library/c++/sunpro
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/giflib

--- a/components/runtime/openjdk-11/pkg5
+++ b/components/runtime/openjdk-11/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "library/c++/harfbuzz",
         "library/giflib",

--- a/components/runtime/openjdk-17/Makefile
+++ b/components/runtime/openjdk-17/Makefile
@@ -22,6 +22,7 @@ include ../../../make-rules/shared-macros.mk
 OPENJDK_VERSION=	17
 OPENJDK_UPDATE=	0
 OPENJDK_BUILD=	10
+COMPONENT_REVISION= 1
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)
 COMPONENT_FMRI=	runtime/java/$(COMPONENT_NAME)$(OPENJDK_VERSION)
@@ -142,8 +143,7 @@ REQUIRED_PACKAGES += system/library/c++/sunpro
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/giflib

--- a/components/runtime/openjdk-17/pkg5
+++ b/components/runtime/openjdk-17/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "library/c++/harfbuzz",
         "library/giflib",

--- a/components/runtime/openjdk-18/Makefile
+++ b/components/runtime/openjdk-18/Makefile
@@ -21,6 +21,7 @@ include ../../../make-rules/shared-macros.mk
 OPENJDK_VERSION=	18
 OPENJDK_UPDATE=	0
 OPENJDK_BUILD=	2.1
+COMPONENT_REVISION= 1
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)
 COMPONENT_REVISION=	1
@@ -134,8 +135,7 @@ REQUIRED_PACKAGES += runtime/java/openjdk17
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/giflib

--- a/components/runtime/openjdk-18/pkg5
+++ b/components/runtime/openjdk-18/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "library/c++/harfbuzz",
         "library/giflib",
@@ -11,8 +10,8 @@
         "system/library",
         "system/library/c++/sunpro",
         "system/library/freetype-2",
-        "system/library/g++-10-runtime",
-        "system/library/gcc-10-runtime",
+        "system/library/g++-13-runtime",
+        "system/library/gcc-13-runtime",
         "system/library/math",
         "x11/library/libx11",
         "x11/library/libxext",

--- a/components/runtime/openjdk-19/Makefile
+++ b/components/runtime/openjdk-19/Makefile
@@ -21,6 +21,7 @@ include ../../../make-rules/shared-macros.mk
 OPENJDK_VERSION=	19
 OPENJDK_UPDATE=	0
 OPENJDK_BUILD=	2
+COMPONENT_REVISION= 1
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)
 COMPONENT_REVISION=	1
@@ -136,8 +137,7 @@ REQUIRED_PACKAGES += runtime/java/openjdk18
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/giflib

--- a/components/runtime/openjdk-19/pkg5
+++ b/components/runtime/openjdk-19/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "library/c++/harfbuzz",
         "library/giflib",
@@ -11,8 +10,8 @@
         "system/library",
         "system/library/c++/sunpro",
         "system/library/freetype-2",
-        "system/library/g++-10-runtime",
-        "system/library/gcc-10-runtime",
+        "system/library/g++-13-runtime",
+        "system/library/gcc-13-runtime",
         "system/library/math",
         "x11/library/libx11",
         "x11/library/libxext",

--- a/components/runtime/openjdk-20/Makefile
+++ b/components/runtime/openjdk-20/Makefile
@@ -23,6 +23,7 @@ OPENJDK_UPDATE=	0
 OPENJDK_BUILD=	2
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)
+COMPONENT_REVISION= 1
 COMPONENT_FMRI=	runtime/java/$(COMPONENT_NAME)$(OPENJDK_VERSION)
 COMPONENT_SUMMARY=	Open-source implementation of the Java Platform, Standard Edition
 COMPONENT_SRC=	jdk$(OPENJDK_VERSION)u-jdk-$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)-ga
@@ -137,8 +138,7 @@ REQUIRED_PACKAGES += runtime/java/openjdk19
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/giflib

--- a/components/runtime/openjdk-20/pkg5
+++ b/components/runtime/openjdk-20/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "library/c++/harfbuzz",
         "library/giflib",
@@ -11,8 +10,8 @@
         "system/library",
         "system/library/c++/sunpro",
         "system/library/freetype-2",
-        "system/library/g++-10-runtime",
-        "system/library/gcc-10-runtime",
+        "system/library/g++-13-runtime",
+        "system/library/gcc-13-runtime",
         "system/library/math",
         "x11/library/libx11",
         "x11/library/libxext",

--- a/components/runtime/openjdk-21/Makefile
+++ b/components/runtime/openjdk-21/Makefile
@@ -23,6 +23,7 @@ OPENJDK_UPDATE=	0
 OPENJDK_BUILD=	2
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)
+COMPONENT_REVISION= 1
 COMPONENT_FMRI=	runtime/java/$(COMPONENT_NAME)$(OPENJDK_VERSION)
 COMPONENT_SUMMARY=	Open-source implementation of the Java Platform, Standard Edition
 COMPONENT_SRC=  jdk$(OPENJDK_VERSION)u-jdk-$(OPENJDK_VERSION).$(OPENJDK_UPDATE).$(OPENJDK_BUILD)-ga
@@ -137,8 +138,7 @@ REQUIRED_PACKAGES += runtime/java/openjdk20
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/giflib

--- a/components/runtime/openjdk-21/pkg5
+++ b/components/runtime/openjdk-21/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "library/c++/harfbuzz",
         "library/giflib",

--- a/components/runtime/openjdk-22/Makefile
+++ b/components/runtime/openjdk-22/Makefile
@@ -22,6 +22,7 @@ OPENJDK_VERSION=	22
 OPENJDK_PATCH=	33
 COMPONENT_NAME=		openjdk
 COMPONENT_VERSION=	$(OPENJDK_VERSION)
+COMPONENT_REVISION= 1
 COMPONENT_FMRI=	runtime/java/$(COMPONENT_NAME)$(OPENJDK_VERSION)
 COMPONENT_SUMMARY=	Open-source implementation of the Java Platform, Standard Edition
 COMPONENT_SRC=	jdk22u-jdk-$(OPENJDK_VERSION)-$(OPENJDK_PATCH)
@@ -136,8 +137,7 @@ REQUIRED_PACKAGES += runtime/java/openjdk21
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
-REQUIRED_PACKAGES += image/library/libjpeg6
-REQUIRED_PACKAGES += image/library/libjpeg6-ijg
+REQUIRED_PACKAGES += image/library/libjpeg
 REQUIRED_PACKAGES += image/library/libpng16
 REQUIRED_PACKAGES += library/c++/harfbuzz
 REQUIRED_PACKAGES += library/giflib

--- a/components/runtime/openjdk-22/pkg5
+++ b/components/runtime/openjdk-22/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "image/library/libjpeg6",
-        "image/library/libjpeg6-ijg",
+        "image/library/libjpeg",
         "image/library/libpng16",
         "library/c++/harfbuzz",
         "library/giflib",


### PR DESCRIPTION
Depends on merging #16035 first