### PR TITLE
libass: update to 0.17.2

### DIFF
--- a/components/library/libass/Makefile
+++ b/components/library/libass/Makefile
@@ -14,17 +14,16 @@
 # Copyright 2019 Michal Nowak
 # Copyright 2020, 2021 Andreas Wacknitz
 #
-BUILD_BITS= 64_and_32
+BUILD_BITS= 64
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libass
-COMPONENT_VERSION=	0.17.1
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	0.17.2
 COMPONENT_SUMMARY=	Portable renderer for the ASS/SSA (Substation Alpha) subtitle format
 COMPONENT_PROJECT_URL=	https://github.com/libass/libass
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:d653be97198a0543c69111122173c41a99e0b91426f9e17f06a858982c2fb03d
+COMPONENT_ARCHIVE_HASH= sha256:a9afb52bf76a2569263fe2038896774c991b35c0968342a03be708e56ea60c3b
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		library/video/libass
 COMPONENT_CLASSIFICATION=System/Multimedia Libraries
@@ -37,10 +36,8 @@ CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --with-pic
 ifeq ($(strip $(MACH)),i386)
 CONFIGURE_OPTIONS.64 += --host=amd64-pc-solaris2.11
-CONFIGURE_OPTIONS.32 += --host=i686-pc-solaris2.11
 else
 CONFIGURE_OPTIONS.64 += --host=sparcv9-sun-solaris2.11
-CONFIGURE_OPTIONS.32 += --host=sparc-sun-solaris2.11
 endif
 
 # build requirement

--- a/components/library/libass/libass.p5m
+++ b/components/library/libass/libass.p5m
@@ -26,11 +26,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.2.1
-link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.2.1
-file path=usr/lib/$(MACH64)/libass.so.9.2.1
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.2.2
+link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.2.2
+file path=usr/lib/$(MACH64)/libass.so.9.2.2
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-link path=usr/lib/libass.so target=libass.so.9.2.1
-link path=usr/lib/libass.so.9 target=libass.so.9.2.1
-file path=usr/lib/libass.so.9.2.1
-file path=usr/lib/pkgconfig/libass.pc

--- a/components/library/libass/manifests/sample-manifest.p5m
+++ b/components/library/libass/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -25,11 +25,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/include/ass/ass.h
 file path=usr/include/ass/ass_types.h
-link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.2.1
-link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.2.1
-file path=usr/lib/$(MACH64)/libass.so.9.2.1
+link path=usr/lib/$(MACH64)/libass.so target=libass.so.9.2.2
+link path=usr/lib/$(MACH64)/libass.so.9 target=libass.so.9.2.2
+file path=usr/lib/$(MACH64)/libass.so.9.2.2
 file path=usr/lib/$(MACH64)/pkgconfig/libass.pc
-link path=usr/lib/libass.so target=libass.so.9.2.1
-link path=usr/lib/libass.so.9 target=libass.so.9.2.1
-file path=usr/lib/libass.so.9.2.1
-file path=usr/lib/pkgconfig/libass.pc


### PR DESCRIPTION
Drop 32-bit build due to some dependencies no longer being available in 32 bit.