### PR TITLE
build-essential: illumos-gate switched to gcc-14 as shadow compiler

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
-COMPONENT_VERSION =	16
+COMPONENT_VERSION =	17
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -122,8 +122,8 @@ depend fmri=developer/as type=require
 depend fmri=developer/astdev type=require
 # gcc-10 is primary compiler
 depend fmri=developer/gcc-10 type=require
-# gcc-7 is shadow compiler
-depend fmri=developer/gcc-7 type=require
+# gcc-14 is shadow compiler
+depend fmri=developer/gcc-14 type=require
 depend fmri=developer/illumos-closed type=require
 # java8 is used by default
 depend fmri=developer/java/openjdk8 type=require


### PR DESCRIPTION
See https://www.illumos.org/issues/16935