### PR TITLE
history: rename library/java/openjdk11.0.11/demo

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -694,6 +694,7 @@ library/java/cairo-java@1.0.8,5.11-2017.0.0.0
 library/java/commons-collections@3.2.1,5.11-2013.0.0.1
 library/java/demo64@0.5.11,5.11-2017.0.0.0 library/java/openjdk8/demo@1.8.112,5.11-2016.1.0.0
 library/java/demo@0.5.11,5.11-2017.0.0.0 library/java/openjdk8/demo@1.8.112,5.11-2016.1.0.0
+library/java/openjdk11.0.11/demo@11.0.11,5.11-2022.0.0.2 library/java/openjdk11/demo
 library/java/openjdk18.0.2/demo@18.0.2,5.11-2022.0.0.1
 library/java/openjdk18/demo@18.0.2.1,5.11-2024.0.0.4
 library/java/openjdk19/demo@19.0.2,5.11-2024.0.0.4


### PR DESCRIPTION
The `library/java/openjdk11/demo` package got mistakenly renamed to `library/java/openjdk11.0.11/demo` in August 2022.  It was renamed back to `library/java/openjdk11/demo` in March 2023, but the `library/java/openjdk11.0.11/demo` package was left lingering without the actual rename in the IPS repo.