### PR TITLE
python/zope.hookable: fix dependencies

### DIFF
--- a/components/python/zope.hookable/Makefile
+++ b/components/python/zope.hookable/Makefile
@@ -11,21 +11,24 @@
 
 #
 # This file was automatically generated using the following command:
-#   $WS_TOOLS/python-integrate-project -d python/zope.hookable zope_hookable
+#   $WS_TOOLS/python-integrate-project zope.hookable
 #
 
 BUILD_STYLE = pyproject
 
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME =		zope_hookable
+COMPONENT_NAME =		zope.hookable
 HUMAN_VERSION =			7.0
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		Zope hookable
 COMPONENT_PROJECT_URL =		http://github.com/zopefoundation/zope.hookable
 COMPONENT_ARCHIVE_HASH =	\
 	sha256:ffd25a6706789752f307d1ee65d23d47436ebf30d1095f14584ebbd03bf921f3
 COMPONENT_LICENSE =		ZPL-2.1
 COMPONENT_LICENSE_FILE =	LICENSE.txt
+
+COMPONENT_SRC =			zope_hookable-$(HUMAN_VERSION)
 
 include $(WS_MAKE_RULES)/common.mk
 
@@ -37,3 +40,7 @@ PYTHON_REQUIRED_PACKAGES += library/python/setuptools
 PYTHON_REQUIRED_PACKAGES += runtime/python
 REQUIRED_PACKAGES += system/library
 TEST_REQUIRED_PACKAGES.python += library/python/setuptools
+TEST_REQUIRED_PACKAGES.python += library/python/sphinx
+TEST_REQUIRED_PACKAGES.python += library/python/sphinx-rtd-theme
+TEST_REQUIRED_PACKAGES.python += library/python/zope-testing
+TEST_REQUIRED_PACKAGES.python += library/python/zope-testrunner

--- a/components/python/zope.hookable/manifests/sample-manifest.p5m
+++ b/components/python/zope.hookable/manifests/sample-manifest.p5m
@@ -41,3 +41,4 @@ depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
     pkg.debug.depend.path=usr/bin
 
 # Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/setuptools-$(PYV)

--- a/components/python/zope.hookable/pkg5
+++ b/components/python/zope.hookable/pkg5
@@ -8,5 +8,5 @@
         "library/python/zope-hookable",
         "library/python/zope-hookable-39"
     ],
-    "name": "zope_hookable"
+    "name": "zope.hookable"
 }

--- a/components/python/zope.hookable/python-integrate-project.conf
+++ b/components/python/zope.hookable/python-integrate-project.conf
@@ -15,6 +15,8 @@
 
 %patch% 01-setuptools.patch
 
+%include-2%
+COMPONENT_SRC =			zope_hookable-$(HUMAN_VERSION)
 %include-3%
 # Force no colors and more verbose output via tox posargs
 TOX_POSARGS += -vv

--- a/components/python/zope.hookable/zope.hookable-PYVER.p5m
+++ b/components/python/zope.hookable/zope.hookable-PYVER.p5m
@@ -41,3 +41,4 @@ depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
     pkg.debug.depend.path=usr/bin
 
 # Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/setuptools-$(PYV)


### PR DESCRIPTION
This and #18846 should be enough to fix the [recent build failure](https://hipster.openindiana.org/jenkins/job/oi-userland/12098/).