### PR TITLE
bass: remove shebang from component.py and makefiles.py

### DIFF
--- a/tools/bass/component.py
+++ b/tools/bass/component.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/tools/bass/makefiles.py
+++ b/tools/bass/makefiles.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #


### PR DESCRIPTION
These files are not executed directly so they do not need the shebang.