### PR TITLE
gtk+2: fix CVE-2024-6655 and other patches

### DIFF
--- a/components/library/gtk+/Makefile
+++ b/components/library/gtk+/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= gtk+
 COMPONENT_VERSION= 2.24.33
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= GTK+ - GIMP Toolkit Library for creation of graphical user interfaces
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.xz
@@ -28,6 +28,8 @@ COMPONENT_ARCHIVE_URL= https://download.gnome.org/sources/$(COMPONENT_NAME)/2.24
 COMPONENT_PROJECT_URL= https://www.gtk.org/
 
 include $(WS_MAKE_RULES)/common.mk
+
+PATH= $(PATH.gnu)
 
 gcc_OPT = -O2
 CFLAGS += -I/usr/X11/include
@@ -41,7 +43,6 @@ COMPONENT_PREP_ACTION = \
           autoconf )
 
 CONFIGURE_OPTIONS += --sysconfdir=$(ETCDIR)
-#CONFIGURE_OPTIONS += --sysconfdir=$(ETCDIR)/$(MACH64)
 CONFIGURE_OPTIONS += --enable-shm
 CONFIGURE_OPTIONS += --with-gdktarget=x11
 CONFIGURE_OPTIONS += --enable-explicit-deps=yes

--- a/components/library/gtk+/gtk2.p5m
+++ b/components/library/gtk+/gtk2.p5m
@@ -29,6 +29,7 @@ file usr/bin/gtk-demo path=usr/demo/jds/bin/gtk-demo mode=0555
 
 file path=etc/gtk-2.0/im-multipress.conf preserve=true
 file path=usr/bin/gtk-builder-convert
+file path=usr/bin/gtk-demo
 file path=usr/bin/gtk-query-immodules-2.0
 file path=usr/bin/gtk-update-icon-cache
 file path=usr/include/gail-1.0/gail/gailwidget.h
@@ -598,4 +599,4 @@ file path=usr/share/man/man1/gtk-query-immodules-2.0.1
 file path=usr/share/man/man1/gtk-update-icon-cache.1
 file path=usr/share/themes/Default/gtk-2.0-key/gtkrc preserve=true
 file path=usr/share/themes/Emacs/gtk-2.0-key/gtkrc preserve=true
-file path=usr/share/themes/Raleigh/gtk-2.0/gtkrc ptrserve=true
+file path=usr/share/themes/Raleigh/gtk-2.0/gtkrc preserve=true

--- a/components/library/gtk+/manifests/sample-manifest.p5m
+++ b/components/library/gtk+/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/library/gtk+/patches/16-lower-severity-of-XID-collisions.patch
+++ b/components/library/gtk+/patches/16-lower-severity-of-XID-collisions.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Sat, 22 Jun 2024 22:08:43 +0200
+Subject: [PATCH] Lower severity of XID collision warnings
+
+---
+ gdk/x11/gdkxid.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdk/x11/gdkxid.c b/gdk/x11/gdkxid.c
+index 1005f9e40c0d..1523fa70b2d3 100644
+--- a/gdk/x11/gdkxid.c
++++ b/gdk/x11/gdkxid.c
+@@ -58,7 +58,7 @@ _gdk_xid_table_insert (GdkDisplay *display,
+ 					    (GEqualFunc) gdk_xid_equal);
+ 
+   if (g_hash_table_lookup (display_x11->xid_ht, xid))
+-    g_warning ("XID collision, trouble ahead");
++    g_debug ("XID collision, trouble ahead");
+ 
+   g_hash_table_insert (display_x11->xid_ht, xid, data);
+ }

--- a/components/library/gtk+/patches/18-Check-for-attribute-availability-before-accessing-it.patch
+++ b/components/library/gtk+/patches/18-Check-for-attribute-availability-before-accessing-it.patch
@@ -1,0 +1,73 @@
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Mon, 13 Mar 2023 11:49:50 +0000
+Subject: Check for attribute availability before accessing it
+
+Starting from GLib 2.76, the standard attribute getters in the GFileInfo
+object will warn if the attribute is unset, instead of silently bailing
+out and returning a default value.
+
+Ported to GTK2 by futalas
+Origin: https://gitlab.gnome.org/GNOME/gtk/-/commit/c1fa916e#note_1852594
+---
+ gtk/gtkfilechooserdefault.c | 6 ++++--
+ gtk/gtkfilesystemmodel.c    | 7 ++++++-
+ gtk/gtkpathbar.c            | 3 ++-
+ 3 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/gtk/gtkfilechooserdefault.c b/gtk/gtkfilechooserdefault.c
+index c113542..8bacca5 100644
+--- a/gtk/gtkfilechooserdefault.c
++++ b/gtk/gtkfilechooserdefault.c
+@@ -6378,10 +6378,12 @@ show_and_select_files (GtkFileChooserDefault *impl,
+       if (!_gtk_file_system_model_iter_is_visible (fsmodel, &iter))
+         {
+           GFileInfo *info = _gtk_file_system_model_get_info (fsmodel, &iter);
++          gboolean has_is_hidden = g_file_info_has_attribute (info, "standard::is-hidden");
++          gboolean has_is_backup = g_file_info_has_attribute (info, "standard::is-backup");
+ 
+           if (!enabled_hidden &&
+-              (g_file_info_get_is_hidden (info) ||
+-               g_file_info_get_is_backup (info)))
++              ((has_is_hidden && g_file_info_get_is_hidden (info)) ||
++               (has_is_backup && g_file_info_get_is_backup (info))))
+             {
+               g_object_set (impl, "show-hidden", TRUE, NULL);
+               enabled_hidden = TRUE;
+diff --git a/gtk/gtkfilesystemmodel.c b/gtk/gtkfilesystemmodel.c
+index 840f1e8..6d8812b 100644
+--- a/gtk/gtkfilesystemmodel.c
++++ b/gtk/gtkfilesystemmodel.c
+@@ -444,13 +444,18 @@ static gboolean
+ node_should_be_visible (GtkFileSystemModel *model, guint id, gboolean filtered_out)
+ {
+   FileModelNode *node = get_node (model, id);
++  gboolean has_is_hidden, has_is_backup;
+   gboolean result;
+ 
+   if (node->info == NULL)
+     return FALSE;
++    
++  has_is_hidden = g_file_info_has_attribute (node->info, "standard::is-hidden");
++  has_is_backup = g_file_info_has_attribute (node->info, "standard::is-backup");
+ 
+   if (!model->show_hidden &&
+-      (g_file_info_get_is_hidden (node->info) || g_file_info_get_is_backup (node->info)))
++      ((has_is_hidden && g_file_info_get_is_hidden (node->info)) ||
++       (has_is_backup && g_file_info_get_is_backup (node->info))))
+     return FALSE;
+ 
+   if (_gtk_file_info_consider_as_directory (node->info))
+diff --git a/gtk/gtkpathbar.c b/gtk/gtkpathbar.c
+index 2813c8e..0f9100a 100644
+--- a/gtk/gtkpathbar.c
++++ b/gtk/gtkpathbar.c
+@@ -1659,7 +1659,8 @@ gtk_path_bar_get_info_callback (GCancellable *cancellable,
+     }
+ 
+   display_name = g_file_info_get_display_name (info);
+-  is_hidden = g_file_info_get_is_hidden (info) || g_file_info_get_is_backup (info);
++  is_hidden = g_file_info_get_attribute_boolean (info, "standard::is-hidden") ||
++              g_file_info_get_attribute_boolean (info, "standard::is-backup");
+ 
+   gtk_widget_push_composite_child ();
+   button_data = make_directory_button (file_info->path_bar, display_name,

--- a/components/library/gtk+/patches/CVE-2024-6655.patch
+++ b/components/library/gtk+/patches/CVE-2024-6655.patch
@@ -1,0 +1,30 @@
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Sat, 15 Jun 2024 14:18:01 -0400
+Subject: Stop looking for modules in cwd
+This is just not a good idea. It is surprising, and can be misused.
+Fixes: https://gitlab.gnome.org/GNOME/gtk/-/issues/6786
+(cherry picked from commit 3bbf0b6176d42836d23c36a6ac410e807ec0a7a7)
+Origin: gtk 3.24.43
+---
+ gtk/gtkmodules.c | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+diff --git a/gtk/gtkmodules.c b/gtk/gtkmodules.c
+index 50729b6..c0f0c30 100644
+--- a/gtk/gtkmodules.c
++++ b/gtk/gtkmodules.c
+@@ -229,13 +229,8 @@ find_module (const gchar *name)
+   gchar *module_name;
+ 
+   module_name = _gtk_find_module (name, "modules");
+-  if (!module_name)
+-    {
+-      /* As last resort, try loading without an absolute path (using system
+-       * library path)
+-       */
+-      module_name = g_module_build_path (NULL, name);
+-    }
++  if (module_name == NULL)
++    return NULL;
+ 
+   module = g_module_open (module_name, G_MODULE_BIND_LOCAL | G_MODULE_BIND_LAZY);
+ 

--- a/components/library/gtk+/pkg5
+++ b/components/library/gtk+/pkg5
@@ -23,8 +23,8 @@
         "x11/library/libxrender"
     ],
     "fmris": [
-        "library/desktop/gtk2/gtk-backend-cups",
-        "library/desktop/gtk2"
+        "library/desktop/gtk2",
+        "library/desktop/gtk2/gtk-backend-cups"
     ],
     "name": "gtk+"
 }


### PR DESCRIPTION
Fix a typo in gtk2.p5m. Add fix for newer glib. Add gtk-demo binary. Add a patch from Arch Linux. Modified Makefile so it works in current environment.