### PR TITLE
screen: use default socket directory (/tmp) rather than user's homes

### DIFF
--- a/components/sysutils/screen/Makefile
+++ b/components/sysutils/screen/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		screen
 COMPONENT_VERSION=	4.9.1
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	GNU Screen terminal multiplexer
 COMPONENT_PROJECT_URL=	https://www.gnu.org/software/screen/
 COMPONENT_FMRI=		terminal/screen
@@ -51,7 +51,6 @@ COMPONENT_PREP_ACTION += ( cd $(@D) ; $(CONFIG_SHELL) autogen.sh );
 
 CONFIGURE_OPTIONS += --enable-colors256
 CONFIGURE_OPTIONS += --with-sys-screenrc=/etc/screenrc
-CONFIGURE_OPTIONS += --disable-socket-dir
 CONFIGURE_OPTIONS += --infodir=$(CONFIGURE_INFODIR)
 
 PROTOTERMINFODIR= $(PROTOUSRSHAREDIR)/lib/terminfo


### PR DESCRIPTION
For some reason, OI's screen is built with --disable-socket-dir, which causes screen to put its socket into ~/.screen by default. At the same time, SOCKDIR_IS_LOCAL_TO_HOST is set in acconfig.h. This has been this way since before oi-userland was even created.

Call me old-fashioned, but I share my $HOME through NFS to a couple of hosts and VMs. This has some rather annoying effects on screen running on OI:

```
mole:1 {44} screen -ls
There are screens on:
        4568.pts-5.burrito      (Dead ???)
        4086.pts-12.burrito     (Dead ???)
        103231.pts-2.mole       (Attached)
        3408.pts-13.burrito     (Dead ???)
Remove dead screens with 'screen -wipe'.

burrito:3 {36} screen -ls
There are screens on:
        4568.pts-5.burrito      (Dead ???)
        4086.pts-12.burrito     (Attached)
        103231.pts-2.mole       (Dead ???)
        3408.pts-13.burrito     (Dead ???)
Remove dead screens with 'screen -wipe'.
```

At the same time, on two VMs running OmniOS and SmartOS, things look different:
```
fajita:0 {2} screen -ls
There is a screen on:
        587.pts-2.fajita        (Attached)

jalapeno:6 {2} screen -ls
There is a screen on:
        25505.pts-15.jalapeno   (Attached)
```
The same is true on FreeBSD and NetBSD, where screen is built from ports and pkgsrc, respectively. So, I suggest building screen without --disable-socket-dir like everyone else, putting an end to this madness.