### PR TITLE
transforms/defaults: drop vendor mediator priority for apache

### DIFF
--- a/transforms/defaults
+++ b/transforms/defaults
@@ -141,11 +141,6 @@ set name=variant.arch value=$(MACH)
 <transform link tmp.fmri=.* -> delete tmp.fmri .* >
 
 #
-# Set the default Apache for mediated links
-#
-<transform link mediator=apache mediator-version=2.2 -> default mediator-priority vendor>
-
-#
 # Set the default Ruby for mediated links
 #
 <transform link mediator=ruby mediator-version=2.3 -> default mediator-priority vendor>


### PR DESCRIPTION
Apache version 2.2 was obsoleted more than seven years ago and so this setting is unused.  Since we have no reason to force any particular Apache version (provided there is more than the one we currently have :-)) this setting should go altogether.

Note: noticed by @AndWac in https://github.com/OpenIndiana/oi-userland/pull/20259#issuecomment-2571622039