### PR TITLE
python/setuptools-rust: replace deprecated wheel.bdist_wheel

### DIFF
--- a/components/python/setuptools-rust/Makefile
+++ b/components/python/setuptools-rust/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		setuptools_rust
 HUMAN_VERSION =			1.10.1
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		Setuptools Rust extension plugin
 COMPONENT_PROJECT_URL =		https://github.com/PyO3/setuptools-rust
 COMPONENT_ARCHIVE_HASH =	\

--- a/components/python/setuptools-rust/patches/01-bdist_wheel.patch
+++ b/components/python/setuptools-rust/patches/01-bdist_wheel.patch
@@ -1,0 +1,24 @@
+https://github.com/PyO3/setuptools-rust/issues/461
+
+--- setuptools_rust-1.10.1/setuptools_rust/build.py.orig
++++ setuptools_rust-1.10.1/setuptools_rust/build.py
+@@ -37,7 +37,7 @@
+ 
+ 
+ try:
+-    from wheel.bdist_wheel import bdist_wheel as CommandBdistWheel
++    from setuptools.command.bdist_wheel import bdist_wheel as CommandBdistWheel
+ except ImportError:  # wheel installation might be deferred in PEP 517
+     from setuptools import Command as CommandBdistWheel
+ 
+--- setuptools_rust-1.10.1/setuptools_rust/setuptools_ext.py.orig
++++ setuptools_rust-1.10.1/setuptools_rust/setuptools_ext.py
+@@ -19,7 +19,7 @@
+ from .extension import Binding, RustBin, RustExtension, Strip
+ 
+ try:
+-    from wheel.bdist_wheel import bdist_wheel
++    from setuptools.command.bdist_wheel import bdist_wheel
+ except ImportError:
+     bdist_wheel = None
+ 

--- a/components/python/setuptools-rust/python-integrate-project.conf
+++ b/components/python/setuptools-rust/python-integrate-project.conf
@@ -13,6 +13,8 @@
 # Copyright 2023 Marcel Telka
 #
 
+%patch% 01-bdist_wheel.patch
+
 %include-3%
 # Tests are supposed to run using 'nox -s test' (see .github/workflows/ci.yml
 # in the git repo).  That in turn calls pytest with 'setuptools_rust', and


### PR DESCRIPTION
See also https://github.com/PyO3/setuptools-rust/issues/461