### PR TITLE
shared-macros.mk: install 32/64-bit in desired order

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -470,6 +470,14 @@ INSTALL_64 =		$(BUILD_DIR_64)/.installed
 INSTALL_32_and_64 =	$(INSTALL_32) $(INSTALL_64)
 $(BUILD_DIR_32)/.installed:       BITS=32
 $(BUILD_DIR_64)/.installed:       BITS=64
+# If we are building both 32 and 64 bit then make sure we install in the
+# desired order: the preferred one last
+ifeq ($(strip $(BUILD_BITS)),64_and_32)
+$(INSTALL_64):	$(INSTALL_32)
+endif
+ifeq ($(strip $(BUILD_BITS)),32_and_64)
+$(INSTALL_32):	$(INSTALL_64)
+endif
 
 # set the default target for installation of the component
 COMPONENT_INSTALL_TARGETS =	install


### PR DESCRIPTION
 I think it is sometimes silently expected that 64-bit is installed _after_ 32-bit when `BUILD_BITS` is `64_and_32` (and vice versa for `32_and_64`).  This is to make sure it is really like that.