### PR TITLE
libjpeg6-ijg: make development files mediated

### DIFF
--- a/components/library/libjpeg6-ijg/Makefile
+++ b/components/library/libjpeg6-ijg/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		libjpeg6-ijg
 COMPONENT_VERSION=	6.0.2
 LIBJPEG_API_VERSION= 6b
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_FMRI= 	image/library/libjpeg6-ijg
 COMPONENT_PROJECT_URL=	http://www.ijg.org/
 COMPONENT_SUMMARY=	libjpeg - Independent JPEG Group library version 6b

--- a/components/library/libjpeg6-ijg/libjpeg6-ijg.p5m
+++ b/components/library/libjpeg6-ijg/libjpeg6-ijg.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -21,7 +22,6 @@ set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
-
 
 file path=usr/include/$(COMPONENT_NAME)/jconfig.h
 file path=usr/include/$(COMPONENT_NAME)/jerror.h

--- a/components/library/libjpeg6-ijg/libjpeg6.p5m
+++ b/components/library/libjpeg6-ijg/libjpeg6.p5m
@@ -13,7 +13,8 @@
 # Copyright 2015 Aurelien Larcher
 #
 
-set name=pkg.fmri value=pkg:/image/library/libjpeg6@6.0.2,$(BUILD_VERSION)
+set name=pkg.fmri value=pkg:/image/library/libjpeg6@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -26,6 +27,14 @@ depend fmri=image/library/libjpeg6-ijg type=require
 
 # Documentation and executables should default to libjpeg-turbo
 depend fmri=image/library/libjpeg-turbo type=require
+
+# Make development files mediated so we can easily switch to different libjpeg version
+<transform link path=usr/include -> default mediator jpeg>
+<transform link path=usr/include -> default mediator-version 6>
+<transform link path=usr/include -> default mediator-implementation ijg>
+<transform link path=usr/lib/.*\.so$ -> default mediator jpeg>
+<transform link path=usr/lib/.*\.so$ -> default mediator-version 6>
+<transform link path=usr/lib/.*\.so$ -> default mediator-implementation ijg>
 
 # Only provide headers and libraries for backward compatibility
 link path=usr/include/jconfig.h      target=$(COMPONENT_NAME)/jconfig.h

--- a/components/library/libjpeg6-ijg/manifests/sample-manifest.p5m
+++ b/components/library/libjpeg6-ijg/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2016 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/library/libjpeg6-ijg/pkg5
+++ b/components/library/libjpeg6-ijg/pkg5
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "SUNWcs",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
This is first small and easily understandable step to obsolete the ancient `libjpeg6-ijg` component.  It effectively changes nothing on-disk (yet).  It just adds `jpeg` mediator for `libjpeg6-ijg` development files to make them replaceable.  This is preparation for future work.