### PR TITLE
Add meson_python Python project

### DIFF
--- a/components/python/meson-python/.gitignore
+++ b/components/python/meson-python/.gitignore
@@ -1,0 +1,1 @@
+/meson_python-0.17.0/

--- a/components/python/meson-python/Makefile
+++ b/components/python/meson-python/Makefile
@@ -1,0 +1,53 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project -d python/meson-python meson_python
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		meson_python
+HUMAN_VERSION =			0.17.0
+COMPONENT_SUMMARY =		Meson Python build backend (PEP 517)
+COMPONENT_PROJECT_URL =		https://github.com/mesonbuild/meson-python
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:142ac0691c31ee5825e7defcf5c9c252fa11b2497f5b9e35ed359e4b0ac467e8
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE
+
+TEST_STYLE = pytest
+
+include $(WS_MAKE_RULES)/common.mk
+
+# This project does not support tox so we need to provide test requirements
+# manually.
+TEST_REQUIREMENTS_EXTRAS += test
+
+# https://github.com/mesonbuild/meson-python/issues/695
+PYTEST_ADDOPTS += --deselect tests/test_sdist.py::test_reproducible
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/meson
+PYTHON_REQUIRED_PACKAGES += library/python/packaging
+PYTHON_REQUIRED_PACKAGES += library/python/pyproject-metadata
+PYTHON_REQUIRED_PACKAGES += library/python/tomli
+PYTHON_REQUIRED_PACKAGES += runtime/python
+TEST_REQUIRED_PACKAGES.python += library/python/build
+TEST_REQUIRED_PACKAGES.python += library/python/cython
+TEST_REQUIRED_PACKAGES.python += library/python/pytest
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-cov
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-mock
+TEST_REQUIRED_PACKAGES.python += library/python/typing-extensions
+TEST_REQUIRED_PACKAGES.python += library/python/wheel

--- a/components/python/meson-python/manifests/sample-manifest.p5m
+++ b/components/python/meson-python/manifests/sample-manifest.p5m
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/meson_python-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/meson_python-$(HUMAN_VERSION).dist-info/MIT.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/meson_python-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_compat.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_editable.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_rpath.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_tags.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_util.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_wheelfile.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/meson-$(PYV)
+depend type=require fmri=pkg:/library/python/packaging-$(PYV)
+depend type=require fmri=pkg:/library/python/pyproject-metadata-$(PYV)
+depend type=require fmri=pkg:/library/python/tomli-$(PYV)

--- a/components/python/meson-python/meson_python-PYVER.p5m
+++ b/components/python/meson-python/meson_python-PYVER.p5m
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/meson_python-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/meson_python-$(HUMAN_VERSION).dist-info/MIT.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/meson_python-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_compat.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_editable.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_rpath.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_tags.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_util.py
+file path=usr/lib/python$(PYVER)/vendor-packages/mesonpy/_wheelfile.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/meson-$(PYV)
+depend type=require fmri=pkg:/library/python/packaging-$(PYV)
+depend type=require fmri=pkg:/library/python/pyproject-metadata-$(PYV)
+depend type=require fmri=pkg:/library/python/tomli-$(PYV)

--- a/components/python/meson-python/pkg5
+++ b/components/python/meson-python/pkg5
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        "library/python/meson-39",
+        "library/python/packaging-39",
+        "library/python/pyproject-metadata-39",
+        "library/python/tomli-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/meson-python",
+        "library/python/meson-python-39"
+    ],
+    "name": "meson_python"
+}

--- a/components/python/meson-python/python-integrate-project.conf
+++ b/components/python/meson-python/python-integrate-project.conf
@@ -1,0 +1,22 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Marcel Telka
+#
+
+%include-3%
+# This project does not support tox so we need to provide test requirements
+# manually.
+TEST_REQUIREMENTS_EXTRAS += test
+
+# https://github.com/mesonbuild/meson-python/issues/695
+PYTEST_ADDOPTS += --deselect tests/test_sdist.py::test_reproducible

--- a/components/python/meson-python/test/results-all.master
+++ b/components/python/meson-python/test/results-all.master
@@ -1,0 +1,133 @@
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(PYTHON)
+cachedir: .pytest_cache
+rootdir: $(@D)
+configfile: pyproject.toml
+testpaths: tests
+collecting ... collected 123 items / 1 deselected / 122 selected
+
+tests/test_consistency.py::test_pyproject_dependencies PASSED
+tests/test_editable.py::test_walk PASSED
+tests/test_editable.py::test_nodes_tree PASSED
+tests/test_editable.py::test_collect PASSED
+tests/test_editable.py::test_mesonpy_meta_finder PASSED
+tests/test_editable.py::test_mesonpy_traversable PASSED
+tests/test_editable.py::test_resources PASSED
+tests/test_editable.py::test_importlib_resources PASSED
+tests/test_editable.py::test_editable_install PASSED
+tests/test_editable.py::test_editble_reentrant PASSED
+tests/test_editable.py::test_editable_pkgutils_walk_packages PASSED
+tests/test_editable.py::test_custom_target_install_dir PASSED
+tests/test_editable.py::test_editable_rebuild[-] PASSED
+tests/test_editable.py::test_editable_rebuild[-verbose] PASSED
+tests/test_editable.py::test_editable_rebuild[-Ccompile-args=-j1-] PASSED
+tests/test_editable.py::test_editable_rebuild[-Ccompile-args=-j1-verbose] PASSED
+tests/test_editable.py::test_editable_verbose PASSED
+tests/test_editable.py::test_editable_rebuild_error[] PASSED
+tests/test_editable.py::test_editable_rebuild_error[verbose] PASSED
+tests/test_examples.py::test_spam PASSED
+tests/test_metadata.py::test_package_name PASSED
+tests/test_metadata.py::test_package_name_from_pyproject PASSED
+tests/test_metadata.py::test_package_name_invalid PASSED
+tests/test_metadata.py::test_unsupported_dynamic PASSED
+tests/test_metadata.py::test_missing_version PASSED
+tests/test_options.py::test_ndebug[] PASSED
+tests/test_options.py::test_ndebug[-Dbuildtype=release] PASSED
+tests/test_options.py::test_ndebug[-Dbuildtype=debug] PASSED
+tests/test_output.py::test_use_ansi_escapes[False-env0-False] PASSED
+tests/test_output.py::test_use_ansi_escapes[True-env1-True] PASSED
+tests/test_output.py::test_use_ansi_escapes[False-env2-False] PASSED
+tests/test_output.py::test_use_ansi_escapes[True-env3-False] PASSED
+tests/test_output.py::test_use_ansi_escapes[False-env4-True] PASSED
+tests/test_output.py::test_use_ansi_escapes[True-env5-True] PASSED
+tests/test_output.py::test_use_ansi_escapes[True-env6-False] PASSED
+tests/test_output.py::test_use_ansi_escapes[True-env7-True] PASSED
+tests/test_output.py::test_use_ansi_escapes[True-env8-False] PASSED
+tests/test_pep517.py::test_get_requires_for_build_wheel[noninja-patchelf] PASSED
+tests/test_pep517.py::test_get_requires_for_build_wheel[noninja-nopatchelf] PASSED
+tests/test_pep517.py::test_get_requires_for_build_wheel[oldninja-patchelf] PASSED
+tests/test_pep517.py::test_get_requires_for_build_wheel[oldninja-nopatchelf] PASSED
+tests/test_pep517.py::test_get_requires_for_build_wheel[newninja-patchelf] PASSED
+tests/test_pep517.py::test_get_requires_for_build_wheel[newninja-nopatchelf] PASSED
+tests/test_pep517.py::test_invalid_config_settings PASSED
+tests/test_pep517.py::test_invalid_config_settings_suggest PASSED
+tests/test_pep517.py::test_validate_config_settings_invalid PASSED
+tests/test_pep517.py::test_validate_config_settings_repeated PASSED
+tests/test_pep517.py::test_validate_config_settings_str PASSED
+tests/test_pep517.py::test_validate_config_settings_list PASSED
+tests/test_pep517.py::test_validate_config_settings_tuple PASSED
+tests/test_pep517.py::test_get_meson_command[None] PASSED
+tests/test_pep517.py::test_get_meson_command[meson] PASSED
+tests/test_pep517.py::test_get_meson_command_bad_path PASSED
+tests/test_pep517.py::test_get_meson_command_bad_python_path PASSED
+tests/test_pep517.py::test_get_meson_command_wrong_version PASSED
+tests/test_pep517.py::test_get_meson_command_error PASSED
+tests/test_project.py::test_unsupported_python_version PASSED
+tests/test_project.py::test_missing_meson_version PASSED
+tests/test_project.py::test_missing_dynamic_version PASSED
+tests/test_project.py::test_user_args PASSED
+tests/test_project.py::test_unknown_user_args[top-level] PASSED
+tests/test_project.py::test_unknown_user_args[meson-args] PASSED
+tests/test_project.py::test_install_tags PASSED
+tests/test_project.py::test_validate_pyproject_config_one PASSED
+tests/test_project.py::test_validate_pyproject_config_all PASSED
+tests/test_project.py::test_validate_pyproject_config_unknown PASSED
+tests/test_project.py::test_validate_pyproject_config_empty PASSED
+tests/test_project.py::test_invalid_build_dir PASSED
+tests/test_project.py::test_compiler SKIPPED (Requires MSVC)
+tests/test_project.py::test_archflags_envvar_parsing[-arch x86_64] SKIPPED
+tests/test_project.py::test_archflags_envvar_parsing[-arch arm64] SKIPPED
+tests/test_project.py::test_archflags_envvar_parsing[-arch arm64 -arch arm64] SKIPPED
+tests/test_project.py::test_archflags_envvar_parsing_invalid[-arch arm64 -arch x86_64] SKIPPED
+tests/test_project.py::test_archflags_envvar_parsing_invalid[-arch arm64 -DFOO=1] SKIPPED
+tests/test_sdist.py::test_no_pep621 PASSED
+tests/test_sdist.py::test_pep621 PASSED
+tests/test_sdist.py::test_dynamic_version PASSED
+tests/test_sdist.py::test_contents PASSED
+tests/test_sdist.py::test_contents_subdirs PASSED
+tests/test_sdist.py::test_contents_unstaged PASSED
+tests/test_sdist.py::test_executable_bit PASSED
+tests/test_sdist.py::test_generated_files PASSED
+tests/test_sdist.py::test_long_path PASSED
+tests/test_tags.py::test_wheel_tag PASSED
+tests/test_tags.py::test_macos_platform_tag SKIPPED (macOS specific ...)
+tests/test_tags.py::test_macos_platform_tag_arm64 SKIPPED (macOS spe...)
+tests/test_tags.py::test_python_host_platform SKIPPED (macOS specifi...)
+tests/test_tags.py::test_tag_empty_wheel PASSED
+tests/test_tags.py::test_tag_purelib_wheel PASSED
+tests/test_tags.py::test_tag_platlib_wheel PASSED
+tests/test_tags.py::test_tag_stable_abi PASSED
+tests/test_tags.py::test_tag_mixed_abi PASSED
+tests/test_wheel.py::test_scipy_like PASSED
+tests/test_wheel.py::test_purelib_and_platlib PASSED
+tests/test_wheel.py::test_pure PASSED
+tests/test_wheel.py::test_configure_data PASSED
+tests/test_wheel.py::test_contents_license_file PASSED
+tests/test_wheel.py::test_contents SKIPPED (Not supported on this pl...)
+tests/test_wheel.py::test_local_lib SKIPPED (Not supported on this p...)
+tests/test_wheel.py::test_rpath SKIPPED (Not supported on this platform)
+tests/test_wheel.py::test_uneeded_rpath SKIPPED (Not supported on th...)
+tests/test_wheel.py::test_executable_bit SKIPPED (Not supported on t...)
+tests/test_wheel.py::test_detect_wheel_tag_module PASSED
+tests/test_wheel.py::test_detect_wheel_tag_script PASSED
+tests/test_wheel.py::test_entrypoints PASSED
+tests/test_wheel.py::test_top_level_modules PASSED
+tests/test_wheel.py::test_purelib_platlib_split PASSED
+tests/test_wheel.py::test_archflags_envvar[x86_64] SKIPPED (macOS sp...)
+tests/test_wheel.py::test_archflags_envvar[arm64] SKIPPED (macOS spe...)
+tests/test_wheel.py::test_subprojects PASSED
+tests/test_wheel.py::test_skip_subprojects[--skip-subprojects] PASSED
+tests/test_wheel.py::test_skip_subprojects[--skip-subprojects=dep] PASSED
+tests/test_wheel.py::test_limited_api PASSED
+tests/test_wheel.py::test_limited_api_bad PASSED
+tests/test_wheel.py::test_limited_api_disabled PASSED
+tests/test_wheel.py::test_install_subdir PASSED
+tests/test_wheel.py::test_vendored_meson PASSED
+tests/test_wheel.py::test_encoding PASSED
+tests/test_wheel.py::test_custom_target_install_dir PASSED
+tests/test_wheelfile.py::test_basic PASSED
+tests/test_wheelfile.py::test_source_date_epoch PASSED
+tests/test_wheelfile.py::test_compression PASSED
+
+=========================== short test summary info ============================
+======== 106 passed, 16 skipped, 1 deselected ========


### PR DESCRIPTION
This is needed to build new version of some other packages, for example `numpy` or `dbus-python`, IIRC.