### PR TITLE
install-types: Add graphic-drivers and SF15K support to SPARC distribution

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -10,7 +10,7 @@
 
 #
 # Copyright 2011 EveryCity Ltd. All rights reserved.
-# Copyright 2013 Klaus Ziegler
+# Copyright 2023 Klaus Ziegler
 #
 
 BUILD_STYLE = pkg
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	10
+COMPONENT_VERSION =	11
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/minimal_sparcv9
+++ b/components/meta-packages/install-types/includes/minimal_sparcv9
@@ -26,6 +26,16 @@ depend type=require fmri=driver/crypto/dca
 depend type=require fmri=driver/crypto/dprov
 depend type=require fmri=driver/crypto/tpm
 depend type=require fmri=driver/firewire
+depend type=require fmri=driver/graphics/afb
+depend type=require fmri=driver/graphics/efb
+depend type=require fmri=driver/graphics/ffb
+depend type=require fmri=driver/graphics/gfb
+depend type=require fmri=driver/graphics/gfxp
+depend type=require fmri=driver/graphics/ifb
+depend type=require fmri=driver/graphics/jfb
+depend type=require fmri=driver/graphics/kfb
+depend type=require fmri=driver/graphics/m64
+depend type=require fmri=driver/graphics/zulu
 depend type=require fmri=driver/misc/ccid
 depend type=require fmri=driver/network/afe
 depend type=require fmri=driver/network/bge
@@ -121,6 +131,7 @@ depend type=require fmri=release/notices
 depend type=require fmri=runtime/perl
 depend type=require fmri=service/fault-management
 depend type=require fmri=service/file-system/smb
+depend type=require fmri=service/key-management/sun-fire-15000
 depend type=require fmri=service/management/sysding
 depend type=require fmri=service/network/ntp
 depend type=require fmri=service/network/ssh
@@ -154,6 +165,7 @@ depend type=require fmri=system/kernel
 depend type=require fmri=system/kernel/cpu-counters
 depend type=require fmri=system/kernel/cpu/sun4v
 depend type=require fmri=system/kernel/dtrace/providers
+depend type=require fmri=system/kernel/dynamic-reconfiguration/sun-fire-15000
 depend type=require fmri=system/kernel/platform
 depend type=require fmri=system/kernel/power
 depend type=require fmri=system/kernel/secure-rpc
@@ -179,6 +191,7 @@ depend type=require fmri=system/library/storage/libmpscsi_vhci
 depend type=require fmri=system/library/storage/scsi-plugins
 depend type=require fmri=system/man
 depend type=require fmri=system/network
+depend type=require fmri=system/network-console
 depend type=require fmri=system/network/nis
 depend type=require fmri=system/network/routing
 depend type=require fmri=system/prerequisite/gnu


### PR DESCRIPTION
They were already added to the SPARC distribution: 2023/09, but will of course also be needed for the upcomming 2024/25 Release for SPARC systems.