### PR TITLE
thunderbird: clear unsupported message

### DIFF
--- a/components/mail/thunderbird/Makefile
+++ b/components/mail/thunderbird/Makefile
@@ -36,6 +36,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =	thunderbird
 COMPONENT_VERSION =	127.0
+COMPONENT_REVISION =	1
 COMPONENT_SUMMARY = Mozilla Thunderbird Email Application
 COMPONENT_PROJECT_URL =	https://www.thunderbird.net/
 COMPONENT_SRC = $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -129,7 +130,9 @@ COMPONENT_PRE_CONFIGURE_ACTION += \
 	echo "ac_add_options --enable-optimize" >> $(MOZCONFIG_NON_DEBUG) ; \
 	echo "ac_add_options --enable-pulseaudio" >> $(MOZCONFIG) ; \
 	echo "ac_add_options --enable-replace-malloc" >> $(MOZCONFIG) ; \
+	echo "ac_add_options --enable-release" >> $(MOZCONFIG) ; \
 	echo "ac_add_options --enable-system-pixman" >> $(MOZCONFIG) ; \
+	echo "ac_add_options --enable-update-channel=release" >> $(MOZCONFIG) ; \
 	echo "ac_add_options --with-intl-api" >> $(MOZCONFIG) ; \
 	echo "ac_add_options --with-system-libevent" >> $(MOZCONFIG) ; \
 	echo "ac_add_options --with-system-zlib" >> $(MOZCONFIG) ; \
@@ -223,7 +226,6 @@ PYTHON_REQUIRED_PACKAGES += library/python/psutil
 PYTHON_REQUIRED_PACKAGES += runtime/python
 REQUIRED_PACKAGES += database/sqlite-3
 REQUIRED_PACKAGES += developer/build/autoconf-213
-REQUIRED_PACKAGES += developer/clang-18
 REQUIRED_PACKAGES += gnome/config/gconf
 REQUIRED_PACKAGES += library/audio/pulseaudio
 REQUIRED_PACKAGES += library/http-parser

--- a/components/mail/thunderbird/patches/01-hide-unsupported-message.patch
+++ b/components/mail/thunderbird/patches/01-hide-unsupported-message.patch
@@ -1,0 +1,19 @@
+--- thunderbird-127.0/comm/mail/base/content/release-candidate.html.old	2024-06-17 16:45:15.458224347 -0400
++++ thunderbird-127.0/comm/mail/base/content/release-candidate.html	2024-06-17 16:55:54.784086465 -0400
+@@ -3,14 +3,10 @@
+    <head>
+      <meta charset="utf-8">
+      <meta name="robots" content="noindex">
+-     <title>Unsupported Thunderbird Version!</title>
++     <title>Thunderbird</title>
+    </head>
+-   <body bgcolor="#D46A6A">
++   <body bgcolor="#FFFFFF">
+      <main>
+-       <h1><b>This is an unsupported version of Thunderbird!!</b></h1>
+-       <h2>Thunderbird monthly releases are not considered stable for general use.</h2>
+-       <p><i>Use at your own risk, this build is the same quality as Thunderbird Beta.</i></p>
+-       <p><b>We recommend downloading the <a href="https://thunderbird.net">latest stable version of Thunderbird</a>.</b></p>
+      </main>
+    </body>
+  </html>

--- a/components/mail/thunderbird/pkg5
+++ b/components/mail/thunderbird/pkg5
@@ -2,7 +2,6 @@
     "dependencies": [
         "database/sqlite-3",
         "developer/build/autoconf-213",
-        "developer/clang-18",
         "gnome/config/gconf",
         "library/audio/pulseaudio",
         "library/c++/harfbuzz",


### PR DESCRIPTION
Non-ESR branch of Thuderbird displays a message saying the software is unsupported.  OpenIndiana isn't supported either.  No need to display such message.