### PR TITLE
augeas: drop dependency on library/glib2/charset-alias

### DIFF
--- a/components/sysutils/augeas/Makefile
+++ b/components/sysutils/augeas/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		augeas
 COMPONENT_VERSION=	1.14.1
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	Augeas is a utility for editing configuration files
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
@@ -36,20 +36,8 @@ include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PRE_CONFIGURE_ACTION += ($(CLONEY) $(SOURCE_DIR) $(@D))
 
-CONFIGURE_OPTIONS += --sysconfdir=/etc
-CONFIGURE_OPTIONS += --localstatedir=/var
-CONFIGURE_OPTIONS += --infodir=$(CONFIGURE_INFODIR)
 CONFIGURE_OPTIONS += --disable-dependency-tracking
 CONFIGURE_OPTIONS += --disable-static
-
-# Needed for "gmake test" to work.
-# SHELLOPTS is exported via make-rules/shared-macros.mk,
-# causing the braceexpand option to be set.
-# This option causes "$1: unbound variable" errors during the check-TESTS,
-# and the gnulib-tests don't even run at all.
-# Note that the below unexports SHELLOPTS, even for targets
-# other than "test."
-unexport SHELLOPTS
 
 COMPONENT_TEST_ARGS		= -k
 COMPONENT_TEST_TRANSFORMER	= $(NAWK)
@@ -57,6 +45,6 @@ COMPONENT_TEST_TRANSFORMS	= "'/TOTAL|FAIL/'"
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(READLINE_PKG)
 REQUIRED_PACKAGES += library/libxml2
-REQUIRED_PACKAGES += library/readline
 REQUIRED_PACKAGES += system/library

--- a/components/sysutils/augeas/augeas-libs.p5m
+++ b/components/sysutils/augeas/augeas-libs.p5m
@@ -27,10 +27,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend fmri=$(COMPONENT_FMRI)-lenses@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)	type=optional
 
-# NOTE: This is an already-available source of "charset.alias" with same
-# content (modulo the comment of what packages use the file) in glib2.
-depend fmri=library/glib2/charset-alias type=require
-
 file path=usr/include/augeas.h
 file path=usr/include/fa.h
 link path=usr/lib/$(MACH64)/libaugeas.so target=libaugeas.so.0.25.0

--- a/components/sysutils/augeas/manifests/sample-manifest.p5m
+++ b/components/sysutils/augeas/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/sysutils/augeas/patches/fix-min-max.patch
+++ b/components/sysutils/augeas/patches/fix-min-max.patch
@@ -1,6 +1,5 @@
-diff -Nru augeas-1.14.1.orig/src/augprint.c augeas-1.14.1/src/augprint.c
---- augeas-1.14.1.orig/src/augprint.c	2023-07-14 13:07:23.000000000 +0200
-+++ augeas-1.14.1/src/augprint.c	2023-07-24 17:05:29.961473790 +0200
+--- augeas-1.14.1/src/augprint.c.orig
++++ augeas-1.14.1/src/augprint.c
 @@ -70,10 +70,13 @@
  #include <augeas.h>
  #include <errno.h>

--- a/components/sysutils/augeas/pkg5
+++ b/components/sysutils/augeas/pkg5
@@ -1,16 +1,16 @@
 {
     "dependencies": [
         "library/libxml2",
-        "library/readline",
+        "library/readline-8",
         "system/library",
         "system/library/gcc-13-runtime"
     ],
     "fmris": [
+        "library/augeas",
         "library/augeas-lenses",
         "library/augeas-libs",
         "library/augeas-tools",
-        "library/augeas-vim",
-        "library/augeas"
+        "library/augeas-vim"
     ],
     "name": "augeas"
 }


### PR DESCRIPTION
`augeas` stopped to generate the `charset.alias` file in [version 1.12.0 released more than five years ago](https://github.com/OpenIndiana/oi-userland/pull/5071/files#diff-d00bd375b6f06229a5836ec546c2894d8510ba0cd95bb87a8f57ca8e7565f371L35) and so it is safe to drop this dependency.

Please note that the `charset.alias` file is [deprecated for at least six years now](https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=commit;h=9f9bf6f6c16efa3d3dbe3605749549c39ebf3197).