### PR TITLE
Add dependency_groups Python project

### DIFF
--- a/components/python/dependency-groups/.gitignore
+++ b/components/python/dependency-groups/.gitignore
@@ -1,0 +1,1 @@
+/dependency_groups-1.3.0/

--- a/components/python/dependency-groups/Makefile
+++ b/components/python/dependency-groups/Makefile
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project -d python/dependency-groups dependency_groups
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		dependency_groups
+HUMAN_VERSION =			1.3.0
+COMPONENT_SUMMARY =		A tool for resolving PEP 735 Dependency Group data
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:5b9751d5d98fbd6dfd038a560a69c8382e41afcbf7ffdbcc28a2a3f85498830f
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE.txt
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/flit-core
+PYTHON_REQUIRED_PACKAGES += library/python/packaging
+PYTHON_REQUIRED_PACKAGES += library/python/tomli
+PYTHON_REQUIRED_PACKAGES += runtime/python

--- a/components/python/dependency-groups/dependency_groups-PYVER.p5m
+++ b/components/python/dependency-groups/dependency_groups-PYVER.p5m
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/dependency-groups-$(PYVER)
+file path=usr/bin/lint-dependency-groups-$(PYVER)
+file path=usr/bin/pip-install-dependency-groups-$(PYVER)
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/LICENSE.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/entry_points.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/__main__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_implementation.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_lint_dependency_groups.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_pip_wrapper.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_toml_compat.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/py.typed
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/packaging-$(PYV)
+depend type=require fmri=pkg:/library/python/tomli-$(PYV)

--- a/components/python/dependency-groups/manifests/sample-manifest.p5m
+++ b/components/python/dependency-groups/manifests/sample-manifest.p5m
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/dependency-groups-$(PYVER)
+file path=usr/bin/lint-dependency-groups-$(PYVER)
+file path=usr/bin/pip-install-dependency-groups-$(PYVER)
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/LICENSE.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups-$(HUMAN_VERSION).dist-info/entry_points.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/__main__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_implementation.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_lint_dependency_groups.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_pip_wrapper.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/_toml_compat.py
+file path=usr/lib/python$(PYVER)/vendor-packages/dependency_groups/py.typed
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/packaging-$(PYV)
+depend type=require fmri=pkg:/library/python/tomli-$(PYV)

--- a/components/python/dependency-groups/patches/01-tox-version.patch
+++ b/components/python/dependency-groups/patches/01-tox-version.patch
@@ -1,0 +1,13 @@
+To bootstrap this we need to remove the tox version constraint.
+See also https://github.com/sirosen/dependency-groups/issues/16
+
+--- dependency_groups-1.3.0/tox.ini.orig
++++ dependency_groups-1.3.0/tox.ini
+@@ -10,7 +10,6 @@
+     ci = py{38,39,310,311,312,313}, covcombine, covreport
+     ci-mypy = mypy-py38, mypy-py313
+     ci-package-check = twine-check
+-minversion = 4.22.0
+ 
+ [testenv]
+ package = wheel

--- a/components/python/dependency-groups/pkg5
+++ b/components/python/dependency-groups/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "library/python/flit-core-39",
+        "library/python/packaging-39",
+        "library/python/tomli-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/dependency-groups",
+        "library/python/dependency-groups-39"
+    ],
+    "name": "dependency_groups"
+}

--- a/components/python/dependency-groups/python-integrate-project.conf
+++ b/components/python/dependency-groups/python-integrate-project.conf
@@ -1,0 +1,16 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Marcel Telka
+#
+
+%patch% 01-tox-version.patch

--- a/components/python/dependency-groups/test/results-all.master
+++ b/components/python/dependency-groups/test/results-all.master
@@ -1,0 +1,43 @@
+py$(PYV): remove tox env folder $(@D)/.tox/py$(PYV)
+py$(PYV): commands[0]> python -m coverage run -m pytest -v
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(@D)/.tox/py$(PYV)/bin/python
+cachedir: .tox/py$(PYV)/.pytest_cache
+rootdir: $(@D)
+configfile: pyproject.toml
+collecting ... collected 30 items
+
+tests/test_lint_cli.py::test_lint_no_groups_ok PASSED
+tests/test_lint_cli.py::test_lint_bad_group_item PASSED
+tests/test_lint_cli.py::test_no_toml_failure PASSED
+tests/test_lint_cli.py::test_dependency_groups_list_format PASSED
+tests/test_resolve_func.py::test_empty_group PASSED
+tests/test_resolve_func.py::test_str_list_group PASSED
+tests/test_resolve_func.py::test_single_include_group PASSED
+tests/test_resolve_func.py::test_sdual_include_group PASSED
+tests/test_resolve_func.py::test_normalized_group_name PASSED
+tests/test_resolve_func.py::test_malformed_group_data PASSED
+tests/test_resolve_func.py::test_malformed_group_query PASSED
+tests/test_resolve_func.py::test_no_such_group_name PASSED
+tests/test_resolve_func.py::test_duplicate_normalized_name PASSED
+tests/test_resolve_func.py::test_cyclic_include PASSED
+tests/test_resolve_func.py::test_cyclic_include_many_steps PASSED
+tests/test_resolve_func.py::test_cyclic_include_self PASSED
+tests/test_resolve_func.py::test_cyclic_include_ring_under_root PASSED
+tests/test_resolve_func.py::test_non_list_data PASSED
+tests/test_resolve_func.py::test_unknown_object_shape[item0] PASSED
+tests/test_resolve_func.py::test_unknown_object_shape[item1] PASSED
+tests/test_resolve_func.py::test_unknown_object_shape[item2] PASSED
+tests/test_resolve_func.py::test_unknown_object_shape[item3] PASSED
+tests/test_resolver_class.py::test_resolver_init_handles_bad_type PASSED
+tests/test_resolver_class.py::test_resolver_init_catches_normalization_conflict PASSED
+tests/test_resolver_class.py::test_lookup_catches_bad_type PASSED
+tests/test_resolver_class.py::test_lookup_on_trivial_normalization PASSED
+tests/test_resolver_class.py::test_lookup_with_include_result PASSED
+tests/test_resolver_class.py::test_lookup_does_not_trigger_cyclic_include PASSED
+tests/test_resolver_class.py::test_expand_contract_model_only_does_inner_lookup_once PASSED
+tests/test_resolver_class.py::test_no_double_parse PASSED
+
+======== 30 passed ========
+  py$(PYV): OK
+  congratulations :)


### PR DESCRIPTION
The [Dependency Groups (PEP 735)](https://peps.python.org/pep-0735/) is a new mechanism to express Python dependencies.  Some projects already started to use it for listing of their test dependencies (primarily `tox >= 4.22.0`) and so we need some way to handle them in our build framework.

Due to [lack of PEP 735 support](https://github.com/stanislavlevin/pyproject_installer/issues/81) in tools we currently use for resolving dependencies we need to find some other (maybe temporary) solution.  This project is such a solution.