### PR TITLE
make-rules: set cargo target linker

### DIFF
--- a/make-rules/cargo.mk
+++ b/make-rules/cargo.mk
@@ -40,6 +40,7 @@ COMPONENT_PREP_ACTION += $(ENV) CARGO_HOME=$(CARGO_ARCHIVES) \
 
 # Common cargo environment
 CARGO_ENV += CARGO_HOME=$(@D)/.cargo
+CARGO_ENV += CARGO_TARGET_$(shell echo $(RUST_TRIPLET) | tr '[a-z]-' '[A-Z]_')_LINKER=$(CARGO_TARGET_LINKER)
 CARGO_ENV += PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)"
 
 # Configure

--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -162,6 +162,8 @@ COMPONENT_TEST_ENV += $(PYTHON_ENV)
 # Set CARGO_HOME to make sure projects built using rust (for example via
 # setuptools-rust) do not pollute user's home directory with cargo bits.
 COMPONENT_BUILD_ENV += CARGO_HOME=$(@D)/.cargo
+# Similarly, force our preferred target linker for cargo.
+COMPONENT_BUILD_ENV += CARGO_TARGET_$(shell echo $(RUST_TRIPLET) | tr '[a-z]-' '[A-Z]_')_LINKER=$(CARGO_TARGET_LINKER)
 
 # Make sure the default Python version is installed last and so is the
 # canonical version.  This is needed for components that keep PYTHON_VERSIONS

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1182,6 +1182,20 @@ PKG_CONFIG_PATH.prepend +=	$(OPENSSL_PKG_CONFIG_PATH)
 OPENSSL_PKG =			library/security/openssl$(subst -10,,-$(subst .,,$(OPENSSL_VERSION)))
 REQUIRED_PACKAGES_SUBST +=	OPENSSL_PKG
 
+#
+# Rust macros
+#
+
+# Rust target triplet
+RUST_TRIPLET = $(RUST_CPU)-$(RUST_VENDOR)-$(RUST_OS)
+RUST_CPU = x86_64
+RUST_VENDOR = unknown
+RUST_OS = illumos
+
+# This is the linker we would like to use with cargo
+CARGO_TARGET_LINKER = $(CC)
+
+
 # Pkg-config paths
 PKG_CONFIG_PATH.32 = /usr/lib/pkgconfig
 PKG_CONFIG_PATH.64 = /usr/lib/$(MACH64)/pkgconfig


### PR DESCRIPTION
This allows to use non-default linker (and so gcc runtime) for rust binaries.  Here _non-default_ means a different than the one used to build rustc.