### PR TITLE
python/pytest: consider entry_points for PYTEST_PLUGINS and pytest_plugins

### DIFF
--- a/components/python/pytest/Makefile
+++ b/components/python/pytest/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		pytest
 HUMAN_VERSION =			8.2.2
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		pytest: simple powerful testing with Python
 COMPONENT_PROJECT_URL =		https://docs.pytest.org/en/latest/
 COMPONENT_ARCHIVE_HASH =	\
@@ -53,7 +54,6 @@ PYTHON_REQUIRED_PACKAGES += library/python/pluggy
 PYTHON_REQUIRED_PACKAGES += library/python/setuptools
 PYTHON_REQUIRED_PACKAGES += library/python/setuptools-scm
 PYTHON_REQUIRED_PACKAGES += library/python/tomli
-PYTHON_REQUIRED_PACKAGES += library/python/wheel
 PYTHON_REQUIRED_PACKAGES += runtime/python
 TEST_REQUIRED_PACKAGES.python += library/python/argcomplete
 TEST_REQUIRED_PACKAGES.python += library/python/attrs

--- a/components/python/pytest/history
+++ b/components/python/pytest/history
@@ -1,4 +1,4 @@
 library/python/pytest-27@2.9.1-2020.0.1.6
 library/python/pytest-34@2.9.1-2020.0.1.3
 library/python/pytest-35@6.1.2,5.11-2022.0.0.3
-library/python/pytest-37@7.4.0,5.11-2023.0.0.1 noincorporate
+library/python/pytest-37@7.4.0,5.11-2023.0.0.2

--- a/components/python/pytest/patches/03-consider_entry_points.patch
+++ b/components/python/pytest/patches/03-consider_entry_points.patch
@@ -1,0 +1,13 @@
+https://github.com/pytest-dev/pytest/pull/12616
+
+--- pytest-8.2.2/src/_pytest/config/__init__.py.orig
++++ pytest-8.2.2/src/_pytest/config/__init__.py
+@@ -835,7 +835,7 @@
+     ) -> None:
+         plugins = _get_plugin_specs_as_list(spec)
+         for import_spec in plugins:
+-            self.import_plugin(import_spec)
++            self.import_plugin(import_spec, consider_entry_points=True)
+ 
+     def import_plugin(self, modname: str, consider_entry_points: bool = False) -> None:
+         """Import a plugin with ``modname``.

--- a/components/python/pytest/pkg5
+++ b/components/python/pytest/pkg5
@@ -7,7 +7,6 @@
         "library/python/setuptools-39",
         "library/python/setuptools-scm-39",
         "library/python/tomli-39",
-        "library/python/wheel-39",
         "runtime/python-39"
     ],
     "fmris": [

--- a/components/python/pytest/python-integrate-project.conf
+++ b/components/python/pytest/python-integrate-project.conf
@@ -15,6 +15,7 @@
 
 %patch% 01-test-plugins-fails.patch
 %patch% 02-test-rmtree.patch
+%patch% 03-consider_entry_points.patch
 %patch% 04-test-pdb-randomly-fails.patch
 
 %include-2%


### PR DESCRIPTION
Backport of https://github.com/pytest-dev/pytest/pull/12616.