### PR TITLE
Add Math::Random::ISAAC Perl module

### DIFF
--- a/components/perl/Math-Random-ISAAC/.gitignore
+++ b/components/perl/Math-Random-ISAAC/.gitignore
@@ -1,0 +1,1 @@
+/Math-Random-ISAAC-1.004/

--- a/components/perl/Math-Random-ISAAC/Makefile
+++ b/components/perl/Math-Random-ISAAC/Makefile
@@ -1,0 +1,46 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module Math::Random::ISAAC
+#
+
+BUILD_STYLE = makemaker
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_PERL_MODULE =		Math::Random::ISAAC
+HUMAN_VERSION =			1.004
+COMPONENT_SUMMARY =		Math::Random::ISAAC - Perl interface to the ISAAC PRNG algorithm
+COMPONENT_CPAN_AUTHOR =		JAWNSY
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:2773f02fbf207e9745e76a037df08bf5a8cc987ed23c57040ce7f7b1561f2b7c
+COMPONENT_LICENSE =		Artistic-2.0 OR GPL-3.0-only
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+#
+# There is circular runtime dependency:
+#
+#	Math-Random-ISAAC recommends Math-Random-ISAAC-XS
+#	Math-Random-ISAAC-XS recommends Math-Random-ISAAC
+#
+# To bootstrap both components we need to build Math-Random-ISAAC first and
+# remove any unresolved runtime dependency on Math-Random-ISAAC-XS.
+#
+MANGLE_DEPEND_RUNTIME += | \
+	$(GNU_GREP) -v '^depend type=require fmri=__TBD pkg\.debug\.depend\.file=Math/Random/ISAAC/XS\.pm'
+
+# Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += library/perl-5/test-nowarnings
+PERL_REQUIRED_PACKAGES += runtime/perl

--- a/components/perl/Math-Random-ISAAC/Math-Random-ISAAC-PERLVER.p5m
+++ b/components/perl/Math-Random-ISAAC/Math-Random-ISAAC-PERLVER.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Math::Random::ISAAC.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/Math::Random::ISAAC::PP.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/Math/Random/ISAAC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Math/Random/ISAAC/PP.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/perl/Math-Random-ISAAC/manifests/sample-manifest.p5m
+++ b/components/perl/Math-Random-ISAAC/manifests/sample-manifest.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Math::Random::ISAAC.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/Math::Random::ISAAC::PP.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/Math/Random/ISAAC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Math/Random/ISAAC/PP.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/perl/Math-Random-ISAAC/perl-integrate-module.conf
+++ b/components/perl/Math-Random-ISAAC/perl-integrate-module.conf
@@ -1,0 +1,32 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Marcel Telka
+#
+
+%hook-manifest%
+# During bootstrap we invoke perl-integrate-module with the -f flag and so we
+# need to drop dependency on Math-Random-ISAAC-XS.
+((FORCE)) && sed -i -e '/^depend.*math-random-isaac-xs/d' $MANIFEST
+
+%include-3%
+#
+# There is circular runtime dependency:
+#
+#	Math-Random-ISAAC recommends Math-Random-ISAAC-XS
+#	Math-Random-ISAAC-XS recommends Math-Random-ISAAC
+#
+# To bootstrap both components we need to build Math-Random-ISAAC first and
+# remove any unresolved runtime dependency on Math-Random-ISAAC-XS.
+#
+MANGLE_DEPEND_RUNTIME += | \
+	$(GNU_GREP) -v '^depend type=require fmri=__TBD pkg\.debug\.depend\.file=Math/Random/ISAAC/XS\.pm'

--- a/components/perl/Math-Random-ISAAC/pkg5
+++ b/components/perl/Math-Random-ISAAC/pkg5
@@ -1,0 +1,17 @@
+{
+    "dependencies": [
+        "library/perl-5/test-nowarnings-536",
+        "library/perl-5/test-nowarnings-538",
+        "library/perl-5/test-nowarnings-540",
+        "runtime/perl-536",
+        "runtime/perl-538",
+        "runtime/perl-540"
+    ],
+    "fmris": [
+        "library/perl-5/math-random-isaac",
+        "library/perl-5/math-random-isaac-536",
+        "library/perl-5/math-random-isaac-538",
+        "library/perl-5/math-random-isaac-540"
+    ],
+    "name": "Math-Random-ISAAC"
+}

--- a/components/perl/Math-Random-ISAAC/test/results-all.master
+++ b/components/perl/Math-Random-ISAAC/test/results-all.master
@@ -1,0 +1,14 @@
+t/01compile.t .............. ok
+t/02sequence.t ............. ok
+t/03memory.t ............... ok
+t/04uniform.t .............. skipped: Author tests not required for installation
+t/05fallback.t ............. skipped: Test::Without::Module and Math::Random::ISAAC::XS required to test fallback ability
+t/06exceptions.t ........... ok
+t/release-dist-manifest.t .. skipped: these tests are for release candidate testing
+t/release-kwalitee.t ....... skipped: these tests are for release candidate testing
+t/release-pod-coverage.t ... skipped: these tests are for release candidate testing
+t/release-pod-syntax.t ..... skipped: these tests are for release candidate testing
+t/release-portability.t .... skipped: these tests are for release candidate testing
+All tests successful.
+Files=11, Tests=609
+Result: PASS


### PR DESCRIPTION
The new version of `Crypt::OpenPGP` Perl module adds new runtime dependency which we do not have satisfied yet.  This creates a tree of unresolved dependencies we need to integrate first before we update the `Crypt::OpenPGP` module.  Here is the complete dependency tree of modules that needs to be integrated:
```
Crypt::OpenPGP version 1.15
        Bytes::Random::Secure
                Crypt::Random::Seed
                        Crypt::Random::TESHA2
                Math::Random::ISAAC
                        Math::Random::ISAAC::XS
                                Math::Random::ISAAC
```