### PR TITLE
Update glib2 to 2.76.4 analogous to solaris-userland

### DIFF
--- a/components/library/glib/Makefile
+++ b/components/library/glib/Makefile
@@ -20,14 +20,13 @@ BUILD_STYLE= meson
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		glib
-COMPONENT_MJR_VERSION=	2.74
-COMPONENT_MNR_VERSION=	7
+COMPONENT_MJR_VERSION=	2.76
+COMPONENT_MNR_VERSION=	4
 COMPONENT_VERSION=	$(COMPONENT_MJR_VERSION).$(COMPONENT_MNR_VERSION)
-COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	GNOME core libraries
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH=	sha256:196ab86c27127a61b7a70c3ba6af7b97bdc01c07cd3b21abd5e778b955eccb1b
+COMPONENT_ARCHIVE_HASH=	sha256:5a5a191c96836e166a7771f7ea6ca2b0069c603c7da3cba1cd38d1694a395dda
 COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/$(COMPONENT_NAME)/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL=	https://wiki.gnome.org/Projects/GLib/
 COMPONENT_FMRI=		library/glib2
@@ -46,7 +45,7 @@ LDFLAGS += -lsocket -lnsl
 # Support for hexadecimal strings in strtod() is available in C99 mode only,
 # but we cannot use -std=c99 because float/double support is broken there
 # (https://www.illumos.org/issues/14935)
-CFLAGS += -std=gnu99
+CFLAGS += -std=gnu11
 
 # We need standard conforming getpwnam_r()/getpwuid_r()
 CPPFLAGS += $(CPP_XPG6MODE)
@@ -58,6 +57,15 @@ CFLAGS += -Wno-error=format-security
 # We do not have getxattr() so disable xattr
 CONFIGURE_OPTIONS += -Dxattr=false
 CONFIGURE_OPTIONS += -Dman=true
+CONFIGURE_OPTIONS += -Druntime_libdir=$(USRLIBDIR)
+CONFIGURE_OPTIONS += -Dcharsetalias_dir=$(USRLIBDIR)
+CONFIGURE_OPTIONS += -Druntime_dir=$(VARDIR)/run
+CONFIGURE_OPTIONS += -Dselinux=disabled
+CONFIGURE_OPTIONS += -Dxattr=false
+CONFIGURE_OPTIONS += -Dlibmount=disabled
+CONFIGURE_OPTIONS += -Dbsymbolic_functions=false
+CONFIGURE_OPTIONS += -Dman=true
+CONFIGURE_OPTIONS += -Dfam=true
 
 COMPONENT_POST_CONFIGURE_ACTION= \
   ( cd $(@D); $(GSED) -i "s/_FILE_OFFSET_BITS=64/_FILE_OFFSET_BITS=$(BITS)/g" ./build.ninja )
@@ -97,6 +105,7 @@ TEST_REQUIRED_PACKAGES += library/desktop/desktop-file-utils
 
 # Auto-generated dependencies
 PYTHON_REQUIRED_PACKAGES += runtime/python
+REQUIRED_PACKAGES += library/file-monitor/gamin
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += library/pcre2
 REQUIRED_PACKAGES += library/zlib

--- a/components/library/glib/glib2.p5m
+++ b/components/library/glib/glib2.p5m
@@ -27,13 +27,17 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 <transform file path=usr/share/locale/([^/]+)(\..+){0,1}(/.+){0,1} -> default facet.locale.%<\1> true>
+<transform file path=usr/bin/.*/gtester-report -> default pkg.depend.bypass-generate .*>
+<transform file path=usr/bin/gtester-report -> default pkg.depend.bypass-generate .*>
+<transform file path=usr/bin/.*/gdbus-codegen -> default pkg.depend.bypass-generate .*>
+<transform file path=usr/bin/gdbus-codegen -> default pkg.depend.bypass-generate .*>
 
 depend fmri=$(COMPONENT_FMRI)/charset-alias@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION) type=require
 
 # At least some of the 32 bit applications are needed when building other packages.
 file path=usr/bin/$(MACH32)/gapplication
 file path=usr/bin/$(MACH32)/gdbus
-file path=usr/bin/$(MACH32)/gdbus-codegen pkg.depend.bypass-generate=.*
+file path=usr/bin/$(MACH32)/gdbus-codegen
 file path=usr/bin/$(MACH32)/gio
 file path=usr/bin/$(MACH32)/gio-querymodules
 file path=usr/bin/$(MACH32)/glib-compile-resources
@@ -45,10 +49,10 @@ file path=usr/bin/$(MACH32)/gobject-query
 file path=usr/bin/$(MACH32)/gresource
 file path=usr/bin/$(MACH32)/gsettings
 file path=usr/bin/$(MACH32)/gtester
-file path=usr/bin/$(MACH32)/gtester-report pkg.depend.bypass-generate=.*
+file path=usr/bin/$(MACH32)/gtester-report
 file path=usr/bin/gapplication
 file path=usr/bin/gdbus
-file path=usr/bin/gdbus-codegen pkg.depend.bypass-generate=.*
+file path=usr/bin/gdbus-codegen
 file path=usr/bin/gio
 file path=usr/bin/gio-querymodules
 file path=usr/bin/glib-compile-resources
@@ -60,7 +64,7 @@ file path=usr/bin/gobject-query
 file path=usr/bin/gresource
 file path=usr/bin/gsettings
 file path=usr/bin/gtester
-file path=usr/bin/gtester-report pkg.depend.bypass-generate=.*
+file path=usr/bin/gtester-report
 file path=usr/include/gio-unix-2.0/gio/gdesktopappinfo.h
 file path=usr/include/gio-unix-2.0/gio/gfiledescriptorbased.h
 file path=usr/include/gio-unix-2.0/gio/gunixfdmessage.h
@@ -138,6 +142,7 @@ file path=usr/include/glib-2.0/gio/ginetsocketaddress.h
 file path=usr/include/glib-2.0/gio/ginitable.h
 file path=usr/include/glib-2.0/gio/ginputstream.h
 file path=usr/include/glib-2.0/gio/gio-autocleanups.h
+file path=usr/include/glib-2.0/gio/gio-visibility.h
 file path=usr/include/glib-2.0/gio/gio.h
 file path=usr/include/glib-2.0/gio/gioenums.h
 file path=usr/include/glib-2.0/gio/gioenumtypes.h
@@ -263,6 +268,7 @@ file path=usr/include/glib-2.0/glib/giochannel.h
 file path=usr/include/glib-2.0/glib/gkeyfile.h
 file path=usr/include/glib-2.0/glib/glib-autocleanups.h
 file path=usr/include/glib-2.0/glib/glib-typeof.h
+file path=usr/include/glib-2.0/glib/glib-visibility.h
 file path=usr/include/glib-2.0/glib/glist.h
 file path=usr/include/glib-2.0/glib/gmacros.h
 file path=usr/include/glib-2.0/glib/gmain.h
@@ -272,6 +278,7 @@ file path=usr/include/glib-2.0/glib/gmem.h
 file path=usr/include/glib-2.0/glib/gmessages.h
 file path=usr/include/glib-2.0/glib/gnode.h
 file path=usr/include/glib-2.0/glib/goption.h
+file path=usr/include/glib-2.0/glib/gpathbuf.h
 file path=usr/include/glib-2.0/glib/gpattern.h
 file path=usr/include/glib-2.0/glib/gpoll.h
 file path=usr/include/glib-2.0/glib/gprimes.h
@@ -313,6 +320,7 @@ file path=usr/include/glib-2.0/glib/gversion.h
 file path=usr/include/glib-2.0/glib/gversionmacros.h
 file path=usr/include/glib-2.0/glib/gwin32.h
 file path=usr/include/glib-2.0/gmodule.h
+file path=usr/include/glib-2.0/gmodule/gmodule-visibility.h
 file path=usr/include/glib-2.0/gobject/gbinding.h
 file path=usr/include/glib-2.0/gobject/gbindinggroup.h
 file path=usr/include/glib-2.0/gobject/gboxed.h
@@ -322,6 +330,7 @@ file path=usr/include/glib-2.0/gobject/glib-enumtypes.h
 file path=usr/include/glib-2.0/gobject/glib-types.h
 file path=usr/include/glib-2.0/gobject/gmarshal.h
 file path=usr/include/glib-2.0/gobject/gobject-autocleanups.h
+file path=usr/include/glib-2.0/gobject/gobject-visibility.h
 file path=usr/include/glib-2.0/gobject/gobject.h
 file path=usr/include/glib-2.0/gobject/gobjectnotifyqueue.c
 file path=usr/include/glib-2.0/gobject/gparam.h
@@ -336,25 +345,26 @@ file path=usr/include/glib-2.0/gobject/gvalue.h
 file path=usr/include/glib-2.0/gobject/gvaluearray.h
 file path=usr/include/glib-2.0/gobject/gvaluecollector.h
 file path=usr/include/glib-2.0/gobject/gvaluetypes.h
+file path=usr/lib/$(MACH64)/gio/modules/libgiofam.so
 file path=usr/lib/$(MACH64)/glib-2.0/include/glibconfig.h
 link path=usr/lib/$(MACH64)/libgio-2.0.so target=libgio-2.0.so.0
-link path=usr/lib/$(MACH64)/libgio-2.0.so.0 target=libgio-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgio-2.0.so.0.7400.7
+link path=usr/lib/$(MACH64)/libgio-2.0.so.0 target=libgio-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgio-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libglib-2.0.so target=libglib-2.0.so.0
-link path=usr/lib/$(MACH64)/libglib-2.0.so.0 target=libglib-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libglib-2.0.so.0.7400.7
+link path=usr/lib/$(MACH64)/libglib-2.0.so.0 target=libglib-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libglib-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libgmodule-2.0.so target=libgmodule-2.0.so.0
 link path=usr/lib/$(MACH64)/libgmodule-2.0.so.0 \
-    target=libgmodule-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgmodule-2.0.so.0.7400.7
+    target=libgmodule-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgmodule-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libgobject-2.0.so target=libgobject-2.0.so.0
 link path=usr/lib/$(MACH64)/libgobject-2.0.so.0 \
-    target=libgobject-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgobject-2.0.so.0.7400.7
+    target=libgobject-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgobject-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libgthread-2.0.so target=libgthread-2.0.so.0
 link path=usr/lib/$(MACH64)/libgthread-2.0.so.0 \
-    target=libgthread-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgthread-2.0.so.0.7400.7
+    target=libgthread-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgthread-2.0.so.0.7600.4
 file path=usr/lib/$(MACH64)/pkgconfig/gio-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gio-unix-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/glib-2.0.pc
@@ -363,23 +373,23 @@ file path=usr/lib/$(MACH64)/pkgconfig/gmodule-export-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gmodule-no-export-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gobject-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gthread-2.0.pc
-file usr/lib/gio-launch-desktop path=usr/bin/gio-launch-desktop mode=0555
+file path=usr/lib/gio/modules/libgiofam.so
 file path=usr/lib/glib-2.0/include/glibconfig.h
 link path=usr/lib/libgio-2.0.so target=libgio-2.0.so.0
-link path=usr/lib/libgio-2.0.so.0 target=libgio-2.0.so.0.7400.7
-file path=usr/lib/libgio-2.0.so.0.7400.7
+link path=usr/lib/libgio-2.0.so.0 target=libgio-2.0.so.0.7600.4
+file path=usr/lib/libgio-2.0.so.0.7600.4
 link path=usr/lib/libglib-2.0.so target=libglib-2.0.so.0
-link path=usr/lib/libglib-2.0.so.0 target=libglib-2.0.so.0.7400.7
-file path=usr/lib/libglib-2.0.so.0.7400.7
+link path=usr/lib/libglib-2.0.so.0 target=libglib-2.0.so.0.7600.4
+file path=usr/lib/libglib-2.0.so.0.7600.4
 link path=usr/lib/libgmodule-2.0.so target=libgmodule-2.0.so.0
-link path=usr/lib/libgmodule-2.0.so.0 target=libgmodule-2.0.so.0.7400.7
-file path=usr/lib/libgmodule-2.0.so.0.7400.7
+link path=usr/lib/libgmodule-2.0.so.0 target=libgmodule-2.0.so.0.7600.4
+file path=usr/lib/libgmodule-2.0.so.0.7600.4
 link path=usr/lib/libgobject-2.0.so target=libgobject-2.0.so.0
-link path=usr/lib/libgobject-2.0.so.0 target=libgobject-2.0.so.0.7400.7
-file path=usr/lib/libgobject-2.0.so.0.7400.7
+link path=usr/lib/libgobject-2.0.so.0 target=libgobject-2.0.so.0.7600.4
+file path=usr/lib/libgobject-2.0.so.0.7600.4
 link path=usr/lib/libgthread-2.0.so target=libgthread-2.0.so.0
-link path=usr/lib/libgthread-2.0.so.0 target=libgthread-2.0.so.0.7400.7
-file path=usr/lib/libgthread-2.0.so.0.7400.7
+link path=usr/lib/libgthread-2.0.so.0 target=libgthread-2.0.so.0.7600.4
+file path=usr/lib/libgthread-2.0.so.0.7600.4
 file path=usr/lib/pkgconfig/gio-2.0.pc
 file path=usr/lib/pkgconfig/gio-unix-2.0.pc
 file path=usr/lib/pkgconfig/glib-2.0.pc
@@ -388,6 +398,8 @@ file path=usr/lib/pkgconfig/gmodule-export-2.0.pc
 file path=usr/lib/pkgconfig/gmodule-no-export-2.0.pc
 file path=usr/lib/pkgconfig/gobject-2.0.pc
 file path=usr/lib/pkgconfig/gthread-2.0.pc
+file path=usr/libexec/$(MACH32)/gio-launch-desktop
+file path=usr/libexec/gio-launch-desktop
 file path=usr/share/aclocal/glib-2.0.m4
 file path=usr/share/aclocal/glib-gettext.m4
 file path=usr/share/aclocal/gsettings.m4
@@ -396,16 +408,17 @@ file path=usr/share/bash-completion/completions/gdbus
 file path=usr/share/bash-completion/completions/gio
 file path=usr/share/bash-completion/completions/gresource
 file path=usr/share/bash-completion/completions/gsettings
-file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libglib-2.0.so.0.7400.7-gdb.py
-file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libgobject-2.0.so.0.7400.7-gdb.py
-file path=usr/share/gdb/auto-load/usr/lib/libglib-2.0.so.0.7400.7-gdb.py
-file path=usr/share/gdb/auto-load/usr/lib/libgobject-2.0.so.0.7400.7-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libglib-2.0.so.0.7600.4-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libgobject-2.0.so.0.7600.4-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/libglib-2.0.so.0.7600.4-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/libgobject-2.0.so.0.7600.4-gdb.py
 file path=usr/share/gettext/its/gschema.its
 file path=usr/share/gettext/its/gschema.loc
 file path=usr/share/glib-2.0/codegen/__init__.py
 file path=usr/share/glib-2.0/codegen/codegen.py
 file path=usr/share/glib-2.0/codegen/codegen_docbook.py
 file path=usr/share/glib-2.0/codegen/codegen_main.py
+file path=usr/share/glib-2.0/codegen/codegen_md.py
 file path=usr/share/glib-2.0/codegen/codegen_rst.py
 file path=usr/share/glib-2.0/codegen/config.py
 file path=usr/share/glib-2.0/codegen/dbustypes.py

--- a/components/library/glib/manifests/sample-manifest.p5m
+++ b/components/library/glib/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -130,6 +130,7 @@ file path=usr/include/glib-2.0/gio/ginetsocketaddress.h
 file path=usr/include/glib-2.0/gio/ginitable.h
 file path=usr/include/glib-2.0/gio/ginputstream.h
 file path=usr/include/glib-2.0/gio/gio-autocleanups.h
+file path=usr/include/glib-2.0/gio/gio-visibility.h
 file path=usr/include/glib-2.0/gio/gio.h
 file path=usr/include/glib-2.0/gio/gioenums.h
 file path=usr/include/glib-2.0/gio/gioenumtypes.h
@@ -255,6 +256,7 @@ file path=usr/include/glib-2.0/glib/giochannel.h
 file path=usr/include/glib-2.0/glib/gkeyfile.h
 file path=usr/include/glib-2.0/glib/glib-autocleanups.h
 file path=usr/include/glib-2.0/glib/glib-typeof.h
+file path=usr/include/glib-2.0/glib/glib-visibility.h
 file path=usr/include/glib-2.0/glib/glist.h
 file path=usr/include/glib-2.0/glib/gmacros.h
 file path=usr/include/glib-2.0/glib/gmain.h
@@ -264,6 +266,7 @@ file path=usr/include/glib-2.0/glib/gmem.h
 file path=usr/include/glib-2.0/glib/gmessages.h
 file path=usr/include/glib-2.0/glib/gnode.h
 file path=usr/include/glib-2.0/glib/goption.h
+file path=usr/include/glib-2.0/glib/gpathbuf.h
 file path=usr/include/glib-2.0/glib/gpattern.h
 file path=usr/include/glib-2.0/glib/gpoll.h
 file path=usr/include/glib-2.0/glib/gprimes.h
@@ -305,6 +308,7 @@ file path=usr/include/glib-2.0/glib/gversion.h
 file path=usr/include/glib-2.0/glib/gversionmacros.h
 file path=usr/include/glib-2.0/glib/gwin32.h
 file path=usr/include/glib-2.0/gmodule.h
+file path=usr/include/glib-2.0/gmodule/gmodule-visibility.h
 file path=usr/include/glib-2.0/gobject/gbinding.h
 file path=usr/include/glib-2.0/gobject/gbindinggroup.h
 file path=usr/include/glib-2.0/gobject/gboxed.h
@@ -314,6 +318,7 @@ file path=usr/include/glib-2.0/gobject/glib-enumtypes.h
 file path=usr/include/glib-2.0/gobject/glib-types.h
 file path=usr/include/glib-2.0/gobject/gmarshal.h
 file path=usr/include/glib-2.0/gobject/gobject-autocleanups.h
+file path=usr/include/glib-2.0/gobject/gobject-visibility.h
 file path=usr/include/glib-2.0/gobject/gobject.h
 file path=usr/include/glib-2.0/gobject/gobjectnotifyqueue.c
 file path=usr/include/glib-2.0/gobject/gparam.h
@@ -328,25 +333,26 @@ file path=usr/include/glib-2.0/gobject/gvalue.h
 file path=usr/include/glib-2.0/gobject/gvaluearray.h
 file path=usr/include/glib-2.0/gobject/gvaluecollector.h
 file path=usr/include/glib-2.0/gobject/gvaluetypes.h
+file path=usr/lib/$(MACH64)/gio/modules/libgiofam.so
 file path=usr/lib/$(MACH64)/glib-2.0/include/glibconfig.h
 link path=usr/lib/$(MACH64)/libgio-2.0.so target=libgio-2.0.so.0
-link path=usr/lib/$(MACH64)/libgio-2.0.so.0 target=libgio-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgio-2.0.so.0.7400.7
+link path=usr/lib/$(MACH64)/libgio-2.0.so.0 target=libgio-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgio-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libglib-2.0.so target=libglib-2.0.so.0
-link path=usr/lib/$(MACH64)/libglib-2.0.so.0 target=libglib-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libglib-2.0.so.0.7400.7
+link path=usr/lib/$(MACH64)/libglib-2.0.so.0 target=libglib-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libglib-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libgmodule-2.0.so target=libgmodule-2.0.so.0
 link path=usr/lib/$(MACH64)/libgmodule-2.0.so.0 \
-    target=libgmodule-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgmodule-2.0.so.0.7400.7
+    target=libgmodule-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgmodule-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libgobject-2.0.so target=libgobject-2.0.so.0
 link path=usr/lib/$(MACH64)/libgobject-2.0.so.0 \
-    target=libgobject-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgobject-2.0.so.0.7400.7
+    target=libgobject-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgobject-2.0.so.0.7600.4
 link path=usr/lib/$(MACH64)/libgthread-2.0.so target=libgthread-2.0.so.0
 link path=usr/lib/$(MACH64)/libgthread-2.0.so.0 \
-    target=libgthread-2.0.so.0.7400.7
-file path=usr/lib/$(MACH64)/libgthread-2.0.so.0.7400.7
+    target=libgthread-2.0.so.0.7600.4
+file path=usr/lib/$(MACH64)/libgthread-2.0.so.0.7600.4
 file path=usr/lib/$(MACH64)/pkgconfig/gio-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gio-unix-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/glib-2.0.pc
@@ -355,23 +361,23 @@ file path=usr/lib/$(MACH64)/pkgconfig/gmodule-export-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gmodule-no-export-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gobject-2.0.pc
 file path=usr/lib/$(MACH64)/pkgconfig/gthread-2.0.pc
-file path=usr/lib/gio-launch-desktop
+file path=usr/lib/gio/modules/libgiofam.so
 file path=usr/lib/glib-2.0/include/glibconfig.h
 link path=usr/lib/libgio-2.0.so target=libgio-2.0.so.0
-link path=usr/lib/libgio-2.0.so.0 target=libgio-2.0.so.0.7400.7
-file path=usr/lib/libgio-2.0.so.0.7400.7
+link path=usr/lib/libgio-2.0.so.0 target=libgio-2.0.so.0.7600.4
+file path=usr/lib/libgio-2.0.so.0.7600.4
 link path=usr/lib/libglib-2.0.so target=libglib-2.0.so.0
-link path=usr/lib/libglib-2.0.so.0 target=libglib-2.0.so.0.7400.7
-file path=usr/lib/libglib-2.0.so.0.7400.7
+link path=usr/lib/libglib-2.0.so.0 target=libglib-2.0.so.0.7600.4
+file path=usr/lib/libglib-2.0.so.0.7600.4
 link path=usr/lib/libgmodule-2.0.so target=libgmodule-2.0.so.0
-link path=usr/lib/libgmodule-2.0.so.0 target=libgmodule-2.0.so.0.7400.7
-file path=usr/lib/libgmodule-2.0.so.0.7400.7
+link path=usr/lib/libgmodule-2.0.so.0 target=libgmodule-2.0.so.0.7600.4
+file path=usr/lib/libgmodule-2.0.so.0.7600.4
 link path=usr/lib/libgobject-2.0.so target=libgobject-2.0.so.0
-link path=usr/lib/libgobject-2.0.so.0 target=libgobject-2.0.so.0.7400.7
-file path=usr/lib/libgobject-2.0.so.0.7400.7
+link path=usr/lib/libgobject-2.0.so.0 target=libgobject-2.0.so.0.7600.4
+file path=usr/lib/libgobject-2.0.so.0.7600.4
 link path=usr/lib/libgthread-2.0.so target=libgthread-2.0.so.0
-link path=usr/lib/libgthread-2.0.so.0 target=libgthread-2.0.so.0.7400.7
-file path=usr/lib/libgthread-2.0.so.0.7400.7
+link path=usr/lib/libgthread-2.0.so.0 target=libgthread-2.0.so.0.7600.4
+file path=usr/lib/libgthread-2.0.so.0.7600.4
 file path=usr/lib/pkgconfig/gio-2.0.pc
 file path=usr/lib/pkgconfig/gio-unix-2.0.pc
 file path=usr/lib/pkgconfig/glib-2.0.pc
@@ -380,6 +386,8 @@ file path=usr/lib/pkgconfig/gmodule-export-2.0.pc
 file path=usr/lib/pkgconfig/gmodule-no-export-2.0.pc
 file path=usr/lib/pkgconfig/gobject-2.0.pc
 file path=usr/lib/pkgconfig/gthread-2.0.pc
+file path=usr/libexec/$(MACH32)/gio-launch-desktop
+file path=usr/libexec/gio-launch-desktop
 file path=usr/share/aclocal/glib-2.0.m4
 file path=usr/share/aclocal/glib-gettext.m4
 file path=usr/share/aclocal/gsettings.m4
@@ -388,16 +396,17 @@ file path=usr/share/bash-completion/completions/gdbus
 file path=usr/share/bash-completion/completions/gio
 file path=usr/share/bash-completion/completions/gresource
 file path=usr/share/bash-completion/completions/gsettings
-file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libglib-2.0.so.0.7400.7-gdb.py
-file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libgobject-2.0.so.0.7400.7-gdb.py
-file path=usr/share/gdb/auto-load/usr/lib/libglib-2.0.so.0.7400.7-gdb.py
-file path=usr/share/gdb/auto-load/usr/lib/libgobject-2.0.so.0.7400.7-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libglib-2.0.so.0.7600.4-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/$(MACH64)/libgobject-2.0.so.0.7600.4-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/libglib-2.0.so.0.7600.4-gdb.py
+file path=usr/share/gdb/auto-load/usr/lib/libgobject-2.0.so.0.7600.4-gdb.py
 file path=usr/share/gettext/its/gschema.its
 file path=usr/share/gettext/its/gschema.loc
 file path=usr/share/glib-2.0/codegen/__init__.py
 file path=usr/share/glib-2.0/codegen/codegen.py
 file path=usr/share/glib-2.0/codegen/codegen_docbook.py
 file path=usr/share/glib-2.0/codegen/codegen_main.py
+file path=usr/share/glib-2.0/codegen/codegen_md.py
 file path=usr/share/glib-2.0/codegen/codegen_rst.py
 file path=usr/share/glib-2.0/codegen/config.py
 file path=usr/share/glib-2.0/codegen/dbustypes.py

--- a/components/library/glib/patches/14-ignored-return-values.patch
+++ b/components/library/glib/patches/14-ignored-return-values.patch
@@ -1,0 +1,39 @@
+This patch fixes ON builds where linter is not happy with unused variables.
+https://bug.oraclecorp.com/pls/bug/webbug_print.show?c_rptno=28964691
+
+Even though it fixes specific behavior of our build environment,
+it can be suitable for upstream.
+
+--- glib-2.52.0/glib/gstring.h	2018-11-27 01:02:11.709901563 +0000
++++ glib-2.52.0/glib/gstring.h	2018-11-27 00:58:52.732310445 +0000
+@@ -167,7 +167,7 @@ g_string_append_c_inline (GString *gstri
+       gstring->str[gstring->len] = 0;
+     }
+   else
+-    g_string_insert_c (gstring, -1, c);
++    (void) g_string_insert_c (gstring, -1, c);
+   return gstring;
+ }
+ #define g_string_append_c(gstr,c)       g_string_append_c_inline (gstr, c)
+--- glib-2.52.0/glib/glib-autocleanups.h	2018-11-27 01:02:26.482700505 +0000
++++ glib-2.52.0/glib/glib-autocleanups.h	2018-11-27 00:59:39.293472971 +0000
+@@ -32,7 +32,7 @@ static inline void
+ g_autoptr_cleanup_gstring_free (GString *string)
+ {
+   if (string)
+-    g_string_free (string, TRUE);
++    (void) g_string_free (string, TRUE);
+ }
+ 
+ /* If adding a cleanup here, please also add a test case to
+--- glib-2.52.0/gobject/gobject.h	2018-11-27 01:02:40.257225970 +0000
++++ glib-2.52.0/gobject/gobject.h	2018-11-27 01:01:12.039457270 +0000
+@@ -722,7 +722,7 @@ 
+     return FALSE;
+ 
+   if (new_object != NULL)
+-    g_object_ref (new_object);
++    (void) g_object_ref (new_object);
+ 
+   *object_ptr = new_object;
+ 

--- a/components/library/glib/patches/16-pkgconfig.patch
+++ b/components/library/glib/patches/16-pkgconfig.patch
@@ -1,0 +1,57 @@
+Solaris pkgconfig file changes
+
+Not suitable for upstream
+
+--- a/glib/meson.build	2019-10-31 16:01:22.777037273 -0700
++++ b/glib/meson.build	2019-10-31 16:01:38.923014840 -0700
+@@ -440,10 +440,10 @@
+   libraries_private : [osx_ldflags, win32_ldflags],
+   subdirs : ['glib-2.0'],
+   extra_cflags : ['-I${libdir}/glib-2.0/include'] + win32_cflags,
+-  variables : ['bindir=' + join_paths('${prefix}', get_option('bindir')),
+-               'glib_genmarshal=' + join_paths('${bindir}', 'glib-genmarshal'),
+-               'gobject_query=' + join_paths('${bindir}', 'gobject-query'),
+-               'glib_mkenums=' + join_paths('${bindir}', 'glib-mkenums')],
++  variables : [
++               'glib_genmarshal=glib-genmarshal',
++               'gobject_query=gobject-query',
++               'glib_mkenums=glib-mkenums'],
+   version : glib_version,
+   install_dir : glib_pkgconfigreldir,
+   filebase : 'glib-2.0',
+--- a/gio/meson.build	2020-03-04 11:38:44.071086819 -0800
++++ b/gio/meson.build	2020-03-04 11:39:13.908503397 -0800
+@@ -881,14 +881,14 @@
+                'schemasdir=' + join_paths('${datadir}', schemas_subdir),
+                'bindir=' + join_paths('${prefix}', get_option('bindir')),
+                'giomoduledir=' + pkgconfig_giomodulesdir,
+-               'gio=' + join_paths('${bindir}', 'gio'),
+-               'gio_querymodules=@0@'.format(pkgconfig_multiarch_bindir / 'gio-querymodules'),
+-               'glib_compile_schemas=@0@'.format(pkgconfig_multiarch_bindir / 'glib-compile-schemas'),
+-               'glib_compile_resources=' + join_paths('${bindir}', 'glib-compile-resources'),
+-               'gdbus=' + join_paths('${bindir}', 'gdbus'),
+-               'gdbus_codegen=' + join_paths('${bindir}', 'gdbus-codegen'),
+-               'gresource=' + join_paths('${bindir}', 'gresource'),
+-               'gsettings=' + join_paths('${bindir}', 'gsettings')],
++               'gio=gio',
++               'gio_querymodules=gio-querymodules',
++               'glib_compile_schemas=glib-compile-schemas',
++               'glib_compile_resources=glib-compile-resources',
++               'gdbus=gdbus',
++               'gdbus_codegen=gdbus-codegen',
++               'gresource=gresource',
++               'gsettings=gsettings'],
+   version : glib_version,
+   install_dir : glib_pkgconfigreldir,
+   filebase : 'gio-2.0',
+--- a/meson.build	2020-03-04 09:02:32.869174026 -0800
++++ b/meson.build	2020-03-04 09:02:58.419670458 -0800
+@@ -1930,7 +1930,7 @@
+   glibconfig_conf.set('g_threads_impl_def', 'WIN32')
+   glib_conf.set('THREADS_WIN32', 1)
+ else
+-  thread_dep = dependency('threads')
++  thread_dep = []
+   threads_implementation = 'posix'
+   pthread_prefix = '''
+       #ifndef _GNU_SOURCE

--- a/components/library/glib/patches/22-fam.patch
+++ b/components/library/glib/patches/22-fam.patch
@@ -1,0 +1,357 @@
+Revert 6aa210e6af965a972a1c3a03e9abd556c45872ac 
+Required for some customers - see 31814220
+
+--- a/meson_options.txt	2023-06-26 07:39:05.868503104 -0700
++++ b/meson_options.txt	2023-06-26 07:39:26.039681486 -0700
+@@ -77,6 +77,11 @@
+        value : false,
+        description : 'Also use posix threads in case the platform defaults to another implementation (on Windows for example)')
+ 
++option('fam',
++       type : 'boolean',
++       value : false,
++       description : 'Use fam for file system monitoring')
++
+ option('tests',
+        type : 'boolean',
+        value : true,
+--- a/gio/meson.build	2023-06-26 07:39:55.405741615 -0700
++++ b/gio/meson.build	2023-06-26 07:40:20.914170757 -0700
+@@ -1100,6 +1100,7 @@
+   endforeach
+ endif
+ 
++subdir('fam')
+ if build_tests
+     subdir('tests')
+ endif
+--- a/docs/reference/gio/overview.xml	2023-06-26 07:43:32.574491070 -0700
++++ b/docs/reference/gio/overview.xml	2023-06-26 07:44:52.171474717 -0700
+@@ -392,7 +392,7 @@
+         The #GFileMonitor implementation for local files that is included
+         in GIO on Linux has the name <literal>inotify</literal>, others that are built
+         are built as modules (depending on the platform) are called
+-        <literal>kqueue</literal> and <literal>win32filemonitor</literal>.
++        <literal>fam</literal>, <literal>kqueue</literal> and <literal>win32filemonitor</literal>.
+       </para><para>
+         The special value <literal>help</literal> can be used to print a list of
+         available implementations to standard output.
+@@ -665,7 +665,7 @@
+       </para>
+       <para>
+         GIO uses this extension point internally, to switch between
+-        its kqueue-based and inotify-based file monitoring implementations.
++        its fam-based and inotify-based file monitoring implementations.
+       </para>
+    </formalpara>
+ 
+--- a/docs/reference/gio/meson.build	2023-06-26 07:45:17.347220450 -0700
++++ b/docs/reference/gio/meson.build	2023-06-26 07:45:33.867624140 -0700
+@@ -3,6 +3,7 @@
+   subdir('xml')
+ 
+   ignore_headers = [
++    'fam',
+     'gdbus-2.0',
+     'inotify',
+     'kqueue',
+--- a/gio/fam/gfamfilemonitor.map	2023-06-26 07:48:33.508579231 -0700
++++ b/gio/fam/gfamfilemonitor.map	2023-06-26 07:42:21.369994717 -0700
+@@ -0,0 +1,8 @@
++{
++global:
++  g_io_module_load;
++  g_io_module_unload;
++  g_io_module_query;
++local:
++  *;
++};
+--- a/gio/fam/gfamfilemonitor.c	2023-06-26 07:48:25.344771924 -0700
++++ b/gio/fam/gfamfilemonitor.c	2023-06-26 07:42:21.365393800 -0700
+@@ -0,0 +1,235 @@
++/*
++ * Copyright © 2015 Canonical Limited
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General
++ * Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
++ *
++ * Author: Ryan Lortie <desrt@desrt.ca>
++ */
++
++#include "config.h"
++
++#include <gio/glocalfilemonitor.h>
++#include <gio/giomodule.h>
++#include "glib-private.h"
++#include <glib-unix.h>
++#include <fam.h>
++
++static GMutex         fam_lock;
++static gboolean       fam_initialised;
++static FAMConnection  fam_connection;
++static GSource       *fam_source;
++
++#define G_TYPE_FAM_FILE_MONITOR      (g_fam_file_monitor_get_type ())
++#define G_FAM_FILE_MONITOR(inst)     (G_TYPE_CHECK_INSTANCE_CAST ((inst), \
++                                      G_TYPE_FAM_FILE_MONITOR, GFamFileMonitor))
++
++typedef GLocalFileMonitorClass GFamFileMonitorClass;
++
++typedef struct
++{
++  GLocalFileMonitor parent_instance;
++
++  FAMRequest request;
++} GFamFileMonitor;
++
++static GType g_fam_file_monitor_get_type (void);
++G_DEFINE_DYNAMIC_TYPE (GFamFileMonitor, g_fam_file_monitor, G_TYPE_LOCAL_FILE_MONITOR)
++
++static gboolean
++g_fam_file_monitor_callback (gint         fd,
++                             GIOCondition condition,
++                             gpointer     user_data)
++{
++  gint64 now = g_source_get_time (fam_source);
++
++  g_mutex_lock (&fam_lock);
++
++  while (FAMPending (&fam_connection))
++    {
++      const gchar *child;
++      FAMEvent ev;
++
++      if (FAMNextEvent (&fam_connection, &ev) != 1)
++        {
++          /* The daemon died.  We're in a really bad situation now
++           * because we potentially have a bunch of request structures
++           * outstanding which no longer make any sense to anyone.
++           *
++           * The best thing that we can do is do nothing.  Notification
++           * won't work anymore for this process.
++           */
++          g_mutex_unlock (&fam_lock);
++
++          g_warning ("Lost connection to FAM (file monitoring) service.  Expect no further file monitor events.");
++
++          return FALSE;
++        }
++
++      /* We expect ev.filename to be a relative path for children in a
++       * monitored directory, and an absolute path for a monitored file
++       * or the directory itself.
++       */
++      if (ev.filename[0] != '/')
++        child = ev.filename;
++      else
++        child = NULL;
++
++      switch (ev.code)
++        {
++        case FAMAcknowledge:
++          g_source_unref (ev.userdata);
++          break;
++
++        case FAMChanged:
++          g_file_monitor_source_handle_event (ev.userdata, G_FILE_MONITOR_EVENT_CHANGED, child, NULL, NULL, now);
++          break;
++
++        case FAMDeleted:
++          g_file_monitor_source_handle_event (ev.userdata, G_FILE_MONITOR_EVENT_DELETED, child, NULL, NULL, now);
++          break;
++
++        case FAMCreated:
++          g_file_monitor_source_handle_event (ev.userdata, G_FILE_MONITOR_EVENT_CREATED, child, NULL, NULL, now);
++          break;
++
++        default:
++          /* unknown type */
++          break;
++        }
++    }
++
++  g_mutex_unlock (&fam_lock);
++
++  return TRUE;
++}
++
++static gboolean
++g_fam_file_monitor_is_supported (void)
++{
++  g_mutex_lock (&fam_lock);
++
++  if (!fam_initialised)
++    {
++      fam_initialised = FAMOpen2 (&fam_connection, "GLib GIO") == 0;
++
++      if (fam_initialised)
++        {
++#ifdef HAVE_FAM_NO_EXISTS
++          /* This is a gamin extension that avoids sending all the
++           * Exists event for dir monitors
++           */
++          FAMNoExists (&fam_connection);
++#endif
++
++          fam_source = g_unix_fd_source_new (FAMCONNECTION_GETFD (&fam_connection), G_IO_IN);
++          g_source_set_callback (fam_source, (GSourceFunc) g_fam_file_monitor_callback, NULL, NULL);
++          g_source_attach (fam_source, GLIB_PRIVATE_CALL(g_get_worker_context) ());
++        }
++    }
++
++  g_mutex_unlock (&fam_lock);
++
++  return fam_initialised;
++}
++
++static gboolean
++g_fam_file_monitor_cancel (GFileMonitor *monitor)
++{
++  GFamFileMonitor *gffm = G_FAM_FILE_MONITOR (monitor);
++
++  g_mutex_lock (&fam_lock);
++
++  g_assert (fam_initialised);
++
++  FAMCancelMonitor (&fam_connection, &gffm->request);
++
++  g_mutex_unlock (&fam_lock);
++
++  return TRUE;
++}
++
++static void
++g_fam_file_monitor_start (GLocalFileMonitor  *local_monitor,
++                          const gchar        *dirname,
++                          const gchar        *basename,
++                          const gchar        *filename,
++                          GFileMonitorSource *source)
++{
++  GFamFileMonitor *gffm = G_FAM_FILE_MONITOR (local_monitor);
++
++  g_mutex_lock (&fam_lock);
++
++  g_assert (fam_initialised);
++
++  g_source_ref ((GSource *) source);
++
++  if (dirname)
++    FAMMonitorDirectory (&fam_connection, dirname, &gffm->request, source);
++  else
++    FAMMonitorFile (&fam_connection, filename, &gffm->request, source);
++
++  g_mutex_unlock (&fam_lock);
++}
++
++static void
++g_fam_file_monitor_init (GFamFileMonitor* monitor)
++{
++}
++
++static void
++g_fam_file_monitor_class_init (GFamFileMonitorClass *class)
++{
++  GFileMonitorClass *file_monitor_class = G_FILE_MONITOR_CLASS (class);
++
++  class->is_supported = g_fam_file_monitor_is_supported;
++  class->start = g_fam_file_monitor_start;
++  file_monitor_class->cancel = g_fam_file_monitor_cancel;
++}
++
++static void
++g_fam_file_monitor_class_finalize (GFamFileMonitorClass *class)
++{
++}
++
++void
++g_io_module_load (GIOModule *module)
++{
++  g_type_module_use (G_TYPE_MODULE (module));
++
++  g_fam_file_monitor_register_type (G_TYPE_MODULE (module));
++
++  g_io_extension_point_implement (G_LOCAL_FILE_MONITOR_EXTENSION_POINT_NAME,
++                                 G_TYPE_FAM_FILE_MONITOR, "fam", 10);
++
++  g_io_extension_point_implement (G_NFS_FILE_MONITOR_EXTENSION_POINT_NAME,
++                                 G_TYPE_FAM_FILE_MONITOR, "fam", 10);
++}
++
++void
++g_io_module_unload (GIOModule *module)
++{
++  g_assert_not_reached ();
++}
++
++char **
++g_io_module_query (void)
++{
++  char *eps[] = {
++    G_LOCAL_FILE_MONITOR_EXTENSION_POINT_NAME,
++    G_NFS_FILE_MONITOR_EXTENSION_POINT_NAME,
++    NULL
++  };
++
++  return g_strdupv (eps);
++}
+--- a/gio/fam/meson.build	2023-06-26 07:51:35.321884298 -0700
++++ b/gio/fam/meson.build	2023-06-26 07:42:21.397568522 -0700
+@@ -0,0 +1,36 @@
++if not get_option('fam')
++  subdir_done()
++endif
++
++fam_dep = cc.find_library('fam')
++fam_c_args = gio_c_args
++if cc.has_function('FAMNoExists', dependencies : fam_dep)
++  fam_c_args += '-DHAVE_FAM_NO_EXISTS=1'
++endif
++
++deps = [
++  fam_dep,
++  libglib_dep,
++  libgobject_dep,
++  libgio_dep,
++]
++
++symbol_map = join_paths(meson.current_source_dir(), 'gfamfilemonitor.map')
++fam_ldflags = cc.get_supported_link_arguments([
++  '-Wl,--version-script,' + symbol_map,
++  '-Wl,-no-undefined',
++])
++
++module = shared_module('giofam', 'gfamfilemonitor.c',
++  include_directories : [gmoduleinc],
++  dependencies : deps,
++  c_args : [fam_c_args, gio_c_args_internal],
++  link_args : fam_ldflags,
++  link_depends : symbol_map,
++  install_dir : glib_giomodulesdir,
++  install : true,
++)
++
++if not meson.is_cross_build()
++  meson.add_install_script('../gio-querymodules-wrapper.py', gio_querymodules.full_path(), glib_giomodulesdir)
++endif
+--- a/gio/gio-querymodules-wrapper.py	2023-06-26 08:02:42.885690403 -0700
++++ b/gio/gio-querymodules-wrapper.py	2023-06-26 08:02:36.411976824 -0700
+@@ -0,0 +1,9 @@
++#!/usr/bin/env python3
++
++import os
++import subprocess
++import sys
++
++if not os.environ.get("DESTDIR"):
++    print("GIO module cache creation...")
++    subprocess.call([sys.argv[1], sys.argv[2]])

--- a/components/library/glib/pkg5
+++ b/components/library/glib/pkg5
@@ -1,5 +1,6 @@
 {
     "dependencies": [
+        "library/file-monitor/gamin",
         "library/libffi",
         "library/pcre2",
         "library/zlib",
@@ -8,8 +9,8 @@
         "system/library"
     ],
     "fmris": [
-        "library/glib2/charset-alias",
-        "library/glib2"
+        "library/glib2",
+        "library/glib2/charset-alias"
     ],
     "name": "glib"
 }


### PR DESCRIPTION
Port fam patch from solaris userland to fix various severe bugs

This will add event port support via gamin and fixes https://github.com/mate-desktop/mate-system-monitor/issues/263 and https://www.illumos.org/issues/16409 plus other coredumps and crashes from MATE or gnome apps related to the error message below should also be fixed. 
```
(<unknown>:2575): CRITICAL **: 07:49:00.733:
unhandled exception (type Glib::Error) in signal handler:
domain: g-io-error-quark
code : 0
what : Unable to find default local file monitor type
```