### PR TITLE
squeak: disable Mpeg3 and pcre plugin

### DIFF
--- a/components/runtime/smalltalk/squeak/Makefile
+++ b/components/runtime/smalltalk/squeak/Makefile
@@ -72,6 +72,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.20.10
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -151,6 +152,8 @@ COMPONENT_PRE_CONFIGURE_ACTION = \
 CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/cmake/configure
 CONFIGURE_OPTIONS +=	--src=$(SOURCE_DIR)/src
 CONFIGURE_OPTIONS +=    --link-shared-lib
+CONFIGURE_OPTIONS +=    --without-RePlugin
+CONFIGURE_OPTIONS +=    --without-Mpeg3Plugin
 
 # in the 64bit case the vm is called squeakvm64 (not squeakvm)
 # the plugin directory under usr/lib/squeak has a _64bit suffix

--- a/components/runtime/smalltalk/squeak/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/squeak/manifests/sample-manifest.p5m
@@ -37,7 +37,6 @@ file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.GStreamerPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.HostWindowPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.ImmX11Plugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.KedamaPlugin2
-file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.Mpeg3Plugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.RomePlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.ScratchPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3833_64bit/so.Squeak3D

--- a/components/runtime/smalltalk/squeak/squeak.p5m
+++ b/components/runtime/smalltalk/squeak/squeak.p5m
@@ -39,7 +39,6 @@ file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.DBusPlugin path=usr/lib
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.FT2Plugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.FT2Plugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.GStreamerPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.GStreamerPlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.KedamaPlugin2 path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.KedamaPlugin2
-file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.Mpeg3Plugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.Mpeg3Plugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.RomePlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.RomePlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.ScratchPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.ScratchPlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.SqueakFFIPrims path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.SqueakFFIPrims

--- a/components/runtime/smalltalk/squeak/test/results-64.master
+++ b/components/runtime/smalltalk/squeak/test/results-64.master
@@ -15,8 +15,7 @@ Failed Tests
 'SocketTest>>#testSocketReuse'
 'SocketTest>>#testUDP'
 'TestVMStatistics>>#testVmStatisticsReportString'
-'TestValueWithinFix>>#testValueWithinTimingRepeat'
 Errors
-Total Number of Passed Tests: 3750
-Total Number of Failures: 13
+Total Number of Passed Tests: 3751
+Total Number of Failures: 12
 Total Number of Errors: 0


### PR DESCRIPTION
the JPEG2 plugin for the JPEG2ReadWriter class is enabled for squeak because it is / was patched for using libjpeg8-turbo

Mpeg3 and PCRE plugins disabled as in opensmalltalk packages