### PR TITLE
transforms/defaults: drop vendor mediator priority for gcc

### DIFF
--- a/transforms/defaults
+++ b/transforms/defaults
@@ -134,11 +134,6 @@ set name=variant.arch value=$(MACH)
 
 
 #
-# Set the default GCC for mediated links
-#
-<transform link mediator=gcc mediator-version=13 -> default mediator-priority vendor>
-
-#
 # Set the default Python for mediated links
 #
 <transform link mediator=python mediator-version=3.9 -> default tmp.fmri %{pkg.fmri} >


### PR DESCRIPTION
We do not need to force our users to use any specific GCC version.  Especially when the current latest GCC (version 14) is being used as the `illumos-gate` shadow compiler.

Please note that the default GCC used for `oi-userland` builds is set here (it does not depend on mediators):
https://github.com/OpenIndiana/oi-userland/blob/ee67bdda368443282ddd3564899b198d5a6b8a6e/make-rules/shared-macros.mk#L651