### PR TITLE
spirv-headers: add 1.3.280.0

### DIFF
--- a/components/x11/spirv-headers/Makefile
+++ b/components/x11/spirv-headers/Makefile
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+#
+
+BUILD_STYLE= cmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		spirv-headers
+COMPONENT_VERSION=	1.3.280.0
+COMPONENT_SUMMARY=	SPIR-V headers
+COMPONENT_PROJECT_URL=	https://registry.khronos.org/SPIR-V/
+COMPONENT_SRC=		SPIRV-Headers-vulkan-sdk-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	vulkan-sdk-$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_URL=	https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:a00906b6bddaac1e37192eff2704582f82ce2d971f1aacee4d51d9db33b0f772
+COMPONENT_FMRI=		x11/library/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION= System/X11
+COMPONENT_LICENSE=	MIT
+COMPONENT_LICENSE_FILE=	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+CMAKE_OPTIONS += -DCMAKE_INSTALL_PREFIX=$(USRDIR)
+
+# Auto-generated dependencies

--- a/components/x11/spirv-headers/manifests/sample-manifest.p5m
+++ b/components/x11/spirv-headers/manifests/sample-manifest.p5m
@@ -1,0 +1,101 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/spirv/1.0/GLSL.std.450.h
+file path=usr/include/spirv/1.0/OpenCL.std.h
+file path=usr/include/spirv/1.0/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/1.0/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/1.0/spirv.core.grammar.json
+file path=usr/include/spirv/1.0/spirv.cs
+file path=usr/include/spirv/1.0/spirv.h
+file path=usr/include/spirv/1.0/spirv.hpp
+file path=usr/include/spirv/1.0/spirv.hpp11
+file path=usr/include/spirv/1.0/spirv.json
+file path=usr/include/spirv/1.0/spirv.lua
+file path=usr/include/spirv/1.0/spirv.py
+file path=usr/include/spirv/1.1/GLSL.std.450.h
+file path=usr/include/spirv/1.1/OpenCL.std.h
+file path=usr/include/spirv/1.1/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/1.1/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/1.1/spirv.core.grammar.json
+file path=usr/include/spirv/1.1/spirv.cs
+file path=usr/include/spirv/1.1/spirv.h
+file path=usr/include/spirv/1.1/spirv.hpp
+file path=usr/include/spirv/1.1/spirv.hpp11
+file path=usr/include/spirv/1.1/spirv.json
+file path=usr/include/spirv/1.1/spirv.lua
+file path=usr/include/spirv/1.1/spirv.py
+file path=usr/include/spirv/1.2/GLSL.std.450.h
+file path=usr/include/spirv/1.2/OpenCL.std.h
+file path=usr/include/spirv/1.2/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/1.2/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/1.2/spirv.core.grammar.json
+file path=usr/include/spirv/1.2/spirv.cs
+file path=usr/include/spirv/1.2/spirv.h
+file path=usr/include/spirv/1.2/spirv.hpp
+file path=usr/include/spirv/1.2/spirv.hpp11
+file path=usr/include/spirv/1.2/spirv.json
+file path=usr/include/spirv/1.2/spirv.lua
+file path=usr/include/spirv/1.2/spirv.py
+file path=usr/include/spirv/spir-v.xml
+file path=usr/include/spirv/unified1/AMD_gcn_shader.h
+file path=usr/include/spirv/unified1/AMD_shader_ballot.h
+file path=usr/include/spirv/unified1/AMD_shader_explicit_vertex_parameter.h
+file path=usr/include/spirv/unified1/AMD_shader_trinary_minmax.h
+file path=usr/include/spirv/unified1/DebugInfo.h
+file path=usr/include/spirv/unified1/GLSL.std.450.h
+file path=usr/include/spirv/unified1/NonSemanticClspvReflection.h
+file path=usr/include/spirv/unified1/NonSemanticDebugBreak.h
+file path=usr/include/spirv/unified1/NonSemanticDebugPrintf.h
+file path=usr/include/spirv/unified1/NonSemanticShaderDebugInfo100.h
+file path=usr/include/spirv/unified1/NonSemanticVkspReflection.h
+file path=usr/include/spirv/unified1/OpenCL.std.h
+file path=usr/include/spirv/unified1/OpenCLDebugInfo100.h
+file path=usr/include/spirv/unified1/extinst.debuginfo.grammar.json
+file path=usr/include/spirv/unified1/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.debugbreak.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.debugprintf.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.vkspreflection.grammar.json
+file path=usr/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
+file path=usr/include/spirv/unified1/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-gcn-shader.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-shader-ballot.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-shader-trinary-minmax.grammar.json
+file path=usr/include/spirv/unified1/spirv.bf
+file path=usr/include/spirv/unified1/spirv.core.grammar.json
+file path=usr/include/spirv/unified1/spirv.cs
+file path=usr/include/spirv/unified1/spirv.h
+file path=usr/include/spirv/unified1/spirv.hpp
+file path=usr/include/spirv/unified1/spirv.hpp11
+file path=usr/include/spirv/unified1/spirv.json
+file path=usr/include/spirv/unified1/spirv.lua
+file path=usr/include/spirv/unified1/spirv.py
+file path=usr/include/spirv/unified1/spv.d
+file path=usr/share/cmake/SPIRV-Headers/SPIRV-HeadersConfig.cmake
+file path=usr/share/cmake/SPIRV-Headers/SPIRV-HeadersConfigVersion.cmake
+file path=usr/share/pkgconfig/SPIRV-Headers.pc

--- a/components/x11/spirv-headers/pkg5
+++ b/components/x11/spirv-headers/pkg5
@@ -1,0 +1,7 @@
+{
+    "dependencies": [],
+    "fmris": [
+        "x11/library/spirv-headers"
+    ],
+    "name": "spirv-headers"
+}

--- a/components/x11/spirv-headers/spirv-headers.p5m
+++ b/components/x11/spirv-headers/spirv-headers.p5m
@@ -1,0 +1,101 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/spirv/1.0/GLSL.std.450.h
+file path=usr/include/spirv/1.0/OpenCL.std.h
+file path=usr/include/spirv/1.0/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/1.0/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/1.0/spirv.core.grammar.json
+file path=usr/include/spirv/1.0/spirv.cs
+file path=usr/include/spirv/1.0/spirv.h
+file path=usr/include/spirv/1.0/spirv.hpp
+file path=usr/include/spirv/1.0/spirv.hpp11
+file path=usr/include/spirv/1.0/spirv.json
+file path=usr/include/spirv/1.0/spirv.lua
+file path=usr/include/spirv/1.0/spirv.py
+file path=usr/include/spirv/1.1/GLSL.std.450.h
+file path=usr/include/spirv/1.1/OpenCL.std.h
+file path=usr/include/spirv/1.1/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/1.1/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/1.1/spirv.core.grammar.json
+file path=usr/include/spirv/1.1/spirv.cs
+file path=usr/include/spirv/1.1/spirv.h
+file path=usr/include/spirv/1.1/spirv.hpp
+file path=usr/include/spirv/1.1/spirv.hpp11
+file path=usr/include/spirv/1.1/spirv.json
+file path=usr/include/spirv/1.1/spirv.lua
+file path=usr/include/spirv/1.1/spirv.py
+file path=usr/include/spirv/1.2/GLSL.std.450.h
+file path=usr/include/spirv/1.2/OpenCL.std.h
+file path=usr/include/spirv/1.2/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/1.2/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/1.2/spirv.core.grammar.json
+file path=usr/include/spirv/1.2/spirv.cs
+file path=usr/include/spirv/1.2/spirv.h
+file path=usr/include/spirv/1.2/spirv.hpp
+file path=usr/include/spirv/1.2/spirv.hpp11
+file path=usr/include/spirv/1.2/spirv.json
+file path=usr/include/spirv/1.2/spirv.lua
+file path=usr/include/spirv/1.2/spirv.py
+file path=usr/include/spirv/spir-v.xml
+file path=usr/include/spirv/unified1/AMD_gcn_shader.h
+file path=usr/include/spirv/unified1/AMD_shader_ballot.h
+file path=usr/include/spirv/unified1/AMD_shader_explicit_vertex_parameter.h
+file path=usr/include/spirv/unified1/AMD_shader_trinary_minmax.h
+file path=usr/include/spirv/unified1/DebugInfo.h
+file path=usr/include/spirv/unified1/GLSL.std.450.h
+file path=usr/include/spirv/unified1/NonSemanticClspvReflection.h
+file path=usr/include/spirv/unified1/NonSemanticDebugBreak.h
+file path=usr/include/spirv/unified1/NonSemanticDebugPrintf.h
+file path=usr/include/spirv/unified1/NonSemanticShaderDebugInfo100.h
+file path=usr/include/spirv/unified1/NonSemanticVkspReflection.h
+file path=usr/include/spirv/unified1/OpenCL.std.h
+file path=usr/include/spirv/unified1/OpenCLDebugInfo100.h
+file path=usr/include/spirv/unified1/extinst.debuginfo.grammar.json
+file path=usr/include/spirv/unified1/extinst.glsl.std.450.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.debugbreak.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.debugprintf.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
+file path=usr/include/spirv/unified1/extinst.nonsemantic.vkspreflection.grammar.json
+file path=usr/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
+file path=usr/include/spirv/unified1/extinst.opencl.std.100.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-gcn-shader.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-shader-ballot.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json
+file path=usr/include/spirv/unified1/extinst.spv-amd-shader-trinary-minmax.grammar.json
+file path=usr/include/spirv/unified1/spirv.bf
+file path=usr/include/spirv/unified1/spirv.core.grammar.json
+file path=usr/include/spirv/unified1/spirv.cs
+file path=usr/include/spirv/unified1/spirv.h
+file path=usr/include/spirv/unified1/spirv.hpp
+file path=usr/include/spirv/unified1/spirv.hpp11
+file path=usr/include/spirv/unified1/spirv.json
+file path=usr/include/spirv/unified1/spirv.lua
+file path=usr/include/spirv/unified1/spirv.py
+file path=usr/include/spirv/unified1/spv.d
+file path=usr/share/cmake/SPIRV-Headers/SPIRV-HeadersConfig.cmake
+file path=usr/share/cmake/SPIRV-Headers/SPIRV-HeadersConfigVersion.cmake
+file path=usr/share/pkgconfig/SPIRV-Headers.pc


### PR DESCRIPTION
Part 1: This needs to be published and installed on the build server before spirv-tools and glslang