### PR TITLE
c_icap: switch to openssl 3.1

### DIFF
--- a/components/sysutils/c_icap/Makefile
+++ b/components/sysutils/c_icap/Makefile
@@ -11,6 +11,7 @@
 # Copyright 2022,2023 Friedrich Kink. All rights reserved.
 #
 
+OPENSSL_VERSION= 3.1
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		c_icap
@@ -37,6 +38,10 @@ include $(WS_MAKE_RULES)/common.mk
 
 CXXFLAGS += -std=c++11
 
+# Provide location for openssl 3.1 headers/libraries
+CFLAGS += -I$(OPENSSL_INCDIR)
+LDFLAGS  += -L$(OPENSSL_LIBDIR)
+
 COMPONENT_PREP_ACTION= ( cd $(@D) && PATH="$(PATH)" autoreconf -f -i -v -W all )
 
 CONFIGURE_OPTIONS += CPPFLAGS=-I/usr/include/openldap
@@ -45,13 +50,13 @@ CONFIGURE_OPTIONS += --disable-dependency-tracking
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(OPENSSL_PKG)
 REQUIRED_PACKAGES += compress/bzip2
 REQUIRED_PACKAGES += database/berkeleydb-5
 REQUIRED_PACKAGES += database/lmdb
 REQUIRED_PACKAGES += library/brotli
 REQUIRED_PACKAGES += library/libmemcached
 REQUIRED_PACKAGES += library/openldap
-REQUIRED_PACKAGES += library/security/openssl
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library

--- a/components/sysutils/c_icap/patches/1-64-bit-ssl-lib.patch
+++ b/components/sysutils/c_icap/patches/1-64-bit-ssl-lib.patch
@@ -1,0 +1,12 @@
+use 64-bit library path
+--- c-icap-server-C_ICAP_0.6.3/configure.ac.old	2024-07-09 23:07:43.640827757 -0400
++++ c-icap-server-C_ICAP_0.6.3/configure.ac	2024-07-09 23:08:03.685797448 -0400
+@@ -369,7 +369,7 @@
+    ICFG_STATE_SAVE(OPENSSL)
+    if test "a$opensslpath" != "a"; then
+         CFLAGS="$CFLAGS -I$opensslpath/include"
+-        LDFLAGS="$LDFLAGS -L$opensslpath/lib"
++        LDFLAGS="$LDFLAGS -L$opensslpath/lib/amd64"
+    fi
+    LIBS="-lssl -lcrypto $LIBS"
+    (test -n "$opensslpath" && echo -n "checking for OpenSSL library under $opensslpath... ") || echo -n "checking for OpenSSL library... ";

--- a/components/sysutils/c_icap/pkg5
+++ b/components/sysutils/c_icap/pkg5
@@ -6,7 +6,7 @@
         "library/brotli",
         "library/libmemcached",
         "library/openldap",
-        "library/security/openssl",
+        "library/security/openssl-31",
         "library/zlib",
         "shell/ksh93",
         "system/library",


### PR DESCRIPTION
c_icap version 0.6.3 version is available, but did not update version since I can not test this.  Patch will work with 0.6.3.