### PR TITLE
Add aiohappyeyeballs Python project

### DIFF
--- a/components/python/aiohappyeyeballs/.gitignore
+++ b/components/python/aiohappyeyeballs/.gitignore
@@ -1,0 +1,1 @@
+/aiohappyeyeballs-2.3.2/

--- a/components/python/aiohappyeyeballs/Makefile
+++ b/components/python/aiohappyeyeballs/Makefile
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project aiohappyeyeballs
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		aiohappyeyeballs
+HUMAN_VERSION =			2.3.2
+COMPONENT_SUMMARY =		Happy Eyeballs
+COMPONENT_PROJECT_URL =		https://github.com/aio-libs/aiohappyeyeballs
+COMPONENT_ARCHIVE_URL =		\
+	https://github.com/aio-libs/aiohappyeyeballs/archive/refs/tags/v$(HUMAN_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:37f3b588a3dc0c8b11d9a59894c74f95a581112c7152609cc9d7398706a93d08
+COMPONENT_LICENSE =		PSF-2.0
+COMPONENT_LICENSE_FILE =	LICENSE
+
+TEST_STYLE = pytest
+
+include $(WS_MAKE_RULES)/common.mk
+
+# This project uses poetry to manage test dependencies.
+TEST_REQUIREMENTS_POETRY += dev
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/poetry-core
+PYTHON_REQUIRED_PACKAGES += runtime/python
+TEST_REQUIRED_PACKAGES.python += library/python/pytest
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-asyncio
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-cov

--- a/components/python/aiohappyeyeballs/aiohappyeyeballs-PYVER.p5m
+++ b/components/python/aiohappyeyeballs/aiohappyeyeballs-PYVER.p5m
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs-$(HUMAN_VERSION).dist-info/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/impl.py
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/types.py
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/utils.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/aiohappyeyeballs/manifests/sample-manifest.p5m
+++ b/components/python/aiohappyeyeballs/manifests/sample-manifest.p5m
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs-$(HUMAN_VERSION).dist-info/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/impl.py
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/types.py
+file path=usr/lib/python$(PYVER)/vendor-packages/aiohappyeyeballs/utils.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/aiohappyeyeballs/pkg5
+++ b/components/python/aiohappyeyeballs/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "library/python/poetry-core-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/aiohappyeyeballs",
+        "library/python/aiohappyeyeballs-39"
+    ],
+    "name": "aiohappyeyeballs"
+}

--- a/components/python/aiohappyeyeballs/python-integrate-project.conf
+++ b/components/python/aiohappyeyeballs/python-integrate-project.conf
@@ -1,0 +1,22 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Marcel Telka
+#
+
+%hook-begin%
+# https://github.com/aio-libs/aiohappyeyeballs/issues/58
+DOWNLOAD_URL='https://github.com/aio-libs/aiohappyeyeballs/archive/refs/tags/v$(HUMAN_VERSION).tar.gz'
+
+%include-3%
+# This project uses poetry to manage test dependencies.
+TEST_REQUIREMENTS_POETRY += dev

--- a/components/python/aiohappyeyeballs/test/results-all.master
+++ b/components/python/aiohappyeyeballs/test/results-all.master
@@ -1,0 +1,38 @@
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(PYTHON)
+cachedir: .pytest_cache
+rootdir: $(@D)
+configfile: pyproject.toml
+asyncio: mode=strict
+collecting ... collected 25 items
+
+tests/test_impl.py::test_single_addr_info_errors PASSED
+tests/test_impl.py::test_single_addr_success PASSED
+tests/test_impl.py::test_single_addr_success_passing_loop PASSED
+tests/test_impl.py::test_multiple_addr_success_second_one PASSED
+tests/test_impl.py::test_multiple_addr_success_second_one_happy_eyeballs PASSED
+tests/test_impl.py::test_multiple_addr_all_fail_happy_eyeballs PASSED
+tests/test_impl.py::test_ipv6_and_ipv4_happy_eyeballs_ipv6_fails PASSED
+tests/test_impl.py::test_ipv6_and_ipv4_happy_eyeballs_ipv4_fails PASSED
+tests/test_impl.py::test_ipv6_and_ipv4_happy_eyeballs_first_ipv6_fails PASSED
+tests/test_impl.py::test_ipv64_happy_eyeballs_interleave_2_first_ipv6_fails PASSED
+tests/test_impl.py::test_ipv6_only_happy_eyeballs_first_ipv6_fails PASSED
+tests/test_impl.py::test_ipv64_laddr_eyeballs_interleave_2_first_ipv6_fails PASSED
+tests/test_impl.py::test_ipv64_laddr_both__eyeballs_first_ipv6_fails PASSED
+tests/test_impl.py::test_ipv64_laddr_bind_fails_eyeballs_first_ipv6_fails PASSED
+tests/test_impl.py::test_ipv64_laddr_bind_fails_eyeballs_interleave_first__ipv6_fails PASSED
+tests/test_impl.py::test_ipv64_laddr_socket_fails PASSED
+tests/test_impl.py::test_ipv64_laddr_socket_blocking_fails PASSED
+tests/test_impl.py::test_ipv64_laddr_eyeballs_ipv4_only_tried PASSED
+tests/test_impl.py::test_ipv64_laddr_bind_fails_all_eyeballs_interleave_first__ipv6_fails PASSED
+tests/test_impl.py::test_all_same_exception PASSED
+tests/test_init.py::test_init PASSED
+tests/test_utils.py::test_pop_addr_infos_interleave PASSED
+tests/test_utils.py::test_remove_addr_infos PASSED
+tests/test_utils.py::test_remove_addr_infos_slow_path PASSED
+tests/test_utils.py::test_addr_to_addr_infos PASSED
+
+4 files skipped due to complete coverage.
+
+
+======== 25 passed ========


### PR DESCRIPTION
This is new runtime dependency for `aiohttp` since version `3.10.0`.  The `aiohttp` package is runtime dependency for `ansible` and `salt` (and test dependency for few other projects).