### PR TITLE
gspell: update to 1.14.0; keep gspell-1.12 library

### DIFF
--- a/components/desktop/gspell-1.12/Makefile
+++ b/components/desktop/gspell-1.12/Makefile
@@ -1,0 +1,75 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Niklas Poslovski
+#
+
+USE_DEFAULT_TEST_TRANSFORMS= yes
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=         gspell
+COMPONENT_MAJOR_VERSION=      1.12
+COMPONENT_VERSION=		$(COMPONENT_MAJOR_VERSION).2
+COMPONENT_REVISION=	1
+COMPONENT_SUMMARY=      A flexible API to implement the spell checking in a GTK+ application
+COMPONENT_PROJECT_URL=  https://gitlab.gnome.org/GNOME/gspell
+COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH= sha256:b4e993bd827e4ceb6a770b1b5e8950fce3be9c8b2b0cbeb22fdf992808dd2139
+COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/$(COMPONENT_NAME)/$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=         library/desktop/gspell
+COMPONENT_CLASSIFICATION=	Applications/Accessories
+COMPONENT_LICENSE=      LGPLv2.1
+COMPONENT_LICENSE_FILE= COPYING
+
+include $(WS_MAKE_RULES)/common.mk
+
+CONFIGURE_OPTIONS += MAKE=gmake
+
+# Disable everything provided by library/desktop/gspell-3:
+# - message catalogs
+# - introspection files
+# - vala support
+CONFIGURE_OPTIONS += --disable-nls
+CONFIGURE_OPTIONS += --disable-introspection
+CONFIGURE_OPTIONS += --disable-vala
+
+# Drop everything provided by library/desktop/gspell-3:
+# - binaries
+# - include files
+# - the so file
+# - pkgconfig file
+COMPONENT_POST_INSTALL_ACTION += \
+	$(RM) -r $(PROTOUSRBINDIR) ; \
+	$(RM) -r $(PROTOUSRINCDIR) ; \
+	$(RM) -r $(PROTOUSRLIBDIR64)/libgspell-1.so ; \
+	$(RM) -r $(PROTOUSRLIBDIR64)/pkgconfig ;
+
+# Testing needs an X server
+TEST_REQUIRED_PACKAGES += x11/server/xvfb
+COMPONENT_PRE_TEST_ACTION += /usr/bin/Xvfb :0 >/dev/null 2>&1 &
+COMPONENT_TEST_ENV += DISPLAY=:0
+COMPONENT_POST_TEST_ACTION += /usr/bin/pkill -x Xvfb ;
+
+# Manually added test dependencies
+# According to the test sources aspell is deprecated and superceded by hunspell.
+# One of the tests is failing with aspell which won't be fixed.
+# We might want to replace aspell (used by enchant) with hunspell later.
+#TEST_REQUIRED_PACKAGES += library/myspell/dictionary/en
+TEST_REQUIRED_PACKAGES += text/aspell/en
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(ICU_LIBRARY_PKG)
+REQUIRED_PACKAGES += library/desktop/gtk3
+REQUIRED_PACKAGES += library/desktop/pango
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/spell-checking/enchant
+REQUIRED_PACKAGES += system/library

--- a/components/desktop/gspell-1.12/gspell.p5m
+++ b/components/desktop/gspell-1.12/gspell.p5m
@@ -1,0 +1,30 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2022 Niklas Poslovski
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# make sure we do have common files (message catalogs) available
+depend type=require fmri=library/desktop/gspell-3
+
+link path=usr/lib/$(MACH64)/libgspell-1.so.2 target=libgspell-1.so.2.3.2
+file path=usr/lib/$(MACH64)/libgspell-1.so.2.3.2

--- a/components/desktop/gspell-1.12/manifests/sample-manifest.p5m
+++ b/components/desktop/gspell-1.12/manifests/sample-manifest.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/lib/$(MACH64)/libgspell-1.so.2 target=libgspell-1.so.2.3.2
+file path=usr/lib/$(MACH64)/libgspell-1.so.2.3.2

--- a/components/desktop/gspell-1.12/patches/01-test-aspell-en.patch
+++ b/components/desktop/gspell-1.12/patches/01-test-aspell-en.patch
@@ -1,0 +1,13 @@
+This assert is well known to fail with aspell.
+See also https://bugzilla.gnome.org/show_bug.cgi?id=772406
+
+--- gspell-1.12.2/testsuite/test-checker.c.orig
++++ gspell-1.12.2/testsuite/test-checker.c
+@@ -108,7 +108,6 @@
+ 	 */
+ 	correctly_spelled = gspell_checker_check_word (checker, "spell-checking", -1, &error);
+ 	g_assert_no_error (error);
+-	g_assert_true (correctly_spelled);
+ 
+ 	correctly_spelled = gspell_checker_check_word (checker, "nrst-auie", -1, &error);
+ 	g_assert_no_error (error);

--- a/components/desktop/gspell-1.12/pkg5
+++ b/components/desktop/gspell-1.12/pkg5
@@ -8,7 +8,7 @@
         "system/library"
     ],
     "fmris": [
-        "library/desktop/gspell-3"
+        "library/desktop/gspell"
     ],
     "name": "gspell"
 }

--- a/components/desktop/gspell-1.12/test/results-all.master
+++ b/components/desktop/gspell-1.12/test/results-all.master
@@ -1,0 +1,13 @@
+PASS: test-checker
+PASS: test-entry
+PASS: test-icu
+PASS: test-inline-checker-text-buffer
+PASS: test-text-iter
+PASS: test-utils
+# TOTAL: 6
+# PASS:  6
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0

--- a/components/desktop/gspell/Makefile
+++ b/components/desktop/gspell/Makefile
@@ -1,49 +1,58 @@
 #
 # This file and its contents are supplied under the terms of the
-# Common Development and Distribution License ("CDDL)". You may
-# only use this file in accordance with the terms of the CDDL.
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
 #
 # A full copy of the text of the CDDL should have accompanied this
-# source. A copy of the CDDL is also available via the Internet at
+# source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
 
 #
-# Copyright 2022 Niklas Poslovski
+# Copyright 2024 Marcel Telka
 #
 
-USE_DEFAULT_TEST_TRANSFORMS= yes
+BUILD_STYLE = meson
+USE_DEFAULT_TEST_TRANSFORMS = yes
+
 include ../../../make-rules/shared-macros.mk
 
-COMPONENT_NAME=         gspell
-COMPONENT_MAJOR_VERSION=      1.12
-COMPONENT_VERSION=		$(COMPONENT_MAJOR_VERSION).2
-COMPONENT_SUMMARY=      A flexible API to implement the spell checking in a GTK+ application
-COMPONENT_PROJECT_URL=  https://gitlab.gnome.org/GNOME/gspell
-COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:b4e993bd827e4ceb6a770b1b5e8950fce3be9c8b2b0cbeb22fdf992808dd2139
-COMPONENT_ARCHIVE_URL=	https://download.gnome.org/sources/$(COMPONENT_NAME)/$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_FMRI=         library/desktop/gspell
+COMPONENT_NAME=			gspell
+HUMAN_VERSION=			1.14.0
+COMPONENT_SUMMARY=		Flexible API to add spell-checking to a GTK application
+COMPONENT_ARCHIVE_HASH=		sha256:64ea1d8e9edc1c25b45a920e80daf67559d1866ffcd7f8432fecfea6d0fe8897
+COMPONENT_FMRI=			library/desktop/gspell-3
 COMPONENT_CLASSIFICATION=	Applications/Accessories
-COMPONENT_LICENSE=      LGPLv2.1
-COMPONENT_LICENSE_FILE= COPYING
+COMPONENT_LICENSE=		LGPL-2.1-or-later
+COMPONENT_LICENSE_FILE=		LICENSES/LGPL-2.1-or-later.txt
 
+include $(WS_MAKE_RULES)/gnome.mk
 include $(WS_MAKE_RULES)/common.mk
 
-CONFIGURE_OPTIONS += MAKE=gmake
+# GNU msgfmt is needed
+PATH = $(PATH.gnu)
 
-# Manually added test dependencies
-# According to the test sources aspell is deprecated and superceded by hunspell.
-# One of the tests is failing with aspell which won't be fixed.
-# We might want to replace aspell (used by enchant) with hunspell later.
-#TEST_REQUIRED_PACKAGES += library/myspell/dictionary/en
-TEST_REQUIRED_PACKAGES += text/aspell/en
+# We do not need installed tests (yet)
+CONFIGURE_OPTIONS += -Dinstall_tests=false
+
+# Testing needs an X server
+TEST_REQUIRED_PACKAGES += x11/server/xvfb
+COMPONENT_PRE_TEST_ACTION += /usr/bin/Xvfb :0 >/dev/null 2>&1 &
+COMPONENT_TEST_ENV += DISPLAY=:0
+COMPONENT_POST_TEST_ACTION += /usr/bin/pkill -x Xvfb ;
+
+# Replace ABI version number by ABIVER
+#GENERATE_EXTRA_CMD += | $(GSED) -e 's/\(gtksourceview-\)$(ABIVER)/\1$$(ABIVER)/' \
+	-e 's/\(GtkSource-\)$(ABIVER)/\1$$(ABIVER)/'
+
+# ABIVER is needed for manifest processing
+#PKG_MACROS += ABIVER=$(ABIVER)
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += $(ICU_LIBRARY_PKG)
 REQUIRED_PACKAGES += library/desktop/gtk3
 REQUIRED_PACKAGES += library/desktop/pango
 REQUIRED_PACKAGES += library/glib2
-REQUIRED_PACKAGES += library/icu
 REQUIRED_PACKAGES += library/spell-checking/enchant
 REQUIRED_PACKAGES += system/library

--- a/components/desktop/gspell/gspell.p5m
+++ b/components/desktop/gspell/gspell.p5m
@@ -10,12 +10,12 @@
 #
 
 #
-# Copyright 2022 Niklas Poslovski
+# Copyright 2024 Marcel Telka
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -39,11 +39,45 @@ file path=usr/include/gspell-1/gspell/gspell-text-buffer.h
 file path=usr/include/gspell-1/gspell/gspell-text-view.h
 file path=usr/include/gspell-1/gspell/gspell.h
 file path=usr/lib/$(MACH64)/girepository-1.0/Gspell-1.typelib
-link path=usr/lib/$(MACH64)/libgspell-1.so target=libgspell-1.so.2.3.2
-link path=usr/lib/$(MACH64)/libgspell-1.so.2 target=libgspell-1.so.2.3.2
-file path=usr/lib/$(MACH64)/libgspell-1.so.2.3.2
+link path=usr/lib/$(MACH64)/libgspell-1.so target=libgspell-1.so.3
+file path=usr/lib/$(MACH64)/libgspell-1.so.3
 file path=usr/lib/$(MACH64)/pkgconfig/gspell-1.pc
 file path=usr/share/gir-1.0/Gspell-1.gir
+file path=usr/share/gtk-doc/html/gspell-1/GspellChecker.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellCheckerDialog.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellEntry.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellEntryBuffer.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguage.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguageChooser.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguageChooserButton.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguageChooserDialog.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellNavigator.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellNavigatorTextView.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellTextBuffer.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellTextView.html
+file path=usr/share/gtk-doc/html/gspell-1/GtkEntry-support.html
+file path=usr/share/gtk-doc/html/gspell-1/GtkTextView-support.html
+file path=usr/share/gtk-doc/html/gspell-1/annexes.html
+file path=usr/share/gtk-doc/html/gspell-1/annotation-glossary.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-1-2.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-1-4.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-1-6.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-full.html
+file path=usr/share/gtk-doc/html/gspell-1/api-reference.html
+file path=usr/share/gtk-doc/html/gspell-1/core-classes.html
+file path=usr/share/gtk-doc/html/gspell-1/home.png
+file path=usr/share/gtk-doc/html/gspell-1/index.html
+file path=usr/share/gtk-doc/html/gspell-1/intro.html
+file path=usr/share/gtk-doc/html/gspell-1/language-choosers.html
+file path=usr/share/gtk-doc/html/gspell-1/left-insensitive.png
+file path=usr/share/gtk-doc/html/gspell-1/left.png
+file path=usr/share/gtk-doc/html/gspell-1/object-tree.html
+file path=usr/share/gtk-doc/html/gspell-1/right-insensitive.png
+file path=usr/share/gtk-doc/html/gspell-1/right.png
+file path=usr/share/gtk-doc/html/gspell-1/spell-checker-dialog.html
+file path=usr/share/gtk-doc/html/gspell-1/style.css
+file path=usr/share/gtk-doc/html/gspell-1/up-insensitive.png
+file path=usr/share/gtk-doc/html/gspell-1/up.png
 file path=usr/share/locale/ab/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ar/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/be/LC_MESSAGES/gspell-1.mo
@@ -66,6 +100,7 @@ file path=usr/share/locale/fur/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/gd/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/gl/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/he/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/hi/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/hr/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/hu/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/id/LC_MESSAGES/gspell-1.mo
@@ -74,6 +109,7 @@ file path=usr/share/locale/is/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/it/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ja/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ka/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/kab/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/kk/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ko/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/lt/LC_MESSAGES/gspell-1.mo
@@ -96,6 +132,8 @@ file path=usr/share/locale/sl/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/sr/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/sr@latin/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/sv/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/ta/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/th/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/tr/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/uk/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/vi/LC_MESSAGES/gspell-1.mo

--- a/components/desktop/gspell/manifests/sample-manifest.p5m
+++ b/components/desktop/gspell/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -39,11 +39,45 @@ file path=usr/include/gspell-1/gspell/gspell-text-buffer.h
 file path=usr/include/gspell-1/gspell/gspell-text-view.h
 file path=usr/include/gspell-1/gspell/gspell.h
 file path=usr/lib/$(MACH64)/girepository-1.0/Gspell-1.typelib
-link path=usr/lib/$(MACH64)/libgspell-1.so target=libgspell-1.so.2.3.2
-link path=usr/lib/$(MACH64)/libgspell-1.so.2 target=libgspell-1.so.2.3.2
-file path=usr/lib/$(MACH64)/libgspell-1.so.2.3.2
+link path=usr/lib/$(MACH64)/libgspell-1.so target=libgspell-1.so.3
+file path=usr/lib/$(MACH64)/libgspell-1.so.3
 file path=usr/lib/$(MACH64)/pkgconfig/gspell-1.pc
 file path=usr/share/gir-1.0/Gspell-1.gir
+file path=usr/share/gtk-doc/html/gspell-1/GspellChecker.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellCheckerDialog.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellEntry.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellEntryBuffer.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguage.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguageChooser.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguageChooserButton.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellLanguageChooserDialog.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellNavigator.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellNavigatorTextView.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellTextBuffer.html
+file path=usr/share/gtk-doc/html/gspell-1/GspellTextView.html
+file path=usr/share/gtk-doc/html/gspell-1/GtkEntry-support.html
+file path=usr/share/gtk-doc/html/gspell-1/GtkTextView-support.html
+file path=usr/share/gtk-doc/html/gspell-1/annexes.html
+file path=usr/share/gtk-doc/html/gspell-1/annotation-glossary.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-1-2.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-1-4.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-1-6.html
+file path=usr/share/gtk-doc/html/gspell-1/api-index-full.html
+file path=usr/share/gtk-doc/html/gspell-1/api-reference.html
+file path=usr/share/gtk-doc/html/gspell-1/core-classes.html
+file path=usr/share/gtk-doc/html/gspell-1/home.png
+file path=usr/share/gtk-doc/html/gspell-1/index.html
+file path=usr/share/gtk-doc/html/gspell-1/intro.html
+file path=usr/share/gtk-doc/html/gspell-1/language-choosers.html
+file path=usr/share/gtk-doc/html/gspell-1/left-insensitive.png
+file path=usr/share/gtk-doc/html/gspell-1/left.png
+file path=usr/share/gtk-doc/html/gspell-1/object-tree.html
+file path=usr/share/gtk-doc/html/gspell-1/right-insensitive.png
+file path=usr/share/gtk-doc/html/gspell-1/right.png
+file path=usr/share/gtk-doc/html/gspell-1/spell-checker-dialog.html
+file path=usr/share/gtk-doc/html/gspell-1/style.css
+file path=usr/share/gtk-doc/html/gspell-1/up-insensitive.png
+file path=usr/share/gtk-doc/html/gspell-1/up.png
 file path=usr/share/locale/ab/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ar/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/be/LC_MESSAGES/gspell-1.mo
@@ -66,6 +100,7 @@ file path=usr/share/locale/fur/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/gd/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/gl/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/he/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/hi/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/hr/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/hu/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/id/LC_MESSAGES/gspell-1.mo
@@ -74,6 +109,7 @@ file path=usr/share/locale/is/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/it/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ja/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ka/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/kab/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/kk/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/ko/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/lt/LC_MESSAGES/gspell-1.mo
@@ -96,6 +132,8 @@ file path=usr/share/locale/sl/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/sr/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/sr@latin/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/sv/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/ta/LC_MESSAGES/gspell-1.mo
+file path=usr/share/locale/th/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/tr/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/uk/LC_MESSAGES/gspell-1.mo
 file path=usr/share/locale/vi/LC_MESSAGES/gspell-1.mo

--- a/components/desktop/gspell/patches/01-test-aspell-en.patch
+++ b/components/desktop/gspell/patches/01-test-aspell-en.patch
@@ -1,0 +1,13 @@
+This assert is well known to fail with aspell.
+See also https://bugzilla.gnome.org/show_bug.cgi?id=772406
+
+--- gspell-1.14.0/tests/unit-tests/test-checker.c.orig
++++ gspell-1.14.0/tests/unit-tests/test-checker.c
+@@ -93,7 +93,6 @@
+ 	 */
+ 	correctly_spelled = gspell_checker_check_word (checker, "spell-checking", -1, &error);
+ 	g_assert_no_error (error);
+-	g_assert_true (correctly_spelled);
+ 
+ 	correctly_spelled = gspell_checker_check_word (checker, "nrst-auie", -1, &error);
+ 	g_assert_no_error (error);

--- a/components/desktop/gspell/test/results-all.master
+++ b/components/desktop/gspell/test/results-all.master
@@ -1,13 +1,14 @@
-PASS: test-checker
-PASS: test-entry
-PASS: test-icu
-PASS: test-inline-checker-text-buffer
-PASS: test-text-iter
-PASS: test-utils
-# TOTAL: 6
-# PASS:  6
-# SKIP:  0
-# XFAIL: 0
-# FAIL:  0
-# XPASS: 0
-# ERROR: 0
+test-checker                    OK
+test-entry                      OK
+test-icu                        OK
+test-inline-checker-text-buffer OK
+test-text-iter                  OK
+test-utils                      OK
+
+Ok:                 6   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   
+


### PR DESCRIPTION
Since the libgspell library soversion changed from 2 to 3 the `gspell-1.14.0` is packaged as `library/desktop/gspell-3` and the library for `gspell-1.12` is kept in the `library/desktop/gspell` package for backward compatibility.

Currently three other components depends on the `library/desktop/gspell` package (and so on the `libgspell-1.so.2` library):

- desktop/venom
- image/geeqie
- image/inkscape

Once they are rebuilt the `library/desktop/gspell` package should be obsoleted.