### PR TITLE
WIP: Mesa/drm/dri fixes

### DIFF
--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -67,9 +67,18 @@ DRI_DRIVERS='i915'
 # Other Gallium drivers: virgl (virtip-gpu), svga (vmware)
 GALLIUM_DRIVERS='i915, crocus'
 
+# 'Vulkan' DRI drivers
+# We have some work to do before these can be enabled
+# Intel: intel, intel_hasvk
+# AMD: amd
+# nvidia: nouveau, nvk
+# swrast: swrast
+# virtio-gpu: virtio
+VULKAN_DRIVERS=''
+
 # Command line options to GNU autoconf configure script
 CONFIGURE_OPTIONS += -Dgallium-drivers=$(GALLIUM_DRIVERS)
-CONFIGURE_OPTIONS += -Dvulkan-drivers=''
+CONFIGURE_OPTIONS += -Dvulkan-drivers=$(VULKAN_DRIVERS)
 CONFIGURE_OPTIONS += -Dgbm=enabled
 CONFIGURE_OPTIONS += -Dglvnd=false
 # Wayland currently requires linux specific socket options and epoll for events.

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -49,6 +49,14 @@ CONFIGURE_OPTIONS += --libdir='lib/mesa/amd64'
 PKG_HARDLINKS += usr/lib/xorg/modules/dri/kms_swrast_dri.so
 PKG_HARDLINKS += usr/lib/xorg/modules/dri/i915_dri.so
 
+# 'Classic' DRI drivers
+# Only add Intel i915 for now as these start getting removed in Mesa 22.x
+# Other Intel classic DRI drivers: i965, iris
+# Other AMD classic DRI drivers: r100, r200, r300, r600
+# Other NVIDIA classic DRI drivers: nv, nouveau
+# Other classic DRI drivers: swrast
+DRI_DRIVERS='i915'
+
 # Command line options to GNU autoconf configure script
 CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, r600'
 CONFIGURE_OPTIONS += -Dvulkan-drivers=''
@@ -66,7 +74,7 @@ CONFIGURE_OPTIONS += -Dosmesa=true
 CONFIGURE_OPTIONS += -Dshared-glapi=enabled
 CONFIGURE_OPTIONS += -Dgallium-xvmc=disabled
 CONFIGURE_OPTIONS += -Dgallium-xa=disabled
-CONFIGURE_OPTIONS += -Ddri-drivers='i915'
+CONFIGURE_OPTIONS += -Ddri-drivers=$(DRI_DRIVERS)
 CONFIGURE_OPTIONS += -Ddri-drivers-path=$(X11_SERVERMODS_DIR)/dri
 CONFIGURE_OPTIONS += -Delf-tls=false
 

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -89,6 +89,7 @@ CONFIGURE_OPTIONS += -Dglx='dri'
 CONFIGURE_OPTIONS += -Degl=enabled
 CONFIGURE_OPTIONS += -Dgles1=enabled
 CONFIGURE_OPTIONS += -Dgles2=enabled
+CONFIGURE_OPTIONS += -Ddri3=enabled
 CONFIGURE_OPTIONS += -Dosmesa=true
 CONFIGURE_OPTIONS += -Dshared-glapi=enabled
 CONFIGURE_OPTIONS += -Dgallium-xvmc=disabled

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -33,6 +33,16 @@ include $(WS_MAKE_RULES)/common.mk
 
 PATCH_LEVEL= 0
 
+# Mesa 21.x requires 2.4.100 - 2.4.109
+# Mesa 22.x requires 2.4.9 - 2.4.110
+# Mesa 24.x requires 2.4.110 - 2.4.119
+# Mesa 25.x requires 2.4.121
+# Note: See below if ever downgrading libdrm
+# Mesa's dri.pc specifies a version requirement in dri.pc for >= the version of libdrm ..
+# .. that Mesa was built against, thus preventing packages from being rebuilt with the older version
+# Note2: see https://gitweb.gentoo.org/repo/gentoo.git/commit?id=a117c20f1b3127d4c397dddef4a7680359f1c9a3 
+LIBDRM_DEPENDENCY='2.4.109'
+
 ARCHLIBSUBDIR.64= /$(MACH64)
 ARCHLIBSUBDIR= $(ARCHLIBSUBDIR.$(BITS))
 

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -89,6 +89,7 @@ CONFIGURE_OPTIONS += -Dglx='dri'
 CONFIGURE_OPTIONS += -Degl=enabled
 CONFIGURE_OPTIONS += -Dgles1=enabled
 CONFIGURE_OPTIONS += -Dgles2=enabled
+CONFIGURE_OPTIONS += -Dopengl=true
 CONFIGURE_OPTIONS += -Ddri3=enabled
 CONFIGURE_OPTIONS += -Dosmesa=true
 CONFIGURE_OPTIONS += -Dshared-glapi=enabled

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -57,8 +57,18 @@ PKG_HARDLINKS += usr/lib/xorg/modules/dri/i915_dri.so
 # Other classic DRI drivers: swrast
 DRI_DRIVERS='i915'
 
+# 'Gallium' DRI drivers
+# Initially add Intel i915 and crocus drivers as a starting point
+# Other Intel Gallium drivers: i915g (future i915), iris
+# Other AMD Gallium drivers: r300, r600, radeonsi
+# Other NVIDIA Gallium drivers: nouveau
+# swrast Gallium driver: swrast
+# Note: swrast gallium driver in future splits to softpipe and llvmpipe (v24)
+# Other Gallium drivers: virgl (virtip-gpu), svga (vmware)
+GALLIUM_DRIVERS='i915, crocus'
+
 # Command line options to GNU autoconf configure script
-CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, r600'
+CONFIGURE_OPTIONS += -Dgallium-drivers=$(GALLIUM_DRIVERS)
 CONFIGURE_OPTIONS += -Dvulkan-drivers=''
 CONFIGURE_OPTIONS += -Dgbm=enabled
 CONFIGURE_OPTIONS += -Dglvnd=false

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= mesa
 COMPONENT_VERSION= 21.3.9
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= The Mesa 3-D Graphics Library
 COMPONENT_SRC= mesa-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= mesa-$(COMPONENT_VERSION).tar.xz
@@ -46,9 +47,10 @@ X11_SERVERLIBS_DIR= /usr/lib/xorg
 CONFIGURE_OPTIONS += --libdir='lib/mesa/amd64'
 
 PKG_HARDLINKS += usr/lib/xorg/modules/dri/kms_swrast_dri.so
+PKG_HARDLINKS += usr/lib/xorg/modules/dri/i915_dri.so
 
 # Command line options to GNU autoconf configure script
-CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, i915, r600'
+CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, r600'
 CONFIGURE_OPTIONS += -Dvulkan-drivers=''
 CONFIGURE_OPTIONS += -Dgbm=enabled
 CONFIGURE_OPTIONS += -Dglvnd=false
@@ -56,15 +58,15 @@ CONFIGURE_OPTIONS += -Dglvnd=false
 CONFIGURE_OPTIONS += -Dplatforms='x11'
 # llvm is disabled due to requiring llvm 16 we do not have 16
 CONFIGURE_OPTIONS += -Dllvm=false
-CONFIGURE_OPTIONS += -Dglx='auto'
+CONFIGURE_OPTIONS += -Dglx='dri'
 CONFIGURE_OPTIONS += -Degl=enabled
 CONFIGURE_OPTIONS += -Dgles1=enabled
 CONFIGURE_OPTIONS += -Dgles2=enabled
 CONFIGURE_OPTIONS += -Dosmesa=true
 CONFIGURE_OPTIONS += -Dshared-glapi=enabled
-CONFIGURE_OPTIONS += -Dgallium-xvmc=enabled
-CONFIGURE_OPTIONS += -Dgallium-xa=enabled
-CONFIGURE_OPTIONS += -Ddri-drivers=''
+CONFIGURE_OPTIONS += -Dgallium-xvmc=disabled
+CONFIGURE_OPTIONS += -Dgallium-xa=disabled
+CONFIGURE_OPTIONS += -Ddri-drivers='i915'
 CONFIGURE_OPTIONS += -Ddri-drivers-path=$(X11_SERVERMODS_DIR)/dri
 CONFIGURE_OPTIONS += -Delf-tls=false
 
@@ -87,7 +89,7 @@ CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
 # Add RPATH to xorg lib directory where is libdrm.
 
 COMPONENT_POST_INSTALL_ACTION.64 += \
-	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0 libxatracker.so.2.5.0 libXvMCr600.so.1.0.0 vdpau/libvdpau_r600.so.1.0.0; do \
+	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0 vdpau/libvdpau_r600.so.1.0.0; do \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
 	  $(PROTOUSRLIBDIR)/mesa/$(MACH64)/$$f ; \
 	done ; \

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -54,7 +54,6 @@ PKG_HARDLINKS += usr/lib/xorg/modules/dri/i915_dri.so
 # Other Intel classic DRI drivers: i965, iris
 # Other AMD classic DRI drivers: r100, r200, r300, r600
 # Other NVIDIA classic DRI drivers: nv, nouveau
-# Other classic DRI drivers: swrast
 DRI_DRIVERS='i915'
 
 # 'Gallium' DRI drivers

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -59,13 +59,14 @@ DRI_DRIVERS='i915'
 
 # 'Gallium' DRI drivers
 # Initially add Intel i915 and crocus drivers as a starting point
-# Other Intel Gallium drivers: i915g (future i915), iris
+# Other Intel Gallium drivers: i915g (future i915), crocus, iris
+# Note: crocus (at a minimum) depends on glslang
 # Other AMD Gallium drivers: r300, r600, radeonsi
 # Other NVIDIA Gallium drivers: nouveau
 # swrast Gallium driver: swrast
 # Note: swrast gallium driver in future splits to softpipe and llvmpipe (v24)
 # Other Gallium drivers: virgl (virtip-gpu), svga (vmware)
-GALLIUM_DRIVERS='i915, crocus'
+GALLIUM_DRIVERS='i915'
 
 # 'Vulkan' DRI drivers
 # We have some work to do before these can be enabled

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -49,9 +49,6 @@ file path=usr/include/mesa/glx.h
 file path=usr/include/mesa/glxext.h
 file path=usr/include/mesa/internal/dri_interface.h
 file path=usr/include/mesa/osmesa.h
-file path=usr/include/xa_composite.h
-file path=usr/include/xa_context.h
-file path=usr/include/xa_tracker.h
 link path=usr/lib/mesa/$(MACH64)/libEGL.so target=libEGL.so.1
 link path=usr/lib/mesa/$(MACH64)/libEGL.so.1 target=libEGL.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libEGL.so.1.0.0
@@ -67,19 +64,12 @@ file path=usr/lib/mesa/$(MACH64)/libGLESv2.so.2.0.0
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so target=libOSMesa.so.8
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8 target=libOSMesa.so.8.0.0
 file path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1 target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0 target=libXvMCr600.so.1.0.0
-file path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libgbm.so target=libgbm.so.1
 link path=usr/lib/mesa/$(MACH64)/libgbm.so.1 target=libgbm.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libgbm.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so target=libglapi.so.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so.0 target=libglapi.so.0.0.0
 file path=usr/lib/mesa/$(MACH64)/libglapi.so.0.0.0
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so target=libxatracker.so.2
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so.2 target=libxatracker.so.2.5.0
-file path=usr/lib/mesa/$(MACH64)/libxatracker.so.2.5.0
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/dri.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/egl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/gbm.pc
@@ -87,7 +77,6 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/gl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
-file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so \
     target=libvdpau_r600.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
@@ -95,7 +84,8 @@ link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0 \
     target=libvdpau_r600.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0.0
-hardlink path=usr/lib/xorg/modules/dri/i915_dri.so target=kms_swrast_dri.so
+hardlink path=usr/lib/xorg/modules/dri/i830_dri.so target=i915_dri.so
+file path=usr/lib/xorg/modules/dri/i915_dri.so
 file path=usr/lib/xorg/modules/dri/kms_swrast_dri.so
 hardlink path=usr/lib/xorg/modules/dri/r600_dri.so target=kms_swrast_dri.so
 hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=kms_swrast_dri.so

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -27,6 +27,8 @@ license mesa.license license='Mesa License (Mixed: MIT, LGPLv2, others)'
 
 # suppress the pkglint for dri modules we place in the xservers load path
 <transform file path=usr/lib/xorg/modules/dri.* -> add pkg.linted.userland.action001.2 true>
+<transform file path=usr/lib/xorg/modules/dri.* -> add pkg.depend.bypass-generate .*>
+
 
 # For several libraries we create direct links
 link path=usr/X11/lib/mesa target=../../lib/mesa
@@ -70,7 +72,6 @@ link path=usr/lib/$(MACH64)/pkgconfig/gl.pc target=../../mesa/$(MACH64)/pkgconfi
 link path=usr/lib/$(MACH64)/pkgconfig/glesv1_cm.pc target=../../mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 link path=usr/lib/$(MACH64)/pkgconfig/glesv2.pc target=../../mesa/$(MACH64)/pkgconfig/glesv2.pc
 link path=usr/lib/$(MACH64)/pkgconfig/osmesa.pc target=../../mesa/$(MACH64)/pkgconfig/osmesa.pc
-link path=usr/lib/$(MACH64)/pkgconfig/xatracker.pc target=../../mesa/$(MACH64)/pkgconfig/xatracker.pc
 
 file path=usr/include/EGL/egl.h
 file path=usr/include/EGL/eglext.h
@@ -98,9 +99,6 @@ file path=usr/include/mesa/glx.h
 file path=usr/include/mesa/glxext.h
 file path=usr/include/mesa/internal/dri_interface.h
 file path=usr/include/mesa/osmesa.h
-file path=usr/include/xa_composite.h
-file path=usr/include/xa_context.h
-file path=usr/include/xa_tracker.h
 link path=usr/lib/mesa/$(MACH64)/libEGL.so target=libEGL.so.1
 link path=usr/lib/mesa/$(MACH64)/libEGL.so.1 target=libEGL.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libEGL.so.1.0.0
@@ -116,19 +114,12 @@ file path=usr/lib/mesa/$(MACH64)/libGLESv2.so.2.0.0
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so target=libOSMesa.so.8
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8 target=libOSMesa.so.8.0.0
 file path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1 target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0 target=libXvMCr600.so.1.0.0
-file path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libgbm.so target=libgbm.so.1
 link path=usr/lib/mesa/$(MACH64)/libgbm.so.1 target=libgbm.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libgbm.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so target=libglapi.so.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so.0 target=libglapi.so.0.0.0
 file path=usr/lib/mesa/$(MACH64)/libglapi.so.0.0.0
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so target=libxatracker.so.2
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so.2 target=libxatracker.so.2.5.0
-file path=usr/lib/mesa/$(MACH64)/libxatracker.so.2.5.0
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/dri.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/egl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/gbm.pc
@@ -136,7 +127,6 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/gl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
-file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so \
     target=libvdpau_r600.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
@@ -144,8 +134,9 @@ link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0 \
     target=libvdpau_r600.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0.0
+hardlink path=usr/lib/xorg/modules/dri/i830_dri.so target=i915_dri.so
 file path=usr/lib/xorg/modules/dri/i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/kms_swrast_dri.so target=i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/r600_dri.so target=i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=i915_dri.so
+file path=usr/lib/xorg/modules/dri/kms_swrast_dri.so
+hardlink path=usr/lib/xorg/modules/dri/r600_dri.so target=kms_swrast_dri.so
+hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=kms_swrast_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/xorg-server/Makefile
+++ b/components/x11/xorg-server/Makefile
@@ -19,7 +19,7 @@ include $(WS_MAKE_RULES)/x11.mk
 
 COMPONENT_NAME=         xorg-server
 COMPONENT_VERSION=      1.19.7
-COMPONENT_REVISION=     11
+COMPONENT_REVISION=     12
 COMPONENT_SUMMARY=      Xorg - X11R7 X server
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
@@ -82,6 +82,7 @@ CONFIGURE_OPTIONS += --enable-dmx
 CONFIGURE_OPTIONS += --enable-dri
 CONFIGURE_OPTIONS += --enable-dri2
 CONFIGURE_OPTIONS += --enable-dri3
+CONFIGURE_OPTIONS += --enable-libdrm
 CONFIGURE_OPTIONS += --disable-glamor
 CONFIGURE_OPTIONS += --enable-glx
 CONFIGURE_OPTIONS += --enable-kdrive


### PR DESCRIPTION
Obsoletes #19640 

As per title. This pull request serves as the beginning of fixing the currently broken state of Mesa / DRM / DRI in OpenIndiana, which has been broken since 7defdf189741d867232df830a2cc385e4ed20f21

The problems which I have identified thus far:

- Mesa currently tries to enable gallium swrast , which can't work as gallium swrast has a dependency on llvm (16 specifically), which we neither have nor enable in the Makefile
- No classic (DRI) drivers explicitly enabled, left entirely to auto detect magic
- No working gallium drivers enabled
- I think Mesa 21.x defaults to dri2, explicitly enable dri3
- xorg-server does not explicitly enable libdrm

With the above in context, starting from a fresh install of OpenIndiana Hipster and updating to the latest available packages, only Vesa (not related to Mesa for the uninformed) is enabled. In this state neither glxinfo nor glxgears are available.

With the changes in this pull request I haven't quite gotten things working to the state that they were previously i.e. accelerated Intel graphics on a Thinkpad X230, but glxinfo and glxgears are now working. I've spent quite a few hours on this problem over the weekend and I have been discussing it with @Toasterson throughout. I will not have any more time to work on this until next weekend at the earliest. Please contribute and we can get this working again before continuing on to further improving the graphical desktop experience with things such as libva, Vulkan and more in Mesa.

Note:

- I haven't generated any new manifests for these changes as of yet
- xorg-server currently does not build due to a missing header, specifically <GL/internal/dri_interface.h>. Our previous Mesa v13.x correctly installed this header, whereas our new Mesa v21.3.9 installs this header to <mesa/internal/dri_interface.h>. I didn't bother to patch this just yet - I symlinked it on my test system.