### PR TITLE
stack-spur: LocalePlugin locale directory, disable JPEGReadWriter2Plugin

### DIFF
--- a/components/runtime/smalltalk/stack-spur/Makefile
+++ b/components/runtime/smalltalk/stack-spur/Makefile
@@ -33,6 +33,15 @@ USE_COMMON_TEST_MASTER= no
 # the SSL module is supporting 1.1 and 3.x but SUnit testframework is not
 USE_OPENSSL10=yes
 
+# currently the JPEGReadWriter2Plugin is disabled in plugins.int
+#
+# the goal is to use libjpeg8-turbo (or any other libjpeg implementation)
+# special care for included header files as the struct sizes vary
+# we 'fix' the Squeak source code that has an old libjpeg included in source
+# this should be fixed upstream in the Squeak sources
+# the default OpenIndiana JPEG_IMPLEM at time of writing is libjpeg8-turbo
+JPEG_IMPLEM=libjpeg8-turbo
+
 include ../../../../make-rules/shared-macros.mk
 
 # there is no official triplet version for opensmalltalk-vm
@@ -41,6 +50,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		stack-spur
 COMPONENT_VERSION=	5.0.3423
+COMPONENT_REVISION=	1
 GIT_TAG=		sun-v5.0.65
 PLUGIN_REV=		5.0-202408021838
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
@@ -76,12 +86,23 @@ PKG_OPTIONS += -DBRANCHID="$(BRANCHID)"
 
 PATH=$(PATH.gnu)
 
+# cleanup the plugin directory
+SOURCE_JPEG = $(SOURCE_DIR)/platforms/Cross/plugins/JPEGReadWriter2Plugin
+
 # opensmalltalk configure script checks for plugins files in builddir
 COMPONENT_PRE_CONFIGURE_ACTION = ( \
 	$(MKDIR) $(BUILD_DIR_32); \
 	cp plugins.ext plugins.int $(BUILD_DIR_32); \
 	$(MKDIR) $(BUILD_DIR_64); \
-	cp plugins.ext plugins.int $(BUILD_DIR_64) \
+	cp plugins.ext plugins.int $(BUILD_DIR_64); \
+        find $(SOURCE_JPEG) \
+     \! -name JPEGReadWriter2Plugin.h \
+     \! -name sqJPEGReadWriter2Plugin.c \
+     \! -name Error.c \
+     \! -name jinclude.h \
+     \! -name jmemdatasrc.c \
+     \! -name jmemdatadst.c \
+  -exec rm {} \; \
 	)
 
 # the Squeak configure script detects the lfcompile flags

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2024 David Stes
 #
 
 
@@ -27,6 +27,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # for the sound plugins, we only package vm-sound-pulse
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
+
+# LocalePlugin (reported upstream to maintainer) requires existence locale dir
+dir path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/locale mode=0755
 
 # the minimal installation consists of the stack-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images

--- a/components/runtime/smalltalk/stack-spur/plugins.int
+++ b/components/runtime/smalltalk/stack-spur/plugins.int
@@ -21,7 +21,7 @@ FloatMathPlugin \
 IA32ABI \
 # JoystickTabletPlugin \
 JPEGReaderPlugin \
-JPEGReadWriter2Plugin \
+# JPEGReadWriter2Plugin \
 Klatt \
 LargeIntegers \
 Matrix2x3Plugin \

--- a/components/runtime/smalltalk/stack-spur/stack-spur.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2024 David Stes
 #
 
 
@@ -27,6 +27,9 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # for the sound plugins, we only package vm-sound-pulse
 # we do not package vm-sound-OSS and vm-sound-Sun
 # on my machine, vm-sound-Sun compiles, but it does not work
+
+# LocalePlugin (reported upstream to maintainer) requires existence locale dir
+dir path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/locale mode=0755
 
 # the minimal installation consists of the stack-spur-nodisplay package
 # which can run "headless" squeak -nodisplay images

--- a/components/runtime/smalltalk/stack-spur/test/results-64.master
+++ b/components/runtime/smalltalk/stack-spur/test/results-64.master
@@ -6,6 +6,7 @@ Failed Tests
 'BorderedMorphTests>>#test01OldInstVarRefs'
 'OrderedDictionaryTest>>#testGrow'
 Errors
+'JPEGReadWriter2Test>>#testHighEntropyImageCanBeWrittenInHighQuality'
 'MCDependencySorterTest>>#testCascadingUnresolved'
 'MCDependencySorterTest>>#testCycle'
 'MCDependencySorterTest>>#testExtraProvisions'
@@ -14,6 +15,6 @@ Errors
 'MCDependencySorterTest>>#testSimpleUnresolved'
 'MCDependencySorterTest>>#testUnusedAlternateProvider'
 'SocketTest>>#testSocketReuse'
-Total Number of Passed Tests: 4690
+Total Number of Passed Tests: 4689
 Total Number of Failures: 2
-Total Number of Errors: 8
+Total Number of Errors: 9


### PR DESCRIPTION
same change as for cog-spur

create an empty "locale" directory in the squeak directory for LocalePlugin for msgfmt files

disable JPEGReadWrite2Plugin  -  the JPEGReaderPlugin is left enabled and provides acceleration support for the Smalltalk classes that support JPEG images