### PR TITLE
cog-spur: fix for LocalePlugin, disable JPEGReadWriter2Plugin

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -27,6 +27,15 @@ USE_COMMON_TEST_MASTER= no
 # the SSL module is supporting 1.1 and 3.x but SUnit testframework is not
 USE_OPENSSL10=yes
 
+# currently the JPEGReadWriter2Plugin is disabled in plugins.int
+#
+# the goal is to use libjpeg8-turbo (or any other libjpeg implementation)
+# special care for included header files as the struct sizes vary
+# we 'fix' the Squeak source code that has an old libjpeg included in source
+# this should be fixed upstream in the Squeak sources
+# the default OpenIndiana JPEG_IMPLEM at time of writing is libjpeg8-turbo
+JPEG_IMPLEM=libjpeg8-turbo
+
 include ../../../../make-rules/shared-macros.mk
 
 # there is no official triplet version for opensmalltalk-vm
@@ -35,6 +44,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.3424
+COMPONENT_REVISION=	1
 GIT_TAG=		sun-v5.0.65
 PLUGIN_REV=		5.0-202408021838-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine
@@ -70,12 +80,24 @@ PKG_OPTIONS += -DBRANCHID="$(BRANCHID)"
 
 PATH=$(PATH.gnu)
 
+# cleanup the plugin directory
+SOURCE_JPEG = $(SOURCE_DIR)/platforms/Cross/plugins/JPEGReadWriter2Plugin
+
+# remove old libjpeg6 b2 sources from tree
 # opensmalltalk configure script checks for plugins files in builddir
 COMPONENT_PRE_CONFIGURE_ACTION = ( \
 	$(MKDIR) $(BUILD_DIR_32); \
 	cp plugins.ext plugins.int $(BUILD_DIR_32); \
 	$(MKDIR) $(BUILD_DIR_64); \
-	cp plugins.ext plugins.int $(BUILD_DIR_64) \
+	cp plugins.ext plugins.int $(BUILD_DIR_64); \
+        find $(SOURCE_JPEG) \
+     \! -name JPEGReadWriter2Plugin.h \
+     \! -name sqJPEGReadWriter2Plugin.c \
+     \! -name Error.c \
+     \! -name jinclude.h \
+     \! -name jmemdatasrc.c \
+     \! -name jmemdatadst.c \
+  -exec rm {} \; \
 	)
 
 # the Squeak configure script detects the lfcompile flags

--- a/components/runtime/smalltalk/cog-spur/cog-spur.p5m
+++ b/components/runtime/smalltalk/cog-spur/cog-spur.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2024 David Stes
 #
 
 
@@ -29,6 +29,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # for the sound plugins, we only package vm-sound-pulse
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
+
+# LocalePlugin (reported upstream to maintainer) requires existence locale dir
+dir path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/locale mode=0755
 
 # the minimal installation consists of the cog-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images

--- a/components/runtime/smalltalk/cog-spur/manifests/cog-spur.p5m
+++ b/components/runtime/smalltalk/cog-spur/manifests/cog-spur.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2024 David Stes
 #
 
 
@@ -29,6 +29,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # for the sound plugins, we only package vm-sound-pulse
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
+
+# LocalePlugin (reported upstream to maintainer) requires existence locale dir
+dir path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/locale mode=0755
 
 # the minimal installation consists of the cog-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images

--- a/components/runtime/smalltalk/cog-spur/plugins.int
+++ b/components/runtime/smalltalk/cog-spur/plugins.int
@@ -21,7 +21,7 @@ FloatMathPlugin \
 IA32ABI \
 # JoystickTabletPlugin \
 JPEGReaderPlugin \
-JPEGReadWriter2Plugin \
+# JPEGReadWriter2Plugin \
 Klatt \
 LargeIntegers \
 Matrix2x3Plugin \

--- a/components/runtime/smalltalk/cog-spur/test/results-64.master
+++ b/components/runtime/smalltalk/cog-spur/test/results-64.master
@@ -7,6 +7,7 @@ Failed Tests
 'BorderedMorphTests>>#test01OldInstVarRefs'
 'OrderedDictionaryTest>>#testGrow'
 Errors
+'JPEGReadWriter2Test>>#testHighEntropyImageCanBeWrittenInHighQuality'
 'MCDependencySorterTest>>#testCascadingUnresolved'
 'MCDependencySorterTest>>#testCycle'
 'MCDependencySorterTest>>#testExtraProvisions'
@@ -15,6 +16,6 @@ Errors
 'MCDependencySorterTest>>#testSimpleUnresolved'
 'MCDependencySorterTest>>#testUnusedAlternateProvider'
 'SocketTest>>#testSocketReuse'
-Total Number of Passed Tests: 4689
+Total Number of Passed Tests: 4688
 Total Number of Failures: 3
-Total Number of Errors: 8
+Total Number of Errors: 9


### PR DESCRIPTION
Disable JPEGReadWriter2Plugin for the moment and remove the libjpeg6 b2 sources from the opensmalltalk vm :  JPEGReadWriter2Plugin should be upgraded to use libjpeg8-turbo as already done in Squeak classic vm.

LocalePlugin respects LANG or LC_ALL environment variables for a locale setting; allows translated messages in Squeak maintained by GNU msgfmt ( Illumos msgfmt works but only in gnu compat mode)

LocalePlugin works but the Cuis smalltalk code that uses LocalePlugin assumes a "locale" directory exists in the installation directory: provide one in the manifest.

