### PR TITLE
glslang: add 14.3.0

### DIFF
--- a/components/x11/glslang/Makefile
+++ b/components/x11/glslang/Makefile
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL)". You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+#
+
+BUILD_STYLE= cmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		glslang
+COMPONENT_VERSION=	14.3.0
+COMPONENT_SUMMARY=	OpenGL and OpenGL ES shader front end and validator
+COMPONENT_PROJECT_URL=	https://github.com/KhronosGroup/glslang
+COMPONENT_SRC=		glslang-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_URL=	https://github.com/KhronosGroup/glslang/archive/refs/tags/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:be6339048e20280938d9cb399fcdd06e04f8654d43e170e8cce5a56c9a754284
+COMPONENT_FMRI=		x11/library/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION= System/X11
+COMPONENT_LICENSE=	BSD-3-Clause
+COMPONENT_LICENSE_FILE=	LICENSE.txt
+
+include $(WS_MAKE_RULES)/common.mk
+
+CMAKE_OPTIONS += -DCMAKE_INSTALL_PREFIX=$(USRDIR)
+CMAKE_OPTIONS += -DCMAKE_BUILD_TYPE=none
+CMAKE_OPTIONS += -DBUILD_SHARED_LIBS=ON
+CMAKE_OPTIONS += -DSPIRV_TOOLS_BUILD_STATIC=OFF
+CMAKE_OPTIONS += -DALLOW_EXTERNAL_SPIRV_TOOLS=ON
+CMAKE_OPTIONS += -DGLSLANG_TEST=ON
+
+COMPONENT_TEST_TRANSFORMS += '-e "s/[0-9. ]*sec//g"'
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/spirv-tools

--- a/components/x11/glslang/glslang.p5m
+++ b/components/x11/glslang/glslang.p5m
@@ -1,0 +1,61 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/glslang
+link path=usr/bin/glslangValidator target=glslang
+file path=usr/bin/spirv-remap
+file path=usr/include/glslang/Include/ResourceLimits.h
+file path=usr/include/glslang/Include/glslang_c_interface.h
+file path=usr/include/glslang/Include/glslang_c_shader_types.h
+file path=usr/include/glslang/MachineIndependent/Versions.h
+file path=usr/include/glslang/Public/ResourceLimits.h
+file path=usr/include/glslang/Public/ShaderLang.h
+file path=usr/include/glslang/Public/resource_limits_c.h
+file path=usr/include/glslang/SPIRV/GlslangToSpv.h
+file path=usr/include/glslang/SPIRV/Logger.h
+file path=usr/include/glslang/SPIRV/SPVRemapper.h
+file path=usr/include/glslang/SPIRV/disassemble.h
+file path=usr/include/glslang/SPIRV/spirv.hpp
+file path=usr/include/glslang/build_info.h
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-config-version.cmake
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-config.cmake
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-targets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-targets.cmake
+link path=usr/lib/$(MACH64)/libSPIRV.so target=libSPIRV.so.14
+file path=usr/lib/$(MACH64)/libSPIRV.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libSPIRV.so.14 target=libSPIRV.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libSPVRemapper.so target=libSPVRemapper.so.14
+file path=usr/lib/$(MACH64)/libSPVRemapper.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libSPVRemapper.so.14 \
+    target=libSPVRemapper.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang-default-resource-limits.so \
+    target=libglslang-default-resource-limits.so.14
+file path=usr/lib/$(MACH64)/libglslang-default-resource-limits.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang-default-resource-limits.so.14 \
+    target=libglslang-default-resource-limits.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang.so target=libglslang.so.14
+file path=usr/lib/$(MACH64)/libglslang.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang.so.14 \
+    target=libglslang.so.$(HUMAN_VERSION)

--- a/components/x11/glslang/manifests/sample-manifest.p5m
+++ b/components/x11/glslang/manifests/sample-manifest.p5m
@@ -1,0 +1,61 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/glslang
+link path=usr/bin/glslangValidator target=glslang
+file path=usr/bin/spirv-remap
+file path=usr/include/glslang/Include/ResourceLimits.h
+file path=usr/include/glslang/Include/glslang_c_interface.h
+file path=usr/include/glslang/Include/glslang_c_shader_types.h
+file path=usr/include/glslang/MachineIndependent/Versions.h
+file path=usr/include/glslang/Public/ResourceLimits.h
+file path=usr/include/glslang/Public/ShaderLang.h
+file path=usr/include/glslang/Public/resource_limits_c.h
+file path=usr/include/glslang/SPIRV/GlslangToSpv.h
+file path=usr/include/glslang/SPIRV/Logger.h
+file path=usr/include/glslang/SPIRV/SPVRemapper.h
+file path=usr/include/glslang/SPIRV/disassemble.h
+file path=usr/include/glslang/SPIRV/spirv.hpp
+file path=usr/include/glslang/build_info.h
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-config-version.cmake
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-config.cmake
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-targets-none.cmake
+file path=usr/lib/$(MACH64)/cmake/glslang/glslang-targets.cmake
+link path=usr/lib/$(MACH64)/libSPIRV.so target=libSPIRV.so.14
+file path=usr/lib/$(MACH64)/libSPIRV.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libSPIRV.so.14 target=libSPIRV.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libSPVRemapper.so target=libSPVRemapper.so.14
+file path=usr/lib/$(MACH64)/libSPVRemapper.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libSPVRemapper.so.14 \
+    target=libSPVRemapper.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang-default-resource-limits.so \
+    target=libglslang-default-resource-limits.so.14
+file path=usr/lib/$(MACH64)/libglslang-default-resource-limits.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang-default-resource-limits.so.14 \
+    target=libglslang-default-resource-limits.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang.so target=libglslang.so.14
+file path=usr/lib/$(MACH64)/libglslang.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libglslang.so.14 \
+    target=libglslang.so.$(HUMAN_VERSION)

--- a/components/x11/glslang/pkg5
+++ b/components/x11/glslang/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "system/library",
+        "system/library/g++-13-runtime",
+        "system/library/math",
+        "x11/library/spirv-tools"
+    ],
+    "fmris": [
+        "x11/library/glslang"
+    ],
+    "name": "glslang"
+}

--- a/components/x11/glslang/test/results-all.maste
+++ b/components/x11/glslang/test/results-all.maste
@@ -1,0 +1,7 @@
+Test project $(@D)
+    Start 1: glslang-testsuite
+1/1 Test #1: glslang-testsuite ................   Passed
+
+100% tests passed, 0 tests failed out of 1
+
+Total Test time (real) =


### PR DESCRIPTION
Part 3: spirv-headers and spirv-tools needs to be installed on the build server before building this package.