### PR TITLE
shared-macros.mk: set CLANG_VERSION conditionally

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -696,7 +696,7 @@ LD =		/usr/bin/ld
 
 # Clang definitions (we only have 64 bit clang)
 CLANG_DEFAULT =		18
-CLANG_VERSION =		$(CLANG_DEFAULT)
+CLANG_VERSION ?=	$(CLANG_DEFAULT)
 CLANG_FULL_VERSION =	$(CLANG_VERSION).1
 CLANG_PREFIX             = /usr/clang/$(CLANG_FULL_VERSION)
 CLANG_BINDIR =		$(CLANG_PREFIX)/bin


### PR DESCRIPTION
This will allow to set `CLANG_VERSION` even before the `shared-macros.mk` include.