### PR TITLE
stack-spur: disable mpeg3 and pcre plugins

### DIFF
--- a/components/runtime/smalltalk/stack-spur/Makefile
+++ b/components/runtime/smalltalk/stack-spur/Makefile
@@ -50,7 +50,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		stack-spur
 COMPONENT_VERSION=	5.0.3423
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 GIT_TAG=		sun-v5.0.65
 PLUGIN_REV=		5.0-202408021838
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine

--- a/components/runtime/smalltalk/stack-spur/plugins.int
+++ b/components/runtime/smalltalk/stack-spur/plugins.int
@@ -26,8 +26,8 @@ Klatt \
 LargeIntegers \
 Matrix2x3Plugin \
 MiscPrimitivePlugin \
-Mpeg3Plugin \
-RePlugin \
+# Mpeg3Plugin \
+# RePlugin \
 SecurityPlugin \
 SerialPlugin \
 SocketPlugin \


### PR DESCRIPTION
makes no difference for gmake test and most smalltalk images