### PR TITLE
zeromq: build only 64bit, because dependent library: libsodium is alr…

### DIFF
--- a/components/library/zeromq/Makefile
+++ b/components/library/zeromq/Makefile
@@ -12,15 +12,15 @@
 #
 # Copyright 2014 Alexander Pyhalov.  All rights reserved.
 # Copyright 2016 Jim Klimov
+# Copyright 2024 Klaus Ziegler
 #
 
-BUILD_BITS= 64_and_32
 USE_DEFAULT_TEST_TRANSFORMS= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libzmq
 COMPONENT_VERSION= 4.3.5
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= Open source message queue optimised for performance
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
@@ -44,13 +44,10 @@ COMPONENT_PREP_ACTION = \
 
 COMPONENT_PRE_CONFIGURE_ACTION = ( $(CLONEY) $(SOURCE_DIR) $(@D) )
 
-# Build docs just once (for one ARCH), parameter varies from version to version
-CONFIGURE_OPTIONS.32 +=	--with-docs
-CONFIGURE_OPTIONS.64 +=	--without-docs
+CONFIGURE_OPTIONS +=	--with-docs
 CONFIGURE_OPTIONS +=	--enable-static=no
 CONFIGURE_OPTIONS +=	--with-libsodium
-CONFIGURE_OPTIONS +=	--sysconfdir=/etc
-CONFIGURE_OPTIONS +=	--localstatedir=/var
+CONFIGURE_OPTIONS +=	--disable-dependency-tracking
 
 # Necessary for tests
 unexport SHELLOPTS

--- a/components/library/zeromq/manifests/sample-manifest.p5m
+++ b/components/library/zeromq/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2024 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,7 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH32)/curve_keygen
 file path=usr/bin/curve_keygen
 file path=usr/include/zmq.h
 file path=usr/include/zmq_utils.h
@@ -31,10 +30,6 @@ link path=usr/lib/$(MACH64)/libzmq.so target=libzmq.so.5.2.5
 link path=usr/lib/$(MACH64)/libzmq.so.5 target=libzmq.so.5.2.5
 file path=usr/lib/$(MACH64)/libzmq.so.5.2.5
 file path=usr/lib/$(MACH64)/pkgconfig/libzmq.pc
-link path=usr/lib/libzmq.so target=libzmq.so.5.2.5
-link path=usr/lib/libzmq.so.5 target=libzmq.so.5.2.5
-file path=usr/lib/libzmq.so.5.2.5
-file path=usr/lib/pkgconfig/libzmq.pc
 file path=usr/share/man/man3/zmq_atomic_counter_dec.3
 file path=usr/share/man/man3/zmq_atomic_counter_destroy.3
 file path=usr/share/man/man3/zmq_atomic_counter_inc.3

--- a/components/library/zeromq/zeromq.p5m
+++ b/components/library/zeromq/zeromq.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020 Alexander Pyhalov
+# Copyright 2024 Klaus Ziegler
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -22,7 +22,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH32)/curve_keygen
 file path=usr/bin/curve_keygen
 file path=usr/include/zmq.h
 file path=usr/include/zmq_utils.h
@@ -30,10 +29,6 @@ link path=usr/lib/$(MACH64)/libzmq.so target=libzmq.so.5.2.5
 link path=usr/lib/$(MACH64)/libzmq.so.5 target=libzmq.so.5.2.5
 file path=usr/lib/$(MACH64)/libzmq.so.5.2.5
 file path=usr/lib/$(MACH64)/pkgconfig/libzmq.pc
-link path=usr/lib/libzmq.so target=libzmq.so.5.2.5
-link path=usr/lib/libzmq.so.5 target=libzmq.so.5.2.5
-file path=usr/lib/libzmq.so.5.2.5
-file path=usr/lib/pkgconfig/libzmq.pc
 file path=usr/share/man/man3/zmq_atomic_counter_dec.3
 file path=usr/share/man/man3/zmq_atomic_counter_destroy.3
 file path=usr/share/man/man3/zmq_atomic_counter_inc.3


### PR DESCRIPTION
…eady 64bit only.