### PR TITLE
pari: update to 2.17.0

### DIFF
--- a/components/scientific/pari/Makefile
+++ b/components/scientific/pari/Makefile
@@ -9,18 +9,20 @@
 #
 
 #
-# Copyright 2021,2022 David Stes
+# Copyright (c) 2021,2022 David Stes
+# Copyright (c) 2023 Andreas Wacknitz
+# Copyright (c) 2024 David Stes
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pari
-COMPONENT_VERSION=	2.15.5
+COMPONENT_VERSION=	2.17.0
 COMPONENT_SUMMARY=	The PARI Computer Algebra System
 COMPONENT_PROJECT_URL=	https://pari.math.u-bordeaux.fr
 COMPONENT_SRC=		pari-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:0efdda7515d9d954f63324c34b34c560e60f73a81c3924a71260a2cc91d5f981
+COMPONENT_ARCHIVE_HASH=	sha256:e723e7cef18d08c6ece2283af9a9b4d56077c22b4fce998faaa588d389b1aea8
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/pub/pari/unix/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		library/math/pari
 COMPONENT_CLASSIFICATION=	Development/Other Languages
@@ -62,8 +64,8 @@ COMPONENT_TEST_TRANSFORMS += '-e "s/gp-dyn..TIME=[ ]*[0-9]*//g"'
 COMPONENT_TEST_TRANSFORMS += '-e "/Total bench/d"'
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += $(READLINE_PKG)
 REQUIRED_PACKAGES += library/gmp
-REQUIRED_PACKAGES += library/readline
 REQUIRED_PACKAGES += runtime/perl
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/scientific/pari/manifests/sample-manifest.p5m
+++ b/components/scientific/pari/manifests/sample-manifest.p5m
@@ -23,8 +23,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-link path=usr/bin/gp target=gp-2.15
-file path=usr/bin/gp-2.15
+link path=usr/bin/gp target=gp-2.17
+file path=usr/bin/gp-2.17
 file path=usr/bin/gphelp
 file path=usr/bin/tex2mail
 link path=usr/include/pari/genpari.h target=pari.h
@@ -46,12 +46,12 @@ file path=usr/include/pari/paristio.h
 file path=usr/include/pari/parisys.h
 file path=usr/include/pari/paritune.h
 file path=usr/lib/$(MACH64)/libpari-gmp.so.$(HUMAN_VERSION)
-link path=usr/lib/$(MACH64)/libpari-gmp.so.8 \
+link path=usr/lib/$(MACH64)/libpari-gmp.so.9 \
     target=libpari-gmp.so.$(HUMAN_VERSION)
 link path=usr/lib/$(MACH64)/libpari.so target=libpari-gmp.so.$(HUMAN_VERSION)
 file path=usr/lib/pari/pari.cfg
-file path=usr/share/man/man1/gp-2.15.1
-link path=usr/share/man/man1/gp.1 target=gp-2.15.1
+file path=usr/share/man/man1/gp-2.17.1
+link path=usr/share/man/man1/gp.1 target=gp-2.17.1
 file path=usr/share/man/man1/gphelp.1
 link path=usr/share/man/man1/pari.1 target=gp.1
 file path=usr/share/man/man1/tex2mail.1

--- a/components/scientific/pari/pari.p5m
+++ b/components/scientific/pari/pari.p5m
@@ -10,7 +10,9 @@
 #
 
 #
-# Copyright 2023 Andreas Wacknitz
+# Copyright (c) 2021,2022 David Stes
+# Copyright (c) 2023 Andreas Wacknitz
+# Copyright (c) 2024 David Stes
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,8 +25,8 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-link path=usr/bin/gp target=gp-2.15
-file path=usr/bin/gp-2.15
+link path=usr/bin/gp target=gp-2.17
+file path=usr/bin/gp-2.17
 file path=usr/bin/gphelp
 file path=usr/bin/tex2mail
 link path=usr/include/pari/genpari.h target=pari.h
@@ -46,12 +48,12 @@ file path=usr/include/pari/paristio.h
 file path=usr/include/pari/parisys.h
 file path=usr/include/pari/paritune.h
 file path=usr/lib/$(MACH64)/libpari-gmp.so.$(HUMAN_VERSION)
-link path=usr/lib/$(MACH64)/libpari-gmp.so.8 \
+link path=usr/lib/$(MACH64)/libpari-gmp.so.9 \
     target=libpari-gmp.so.$(HUMAN_VERSION)
 link path=usr/lib/$(MACH64)/libpari.so target=libpari-gmp.so.$(HUMAN_VERSION)
 file path=usr/lib/pari/pari.cfg
-file path=usr/share/man/man1/gp-2.15.1
-link path=usr/share/man/man1/gp.1 target=gp-2.15.1
+file path=usr/share/man/man1/gp-2.17.1
+link path=usr/share/man/man1/gp.1 target=gp-2.17.1
 file path=usr/share/man/man1/gphelp.1
 link path=usr/share/man/man1/pari.1 target=gp.1
 file path=usr/share/man/man1/tex2mail.1

--- a/components/scientific/pari/pkg5
+++ b/components/scientific/pari/pkg5
@@ -1,7 +1,7 @@
 {
     "dependencies": [
         "library/gmp",
-        "library/readline",
+        "library/readline-8",
         "runtime/perl",
         "system/library",
         "system/library/math",

--- a/components/scientific/pari/test/results-all.master
+++ b/components/scientific/pari/test/results-all.master
@@ -58,6 +58,7 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing ellisogeny          
 * Testing ellisomat           
 * Testing ellissupersingular    
+! Skipping ellmanin: optional package elldata not installed.
 ! Skipping ellmodulareqn: optional package seadata not installed.
 * Testing ellnf               
 * Testing ellpadic            
@@ -95,6 +96,7 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing gchar               
 * Testing gchar-large         
 * Testing gchar-lfun          
+* Testing genus2              
 * Testing genus2red           
 * Testing graph               
 * Testing harmonic            
@@ -121,6 +123,7 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing lex                 
 * Testing lfun                
 ! Skipping lfunartin: optional package galpol not installed.
+* Testing lfunlarge           
 * Testing lfunquad            
 * Testing lfuntype            
 * Testing lift                
@@ -167,6 +170,7 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing nfpolsturm          
 * Testing nfrootsof1          
 * Testing nfsplitting         
+* Testing nfweilheight        
 * Testing norm                
 * Testing number              
 * Testing objets              
@@ -187,14 +191,16 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing pow                 
 * Testing prec                
 * Testing prime               
+* Testing primorial           
 * Testing print               
 * Testing printf              
 * Testing program             
-! Skipping programming: optional package elldata not installed.
+* Testing programming         
 * Testing qf                  
 * Testing qfb                 
 * Testing qfbclassno          
 * Testing qfbsolve            
+* Testing qfcvp               
 * Testing qfisom              
 * Testing qfsolve             
 * Testing quad                
@@ -249,5 +255,5 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing zetamult            
 * Testing zn                  
 * Testing zncoppersmith       
-The following tests were skipped: ellglobalred ellheight ellmodulareqn galois galoischartable galpol lfunartin member nflistA5 nflistQTall programming
+The following tests were skipped: ellglobalred ellheight ellmanin ellmodulareqn galois galoischartable galpol lfunartin member nflistA5 nflistQTall
 make[1]: Leaving directory '$(@D)/Osolaris-ix86'


### PR DESCRIPTION
Updated to the newly released pari 2.17.0

I ran "gmake test" before I installed the optional pari-elldata package.

I tested installing pari-elldata and it seems to work fine for pari 2.17.0.  So I think pari-elldata does NOT require a rebuild or update.   The elldata package itself was not updated upstream as far as I can see.

To test elldata there is a test case at the PARI website, and that test worked fine for me with pari 2.17.0.
