### PR TITLE
Add Class-ErrorHandler Perl distribution

### DIFF
--- a/components/perl/Class-ErrorHandler/.gitignore
+++ b/components/perl/Class-ErrorHandler/.gitignore
@@ -1,0 +1,1 @@
+/Class-ErrorHandler-0.04/

--- a/components/perl/Class-ErrorHandler/Class-ErrorHandler-PERLVER.p5m
+++ b/components/perl/Class-ErrorHandler/Class-ErrorHandler-PERLVER.p5m
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Class::ErrorHandler.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/Class/ErrorHandler.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/perl/Class-ErrorHandler/Makefile
+++ b/components/perl/Class-ErrorHandler/Makefile
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module Class-ErrorHandler
+#
+
+BUILD_STYLE = makemaker
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		Class-ErrorHandler
+HUMAN_VERSION =			0.04
+COMPONENT_SUMMARY =		Base class for error handling
+COMPONENT_CPAN_AUTHOR =		TOKUHIROM
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:342d2dcfc797a20bee8179b1b96b85c0ae7a5b48827359523cd8c74c3e704502
+COMPONENT_LICENSE =		Artistic-1.0 OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += library/perl-5/extutils-makemaker
+PERL_REQUIRED_PACKAGES += runtime/perl

--- a/components/perl/Class-ErrorHandler/manifests/sample-manifest.p5m
+++ b/components/perl/Class-ErrorHandler/manifests/sample-manifest.p5m
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Class::ErrorHandler.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/Class/ErrorHandler.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/perl/Class-ErrorHandler/pkg5
+++ b/components/perl/Class-ErrorHandler/pkg5
@@ -1,0 +1,17 @@
+{
+    "dependencies": [
+        "library/perl-5/extutils-makemaker-536",
+        "library/perl-5/extutils-makemaker-538",
+        "library/perl-5/extutils-makemaker-540",
+        "runtime/perl-536",
+        "runtime/perl-538",
+        "runtime/perl-540"
+    ],
+    "fmris": [
+        "library/perl-5/class-errorhandler",
+        "library/perl-5/class-errorhandler-536",
+        "library/perl-5/class-errorhandler-538",
+        "library/perl-5/class-errorhandler-540"
+    ],
+    "name": "Class-ErrorHandler"
+}

--- a/components/perl/Class-ErrorHandler/test/results-all.master
+++ b/components/perl/Class-ErrorHandler/test/results-all.master
@@ -1,0 +1,5 @@
+t/00-compile.t .. ok
+t/01-errors.t ... ok
+All tests successful.
+Files=2, Tests=10
+Result: PASS


### PR DESCRIPTION
This is runtime dependency for `Convert-PEM`.  The `Convert-PEM` is new runtime dependency for recent `Crypt-DSA`.