### PR TITLE
make-rules: non-default gcc and clang build deps should work after common.mk include

### DIFF
--- a/make-rules/common.mk
+++ b/make-rules/common.mk
@@ -225,18 +225,6 @@ COMPONENT_PRE_TEST_ACTION += $(COMPONENT_PRE_TEST_ACTION.$(MACH))
 COMPONENT_POST_TEST_ACTION += $(COMPONENT_POST_TEST_ACTION.$(BITS))
 COMPONENT_POST_TEST_ACTION += $(COMPONENT_POST_TEST_ACTION.$(MACH))
 
-# If component asked for non-default gcc version we need to make sure it is
-# installed
-ifneq ($(strip $(GCC_VERSION)),$(GCC_DEFAULT))
-USERLAND_REQUIRED_PACKAGES += developer/gcc-$(GCC_VERSION)
-endif
-
-# If component asked for non-default clang version we need to make sure it is
-# installed
-ifneq ($(strip $(CLANG_VERSION)),$(CLANG_DEFAULT))
-USERLAND_REQUIRED_PACKAGES += developer/clang-$(CLANG_VERSION)
-endif
-
 # In an ideal world all components should support parallel build but it is
 # often not the case.  So by default we do not run parallel build and allow
 # components to opt-in for parallel build by setting USE_PARALLEL_BUILD = yes.

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -641,6 +641,10 @@ GCC_DEFAULT =	13
 GCC_VERSION ?=	$(GCC_DEFAULT)
 GCC_ROOT =	/usr/gcc/$(GCC_VERSION)
 
+# If a component asked for non-default gcc version we need to make sure it is
+# installed
+USERLAND_REQUIRED_PACKAGES += $(if $(filter-out $(GCC_DEFAULT),$(GCC_VERSION)),developer/gcc-$(GCC_VERSION))
+
 # Define runtime package names to be used in dependencies
 GCC_RUNTIME_PKG =	system/library/gcc-$(GCC_VERSION)-runtime
 GXX_RUNTIME_PKG =	system/library/g++-$(GCC_VERSION)-runtime
@@ -706,6 +710,10 @@ CLANG_RUNTIME_PKG        = runtime/clang-$(CLANG_VERSION)
 REQUIRED_PACKAGES_SUBST += CLANG_DEVELOPER_PKG
 REQUIRED_PACKAGES_SUBST += CLANG_RUNTIME_PKG
 PATH.prepend +=		$(CLANG_BINDIR)
+
+# If a component asked for non-default clang version we need to make sure it is
+# installed
+USERLAND_REQUIRED_PACKAGES += $(if $(filter-out $(CLANG_DEFAULT),$(CLANG_VERSION)),$(CLANG_DEVELOPER_PKG))
 
 # Python definitions
 PYTHON.3.9.VENDOR_PACKAGES.64 = /usr/lib/python3.9/vendor-packages


### PR DESCRIPTION
This allows the `GCC_VERSION` and `CLANG_VERSION` to be specified anywhere in component's `Makefile` and still the proper gcc/clang build dependency will appear in `USERLAND_REQUIRED_PACKAGES`.