### PR TITLE
Disable database/opensearch

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -20,6 +20,7 @@
 # /^package$/d
 #
 # Temporarily disable failing builds:
+/^database\/opensearch/d
 /^web\/php\/php-8_2-ext-redis$/d
 # Our build server fails to build the following packages (the builds succeed on other build systems):
 /^desktop\/libayatana-appindicator$/d


### PR DESCRIPTION
The opensearch build [failed with strange error](https://hipster.openindiana.org/jenkins/job/oi-userland/lastFailedBuild/).  Disable it for now.