### PR TITLE
timescaledb: add postgresql extension timescaledb 2.16.0

### DIFF
--- a/components/database/postgresql-16-timescaledb/Makefile
+++ b/components/database/postgresql-16-timescaledb/Makefile
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024, Carsten Grzemba
+#
+BUILD_STYLE= justmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=	timescaledb
+COMPONENT_VERSION=	2.16.0
+COMPONENT_SUMMARY=	Timescaledb extension for PostgreSQL
+COMPONENT_SRC = $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:c68c12c3d62f2e3c46d277d2558c20e31d3826b84e15a8594d1084874a1ea9a4
+COMPONENT_ARCHIVE_URL=	https://github.com/timescale/timescaledb/archive/refs/tags/$(COMPONENT_ARCHIVE)
+COMPONENT_PROJECT_URL=	www.timescale.com
+COMPONENT_FMRI=	database/postgres-$(PG_VERNUM)/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION=	System/Databases
+COMPONENT_LICENSE=	Apache-2.0 TSL
+COMPONENT_LICENSE_FILE=	LICENSE
+
+TEST_TARGET= $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+
+COMPONENT_BUILD_ACTION= cd $(@D); $(ENV) $(COMPONENT_BUILD_ENV) ./bootstrap -DUSE_OPENSSL=0 && cd build && gmake
+
+COMPONENT_INSTALL_ACTION= cd $(@D)/build && $(ENV) $(COMPONENT_INSTALL_ENV) gmake install DESTDIR=$(PROTO_DIR)
+
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(PG_LIBRARY_PKG)
+REQUIRED_PACKAGES += system/library

--- a/components/database/postgresql-16-timescaledb/manifests/sample-manifest.p5m
+++ b/components/database/postgresql-16-timescaledb/manifests/sample-manifest.p5m
@@ -1,0 +1,63 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/postgres/16/lib/$(MACH64)/timescaledb-$(HUMAN_VERSION).so
+file path=usr/postgres/16/lib/$(MACH64)/timescaledb-tsl-$(HUMAN_VERSION).so
+file path=usr/postgres/16/lib/$(MACH64)/timescaledb.so
+file path=usr/postgres/16/share/extension/timescaledb--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.3--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.11.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.11.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.11.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.12.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.12.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.12.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.13.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.13.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.14.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.14.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.14.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.3--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.5.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.5.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.5.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.6.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.6.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.7.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.7.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.7.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.8.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.8.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.3--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb.control

--- a/components/database/postgresql-16-timescaledb/pkg5
+++ b/components/database/postgresql-16-timescaledb/pkg5
@@ -1,0 +1,10 @@
+{
+    "dependencies": [
+        "database/postgres-16/library",
+        "system/library"
+    ],
+    "fmris": [
+        "database/postgres-16/timescaledb"
+    ],
+    "name": "timescaledb"
+}

--- a/components/database/postgresql-16-timescaledb/timescaledb.p5m
+++ b/components/database/postgresql-16-timescaledb/timescaledb.p5m
@@ -1,0 +1,65 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# file LICENSE-APACHE path=usr/share/doc/timescale/LICENSE-APACHE
+# file tsl/LICENSE-TIMESCALE path=usr/share/doc/timescale/LICENSE-TIMESCALE
+file path=usr/postgres/16/lib/$(MACH64)/timescaledb-$(HUMAN_VERSION).so
+file path=usr/postgres/16/lib/$(MACH64)/timescaledb-tsl-$(HUMAN_VERSION).so
+file path=usr/postgres/16/lib/$(MACH64)/timescaledb.so
+file path=usr/postgres/16/share/extension/timescaledb--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.10.3--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.11.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.11.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.11.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.12.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.12.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.12.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.13.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.13.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.14.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.14.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.14.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.15.3--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.5.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.5.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.5.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.6.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.6.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.7.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.7.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.7.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.8.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.8.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.0--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.1--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.2--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb--2.9.3--$(HUMAN_VERSION).sql
+file path=usr/postgres/16/share/extension/timescaledb.control


### PR DESCRIPTION
This extension is a prerequisite for Zabbix server 7