### PR TITLE
python/cssselect: add 1.2.0

### DIFF
--- a/components/python/cssselect/Makefile
+++ b/components/python/cssselect/Makefile
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project cssselect
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		cssselect
+HUMAN_VERSION =			1.2.0
+COMPONENT_SUMMARY =		cssselect - cssselect parses CSS3 Selectors and translates them to XPath 1.0
+COMPONENT_PROJECT_URL =		https://github.com/scrapy/cssselect
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:666b19839cfaddb9ce9d36bfe4c969132c647b92fc9088c4e23f786b30f1b3dc
+COMPONENT_LICENSE =		BSD-3-Clause
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools
+PYTHON_REQUIRED_PACKAGES += library/python/wheel
+PYTHON_REQUIRED_PACKAGES += runtime/python
+TEST_REQUIRED_PACKAGES.python += library/python/lxml
+TEST_REQUIRED_PACKAGES.python += library/python/pytest
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-cov
+TEST_REQUIRED_PACKAGES.python += library/python/sybil

--- a/components/python/cssselect/cssselect-PYVER.p5m
+++ b/components/python/cssselect/cssselect-PYVER.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/AUTHORS
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/parser.py
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/xpath.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/cssselect/manifests/sample-manifest.p5m
+++ b/components/python/cssselect/manifests/sample-manifest.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/AUTHORS
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect-$(HUMAN_VERSION).dist-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/parser.py
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/cssselect/xpath.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/cssselect/pkg5
+++ b/components/python/cssselect/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "library/python/setuptools-39",
+        "library/python/wheel-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/cssselect",
+        "library/python/cssselect-39"
+    ],
+    "name": "cssselect"
+}

--- a/components/python/cssselect/test/results-all.master
+++ b/components/python/cssselect/test/results-all.master
@@ -1,0 +1,36 @@
+py$(PYV): remove tox env folder $(@D)/.tox/py$(PYV)
+py$(PYV): commands[0]> python -m pytest --cov=cssselect --cov-report=term-missing --cov-report=html --cov-report=xml --verbose cssselect tests docs
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(@D)/.tox/py$(PYV)/bin/python
+cachedir: .tox/py$(PYV)/.pytest_cache
+rootdir: $(@D)
+configfile: setup.cfg
+collecting ... collected 22 items
+
+docs/index.rst::line:20,column:1 PASSED
+docs/index.rst::line:21,column:1 PASSED
+docs/index.rst::line:26,column:1 PASSED
+docs/index.rst::line:35,column:1 PASSED
+docs/index.rst::line:36,column:1 PASSED
+docs/index.rst::line:41,column:1 PASSED
+tests/test_cssselect.py::TestCssselect::test_argument_types PASSED
+tests/test_cssselect.py::TestCssselect::test_css_export PASSED
+tests/test_cssselect.py::TestCssselect::test_lang PASSED
+tests/test_cssselect.py::TestCssselect::test_parse_errors PASSED
+tests/test_cssselect.py::TestCssselect::test_parser PASSED
+tests/test_cssselect.py::TestCssselect::test_pseudo_elements PASSED
+tests/test_cssselect.py::TestCssselect::test_quoting PASSED
+tests/test_cssselect.py::TestCssselect::test_select PASSED
+tests/test_cssselect.py::TestCssselect::test_select_shakespeare PASSED
+tests/test_cssselect.py::TestCssselect::test_series PASSED
+tests/test_cssselect.py::TestCssselect::test_specificity PASSED
+tests/test_cssselect.py::TestCssselect::test_tokenizer PASSED
+tests/test_cssselect.py::TestCssselect::test_translation PASSED
+tests/test_cssselect.py::TestCssselect::test_unicode PASSED
+tests/test_cssselect.py::TestCssselect::test_unicode_escapes PASSED
+tests/test_cssselect.py::TestCssselect::test_xpath_pseudo_elements PASSED
+
+
+======== 22 passed ========
+  py$(PYV): OK
+  congratulations :)


### PR DESCRIPTION
This is one of three missing dependencies for inkscape.
python-integrate-project script does not work for me.