### PR TITLE
ntpd: apply upstream patch 3943 to fix NTP over link-local IPv6

### DIFF
--- a/components/network/ntp/Makefile
+++ b/components/network/ntp/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		ntp
 HUMAN_VERSION=		4.2.8p18
 COMPONENT_VERSION=	$(subst p,.,$(HUMAN_VERSION))
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Network Time Protocol Daemon v4
 COMPONENT_DESCRIPTION=	Network Time Protocol v4, NTP Daemon and Utilities
 COMPONENT_PROJECT_URL=	https://www.ntp.org/

--- a/components/network/ntp/patches/30-linklocal.patch
+++ b/components/network/ntp/patches/30-linklocal.patch
@@ -1,0 +1,13 @@
+https://bugs.ntp.org/show_bug.cgi?id=3943
+
+--- ntpd/ntp_io.c	2024-08-12 21:52:15 +0000
++++ ntpd/ntp_io.c	2024-08-12 21:52:15 +0000
+@@ -3205,7 +3205,7 @@
+ 	}
+ 
+ 	do {
+-		if (INT_LL_OF_GLOB & src->flags) {
++		if (ismcast && INT_LL_OF_GLOB & src->flags) {
+ 			/* avoid duplicate multicasts on same IPv6 net */
+ 			goto loop;
+ 		}


### PR DESCRIPTION
While I was working on fixes to scoped link-local addresses under [illumos bug 16370](http://illumos.org/issues/16370), using NTP as part of my testing, openindiana upgraded ntpd from 4.2.8p17 to 4.28.p18.

Unfortunately, that release included a change (https://bugs.ntp.org/show_bug.cgi?id=3913) which as an unintended consequence broke transmission of packets with link-local sources, reported as https://bugs.ntp.org/show_bug.cgi?id=3943.

Here's the upstream patch which fixes that regression.



 