### PR TITLE
Set SONAME links to point to libjpeg8-turbo

### DIFF
--- a/components/library/libjpeg-turbo/Makefile
+++ b/components/library/libjpeg-turbo/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libjpeg-turbo
 COMPONENT_VERSION= 3.0.2
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_SUMMARY= libjpeg -JPEG Turbo libraries
 COMPONENT_PROJECT_URL= https://www.libjpeg-turbo.org/
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/library/libjpeg-turbo/libjpeg-turbo.p5m
+++ b/components/library/libjpeg-turbo/libjpeg-turbo.p5m
@@ -79,8 +79,9 @@ link path=usr/lib/$(MACH64)/cmake/libjpeg-turboTargets-release.cmake target=../.
 link path=usr/lib/$(MACH64)/cmake/libjpeg-turboTargets.cmake target=../../libjpeg8-turbo/lib/$(MACH64)/cmake/libjpeg-turbo/libjpeg-turboTargets.cmake
 
 # Add symlinks so libjpeg-turbo can be detected from cmake and non pkgconfig builds
-#link path=usr/lib/$(MACH64)/libjpeg.so \
-#	target=../libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.3.2
+link path=usr/lib/$(MACH64)/libjpeg.so \
+	target=../libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.3.2
+# This links provide proper SONAME links
 link path=usr/lib/$(MACH64)/libjpeg.so.8 \
 	target=../libjpeg8-turbo/lib/$(MACH64)/libjpeg.so.8.3.2
 link path=usr/lib/$(MACH64)/libturbojpeg.so \

--- a/components/library/libjpeg6-ijg/Makefile
+++ b/components/library/libjpeg6-ijg/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		libjpeg6-ijg
 COMPONENT_VERSION=	6.0.2
 LIBJPEG_API_VERSION= 6b
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_FMRI= 	image/library/libjpeg6-ijg
 COMPONENT_PROJECT_URL=	http://www.ijg.org/
 COMPONENT_SUMMARY=	libjpeg - Independent JPEG Group library version 6b

--- a/components/library/libjpeg6-ijg/libjpeg6.p5m
+++ b/components/library/libjpeg6-ijg/libjpeg6.p5m
@@ -27,10 +27,8 @@ depend fmri=image/library/libjpeg6-ijg type=require
 # Documentation and executables should default to libjpeg-turbo
 depend fmri=image/library/libjpeg-turbo type=require
 
-# Only provide headers and libraries for backward compatibility
-link path=usr/lib/libjpeg.so         target=$(COMPONENT_NAME)/lib/libjpeg.so.62.0.0
+# Only provide libraries for backward compatibility of already compiled applications
 link path=usr/lib/libjpeg.so.62      target=$(COMPONENT_NAME)/lib/libjpeg.so.62.0.0
 link path=usr/lib/libjpeg.so.62.0.0  target=$(COMPONENT_NAME)/lib/libjpeg.so.62.0.0
-link path=usr/lib/$(MACH64)/libjpeg.so        target=../$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62.0.0
 link path=usr/lib/$(MACH64)/libjpeg.so.62     target=../$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62.0.0
 link path=usr/lib/$(MACH64)/libjpeg.so.62.0.0 target=../$(COMPONENT_NAME)/lib/$(MACH64)/libjpeg.so.62.0.0


### PR DESCRIPTION
All existing packages still work thanks to SONAME
all newly built packages link against libjpeg-turbo