### PR TITLE
transforms/defaults: drop vendor mediator priority for java

### DIFF
--- a/transforms/defaults
+++ b/transforms/defaults
@@ -151,11 +151,6 @@ set name=variant.arch value=$(MACH)
 <transform link mediator=ruby mediator-version=2.3 -> default mediator-priority vendor>
 
 #
-# Set the default Java for mediated links
-#
-<transform link mediator=java mediator-version=17 -> default mediator-priority vendor>
-
-#
 # Set the default MySQL for mediated links
 #
 <transform link mediator=mysql mediator-implementation=mariadb mediator-version=10.6 -> default mediator-priority vendor>


### PR DESCRIPTION
I do not see any reason why we do want/need to prefer Java 17.  If there is any please let me know.