### PR TITLE
remove glm driver from SPARC distribution, conflicts with driver-spar…

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -10,7 +10,7 @@
 
 #
 # Copyright 2011 EveryCity Ltd. All rights reserved.
-# Copyright 2023 Klaus Ziegler
+# Copyright 2024 Klaus Ziegler
 #
 
 BUILD_STYLE = pkg
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	11
+COMPONENT_VERSION =	12
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/minimal_sparcv9
+++ b/components/meta-packages/install-types/includes/minimal_sparcv9
@@ -99,7 +99,6 @@ depend type=require fmri=driver/sparc/platform
 depend type=require fmri=driver/storage/aac
 depend type=require fmri=driver/storage/blkdev
 depend type=require fmri=driver/storage/fas/header-fas
-depend type=require fmri=driver/storage/glm
 depend type=require fmri=driver/storage/isp
 depend type=require fmri=driver/storage/mpt_sas
 depend type=require fmri=driver/storage/mr_sas


### PR DESCRIPTION
…c-platform.p5m - pkglint has been used for SPARC illumos-gate build