### PR TITLE
sysutils/fastfetch: new package

### DIFF
--- a/components/sysutils/fastfetch/Makefile
+++ b/components/sysutils/fastfetch/Makefile
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Carter Li
+#
+
+BUILD_STYLE=cmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           fastfetch
+COMPONENT_VERSION=        2.17.2
+COMPONENT_SUMMARY=        An actively maintained, feature-rich and performance oriented, neofetch like system information tool
+COMPONENT_PROJECT_URL=    https://github.com/fastfetch-cli/fastfetch
+COMPONENT_FMRI=           application/fastfetch
+COMPONENT_CLASSIFICATION= Applications/System Utilities
+COMPONENT_SRC=            $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=    https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=   sha256:f41322a9d9601a5a5a74f67a3253c7e8631e6241053094d050cf02bbade8cbcd
+COMPONENT_LICENSE=        MIT
+COMPONENT_LICENSE_FILE=   LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+CMAKE_OPTIONS += -DSET_TWEAK=Off
+CMAKE_OPTIONS += -DENABLE_LTO=Off
+
+COMPONENT_TEST_CMD = ./fastfetch --list-features && ./fastfetch
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/sysutils/fastfetch/fastfetch.p5m
+++ b/components/sysutils/fastfetch/fastfetch.p5m
@@ -1,0 +1,61 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Carter Li
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/fastfetch
+file path=usr/bin/flashfetch
+file path=usr/share/bash-completion/completions/fastfetch
+file path=usr/share/fastfetch/presets/all.jsonc
+file path=usr/share/fastfetch/presets/archey.jsonc
+file path=usr/share/fastfetch/presets/btw.jsonc
+file path=usr/share/fastfetch/presets/ci.jsonc
+file path=usr/share/fastfetch/presets/examples/10.jsonc
+file path=usr/share/fastfetch/presets/examples/11.jsonc
+file path=usr/share/fastfetch/presets/examples/12.jsonc
+file path=usr/share/fastfetch/presets/examples/13.jsonc
+file path=usr/share/fastfetch/presets/examples/14.jsonc
+file path=usr/share/fastfetch/presets/examples/15.jsonc
+file path=usr/share/fastfetch/presets/examples/16.jsonc
+file path=usr/share/fastfetch/presets/examples/17.jsonc
+file path=usr/share/fastfetch/presets/examples/18.jsonc
+file path=usr/share/fastfetch/presets/examples/19.jsonc
+file path=usr/share/fastfetch/presets/examples/2.jsonc
+file path=usr/share/fastfetch/presets/examples/20.jsonc
+file path=usr/share/fastfetch/presets/examples/21.jsonc
+file path=usr/share/fastfetch/presets/examples/22.jsonc
+file path=usr/share/fastfetch/presets/examples/3.jsonc
+file path=usr/share/fastfetch/presets/examples/4.jsonc
+file path=usr/share/fastfetch/presets/examples/5.jsonc
+file path=usr/share/fastfetch/presets/examples/6.jsonc
+file path=usr/share/fastfetch/presets/examples/7.jsonc
+file path=usr/share/fastfetch/presets/examples/8.jsonc
+file path=usr/share/fastfetch/presets/examples/9.jsonc
+file path=usr/share/fastfetch/presets/hardware.jsonc
+file path=usr/share/fastfetch/presets/neofetch.jsonc
+file path=usr/share/fastfetch/presets/paleofetch.jsonc
+file path=usr/share/fastfetch/presets/screenfetch.jsonc
+file path=usr/share/fastfetch/presets/software.jsonc
+file path=usr/share/fish/vendor_completions.d/fastfetch.fish
+file path=usr/share/licenses/fastfetch/LICENSE
+file path=usr/share/man/man1/fastfetch.1

--- a/components/sysutils/fastfetch/manifests/sample-manifest.p5m
+++ b/components/sysutils/fastfetch/manifests/sample-manifest.p5m
@@ -1,0 +1,61 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/fastfetch
+file path=usr/bin/flashfetch
+file path=usr/share/bash-completion/completions/fastfetch
+file path=usr/share/fastfetch/presets/all.jsonc
+file path=usr/share/fastfetch/presets/archey.jsonc
+file path=usr/share/fastfetch/presets/btw.jsonc
+file path=usr/share/fastfetch/presets/ci.jsonc
+file path=usr/share/fastfetch/presets/examples/10.jsonc
+file path=usr/share/fastfetch/presets/examples/11.jsonc
+file path=usr/share/fastfetch/presets/examples/12.jsonc
+file path=usr/share/fastfetch/presets/examples/13.jsonc
+file path=usr/share/fastfetch/presets/examples/14.jsonc
+file path=usr/share/fastfetch/presets/examples/15.jsonc
+file path=usr/share/fastfetch/presets/examples/16.jsonc
+file path=usr/share/fastfetch/presets/examples/17.jsonc
+file path=usr/share/fastfetch/presets/examples/18.jsonc
+file path=usr/share/fastfetch/presets/examples/19.jsonc
+file path=usr/share/fastfetch/presets/examples/2.jsonc
+file path=usr/share/fastfetch/presets/examples/20.jsonc
+file path=usr/share/fastfetch/presets/examples/21.jsonc
+file path=usr/share/fastfetch/presets/examples/22.jsonc
+file path=usr/share/fastfetch/presets/examples/3.jsonc
+file path=usr/share/fastfetch/presets/examples/4.jsonc
+file path=usr/share/fastfetch/presets/examples/5.jsonc
+file path=usr/share/fastfetch/presets/examples/6.jsonc
+file path=usr/share/fastfetch/presets/examples/7.jsonc
+file path=usr/share/fastfetch/presets/examples/8.jsonc
+file path=usr/share/fastfetch/presets/examples/9.jsonc
+file path=usr/share/fastfetch/presets/hardware.jsonc
+file path=usr/share/fastfetch/presets/neofetch.jsonc
+file path=usr/share/fastfetch/presets/paleofetch.jsonc
+file path=usr/share/fastfetch/presets/screenfetch.jsonc
+file path=usr/share/fastfetch/presets/software.jsonc
+file path=usr/share/fish/vendor_completions.d/fastfetch.fish
+file path=usr/share/licenses/fastfetch/LICENSE
+file path=usr/share/man/man1/fastfetch.1

--- a/components/sysutils/fastfetch/pkg5
+++ b/components/sysutils/fastfetch/pkg5
@@ -1,0 +1,10 @@
+{
+    "dependencies": [
+        "system/library",
+        "system/library/math"
+    ],
+    "fmris": [
+        "application/fastfetch"
+    ],
+    "name": "fastfetch"
+}


### PR DESCRIPTION
I'd like to introduce [fastfetch](https://github.com/fastfetch-cli/fastfetch) to openindiana. It's a maintained, feature-rich and performance oriented, [neofetch](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/sysutils/neofetch) like system information tool. I have tested it in VM and it worked fine for me

![image](https://github.com/fastfetch-cli/fastfetch/assets/6134068/0790f416-fa3d-4978-bd61-1340d79b4637)

[Fastfetch uses CMake](https://github.com/fastfetch-cli/fastfetch/wiki/Building). The build steps are as simple as `cmake . && cmake --build .` I have made the Makefile based on [cmake.mk](https://github.com/OpenIndiana/oi-userland/blob/oi/hipster/templates/cmake.mk).