### PR TITLE
clang-18: fix bug D140075

### DIFF
--- a/components/developer/clang-18/Makefile
+++ b/components/developer/clang-18/Makefile
@@ -24,7 +24,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		clang
 COMPONENT_VERSION=	18.1.8
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 CLANG_VERSION=		$(firstword $(subst ., ,$(COMPONENT_VERSION)))
 COMPONENT_SUMMARY=	LLVM tools and Clang compiler
 COMPONENT_PROJECT_URL=	https://llvm.org/

--- a/components/developer/clang-18/patches/Bug-D140075-expose-using-shadow-types-and-declarations-in-libclang.patch
+++ b/components/developer/clang-18/patches/Bug-D140075-expose-using-shadow-types-and-declarations-in-libclang.patch
@@ -1,0 +1,150 @@
+See https://reviews.llvm.org/D140075
+See https://bugzilla.mozilla.org/show_bug.cgi?id=1795899
+
+diff --git a/clang/include/clang-c/Index.h b/clang/include/clang-c/Index.h
+--- a/tools/clang/include/clang-c/Index.h
++++ b/tools/clang/include/clang-c/Index.h
+@@ -2795,7 +2795,9 @@
+ 
+   CXType_ExtVector = 176,
+   CXType_Atomic = 177,
+-  CXType_BTFTagAttributed = 178
++  CXType_BTFTagAttributed = 178,
++
++  CXType_Using = 179
+ };
+ 
+ /**
+diff --git a/clang/lib/Sema/SemaCodeComplete.cpp b/clang/lib/Sema/SemaCodeComplete.cpp
+--- a/tools/clang/lib/Sema/SemaCodeComplete.cpp
++++ b/tools/clang/lib/Sema/SemaCodeComplete.cpp
+@@ -4062,6 +4062,7 @@
+     return CXCursor_TranslationUnit;
+ 
+   case Decl::Using:
++  case Decl::UsingShadow:
+   case Decl::UnresolvedUsingValue:
+   case Decl::UnresolvedUsingTypename:
+     return CXCursor_UsingDeclaration;
+diff --git a/clang/test/Index/print-type.cpp b/clang/test/Index/print-type.cpp
+--- a/tools/clang/test/Index/print-type.cpp
++++ b/tools/clang/test/Index/print-type.cpp
+@@ -92,6 +92,14 @@
+ }
+ 
+ inline namespace InlineNS {}
++
++namespace ToBeExported {
++  typedef int ToBeExportedType;
++}
++
++using ToBeExported::ToBeExportedType;
++void UseToBeExported(ToBeExportedType f);
++
+ // RUN: c-index-test -test-print-type %s -std=c++14 | FileCheck %s
+ // CHECK: Namespace=outer:1:11 (Definition) [type=] [typekind=Invalid] [isPOD=0]
+ // CHECK: ClassTemplate=Foo:4:8 (Definition) [type=] [typekind=Invalid] [isPOD=0]
+@@ -207,3 +215,5 @@
+ // CHECK: EnumDecl=(unnamed enum at {{.*}}:87:3 (Definition) [type=X::(unnamed enum at {{.*}}print-type.cpp:87:3)] [typekind=Enum] [isPOD=1] [isAnon=1]
+ // CHECK: Namespace=:90:11 (Definition) [type=] [typekind=Invalid] [isPOD=0] [isAnon=1]
+ // CHECK: Namespace=InlineNS:94:18 (Definition) [type=] [typekind=Invalid] [isPOD=0] [isAnonRecDecl=0] [isInlineNamespace=1]
++// CHECK: UsingDeclaration=ToBeExportedType[97:15] [type=] [typekind=Invalid] [isPOD=0] [isAnonRecDecl=0]
++// CHECK: ParmDecl=f:101:39 (Definition) [type=ToBeExportedType] [typekind=Elaborated] [canonicaltype=int] [canonicaltypekind=Int] [isPOD=1] [isAnonRecDecl=0]
+diff --git a/clang/tools/libclang/CXCursor.cpp b/clang/tools/libclang/CXCursor.cpp
+--- a/tools/clang/tools/libclang/CXCursor.cpp
++++ b/tools/clang/tools/libclang/CXCursor.cpp
+@@ -1276,6 +1276,10 @@
+     return MakeCursorTypeRef(Tag->getDecl(), Loc, TU);
+   if (const TemplateTypeParmType *TemplP = Ty->getAs<TemplateTypeParmType>())
+     return MakeCursorTypeRef(TemplP->getDecl(), Loc, TU);
++  if (const UsingType *Using = Ty->getAs<UsingType>())
++    if (const UsingShadowDecl *Shadow = Using->getFoundDecl())
++      if (const auto *TD = dyn_cast_or_null<TypeDecl>(Shadow->getTargetDecl()))
++        return MakeCursorTypeRef(TD, Loc, TU);
+ 
+   return cursor;
+ }
+diff --git a/clang/tools/libclang/CXType.cpp b/clang/tools/libclang/CXType.cpp
+--- a/tools/clang/tools/libclang/CXType.cpp
++++ b/tools/clang/tools/libclang/CXType.cpp
+@@ -100,6 +100,7 @@
+     TKCASE(Record);
+     TKCASE(Enum);
+     TKCASE(Typedef);
++    TKCASE(Using);
+     TKCASE(ObjCInterface);
+     TKCASE(ObjCObject);
+     TKCASE(ObjCObjectPointer);
+@@ -221,24 +222,9 @@
+   return std::nullopt;
+ }
+ 
+-CXType clang_getCursorType(CXCursor C) {
+-  using namespace cxcursor;
+-
+-  CXTranslationUnit TU = cxcursor::getCursorTU(C);
+-  if (!TU)
+-    return MakeCXType(QualType(), TU);
+-
+-  ASTContext &Context = cxtu::getASTUnit(TU)->getASTContext();
+-  if (clang_isExpression(C.kind)) {
+-    QualType T = cxcursor::getCursorExpr(C)->getType();
+-    return MakeCXType(T, TU);
+-  }
+-
+-  if (clang_isDeclaration(C.kind)) {
+-    const Decl *D = cxcursor::getCursorDecl(C);
++static CXType getDeclType(const Decl* D, CXTranslationUnit TU, ASTContext &Context) {
+     if (!D)
+       return MakeCXType(QualType(), TU);
+-
+     if (const TypeDecl *TD = dyn_cast<TypeDecl>(D))
+       return MakeCXType(Context.getTypeDeclType(TD), TU);
+     if (const ObjCInterfaceDecl *ID = dyn_cast<ObjCInterfaceDecl>(D))
+@@ -251,9 +237,27 @@
+       return MakeCXType(PD->getType(), TU);
+     if (const FunctionTemplateDecl *FTD = dyn_cast<FunctionTemplateDecl>(D))
+       return MakeCXType(FTD->getTemplatedDecl()->getType(), TU);
++    if (const auto *UD = dyn_cast<UsingShadowDecl>(D))
++      return getDeclType(UD->getTargetDecl(), TU, Context);
+     return MakeCXType(QualType(), TU);
++}
++
++CXType clang_getCursorType(CXCursor C) {
++  using namespace cxcursor;
++
++  CXTranslationUnit TU = cxcursor::getCursorTU(C);
++  if (!TU)
++    return MakeCXType(QualType(), TU);
++
++  ASTContext &Context = cxtu::getASTUnit(TU)->getASTContext();
++  if (clang_isExpression(C.kind)) {
++    QualType T = cxcursor::getCursorExpr(C)->getType();
++    return MakeCXType(T, TU);
+   }
+ 
++  if (clang_isDeclaration(C.kind))
++    return getDeclType(cxcursor::getCursorDecl(C), TU, Context);
++
+   if (clang_isReference(C.kind)) {
+     switch (C.kind) {
+     case CXCursor_ObjCSuperClassRef: {
+@@ -503,6 +507,9 @@
+   case Type::Typedef:
+     D = cast<TypedefType>(TP)->getDecl();
+     break;
++  case Type::Using:
++    D = cast<UsingType>(TP)->getFoundDecl();
++    break;
+   case Type::ObjCObject:
+     D = cast<ObjCObjectType>(TP)->getInterface();
+     break;
+@@ -600,6 +607,7 @@
+     TKIND(Record);
+     TKIND(Enum);
+     TKIND(Typedef);
++    TKIND(Using);
+     TKIND(ObjCInterface);
+     TKIND(ObjCObject);
+     TKIND(ObjCObjectPointer);
+


### PR DESCRIPTION
The problem is that there are multiple cstddefs on the system (one from clang, one from gcc). The wrong one gets used by a rust program, which effect firefox builds using gcc.  Firefox will not build with clang without a bunch of work. The area of code which is affected is used for debugging.  The code has to be compiled, even if it doesn't get used under normal firefox builds.   I am using an ugly workaround to bypass this problem https://github.com/OpenIndiana/oi-userland/blob/oi/hipster/components/web/firefox/patches/07-Regression-in-Bug1869835-profiler-rust-typecast-error.patch -- this firefox patch can be dropped with this clang patch

Building firefox with debug support on OpenIndiana has been broken since late December 2023.  The problem is found in Firefox bug report https://bugzilla.mozilla.org/show_bug.cgi?id=1795899 (reported by Oracle in October 2022).  Mozilla developed a solution which requires a patch to clang and to bindgen (at least the copy used by Firefox). Based on this bug report, Oracle expressed interest in having the clang patch integrated.  I can confirm this fixes debug build in Firefox 124.  Since that time, Mozilla moved code around and debug builds needs some fixes to work again. It will help to have this clang patch integrated in OI.  Troubleshooting firefox problems without a working debug is very slow.

