### PR TITLE
Fix: Add dconf-editor to mate-desktop which is needed by applets

### DIFF
--- a/components/desktop/mate/mate-desktop/Makefile
+++ b/components/desktop/mate/mate-desktop/Makefile
@@ -24,6 +24,7 @@ include $(WS_MAKE_RULES)/mate.mk
 COMPONENT_NAME=		mate-desktop
 COMPONENT_MJR_VERSION=	1.28
 COMPONENT_MNR_VERSION=	1
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY=	Additional UI API for MATE Desktop
 COMPONENT_ARCHIVE_HASH= sha256:71ed1bcf775e2cbba4d80a73c33c795d3864e6ce429a37eed875885ac86b206e
 COMPONENT_LICENSE=	GPLv2, LGPLv2, FDLv1.1
@@ -32,6 +33,10 @@ include $(WS_MAKE_RULES)/common.mk
 
 # Build dependencies
 REQUIRED_PACKAGES += data/iso-codes
+
+# Add dconf-editor as dependency as otherwise mate-applets crash
+# as this is a non binary dependency it is not detected automatically
+REQUIRED_PACKAGES += gnome/config/dconf/dconf-editor
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += gnome/config/dconf

--- a/components/desktop/mate/mate-desktop/mate-desktop.p5m
+++ b/components/desktop/mate/mate-desktop/mate-desktop.p5m
@@ -27,6 +27,10 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=gnome/theme/background/os-backgrounds
 
+# Add dconf-editor as dependency as otherwise mate-applets crash
+# as this is a non binary dependency it is not detected automatically
+depend type=require fmri=gnome/config/dconf/dconf-editor
+
 file path=usr/bin/mate-about
 file path=usr/bin/mate-color-select
 file path=usr/include/mate-desktop-2.0/libmate-desktop/mate-bg-crossfade.h

--- a/components/desktop/mate/mate-desktop/pkg5
+++ b/components/desktop/mate/mate-desktop/pkg5
@@ -2,6 +2,7 @@
     "dependencies": [
         "data/iso-codes",
         "gnome/config/dconf",
+        "gnome/config/dconf/dconf-editor",
         "library/desktop/atk",
         "library/desktop/cairo",
         "library/desktop/gdk-pixbuf",


### PR DESCRIPTION
This fixes the situation where the missing dconf-editor causes mate-applets to crash on fresh systems.