### PR TITLE
samba: fix fruit service propagation via avahi

### DIFF
--- a/components/network/samba/Makefile
+++ b/components/network/samba/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		samba
 COMPONENT_VERSION =		4.21.0
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		samba - A Windows SMB/CIFS fileserver for UNIX
 COMPONENT_SRC =			$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL =		https://www.samba.org/

--- a/components/network/samba/patches/07-avahi_fruit_propagation.patch
+++ b/components/network/samba/patches/07-avahi_fruit_propagation.patch
@@ -1,0 +1,26 @@
+# This patch fixes the avahi service propagation.
+# It changes the propagated port from 0 to 9, making, e.g. 
+# timecapsule advertisement with MacOS working again.
+# Nevertheless, there is no communication done over that port.
+
+
+--- source3/smbd/avahi_register.c.old	2024-09-19 12:39:33.000000000 +0200
++++ source3/smbd/avahi_register.c	2024-09-19 12:41:02.000000000 +0200
+@@ -186,7 +186,7 @@
+ 			error = avahi_entry_group_add_service_strlst(
+ 				    state->entry_group, AVAHI_IF_UNSPEC,
+ 				    AVAHI_PROTO_UNSPEC, 0, hostname,
+-				    "_adisk._tcp", NULL, NULL, 0, adisk);
++				    "_adisk._tcp", NULL, NULL, 9, adisk);
+ 			avahi_string_list_free(adisk);
+ 			adisk = NULL;
+ 			if (error != AVAHI_OK) {
+@@ -212,7 +212,7 @@
+ 		error = avahi_entry_group_add_service_strlst(
+ 			    state->entry_group, AVAHI_IF_UNSPEC,
+ 			    AVAHI_PROTO_UNSPEC, 0, hostname,
+-			    "_device-info._tcp", NULL, NULL, 0,
++			    "_device-info._tcp", NULL, NULL, 9,
+ 			    dinfo);
+ 		avahi_string_list_free(dinfo);
+ 		if (error != AVAHI_OK) {


### PR DESCRIPTION
This pr re-introduces a patch that was removed. The patch set a dummy port that is not used for any communication.
Nevertheless, a port number larger than 0 is needed for a proper service propagation.