### PR TITLE
gdk-pixbuf: drop loaders.cache

### DIFF
--- a/components/library/gdk-pixbuf/Makefile
+++ b/components/library/gdk-pixbuf/Makefile
@@ -22,7 +22,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         gdk-pixbuf
 HUMAN_VERSION=		2.42.12
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	GdkPixbuf: Image loading library
 COMPONENT_ARCHIVE_HASH=	sha256:b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7
 COMPONENT_FMRI=         library/desktop/gdk-pixbuf
@@ -46,10 +46,15 @@ CONFIGURE_OPTIONS += -Dbuiltin_loaders=none
 # Do not install tests
 CONFIGURE_OPTIONS += -Dinstalled_tests=false
 
-COMPONENT_POST_INSTALL_ACTION += LD_LIBRARY_PATH=$(PROTOUSRLIBDIR.$(BITS)) \
-	$(PROTO_DIR)/$(CONFIGURE_BINDIR.$(BITS))/gdk-pixbuf-query-loaders \
-	   $(PROTOUSRLIBDIR.$(BITS))/gdk-pixbuf-2.0/*/loaders/*.so | sed -e "s:$(PROTO_DIR)/*:/:" \
-	   > $(PROTOUSRLIBDIR.$(BITS))/gdk-pixbuf-2.0/2.10.0/loaders.cache ;
+# Dynamic library version number
+SOVER := 0.$(shell printf '%s00.%s' $(wordlist 2,3,$(subst ., ,$(COMPONENT_VERSION))))
+SOVER_RE = $(subst .,\.,$(SOVER))
+
+# Replace library version number by SOVER
+GENERATE_EXTRA_CMD += | $(GSED) -e 's/$(SOVER_RE)/$$(SOVER)/'
+
+# SOVER is needed for manifest processing
+PKG_MACROS += SOVER=$(SOVER)
 
 # Manually added build dependencies
 PYTHON_REQUIRED_PACKAGES += library/python/gi-docgen

--- a/components/library/gdk-pixbuf/gdk-pixbuf-32.p5m
+++ b/components/library/gdk-pixbuf/gdk-pixbuf-32.p5m
@@ -23,6 +23,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Need to generate loaders.cache
+depend type=require fmri=service/gnome/desktop-cache
+
 # Otherwise `gdk-pixbuf-csource` won't recognize file types
 depend type=require fmri=desktop/shared-mime-info
 
@@ -34,7 +37,6 @@ file path=usr/bin/$(MACH32)/gdk-pixbuf-csource
 file path=usr/bin/$(MACH32)/gdk-pixbuf-pixdata
 file path=usr/bin/$(MACH32)/gdk-pixbuf-query-loaders
 file path=usr/bin/$(MACH32)/gdk-pixbuf-thumbnailer
-file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ani.so
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-bmp.so
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-gif.so
@@ -51,6 +53,6 @@ file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xpm.so
 file path=usr/lib/girepository-1.0/GdkPixbuf-2.0.typelib
 file path=usr/lib/girepository-1.0/GdkPixdata-2.0.typelib
 link path=usr/lib/libgdk_pixbuf-2.0.so target=libgdk_pixbuf-2.0.so.0
-link path=usr/lib/libgdk_pixbuf-2.0.so.0 target=libgdk_pixbuf-2.0.so.0.4200.12
-file path=usr/lib/libgdk_pixbuf-2.0.so.0.4200.12
+file path=usr/lib/libgdk_pixbuf-2.0.so.$(SOVER)
+link path=usr/lib/libgdk_pixbuf-2.0.so.0 target=libgdk_pixbuf-2.0.so.$(SOVER)
 file path=usr/lib/pkgconfig/gdk-pixbuf-2.0.pc

--- a/components/library/gdk-pixbuf/gdk-pixbuf.p5m
+++ b/components/library/gdk-pixbuf/gdk-pixbuf.p5m
@@ -23,6 +23,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Need to generate loaders.cache
+depend type=require fmri=service/gnome/desktop-cache
+
 # Otherwise `gdk-pixbuf-csource` won't recognize file types
 depend type=require fmri=desktop/shared-mime-info
 
@@ -46,7 +49,6 @@ file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-simple-anim.h
 file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-transform.h
 file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h
 file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixdata.h
-file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders.cache
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ani.so
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-bmp.so
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-gif.so
@@ -63,9 +65,9 @@ file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xpm.so
 file path=usr/lib/$(MACH64)/girepository-1.0/GdkPixbuf-2.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GdkPixdata-2.0.typelib
 link path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so target=libgdk_pixbuf-2.0.so.0
+file path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so.$(SOVER)
 link path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so.0 \
-    target=libgdk_pixbuf-2.0.so.0.4200.12
-file path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so.0.4200.12
+    target=libgdk_pixbuf-2.0.so.$(SOVER)
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-pixbuf-2.0.pc
 file path=usr/share/gir-1.0/GdkPixbuf-2.0.gir
 file path=usr/share/gir-1.0/GdkPixdata-2.0.gir

--- a/components/library/gdk-pixbuf/manifests/sample-manifest.p5m
+++ b/components/library/gdk-pixbuf/manifests/sample-manifest.p5m
@@ -44,7 +44,6 @@ file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-simple-anim.h
 file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-transform.h
 file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h
 file path=usr/include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixdata.h
-file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders.cache
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ani.so
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-bmp.so
 file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-gif.so
@@ -62,10 +61,9 @@ file path=usr/lib/$(MACH64)/girepository-1.0/GdkPixbuf-2.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/GdkPixdata-2.0.typelib
 link path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so target=libgdk_pixbuf-2.0.so.0
 link path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so.0 \
-    target=libgdk_pixbuf-2.0.so.0.4200.12
-file path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so.0.4200.12
+    target=libgdk_pixbuf-2.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libgdk_pixbuf-2.0.so.$(SOVER)
 file path=usr/lib/$(MACH64)/pkgconfig/gdk-pixbuf-2.0.pc
-file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-ani.so
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-bmp.so
 file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-gif.so
@@ -82,8 +80,8 @@ file path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xpm.so
 file path=usr/lib/girepository-1.0/GdkPixbuf-2.0.typelib
 file path=usr/lib/girepository-1.0/GdkPixdata-2.0.typelib
 link path=usr/lib/libgdk_pixbuf-2.0.so target=libgdk_pixbuf-2.0.so.0
-link path=usr/lib/libgdk_pixbuf-2.0.so.0 target=libgdk_pixbuf-2.0.so.0.4200.12
-file path=usr/lib/libgdk_pixbuf-2.0.so.0.4200.12
+link path=usr/lib/libgdk_pixbuf-2.0.so.0 target=libgdk_pixbuf-2.0.so.$(SOVER)
+file path=usr/lib/libgdk_pixbuf-2.0.so.$(SOVER)
 file path=usr/lib/pkgconfig/gdk-pixbuf-2.0.pc
 file path=usr/share/gir-1.0/GdkPixbuf-2.0.gir
 file path=usr/share/gir-1.0/GdkPixdata-2.0.gir


### PR DESCRIPTION
... and depend on `service/gnome/desktop-cache` to make sure the `loaders.cache` file is created.

This is second part of the fix for the `Unrecognized image file format` error.  The first part is in #19074.