### PR TITLE
spirv-tools: add 2024.2

### DIFF
--- a/components/x11/spirv-tools/Makefile
+++ b/components/x11/spirv-tools/Makefile
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+#
+
+BUILD_STYLE= cmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		spirv-tools
+COMPONENT_VERSION=	2024.2
+COMPONENT_SUMMARY=	API and commands for processing SPIR-V modules
+COMPONENT_PROJECT_URL=	https://www.khronos.org/spir/
+COMPONENT_SRC=		SPIRV-Tools-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_URL=	https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:58c5f4e6961c3d4936f7dbcd7f0b495c830b96972ee731452eaa9ade873f0095
+COMPONENT_FMRI=		x11/library/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION= System/X11
+COMPONENT_LICENSE=	Apache-2.0
+COMPONENT_LICENSE_FILE=	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+CMAKE_OPTIONS += -DCMAKE_INSTALL_PREFIX=$(USRDIR)
+CMAKE_OPTIONS += -DCMAKE_INSTALL_LIBDIR=lib/amd64
+CMAKE_OPTIONS += -DCMAKE_BUILD_TYPE=none
+CMAKE_OPTIONS += -DBUILD_SHARED_LIBS=ON
+CMAKE_OPTIONS += -DSPIRV_TOOLS_BUILD_STATIC=OFF
+CMAKE_OPTIONS += -DSPIRV-Headers_SOURCE_DIR=/usr
+
+COMPONENT_TEST_TRANSFORMS += '-e "s/[0-9. ]*sec//g"'
+
+# Build dependencies
+REQUIRED_PACKAGES += x11/library/spirv-headers
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += SUNWcs
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/x11/spirv-tools/manifests/sample-manifest.p5m
+++ b/components/x11/spirv-tools/manifests/sample-manifest.p5m
@@ -1,0 +1,70 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/spirv-as
+file path=usr/bin/spirv-cfg
+file path=usr/bin/spirv-dis
+file path=usr/bin/spirv-lesspipe.sh
+file path=usr/bin/spirv-link
+file path=usr/bin/spirv-lint
+file path=usr/bin/spirv-objdump
+file path=usr/bin/spirv-opt
+file path=usr/bin/spirv-reduce
+file path=usr/bin/spirv-val
+file path=usr/include/spirv-tools/instrument.hpp
+file path=usr/include/spirv-tools/libspirv.h
+file path=usr/include/spirv-tools/libspirv.hpp
+file path=usr/include/spirv-tools/linker.hpp
+file path=usr/include/spirv-tools/optimizer.hpp
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-link/SPIRV-Tools-linkConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-opt/SPIRV-Tools-optConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools/SPIRV-ToolsConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools/SPIRV-ToolsTarget-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools/SPIRV-ToolsTarget.cmake
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-diff.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-link.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-lint.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-opt.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-reduce.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-shared.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools.so
+file path=usr/lib/$(MACH64)/pkgconfig/SPIRV-Tools-shared.pc
+file path=usr/lib/$(MACH64)/pkgconfig/SPIRV-Tools.pc

--- a/components/x11/spirv-tools/patches/01-add-sunos.patch
+++ b/components/x11/spirv-tools/patches/01-add-sunos.patch
@@ -1,0 +1,22 @@
+--- SPIRV-Tools-2024.3/CMakeLists.txt.old	2024-11-18 14:18:25.146940505 -0500
++++ SPIRV-Tools-2024.3/CMakeLists.txt	2024-11-18 14:19:01.876955989 -0500
+@@ -78,6 +78,8 @@
+   add_definitions(-DSPIRV_GNU)
+ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "QNX")
+   add_definitions(-DSPIRV_QNX)
++elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "SunOS")
++  add_definitions(-DSPIRV_SUNOS)
+ else()
+   message(FATAL_ERROR "Your platform '${CMAKE_SYSTEM_NAME}' is not supported!")
+ endif()
+--- SPIRV-Tools-2024.3/source/print.cpp.old	2024-11-18 14:25:14.998945818 -0500
++++ SPIRV-Tools-2024.3/source/print.cpp	2024-11-18 14:25:48.464713809 -0500
+@@ -17,7 +17,7 @@
+ #if defined(SPIRV_ANDROID) || defined(SPIRV_LINUX) || defined(SPIRV_MAC) || \
+     defined(SPIRV_IOS) || defined(SPIRV_TVOS) || defined(SPIRV_FREEBSD) ||  \
+     defined(SPIRV_OPENBSD) || defined(SPIRV_EMSCRIPTEN) ||                  \
+-    defined(SPIRV_FUCHSIA) || defined(SPIRV_GNU) || defined(SPIRV_QNX)
++    defined(SPIRV_FUCHSIA) || defined(SPIRV_GNU) || defined(SPIRV_QNX) || defined(SPIRV_SUNOS)
+ namespace spvtools {
+ 
+ clr::reset::operator const char*() { return "\x1b[0m"; }

--- a/components/x11/spirv-tools/pkg5
+++ b/components/x11/spirv-tools/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "system/library",
+        "system/library/g++-13-runtime",
+        "system/library/math",
+        "x11/library/spirv-headers"
+    ],
+    "fmris": [
+        "x11/library/spirv-tools"
+    ],
+    "name": "spirv-tools"
+}

--- a/components/x11/spirv-tools/spirv-tools.p5m
+++ b/components/x11/spirv-tools/spirv-tools.p5m
@@ -1,0 +1,70 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/spirv-as
+file path=usr/bin/spirv-cfg
+file path=usr/bin/spirv-dis
+file path=usr/bin/spirv-lesspipe.sh
+file path=usr/bin/spirv-link
+file path=usr/bin/spirv-lint
+file path=usr/bin/spirv-objdump
+file path=usr/bin/spirv-opt
+file path=usr/bin/spirv-reduce
+file path=usr/bin/spirv-val
+file path=usr/include/spirv-tools/instrument.hpp
+file path=usr/include/spirv-tools/libspirv.h
+file path=usr/include/spirv-tools/libspirv.hpp
+file path=usr/include/spirv-tools/linker.hpp
+file path=usr/include/spirv-tools/optimizer.hpp
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-diff/SPIRV-Tools-diffTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-link/SPIRV-Tools-linkConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-link/SPIRV-Tools-linkTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-lint/SPIRV-Tools-lintTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-opt/SPIRV-Tools-optConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-opt/SPIRV-Tools-optTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-reduce/SPIRV-Tools-reduceTarget.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsTargets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools-tools/SPIRV-Tools-toolsTargets.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools/SPIRV-ToolsConfig.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools/SPIRV-ToolsTarget-none.cmake
+file path=usr/lib/$(MACH64)/cmake/SPIRV-Tools/SPIRV-ToolsTarget.cmake
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-diff.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-link.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-lint.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-opt.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-reduce.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools-shared.so
+file path=usr/lib/$(MACH64)/libSPIRV-Tools.so
+file path=usr/lib/$(MACH64)/pkgconfig/SPIRV-Tools-shared.pc
+file path=usr/lib/$(MACH64)/pkgconfig/SPIRV-Tools.pc

--- a/components/x11/spirv-tools/test/results-all.master
+++ b/components/x11/spirv-tools/test/results-all.master
@@ -1,0 +1,13 @@
+Test project $(@D)
+    Start 1: spirv-tools-copyrights
+1/4 Test #1: spirv-tools-copyrights .......................   Passed
+    Start 2: spirv-tools_expect_unittests
+2/4 Test #2: spirv-tools_expect_unittests .................   Passed
+    Start 3: spirv-tools_spirv_test_framework_unittests
+3/4 Test #3: spirv-tools_spirv_test_framework_unittests ...   Passed
+    Start 4: spirv_opt_cli_tools_tests
+4/4 Test #4: spirv_opt_cli_tools_tests ....................   Passed
+
+100% tests passed, 0 tests failed out of 4
+
+Total Test time (real) =


### PR DESCRIPTION
Part 2: spirv-headers needs to be installed on the build server before building this package.  This tools package is a dependency for glslang