### PR TITLE
web/php/php-8_2: mysqlnd as default for mysqli and pdo_mysql

### DIFF
--- a/components/web/php/php-8_2/Makefile
+++ b/components/web/php/php-8_2/Makefile
@@ -32,10 +32,9 @@ COMPONENT_FMRI=         web/$(COMPONENT_NAME)-82
 COMPONENT_CLASSIFICATION=Meta Packages/Group Packages
 COMPONENT_LICENSE=      PHP License
 COMPONENT_LICENSE_FILE= LICENSE
+COMPONENT_REVISION= 1
 
 include $(WS_MAKE_RULES)/common.mk
-
-MYSQL_DIR=		$(MYSQL_HOME)
 
 # Apache Paths
 AP_PREFIX=		/usr/apache2/2.4
@@ -52,9 +51,6 @@ CFLAGS +=        	$(CC_BITS) -D_XPG4_2 -D__EXTENSIONS__ -D__solaris__
 CFLAGS +=		-I/usr/include/openldap
 CPPFLAGS +=      	$(CPP_XPG6MODE)
 LDFLAGS +=       	-lldap_r
-CPPFLAGS +=      	-I$(MYSQL_INCDIR)
-CFLAGS +=        	-I$(MYSQL_INCDIR)
-LDFLAGS +=       	-L$(MYSQL_LIBDIR)
 
 # build with the system default libjpeg
 CFLAGS+=                $(JPEG_CPPFLAGS) $(JPEG_CFLAGS)
@@ -137,12 +133,10 @@ CONFIGURE_OPTIONS += --enable-soap=shared
 CONFIGURE_OPTIONS += --enable-sockets=shared
 CONFIGURE_OPTIONS += --enable-mysqlnd=shared
 CONFIGURE_OPTIONS += --with-snmp=shared
+CONFIGURE_OPTIONS += --with-mysqli=shared,mysqlnd
+CONFIGURE_OPTIONS += --with-pdo-mysql=shared,mysqlnd
 
 # Extensions, dependent on other packages
-
-# Since PHP 8.2 and later, compiling mysqli extension with libmysql is no longer supported.
-#CONFIGURE_OPTIONS += --with-mysqli=shared,$(MYSQL_BINDIR)/mysql_config
-CONFIGURE_OPTIONS += --with-pdo-mysql=shared,$(MYSQL_DIR)
 CONFIGURE_OPTIONS += --with-pgsql=shared,$(PG_BINDIR)
 CONFIGURE_OPTIONS += --with-pdo-pgsql=shared,$(PG_BINDIR)
 
@@ -222,7 +216,6 @@ COMPONENT_TEST_TRANSFORMS += \
     '-e "/.*/d" '
 
 # Manually added build dependencies
-REQUIRED_PACKAGES += $(MYSQL_CLIENT_PKG)
 REQUIRED_PACKAGES += $(PG_DEVELOPER_PKG)
 REQUIRED_PACKAGES += $(PG_SERVICE_PKG)
 REQUIRED_PACKAGES += web/server/apache-24
@@ -231,7 +224,6 @@ REQUIRED_PACKAGES += web/server/apache-24
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(ICU_LIBRARY_PKG)
-REQUIRED_PACKAGES += $(MYSQL_LIBRARY_PKG)
 REQUIRED_PACKAGES += $(PG_LIBRARY_PKG)
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += compress/bzip2

--- a/components/web/php/php-8_2/files/first_mysqlnd.ini
+++ b/components/web/php/php-8_2/files/first_mysqlnd.ini
@@ -1,0 +1,2 @@
+[mysqlnd]
+extension=mysqlnd.so

--- a/components/web/php/php-8_2/files/mysqli.ini
+++ b/components/web/php/php-8_2/files/mysqli.ini
@@ -1,0 +1,2 @@
+[mysqli]
+extension=mysqli.so

--- a/components/web/php/php-8_2/php82-ext-mysql.p5m
+++ b/components/web/php/php-8_2/php82-ext-mysql.p5m
@@ -29,7 +29,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=pkg:/$(COMPONENT_FMRI)/php-common
 
+# has to be loaded before mysqli and pdo_mysql
+file files/first_mysqlnd.ini path=etc/php/8.2/conf.d/first_mysqlnd.ini preserve=true mode=0644
+
 file files/pdo_mysql.ini path=etc/php/8.2/conf.d/pdo_mysql.ini preserve=true mode=0644
+file files/mysqli.ini path=etc/php/8.2/conf.d/mysqli.ini preserve=true mode=0644
 
 file path=usr/php/8.2/include/php/ext/mysqlnd/config-win.h
 file path=usr/php/8.2/include/php/ext/mysqlnd/mysql_float_to_double.h
@@ -58,6 +62,6 @@ file path=usr/php/8.2/include/php/ext/mysqlnd/mysqlnd_structs.h
 file path=usr/php/8.2/include/php/ext/mysqlnd/mysqlnd_vio.h
 file path=usr/php/8.2/include/php/ext/mysqlnd/mysqlnd_wireprotocol.h
 file path=usr/php/8.2/include/php/ext/mysqlnd/php_mysqlnd.h
-#file path=usr/php/8.2/extensions/mysqli.so
+file path=usr/php/8.2/extensions/mysqli.so
 file path=usr/php/8.2/extensions/pdo_mysql.so
 file path=usr/php/8.2/extensions/mysqlnd.so

--- a/components/web/php/php-8_2/pkg5
+++ b/components/web/php/php-8_2/pkg5
@@ -2,8 +2,6 @@
     "dependencies": [
         "SUNWcs",
         "compress/bzip2",
-        "database/mariadb-106/client",
-        "database/mariadb-106/library",
         "database/postgres-16/developer",
         "database/postgres-16/library",
         "database/sqlite-3",


### PR DESCRIPTION
switching to mysqlnd not only makes mysqli possible with 8.2+ but also offers additional, good features.
for details see: https://www.php.net/manual/en/mysqlinfo.library.choosing.php
