### PR TITLE
pari: update test results with elldata

### DIFF
--- a/components/scientific/pari/Makefile
+++ b/components/scientific/pari/Makefile
@@ -22,7 +22,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pari
 COMPONENT_VERSION=	2.17.0
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	The PARI Computer Algebra System
 COMPONENT_PROJECT_URL=	https://pari.math.u-bordeaux.fr
 COMPONENT_SRC=		pari-$(COMPONENT_VERSION)
@@ -38,8 +38,8 @@ include $(WS_MAKE_RULES)/common.mk
 
 PATH= $(PATH.gnu)
 
-# Configure complains when built outside of source tree
-# The PARI script config/genfunclist uses find -type f and fails on symlinks
+# Configure has an option --builddir but this fails when built outside of source tree
+# The PARI script config/genfunclist uses find -type f and skips symlinks
 COMPONENT_PRE_CONFIGURE_ACTION= ( $(CLONEY) $(SOURCE_DIR) $(@D) )
 
 # PARI/gp Configure is not autoconf 
@@ -49,7 +49,7 @@ CONFIGURE_SCRIPT= $(SOURCE_DIR)/Configure
 CONFIGURE_OPTIONS= --prefix=$(CONFIGURE_PREFIX)
 # PARI/gp installs its 64bit library in /usr/lib
 CONFIGURE_OPTIONS += --libdir=$(USRLIBDIR64)
-# multi-threaded libraries
+# multi-threaded libraries (enables tls, or thread local stack)
 CONFIGURE_OPTIONS += --mt=pthread
 CONFIGURE_OPTIONS += --with-readline
 
@@ -69,6 +69,9 @@ COMPONENT_TEST_TARGETS= dyntest-all
 COMPONENT_TEST_TRANSFORMS += '-e "s/gp-sta..TIME=[ ]*[0-9]*//g"'
 COMPONENT_TEST_TRANSFORMS += '-e "s/gp-dyn..TIME=[ ]*[0-9]*//g"'
 COMPONENT_TEST_TRANSFORMS += '-e "/Total bench/d"'
+
+# gmake test dependencies
+TEST_REQUIRED_PACKAGES += library/math/pari-elldata
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(READLINE_PKG)

--- a/components/scientific/pari/patches/01-genfunclist.patch
+++ b/components/scientific/pari/patches/01-genfunclist.patch
@@ -1,0 +1,11 @@
+--- pari-2.13.3/config/genfunclist	Wed Mar 25 12:58:26 2020
++++ p0/pari-2.13.3/config/genfunclist	Mon Nov 22 15:52:15 2021
+@@ -2,7 +2,7 @@
+ FL="$1"
+ DIR="$2"
+ TMPFL=$FL.tmp$$
+-(cd $DIR && find ../functions -name CVS -prune -o -name '.*' -prune -o -name '*~' -prune -o -type f -print | env LANG= LC_COLLATE= LC_ALL= sort | xargs cksum ) > $TMPFL
++(cd $DIR && find ../functions -name CVS -prune -o -name '.*' -prune -o -name '*~' -prune -o -type l -print | env LANG= LC_COLLATE= LC_ALL= sort | xargs cksum ) > $TMPFL
+ if cmp $FL $TMPFL >/dev/null 2>&1; then
+         rm -f $TMPFL
+ else

--- a/components/scientific/pari/test/results-all.master
+++ b/components/scientific/pari/test/results-all.master
@@ -52,13 +52,13 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing ell                 
 * Testing ellanal             
 * Testing ellff               
-! Skipping ellglobalred: optional package elldata not installed.
-! Skipping ellheight: optional package elldata not installed.
+* Testing ellglobalred        
+* Testing ellheight           
 * Testing elliptic            
 * Testing ellisogeny          
 * Testing ellisomat           
 * Testing ellissupersingular    
-! Skipping ellmanin: optional package elldata not installed.
+* Testing ellmanin            
 ! Skipping ellmodulareqn: optional package seadata not installed.
 * Testing ellnf               
 * Testing ellpadic            
@@ -138,7 +138,7 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing mathnf              
 * Testing matpermanent        
 * Testing matsnf              
-! Skipping member: optional package elldata not installed.
+* Testing member              
 * Testing memory              
 * Testing mf                  
 * Testing mfgaloisrep         
@@ -255,5 +255,5 @@ make[1]: Entering directory '$(@D)/Osolaris-ix86'
 * Testing zetamult            
 * Testing zn                  
 * Testing zncoppersmith       
-The following tests were skipped: ellglobalred ellheight ellmanin ellmodulareqn galois galoischartable galpol lfunartin member nflistA5 nflistQTall
+The following tests were skipped: ellmodulareqn galois galoischartable galpol lfunartin nflistA5 nflistQTall
 make[1]: Leaving directory '$(@D)/Osolaris-ix86'


### PR DESCRIPTION

Ran "gmake test" with optional package "elldata" installed.

Updated results file for the test results when elldata is installed.

Added my patch for genfunclist again, as initially contributed for PARI 2.13.   This is because I think that under some conditions the file src/funclist is regenerated and without my patch, the file src/funclist will be populated with an empty list of functions.

The patch was used in the past for PARI 2.13, 2.15 and 2.17 initial version.