### PR TITLE
install-types: drop web/data/firefox-bookmarks from mate_install

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	8
+COMPONENT_VERSION =	9
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -94,7 +94,6 @@ depend type=require fmri=terminal/luit
 depend type=require fmri=terminal/xterm
 depend type=require fmri=web/browser/firefox
 depend type=require fmri=web/browser/w3m
-depend type=require fmri=web/data/firefox-bookmarks
 depend type=require fmri=x11/colormap-utilities
 depend type=require fmri=x11/compatibility/links-svid
 depend type=require fmri=x11/data/workspace-patterns


### PR DESCRIPTION
The `web/data/firefox-bookmarks` package was obsoleted in #18997.