### PR TITLE
minimal_amd64: add driver/network/igc

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	13
+COMPONENT_VERSION =	14
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/minimal_amd64
+++ b/components/meta-packages/install-types/includes/minimal_amd64
@@ -56,6 +56,7 @@ depend type=require fmri=driver/network/ib
 depend type=require fmri=driver/network/ibdma
 depend type=require fmri=driver/network/ibp
 depend type=require fmri=driver/network/igb
+depend type=require fmri=driver/network/igc
 depend type=require fmri=driver/network/iprb
 depend type=require fmri=driver/network/ixgb
 depend type=require fmri=driver/network/ixgbe


### PR DESCRIPTION
Add igc to install media and installed systems after next update.