### PR TITLE
xz Remove Backdoor activation code.

### DIFF
--- a/components/archiver/xz/Makefile
+++ b/components/archiver/xz/Makefile
@@ -27,6 +27,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		xz
 COMPONENT_VERSION=	5.6.1
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY=	XZ Utils - loss-less file compression application and library
 COMPONENT_PROJECT_URL=	https://tukaani.org/xz/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -39,6 +40,8 @@ COMPONENT_CLASSIFICATION= Applications/System Utilities
 COMPONENT_LICENSE=	0BSD, GPLv2+,GPLv3+, LGPLv2.1, CC BY-SA 4.0
 
 include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_PRE_CONFIGURE_ACTION= ( cd $(SOURCE_DIR) && rm m4/build-to-host.m4 && autoreconf -fi )
 
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --disable-rpath


### PR DESCRIPTION
This change removes the backdoored fourth file in the release tarball and regenerates a clean version with autoreconf. Unfortunately, we cannot use `autogen.sh` as we are missing the p4oa utility which is needed to build translated manfiles. Checking with diff shows that the backdoor activation was removed.

We are not affected by the backdoor as the code was already limiting itself to linux only as far as people can tell. However, it doesn't hurt to be cautious.

Our OpenSSH daemon does link to liblzma so on the off chance that it was activated it now should not be included in the build.