### PR TITLE
x11.mk: set defaults for X11 libraries to 64bit - libXft can't be bui…

### DIFF
--- a/make-rules/x11.mk
+++ b/make-rules/x11.mk
@@ -90,7 +90,7 @@ endif
 # Set defaults for X11 libraries
 #
 ifeq ($(strip $(X11_CATEGORY)),LIB)
-BUILD_BITS = 32_and_64
+BUILD_BITS = 64
 PATH=$(PATH.gnu)
 COMPONENT_CLASSIFICATION = System/X11
 COMPONENT_LICENSE        = MIT License


### PR DESCRIPTION
…ld, because libfontconfig is only 64Bit.