### PR TITLE
Add TinyXML-2

### DIFF
--- a/components/library/tinyxml2/Makefile
+++ b/components/library/tinyxml2/Makefile
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Marcel Telka
+#
+
+BUILD_STYLE = cmake
+USE_DEFAULT_TEST_TRANSFORMS = yes
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		tinyxml2
+COMPONENT_VERSION =		10.0.0
+COMPONENT_SUMMARY =		Simple, small, efficient, C++ XML parser that can be easily integrated into other programs
+COMPONENT_PROJECT_URL =		https://github.com/leethomason/tinyxml2
+COMPONENT_SRC =			$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE =		$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL =		https://github.com/leethomason/tinyxml2/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH =	sha256:3bdf15128ba16686e69bce256cc468e76c7b94ff2c7f391cc5ec09e40bff3839
+COMPONENT_FMRI =		library/tinyxml2
+COMPONENT_CLASSIFICATION =	System/Libraries
+COMPONENT_LICENSE =		Zlib
+COMPONENT_LICENSE_FILE =	LICENSE.txt
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Build shared library
+CMAKE_OPTIONS += -DBUILD_SHARED_LIBS=ON
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += system/library

--- a/components/library/tinyxml2/manifests/sample-manifest.p5m
+++ b/components/library/tinyxml2/manifests/sample-manifest.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/tinyxml2.h
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-config-version.cmake
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-config.cmake
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-shared-targets-noconfig.cmake
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-shared-targets.cmake
+link path=usr/lib/$(MACH64)/libtinyxml2.so target=libtinyxml2.so.10
+file path=usr/lib/$(MACH64)/libtinyxml2.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libtinyxml2.so.10 \
+    target=libtinyxml2.so.$(HUMAN_VERSION)
+file path=usr/lib/$(MACH64)/pkgconfig/tinyxml2.pc

--- a/components/library/tinyxml2/pkg5
+++ b/components/library/tinyxml2/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "system/library",
+        "system/library/g++-13-runtime",
+        "system/library/gcc-13-runtime"
+    ],
+    "fmris": [
+        "library/tinyxml2"
+    ],
+    "name": "tinyxml2"
+}

--- a/components/library/tinyxml2/test/results-all.master
+++ b/components/library/tinyxml2/test/results-all.master
@@ -1,0 +1,3 @@
+    Start 1: xmltest
+1/1 Test #1: xmltest ..........................   Passed    
+100% tests passed, 0 tests failed out of 1

--- a/components/library/tinyxml2/tinyxml2.p5m
+++ b/components/library/tinyxml2/tinyxml2.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Marcel Telka
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/tinyxml2.h
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-config-version.cmake
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-config.cmake
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-shared-targets-noconfig.cmake
+file path=usr/lib/$(MACH64)/cmake/tinyxml2/tinyxml2-shared-targets.cmake
+link path=usr/lib/$(MACH64)/libtinyxml2.so target=libtinyxml2.so.10
+file path=usr/lib/$(MACH64)/libtinyxml2.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libtinyxml2.so.10 \
+    target=libtinyxml2.so.$(HUMAN_VERSION)
+file path=usr/lib/$(MACH64)/pkgconfig/tinyxml2.pc


### PR DESCRIPTION
This is a replacement for deprecated TinyXML.
It is needed for updated rarian.