### PR TITLE
curl: remove heimdal-gsssapi dependency

### DIFF
--- a/components/web/curl/Makefile
+++ b/components/web/curl/Makefile
@@ -28,6 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         curl
 COMPONENT_VERSION=      8.11.0
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=      The CURL Network Utility and Library
 COMPONENT_DESCRIPTION=	A command-line tool and library for transforming data with URL syntax
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/web/curl/patches/000-configure.ac.patch
+++ b/components/web/curl/patches/000-configure.ac.patch
@@ -1,5 +1,6 @@
+Enable illumos gss support.  It is incorrectly assumed to be heimdal--do not add to libcurl.pc file
 --- curl-8.11.0/configure.ac.~1~	2024-11-06 02:09:19.000000000 -0500
-+++ curl-8.11.0/configure.ac	2024-11-06 19:05:30.999538226 -0500
++++ curl-8.11.0/configure.ac	2024-11-09 18:58:22.382807139 -0500
 @@ -2043,6 +2043,9 @@
              *-hp-hpux*)
                gss_libname="gss"
@@ -10,7 +11,7 @@
              *)
                gss_libname="gssapi"
                ;;
-@@ -2064,7 +2067,7 @@
+@@ -2064,14 +2067,14 @@
          LIBS="-lgss $LIBS"
          ;;
        *)
@@ -18,4 +19,12 @@
 +        LIBS="-lgss $LIBS"
          ;;
      esac
+   fi
+   if test -n "$gnu_gss"; then
+     LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE gss"
+   elif test "x$not_mit" = "x1"; then
+-    LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE heimdal-gssapi"
++    LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE"
+   else
+     LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE mit-krb5-gssapi"
    fi


### PR DESCRIPTION
This fixes the reported issue where libcurl expects heimdal-gssapi library to be available.  