### PR TITLE
transforms/generate-cleanup: link target could start with MACH

### DIFF
--- a/transforms/generate-cleanup
+++ b/transforms/generate-cleanup
@@ -97,18 +97,12 @@
 <transform dir file link hardlink -> \
 	edit path "^(usr\/gcc\/)\d+\/" "\1$!(GCCVER)/">
 
-<transform dir file link hardlink -> \
-	edit target "/(sparcv9|amd64)$" "/$!(MACH64)">
-<transform dir file link hardlink -> \
-	edit target "/(sparcv9|amd64)/" "/$!(MACH64)/">
-<transform dir file link hardlink -> \
-	edit target "/(sparcv7|i86)$" "/$!(MACH32)">
-<transform dir file link hardlink -> \
-	edit target "/(sparcv7|i86)/" "/$!(MACH32)/">
-<transform dir file link hardlink -> \
-	edit target "/(sparc|i386)$" "/$!(MACH)">
-<transform dir file link hardlink -> \
-	edit target "/(sparc|i386)/" "/$!(MACH)/">
+<transform link hardlink -> \
+	edit target "(^|/)(sparcv9|amd64)(/|$)" "\1$!(MACH64)\3">
+<transform link hardlink -> \
+	edit target "(^|/)(sparcv7|i86)(/|$)" "\1$!(MACH32)\3">
+<transform link hardlink -> \
+	edit target "(^|/)(sparc|i386)(/|$)" "\1$!(MACH)\3">
 
 # <transform dir file link hardlink -> \
 # 	edit path "$(COMPONENT_NAME)" "$!(COMPONENT_NAME)">


### PR DESCRIPTION
This will make sure that link targets starting with `amd64`, `i86`, or `i386` are properly converted to their `MACH64`/`MACH32`/`MACH` variables.  For example, `target=amd64/...` would not be converted to `target=$(MACH64)/...` without this change.

This change also merges pairs of similar transforms to cut six transforms down to three only making them easier to read.  In addition, both `file` and `dir` actions are removed from these transforms because such actions does not have the `target` attribute.