### PR TITLE
ffmpeg: move runtime libraries to own package

### DIFF
--- a/components/encumbered/ffmpeg/Makefile
+++ b/components/encumbered/ffmpeg/Makefile
@@ -21,11 +21,11 @@ COMPONENT_NAME=         ffmpeg
 # Many projects still rely on the old libavcodec api which has been deprecated with ffmpeg-6.0.
 # Version 7.0 removed its compatibility fallback mechanisms and firefox does not support the new api yet.
 # Thus, we have to revert the update to 7.0 and deliver 6.1.1 with a fake version 7.0.
-COMPONENT_VERSION=      6.1.1
-IPS_COMPONENT_VERSION=	7.0
-COMPONENT_REVISION=		1
+HUMAN_VERSION=		6.1.1
+COMPONENT_VERSION=	7.0
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=      A very fast video and audio converter
-COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= sha256:8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968
 COMPONENT_PROJECT_URL=  https://www.ffmpeg.org
@@ -33,6 +33,9 @@ COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/releases/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=         video/ffmpeg
 COMPONENT_CLASSIFICATION= System/Multimedia Libraries
 COMPONENT_LICENSE=      LGPLv2.1+, GPLv2, MIT/X11/BSD-style
+
+COMPONENT_FMRI.library =	library/ffmpeg-6
+COMPONENT_SUMMARY.library =	$(COMPONENT_SUMMARY) (runtime libraries)
 
 include $(WS_MAKE_RULES)/encumbered.mk
 include $(WS_MAKE_RULES)/common.mk
@@ -133,7 +136,6 @@ REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += video/rtmpdump
-REQUIRED_PACKAGES += x11/library/libdrm
 REQUIRED_PACKAGES += x11/library/libx11
 REQUIRED_PACKAGES += x11/library/libxcb
 REQUIRED_PACKAGES += x11/library/libxext

--- a/components/encumbered/ffmpeg/ffmpeg.p5m
+++ b/components/encumbered/ffmpeg/ffmpeg.p5m
@@ -169,29 +169,13 @@ file path=usr/include/libswscale/swscale.h
 file path=usr/include/libswscale/version.h
 file path=usr/include/libswscale/version_major.h
 link path=usr/lib/$(MACH64)/libavcodec.so target=libavcodec.so.60.31.102
-link path=usr/lib/$(MACH64)/libavcodec.so.60 target=libavcodec.so.60.31.102
-file path=usr/lib/$(MACH64)/libavcodec.so.60.31.102
 link path=usr/lib/$(MACH64)/libavdevice.so target=libavdevice.so.60.3.100
-link path=usr/lib/$(MACH64)/libavdevice.so.60 target=libavdevice.so.60.3.100
-file path=usr/lib/$(MACH64)/libavdevice.so.60.3.100
 link path=usr/lib/$(MACH64)/libavfilter.so target=libavfilter.so.9.12.100
-link path=usr/lib/$(MACH64)/libavfilter.so.9 target=libavfilter.so.9.12.100
-file path=usr/lib/$(MACH64)/libavfilter.so.9.12.100
 link path=usr/lib/$(MACH64)/libavformat.so target=libavformat.so.60.16.100
-link path=usr/lib/$(MACH64)/libavformat.so.60 target=libavformat.so.60.16.100
-file path=usr/lib/$(MACH64)/libavformat.so.60.16.100
 link path=usr/lib/$(MACH64)/libavutil.so target=libavutil.so.58.29.100
-link path=usr/lib/$(MACH64)/libavutil.so.58 target=libavutil.so.58.29.100
-file path=usr/lib/$(MACH64)/libavutil.so.58.29.100
 link path=usr/lib/$(MACH64)/libpostproc.so target=libpostproc.so.57.3.100
-link path=usr/lib/$(MACH64)/libpostproc.so.57 target=libpostproc.so.57.3.100
-file path=usr/lib/$(MACH64)/libpostproc.so.57.3.100
 link path=usr/lib/$(MACH64)/libswresample.so target=libswresample.so.4.12.100
-link path=usr/lib/$(MACH64)/libswresample.so.4 target=libswresample.so.4.12.100
-file path=usr/lib/$(MACH64)/libswresample.so.4.12.100
 link path=usr/lib/$(MACH64)/libswscale.so target=libswscale.so.7.5.100
-link path=usr/lib/$(MACH64)/libswscale.so.7 target=libswscale.so.7.5.100
-file path=usr/lib/$(MACH64)/libswscale.so.7.5.100
 file path=usr/lib/$(MACH64)/pkgconfig/libavcodec.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libavdevice.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libavfilter.pc

--- a/components/encumbered/ffmpeg/library.p5m
+++ b/components/encumbered/ffmpeg/library.p5m
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2015 Alexander Pyhalov
+# Copyright (c) 2021 Tim Mooney.  All rights reserved.
+# Copyright 2023 Niklas Poslovski
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@6.1.1,$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/lib/$(MACH64)/libavcodec.so.60 target=libavcodec.so.60.31.102
+file path=usr/lib/$(MACH64)/libavcodec.so.60.31.102
+link path=usr/lib/$(MACH64)/libavdevice.so.60 target=libavdevice.so.60.3.100
+file path=usr/lib/$(MACH64)/libavdevice.so.60.3.100
+link path=usr/lib/$(MACH64)/libavfilter.so.9 target=libavfilter.so.9.12.100
+file path=usr/lib/$(MACH64)/libavfilter.so.9.12.100
+link path=usr/lib/$(MACH64)/libavformat.so.60 target=libavformat.so.60.16.100
+file path=usr/lib/$(MACH64)/libavformat.so.60.16.100
+link path=usr/lib/$(MACH64)/libavutil.so.58 target=libavutil.so.58.29.100
+file path=usr/lib/$(MACH64)/libavutil.so.58.29.100
+link path=usr/lib/$(MACH64)/libpostproc.so.57 target=libpostproc.so.57.3.100
+file path=usr/lib/$(MACH64)/libpostproc.so.57.3.100
+link path=usr/lib/$(MACH64)/libswresample.so.4 target=libswresample.so.4.12.100
+file path=usr/lib/$(MACH64)/libswresample.so.4.12.100
+link path=usr/lib/$(MACH64)/libswscale.so.7 target=libswscale.so.7.5.100
+file path=usr/lib/$(MACH64)/libswscale.so.7.5.100

--- a/components/encumbered/ffmpeg/pkg5
+++ b/components/encumbered/ffmpeg/pkg5
@@ -23,13 +23,13 @@
         "system/library",
         "system/library/math",
         "video/rtmpdump",
-        "x11/library/libdrm",
         "x11/library/libx11",
         "x11/library/libxcb",
         "x11/library/libxext",
         "x11/library/libxv"
     ],
     "fmris": [
+        "library/ffmpeg-6",
         "video/ffmpeg"
     ],
     "name": "ffmpeg"


### PR DESCRIPTION
This is step towards the seamless upgrade to ffmpeg 7.0.