### PR TITLE
Enable database/opensearch

### DIFF
--- a/components/components.ignore
+++ b/components/components.ignore
@@ -20,7 +20,6 @@
 # /^package$/d
 #
 # Temporarily disable failing builds:
-/^database\/opensearch/d
 /^web\/php\/php-8_2-ext-redis$/d
 # Our build server fails to build the following packages (the builds succeed on other build systems):
 /^desktop\/libayatana-appindicator$/d


### PR DESCRIPTION
I suspect the opensearch build [failed previously](https://hipster.openindiana.org/jenkins/job/oi-userland/12648/) because it was built concurrently with the heavyweight openjdk-23 that eat most of the build server resources.  Let's try to build the opensearch again and alone this time.