### PR TITLE
sqlite: update to 3.47.2

### DIFF
--- a/components/database/sqlite/Makefile
+++ b/components/database/sqlite/Makefile
@@ -23,16 +23,17 @@
 #
 
 BUILD_BITS= 64_and_32
+ENV=/usr/bin/env
 USE_PARALLEL_BUILD= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         sqlite
-COMPONENT_VERSION=      3.46.1
-TARBALL_VERSION=		3460100
+COMPONENT_VERSION=      3.47.2
+TARBALL_VERSION=		3470200
 COMPONENT_SUMMARY=		in-process SQL database engine library
 COMPONENT_SRC=          sqlite-src-$(TARBALL_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).zip
-COMPONENT_ARCHIVE_HASH= sha256:def3fc292eb9ecc444f6c1950e5c79d8462ed5e7b3d605fd6152d145e1d5abb4
+COMPONENT_ARCHIVE_HASH= sha256:e6a471f1238225f34c2c48c5601b54024cc538044368230f59ff0672be1fc623
 COMPONENT_PROJECT_URL=  https://www.sqlite.org
 COMPONENT_ARCHIVE_URL=  $(COMPONENT_PROJECT_URL)/2024/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=         database/sqlite-3
@@ -72,12 +73,10 @@ CONFIGURE_OPTIONS		+= --enable-readline
 CONFIGURE_OPTIONS		+= --enable-fts3
 CONFIGURE_OPTIONS		+= --enable-fts4
 CONFIGURE_OPTIONS		+= --enable-fts5
-CONFIGURE_OPTIONS		+= --enable-json1
 CONFIGURE_OPTIONS		+= --enable-update-limit
 CONFIGURE_OPTIONS		+= --enable-rtree
 CONFIGURE_OPTIONS		+= --enable-threadsafe 
 CONFIGURE_OPTIONS		+= --enable-shared
-CONFIGURE_OPTIONS		+= --enable-dynamic-extensions
 
 CONFIGURE_ENV.64 += TCLLIBDIR=$(USRLIBDIR)/tcl8.6/sqlite3/$(MACH64)
 
@@ -86,7 +85,10 @@ COMPONENT_BUILD_ENV += PATH=$(PATH)
 COMPONENT_INSTALL_ENV += PATH=$(PATH)
 
 # Install sqlite3(1) man page
-COMPONENT_POST_INSTALL_ACTION += $(MKDIR) $(PROTO_DIR)$(USRSHAREMAN1DIR) ; $(CP) $(SOURCE_DIR)/sqlite3.1 $(PROTO_DIR)$(USRSHAREMAN1DIR)/
+COMPONENT_POST_INSTALL_ACTION += $(MKDIR) $(PROTO_DIR)$(USRSHAREMAN1DIR) ; $(CP) $(SOURCE_DIR)/sqlite3.1 $(PROTO_DIR)$(USRSHAREMAN1DIR)/ ;
+
+# Move tcl components to expected location
+COMPONENT_POST_INSTALL_ACTION.64 += $(MKDIR) $(PROTO_DIR)/usr/lib/tcl8.6/sqlite3/amd64 ; /usr/bin/mv $(PROTOUSRLIBDIR.64)/sqlite$(COMPONENT_VERSION)/* $(PROTO_DIR)/usr/lib/tcl8.6/sqlite3/amd64/ ;
 
 COMPONENT_TEST_TARGETS= test
 

--- a/components/database/sqlite/manifests/sample-manifest.p5m
+++ b/components/database/sqlite/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -35,6 +35,6 @@ link path=usr/lib/libsqlite3.so target=libsqlite3.so.0.8.6
 link path=usr/lib/libsqlite3.so.0 target=libsqlite3.so.0.8.6
 file path=usr/lib/libsqlite3.so.0.8.6
 file path=usr/lib/pkgconfig/sqlite3.pc
-file path=usr/lib/tcl8.6/sqlite3/$(MACH64)/libtclsqlite3.so
+file path=usr/lib/tcl8.6/sqlite3/$(MACH64)/libsqlite$(HUMAN_VERSION).so
 file path=usr/lib/tcl8.6/sqlite3/$(MACH64)/pkgIndex.tcl
 file path=usr/share/man/man1/sqlite3.1

--- a/components/database/sqlite/patches/02-tclext-add-fpic.patch
+++ b/components/database/sqlite/patches/02-tclext-add-fpic.patch
@@ -1,0 +1,13 @@
+CFLAGS aren't getting set in buildtclext.tcl. Force -fPIC usage.
+
+--- sqlite-src-3470200/tool/buildtclext.tcl.~1~	2024-12-07 15:57:39.000000000 -0500
++++ sqlite-src-3470200/tool/buildtclext.tcl	2025-01-05 02:22:29.634735763 -0500
+@@ -256,7 +256,7 @@
+ 
+   # Generate and execute the command with which to do the compilation.
+   #
+-  set cmd "$CMD tclsqlite3.c -o $OUT $LIBS"
++  set cmd "$CMD tclsqlite3.c -fPIC -o $OUT $LIBS"
+   puts $cmd
+   file delete -force $OUT
+   catch {exec {*}$cmd} errmsg

--- a/components/database/sqlite/patches/04-Makefile-add-fpic.patch
+++ b/components/database/sqlite/patches/04-Makefile-add-fpic.patch
@@ -1,0 +1,20 @@
+CFLAGS are not getting set when calling buildtclext.tcl. Force use of -fPIC
+
+--- sqlite-src-3470200/Makefile.in.old	2025-01-05 01:42:46.574367786 -0500
++++ sqlite-src-3470200/Makefile.in	2025-01-05 01:45:05.458936726 -0500
+@@ -1594,13 +1594,13 @@
+ # by --with-tclsh=
+ #
+ tclextension:	tclsqlite3.c
+-	$(TCLSH_CMD) $(TOP)/tool/buildtclext.tcl --build-only --cc "$(CC)" $(CFLAGS) $(OPT_FEATURE_FLAGS) $(OPTS)
++	$(TCLSH_CMD) $(TOP)/tool/buildtclext.tcl --build-only --cc "$(CC)" $(CFLAGS) -fPIC $(OPT_FEATURE_FLAGS) $(OPTS)
+ 
+ # Install the SQLite TCL extension in a way that is appropriate for $TCLSH_CMD
+ # to find it.
+ #
+ tclextension-install:	tclsqlite3.c
+-	$(TCLSH_CMD) $(TOP)/tool/buildtclext.tcl --destdir "$(DESTDIR)" --cc "$(CC)" $(CFLAGS) $(OPT_FEATURE_FLAGS) $(OPTS)
++	$(TCLSH_CMD) $(TOP)/tool/buildtclext.tcl --destdir "$(DESTDIR)" --cc "$(CC)" -fPIC $(CFLAGS) $(OPT_FEATURE_FLAGS) $(OPTS)
+ 
+ # Install the SQLite TCL extension that is used by $TCLSH_CMD
+ #

--- a/components/database/sqlite/sqlite-tcl.p5m
+++ b/components/database/sqlite/sqlite-tcl.p5m
@@ -37,6 +37,5 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 # Note these files have been manually moved here from the main package.
-
-file path=usr/lib/tcl8.6/sqlite3/$(MACH64)/libtclsqlite3.so
+file path=usr/lib/tcl8.6/sqlite3/$(MACH64)/libsqlite$(HUMAN_VERSION).so
 file path=usr/lib/tcl8.6/sqlite3/$(MACH64)/pkgIndex.tcl

--- a/components/database/sqlite/test/results-all.master
+++ b/components/database/sqlite/test/results-all.master
@@ -1,1 +1,6 @@
 fuzzcheck: 0 errors out of 46388 tests 
+0 errors out of 391114 tests
+All memory allocations freed - no leaks
+Maximum memory usage: 9159768 bytes
+Current memory usage: 0 bytes
+Number of malloc()  : -1 calls


### PR DESCRIPTION
tcl component did not get compiled with -fPIC.  A new tcl script was added for the 3.47 branch--force -fPIC usage calling the scripts and within the script.

Changed ENV to get more information from test results.

Removed unsupported CONFIGURE_OPTIONS.
