### PR TITLE
setup.py.mk: fix numpy build

### DIFF
--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -194,7 +194,6 @@ COMPONENT_INSTALL_CMD = $(PYTHON) setup.py --no-user-cfg install
 COMPONENT_INSTALL_ARGS +=	--root $(PROTO_DIR) 
 COMPONENT_INSTALL_ARGS +=	--install-lib=$(PYTHON_LIB)
 COMPONENT_INSTALL_ARGS +=	--install-data=$(PYTHON_DATA)
-COMPONENT_INSTALL_ARGS +=	--skip-build
 COMPONENT_INSTALL_ARGS +=	--force
 
 # install the built source into a prototype area


### PR DESCRIPTION
numpy package is missing five files caused by the --skip-build argument.  See https://bugs.gentoo.org/717594

numpy will need to be rebuilt after this PR is integrated.