### PR TITLE
components/Makefile: move components.mk removal from clean to clobber

### DIFF
--- a/components/Makefile
+++ b/components/Makefile
@@ -105,11 +105,11 @@ update-metadata:	$(COMPONENT_DIRS.nolog)
 component-hook:	$(COMPONENT_DIRS.nosetup)
 
 clean:		$(COMPONENT_DIRS.nosetup)
-	$(RM) $(WS_TOP)/components/$(ENCUMBERED)components.mk \
-	$(WS_TOP)/components/mapping.json \
+	$(RM) $(WS_TOP)/components/mapping.json \
 	.profile
 
 clobber:	$(COMPONENT_DIRS.nosetup) clean
+	$(RM) $(WS_TOP)/components/$(ENCUMBERED)components.mk
 	@cd $(WS_TOP)/tools ; echo "clobbering tools..." ; $(GMAKE) clobber
 	$(RM) -r $(WS_REPO) $(WS_LOGS) $(WS_LINT_CACHE) $(WS_MACH)/perl-meta-deps-cache
 


### PR DESCRIPTION
This will allow to run the top level `gmake clean` to cleanup the build tree without loosing the `components.mk` file.  Without this any attempt to cleanup the build tree (either using `clean` or `clobber` targets) removes the `components.mk` file and so it is unnecessarily inconvenient to run any top level target (for example `build` or `publish`) on the prearranged set of components with the cleaned up tree beforehand.

After this, if one wants the complete cleanup (including the `components.mk` file) the `gmake clobber` top level command needs to be run.