### PR TITLE
transforms/defaults: drop vendor mediator priority for php

### DIFF
--- a/transforms/defaults
+++ b/transforms/defaults
@@ -161,11 +161,6 @@ set name=variant.arch value=$(MACH)
 <transform link mediator=java mediator-version=17 -> default mediator-priority vendor>
 
 #
-# Set the default PHP for mediated links
-#
-<transform link mediator=php mediator-version=8.2 -> default mediator-priority vendor>
-
-#
 # Set the default MySQL for mediated links
 #
 <transform link mediator=mysql mediator-implementation=mariadb mediator-version=10.6 -> default mediator-priority vendor>


### PR DESCRIPTION
This effectively reverts #19894 because:
- I see no reason why we would need that,
- it is unused.