### PR TITLE
Fix REQUIRED_PACKAGES for slim_source

### DIFF
--- a/components/openindiana/slim_source/Makefile
+++ b/components/openindiana/slim_source/Makefile
@@ -147,3 +147,5 @@ REQUIRED_PACKAGES += system/install/text-install
 REQUIRED_PACKAGES += system/library/install/libinstzones
 REQUIRED_PACKAGES += system/library/storage/ima/header-ima
 REQUIRED_PACKAGES += system/zones/internal
+REQUIRED_PACKAGES += library/desktop/libglade
+REQUIRED_PACKAGES += gnome/config/gconf


### PR DESCRIPTION
This Add the two Required packages currently missing for slim_source. Note that the Makefile overrides many things from the scripted version so en-prep needs to be run manually on the buildserver for it to install any missing packages. 