### PR TITLE
make-rules: move parallel build setup from shared-macros.mk to common.mk

### DIFF
--- a/make-rules/common.mk
+++ b/make-rules/common.mk
@@ -236,3 +236,12 @@ endif
 ifneq ($(strip $(CLANG_VERSION)),$(CLANG_DEFAULT))
 USERLAND_REQUIRED_PACKAGES += developer/clang-$(CLANG_VERSION)
 endif
+
+# In an ideal world all components should support parallel build but it is
+# often not the case.  So by default we do not run parallel build and allow
+# components to opt-in for parallel build by setting USE_PARALLEL_BUILD = yes.
+PARALLEL_JOBS ?= $(shell /usr/sbin/psrinfo -t -c)
+ifeq ($(strip $(USE_PARALLEL_BUILD)),yes)
+COMPONENT_BUILD_GMAKE_ARGS += -j$(PARALLEL_JOBS)
+COMPONENT_BUILD_SETUP_PY_ARGS += -j$(PARALLEL_JOBS)
+endif

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -452,16 +452,6 @@ CONFIGURE_NO_ARCH =	$(BUILD_DIR_NO_ARCH)/.configured
 CONFIGURE_32 =		$(BUILD_DIR_32)/.configured
 CONFIGURE_64 =		$(BUILD_DIR_64)/.configured
 
-# In ideal world all components should support parallel build but it is often
-# not the case.  So by default we do not run parallel build and allow
-# components to opt-in for parallel build by setting USE_PARALLEL_BUILD = yes
-# before the shared-macros.mk file is included.
-PARALLEL_JOBS ?= $(shell /usr/sbin/psrinfo -t -c)
-ifeq ($(strip $(USE_PARALLEL_BUILD)),yes)
-COMPONENT_BUILD_GMAKE_ARGS += -j$(PARALLEL_JOBS)
-COMPONENT_BUILD_SETUP_PY_ARGS += -j$(PARALLEL_JOBS)
-endif
-
 BUILD_DIR_NO_ARCH =	$(BUILD_DIR)/$(MACH)
 BUILD_DIR_32 =		$(BUILD_DIR)/$(MACH32)
 BUILD_DIR_64 =		$(BUILD_DIR)/$(MACH64)


### PR DESCRIPTION
This will allow a bit more flexible parallel build setup and usage.