### PR TITLE
desktop-cache: package loaders.cache files for gdk-pixbuf

### DIFF
--- a/components/desktop/desktop-cache/Makefile
+++ b/components/desktop/desktop-cache/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= desktop-cache
 COMPONENT_VERSION= 0.2.2
-COMPONENT_REVISION= 14
+COMPONENT_REVISION= 15
 COMPONENT_SUMMARY= desktop-cache is a set of SMF services used to update the various GNOME desktop caches.
 COMPONENT_SRC= desktop-cache-smf-services-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2

--- a/components/desktop/desktop-cache/desktop-cache.p5m
+++ b/components/desktop/desktop-cache/desktop-cache.p5m
@@ -26,6 +26,14 @@ file files/gio-module-cache.xml \
 file files/gio-module-cache.sh path=lib/svc/method/gio-module-cache
 file files/gio-module-cache.8s path=usr/share/man/man8s/gio-module-cache.8s
 
+# Deliver empty loaders.cache files for gdk-pixbuf and make sure they are
+# updated once installed.  This will also make sure they are removed when the
+# package is uninstalled.
+file files/empty path=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
+    refresh_fmri=svc:/application/desktop-cache/pixbuf-loaders-installer:default
+file files/empty path=usr/lib/amd64/gdk-pixbuf-2.0/2.10.0/loaders.cache \
+    refresh_fmri=svc:/application/desktop-cache/pixbuf-loaders-installer:default
+
 file path=lib/svc/manifest/application/desktop-cache/desktop-mime-cache.xml
 file path=lib/svc/manifest/application/desktop-cache/gconf-cache.xml
 file path=lib/svc/manifest/application/desktop-cache/icon-cache.xml

--- a/components/desktop/desktop-cache/patches/08-gdk-pixbuf-prefer-64.patch
+++ b/components/desktop/desktop-cache/patches/08-gdk-pixbuf-prefer-64.patch
@@ -20,7 +20,7 @@ Do not generate gdk-pixbuf.loaders in /etc
 +for ARCH in $(/bin/isainfo) ; do
 +  BINDIR='/usr/bin'
 +  DIR="$ARCH"
-+  [ "$ARCH" == "i386" ] && BIDDIR='/usr/bin/i86' && DIR=''
++  [ "$ARCH" == "i386" ] && BINDIR='/usr/bin/i86' && DIR=''
 +
 +  test -x $BINDIR/gdk-pixbuf-query-loaders || {
        echo "gdk-pixbuf-query-loaders not installed"
@@ -61,7 +61,7 @@ Do not generate gdk-pixbuf.loaders in /etc
 +for ARCH in $(/bin/isainfo) ; do
 +  BINDIR='/usr/bin'
 +  DIR="$ARCH"
-+  [ "$ARCH" == "i386" ] && BIDDIR='/usr/bin/i86' && DIR=''
++  [ "$ARCH" == "i386" ] && BINDIR='/usr/bin/i86' && DIR=''
 +
 +  test -x $BINDIR/gdk-pixbuf-query-loaders || {
        echo "gdk-pixbuf-query-loaders not installed"


### PR DESCRIPTION
I noticed that `loaders.cache` files are not created automatically when `desktop-cache` is upgraded from `0.2.2-2024.0.0.13` to `0.2.2-2024.0.0.14`.  To fix this I added both files to the package.  Also, the 32 bit `loaders.cache` is incorrect due to a typo in the `pixbuf-loaders-installer`.