### PR TITLE
cog-spur: disable mpeg3 and pcre plugins

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -44,7 +44,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.3424
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 GIT_TAG=		sun-v5.0.65
 PLUGIN_REV=		5.0-202408021838-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine

--- a/components/runtime/smalltalk/cog-spur/plugins.int
+++ b/components/runtime/smalltalk/cog-spur/plugins.int
@@ -26,8 +26,8 @@ Klatt \
 LargeIntegers \
 Matrix2x3Plugin \
 MiscPrimitivePlugin \
-Mpeg3Plugin \
-RePlugin \
+# Mpeg3Plugin \
+# RePlugin \
 SecurityPlugin \
 SerialPlugin \
 SocketPlugin \


### PR DESCRIPTION
makes no difference for gmake test and most smalltalk images