### PR TITLE
setup.py.mk: move build, install and test rules to common-rules.mk

### DIFF
--- a/make-rules/common-rules.mk
+++ b/make-rules/common-rules.mk
@@ -1,0 +1,79 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+#
+
+#
+# Common rules used for building, installing, and testing of components.
+#
+
+# build the configured source
+$(BUILD_DIR)/%/.built:	$(SOURCE_DIR)/.prep
+	$(RM) -r $(@D) ; $(MKDIR) $(@D)
+	$(ENV) $(CLONEY_ARGS) $(CLONEY) $(SOURCE_DIR) $(@D)
+	$(COMPONENT_PRE_BUILD_ACTION)
+	(cd $(@D)$(COMPONENT_SUBDIR:%=/%) ; $(ENV) $(COMPONENT_BUILD_ENV) \
+		$(COMPONENT_BUILD_CMD) $(COMPONENT_BUILD_ARGS))
+	$(COMPONENT_POST_BUILD_ACTION)
+	$(TOUCH) $@
+
+# install the built source into a prototype area
+$(BUILD_DIR)/%/.installed:	$(BUILD_DIR)/%/.built
+	$(COMPONENT_PRE_INSTALL_ACTION)
+	(cd $(@D)$(COMPONENT_SUBDIR:%=/%) ; $(ENV) $(COMPONENT_INSTALL_ENV) \
+		$(COMPONENT_INSTALL_CMD) $(COMPONENT_INSTALL_ARGS))
+	$(COMPONENT_POST_INSTALL_ACTION)
+	$(TOUCH) $@
+
+# test the built source
+COMPONENT_TEST_DEP +=	$(BUILD_DIR)/%/.built
+
+$(BUILD_DIR)/%/.tested-and-compared:    $(COMPONENT_TEST_DEP)
+	$(RM) -rf $(COMPONENT_TEST_BUILD_DIR)
+	$(MKDIR) $(COMPONENT_TEST_BUILD_DIR)
+	$(COMPONENT_PRE_TEST_ACTION)
+	-(cd $(COMPONENT_TEST_DIR) ; \
+		$(COMPONENT_TEST_ENV_CMD) $(COMPONENT_TEST_ENV) \
+		$(COMPONENT_TEST_CMD) \
+		$(COMPONENT_TEST_ARGS) $(COMPONENT_TEST_TARGETS)) \
+		&> $(COMPONENT_TEST_OUTPUT)
+	$(COMPONENT_POST_TEST_ACTION)
+	$(COMPONENT_TEST_CREATE_TRANSFORMS)
+	$(COMPONENT_TEST_PERFORM_TRANSFORM)
+	$(COMPONENT_TEST_COMPARE)
+	$(COMPONENT_TEST_CLEANUP)
+	$(TOUCH) $@
+
+$(BUILD_DIR)/%/.tested:    SHELLOPTS=pipefail
+$(BUILD_DIR)/%/.tested:    $(COMPONENT_TEST_DEP)
+	$(RM) -rf $(COMPONENT_TEST_BUILD_DIR)
+	$(MKDIR) $(COMPONENT_TEST_BUILD_DIR)
+	$(COMPONENT_PRE_TEST_ACTION)
+	(cd $(COMPONENT_TEST_DIR) ; \
+		$(COMPONENT_TEST_ENV_CMD) $(COMPONENT_TEST_ENV) \
+		$(COMPONENT_TEST_CMD) \
+		$(COMPONENT_TEST_ARGS) $(COMPONENT_TEST_TARGETS)) \
+		|& $(TEE) $(COMPONENT_TEST_OUTPUT)
+	$(COMPONENT_POST_TEST_ACTION)
+	$(COMPONENT_TEST_CREATE_TRANSFORMS)
+	$(COMPONENT_TEST_PERFORM_TRANSFORM)
+	$(COMPONENT_TEST_CLEANUP)
+	$(TOUCH) $@

--- a/make-rules/common.mk
+++ b/make-rules/common.mk
@@ -76,6 +76,12 @@ endif
 ifneq ($(strip $(BUILD_STYLE)),archive)
 ifneq ($(strip $(BUILD_STYLE)),pkg)
 include $(WS_MAKE_RULES)/$(strip $(BUILD_STYLE)).mk
+
+# Include common rules used by build styles that opted to use them
+USE_COMMON_RULES ?= no
+ifneq ($(strip $(USE_COMMON_RULES)),no)
+include $(WS_MAKE_RULES)/common-rules.mk
+endif
 endif
 endif
 


### PR DESCRIPTION
The main idea behind this is to avoid code duplication for many (possibly all) build styles.  The plan is to slowly convert all build styles to use the common rules in `common-rules.mk`.  Slowly, because these rules could slightly differ between various build styles and so it would be a lot of work to do it properly for all styles in one go.

Since this change just moves unmodified rules from `setup.py.mk` to `common-rules.mk` (and uses the `common-rules.mk` only when opted to do so) it should be basically no-op for all build styles.