### PR TITLE
bass: add --no-print-directory to run_make()

### DIFF
--- a/tools/bass/component.py
+++ b/tools/bass/component.py
@@ -90,7 +90,7 @@ class Component(object):
         if self.debug:
             logger.debug('Executing \'gmake %s\' in %s', targets, path)
 
-        proc = subprocess.Popen(['gmake', '-s', targets],
+        proc = subprocess.Popen(['gmake', '-s', '--no-print-directory', targets],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 cwd=path,


### PR DESCRIPTION
This is needed to fix the corrupted `pkg5` files when `gmake` is used with the `-C` option.  The encumbered build server uses `-C` with `gmake`.

Example:
```
$ cd components/encumbered/gst-libav1/
$ git status .
On branch oi/hipster
Your branch is up to date with 'origin/oi/hipster'.

nothing to commit, working tree clean
$ env - gmake update-metadata
generating metadata: encumbered/gst-libav1
$ git status .
On branch oi/hipster
Your branch is up to date with 'origin/oi/hipster'.

nothing to commit, working tree clean
$ env - gmake -C . update-metadata
gmake: Entering directory '/data/builds/ul-workspace/components/encumbered/gst-libav1'
generating metadata: encumbered/gst-libav1
gmake: Leaving directory '/data/builds/ul-workspace/components/encumbered/gst-libav1'
$ git status .
On branch oi/hipster
Your branch is up to date with 'origin/oi/hipster'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   pkg5

no changes added to commit (use "git add" and/or "git commit -a")

nothing to commit, working tree clean
$ git diff .
diff --git a/components/encumbered/gst-libav1/pkg5 b/components/encumbered/gst-libav1/pkg5
index daaf875632..50563e7b7f 100644
--- a/components/encumbered/gst-libav1/pkg5
+++ b/components/encumbered/gst-libav1/pkg5
@@ -1,14 +1,18 @@
 {
     "dependencies": [
+        "gmake[1]: Entering directory '/data/builds/ul-workspace/components/encumbered/gst-libav1'",
         "developer/ffmpeg-7",
         "library/audio/gstreamer1",
         "library/audio/gstreamer1/plugin/base",
         "library/ffmpeg-7",
         "library/glib2",
-        "system/library"
+        "system/library",
+        "gmake[1]: Leaving directory '/data/builds/ul-workspace/components/encumbered/gst-libav1'"
     ],
     "fmris": [
-        "library/audio/gstreamer1/plugin/libav"
+        "gmake[1]: Entering directory '/data/builds/ul-workspace/components/encumbered/gst-libav1'",
+        "library/audio/gstreamer1/plugin/libav",
+        "gmake[1]: Leaving directory '/data/builds/ul-workspace/components/encumbered/gst-libav1'"
     ],
-    "name": "gst-libav"
+    "name": "gmake[1]: Entering directory '/data/builds/ul-workspace/components/encumbered/gst-libav1'"
 }
$
```