### PR TITLE
libxml2: fix regression with xml catalog path

### DIFF
--- a/components/library/libxml2/Makefile
+++ b/components/library/libxml2/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libxml2
 HUMAN_VERSION=		2.13.4
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Libxml2 is the XML C parser and toolkit developed for the Gnome project
 COMPONENT_ARCHIVE_HASH=	sha256:65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650
 COMPONENT_FMRI=		library/libxml2
@@ -49,6 +50,8 @@ include $(WS_MAKE_RULES)/common.mk
 CFLAGS += $(CPP_LARGEFILES)
 CFLAGS += $(XPG7MODE)
 
+CONFIGURE_OPTIONS += --sysconfdir=$(ETCDIR)
+CONFIGURE_OPTIONS += --localstatedir="$(VARDIR)"
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --with-pic
 CONFIGURE_OPTIONS += --with-icu


### PR DESCRIPTION
This fixes the regression I introduced few hours back during the `libxml2` upgrade to `2.13.4` in #18864.
```
$ /usr/bin/xsltproc http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
I/O error : unsupported protocol: https
warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl"
cannot parse http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
$
```
With this PR merged the `xsltproc` should again start to work properly.