### PR TITLE
openconnect: fix exec bits

### DIFF
--- a/components/network/openconnect/Makefile
+++ b/components/network/openconnect/Makefile
@@ -22,7 +22,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		openconnect
 COMPONENT_VERSION=	9.12
-COMPONENT_REVISION=	0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	An SSL VPN client (intended to be) compatible with Cisco AnyConnect and Juniper Pulse
 COMPONENT_ARCHIVE=	$(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -36,6 +36,8 @@ COMPONENT_LICENSE=	LGPLv2.1
 COMPONENT_LICENSE_FILE=	COPYING.LGPL
 
 include $(WS_MAKE_RULES)/common.mk
+
+PATH= $(PATH.gnu)
 
 COMPONENT_PREP_ACTION = \
 	(cd $(@D) && \
@@ -52,7 +54,12 @@ unexport SHELLOPTS
 CONFIGURE_OPTIONS += --with-system-cafile=/etc/certs/ca-certificates.crt
 CONFIGURE_OPTIONS += --without-gnutls
 CONFIGURE_OPTIONS += --without-libpcsclite
-CONFIGURE_OPTIONS += --libexecdir=/usr/lib/$(MACH64)
+
+# Replace python3 shebang lines with properly versioned ones.
+COMPONENT_POST_INSTALL_ACTION += \
+	for file in $(PROTO_DIR)/usr/libexec/openconnect/*.py ; do \
+	$(GSED) -i 's/python3/python$(PYTHON_VERSION)/' $$file ; \
+	done  ;
 
 # Manually added dependencies
 REQUIRED_PACKAGES += SUNWcs
@@ -60,11 +67,13 @@ REQUIRED_PACKAGES += network/vpnc-scripts
 REQUIRED_PACKAGES += driver/network/header-tun
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += $(OPENSSL_PKG)
 REQUIRED_PACKAGES += library/libproxy
 REQUIRED_PACKAGES += library/libxml2
 REQUIRED_PACKAGES += library/lz4
-REQUIRED_PACKAGES += library/security/openssl-31
 REQUIRED_PACKAGES += library/zlib
+REQUIRED_PACKAGES += shell/bash
+REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += system/library/security/gss

--- a/components/network/openconnect/manifests/sample-manifest.p5m
+++ b/components/network/openconnect/manifests/sample-manifest.p5m
@@ -27,13 +27,13 @@ file path=usr/include/openconnect.h
 link path=usr/lib/$(MACH64)/libopenconnect.so target=libopenconnect.so.5.9.0
 link path=usr/lib/$(MACH64)/libopenconnect.so.5 target=libopenconnect.so.5.9.0
 file path=usr/lib/$(MACH64)/libopenconnect.so.5.9.0
-file path=usr/lib/$(MACH64)/openconnect/csd-post.sh
-file path=usr/lib/$(MACH64)/openconnect/csd-wrapper.sh
-file path=usr/lib/$(MACH64)/openconnect/hipreport-android.sh
-file path=usr/lib/$(MACH64)/openconnect/hipreport.sh
-file path=usr/lib/$(MACH64)/openconnect/tncc-emulate.py
-file path=usr/lib/$(MACH64)/openconnect/tncc-wrapper.py
 file path=usr/lib/$(MACH64)/pkgconfig/openconnect.pc
+file path=usr/libexec/openconnect/csd-post.sh
+file path=usr/libexec/openconnect/csd-wrapper.sh
+file path=usr/libexec/openconnect/hipreport-android.sh
+file path=usr/libexec/openconnect/hipreport.sh
+file path=usr/libexec/openconnect/tncc-emulate.py
+file path=usr/libexec/openconnect/tncc-wrapper.py
 file path=usr/sbin/openconnect
 file path=usr/share/bash-completion/completions/openconnect
 file path=usr/share/doc/openconnect/anyconnect.html

--- a/components/network/openconnect/openconnect.p5m
+++ b/components/network/openconnect/openconnect.p5m
@@ -29,16 +29,23 @@ depend type=require fmri=network/vpnc-scripts
 depend type=require fmri=driver/network/tun variant.opensolaris.zone=global
 depend type=require fmri=driver/network/tap variant.opensolaris.zone=global
 
+# do not included android sprecific file
+<transform path=usr/libexec/openconnect/hipreport-android.sh -> drop>
+# python file dependency checks in usr/libexec/openconnect is not supported by gmake REQUIRED_PACKAGES
+<transform file path=usr/libexec/openconnect/tncc-emulate.py -> add pkg.depend.bypass-generate .* >
+<transform file path=usr/libexec/openconnect/tncc-wrapper.py -> add pkg.depend.bypass-generate .* >
+
 file path=usr/include/openconnect.h
 link path=usr/lib/$(MACH64)/libopenconnect.so target=libopenconnect.so.5.9.0
 link path=usr/lib/$(MACH64)/libopenconnect.so.5 target=libopenconnect.so.5.9.0
 file path=usr/lib/$(MACH64)/libopenconnect.so.5.9.0
-file path=usr/lib/$(MACH64)/openconnect/csd-post.sh
-file path=usr/lib/$(MACH64)/openconnect/csd-wrapper.sh
-file path=usr/lib/$(MACH64)/openconnect/hipreport.sh
-file path=usr/lib/$(MACH64)/openconnect/tncc-emulate.py
-file path=usr/lib/$(MACH64)/openconnect/tncc-wrapper.py
 file path=usr/lib/$(MACH64)/pkgconfig/openconnect.pc
+file path=usr/libexec/openconnect/csd-post.sh
+file path=usr/libexec/openconnect/csd-wrapper.sh
+file path=usr/libexec/openconnect/hipreport-android.sh
+file path=usr/libexec/openconnect/hipreport.sh
+file path=usr/libexec/openconnect/tncc-emulate.py
+file path=usr/libexec/openconnect/tncc-wrapper.py
 file path=usr/sbin/openconnect
 file path=usr/share/bash-completion/completions/openconnect
 file path=usr/share/doc/openconnect/anyconnect.html

--- a/components/network/openconnect/pkg5
+++ b/components/network/openconnect/pkg5
@@ -8,6 +8,8 @@
         "library/security/openssl-31",
         "library/zlib",
         "network/vpnc-scripts",
+        "shell/bash",
+        "shell/ksh93",
         "system/library",
         "system/library/math",
         "system/library/security/gss"


### PR DESCRIPTION

Move the user executables from/usr/ib/openconnect to/usr/libexec/openconnect so 
1) the execute bits get set
2) use the default path that openconnect assumes

Assorted other fixes to compile the code and handle gmake REQUIRED_PACKAGES