### PR TITLE
net-snmp: force include from build dir

### DIFF
--- a/components/sysutils/net-snmp/Makefile
+++ b/components/sysutils/net-snmp/Makefile
@@ -34,7 +34,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		net-snmp
 COMPONENT_VERSION=	5.9.4
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	Net-SNMP Agent files and libraries
 COMPONENT_PROJECT_URL=	http://www.net-snmp.org/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -62,6 +62,10 @@ PATH= $(PATH.gnu)
 DOXYGEN= /usr/bin/doxygen
 
 CONFIGURE_ENV.64 += PERL=$(PERL)
+
+# Make sure generated files from build dir are used instead of files already
+# installed in /usr/include
+CFLAGS += -I$(BUILD_DIR_$(BITS))/include
 
 CONFIGURE_OPTIONS += --enable-static=no
 # should not be used anylonger


### PR DESCRIPTION
This prevents possible build failure in a case when the installed `net-snmp` is significantly different (for example when it is very old) than the one we are building.  Unlikely to happen with OpenIndiana these days, but better to fix while here.

In my case it happened that `/usr/include/net-snmp/net-snmp-config.h` had no `NETSNMP_NO_DEPRECATED_FUNCTIONS` defined and so the `ASN.c` compilation failed with this error:
```
In file included from ....../components/sysutils/net-snmp/net-snmp-5.9.4/include/net-snmp/library/snmp_impl.h:39:0,            
                 from ASN.xs:9:
....../components/sysutils/net-snmp/net-snmp-5.9.4/include/net-snmp/types.h:307:33: error: expected ':', ',', ';', '}' or '__attribute__' before 'NETSNMP_ATTRIBUTE_DEPRECATED'
     u_short         remote_port NETSNMP_ATTRIBUTE_DEPRECATED;
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```