### PR TITLE
pango: update to 1.56.0

### DIFF
--- a/components/library/pango/Makefile
+++ b/components/library/pango/Makefile
@@ -20,48 +20,30 @@ USE_DEFAULT_TEST_TRANSFORMS= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         pango
-COMPONENT_MJR_VERSION=	1.55
-COMPONENT_VERSION=      $(COMPONENT_MJR_VERSION).5
+HUMAN_VERSION=		1.56.0
 COMPONENT_SUMMARY=      GNOME core text and font handling libraries
-COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
-COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:e396126ea08203cbd8ef12638e6222e2e1fd8aa9cac6743072fedc5f2d820dd8
-COMPONENT_ARCHIVE_URL=  https://download.gnome.org/sources/pango/$(COMPONENT_MJR_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:1fb98b338ee6f7cf8ef96153b7d242f4568fe60f9b7434524eca630a57bd538b
 COMPONENT_PROJECT_URL=  https://www.pango.org/
 COMPONENT_FMRI=         library/desktop/pango
 COMPONENT_CLASSIFICATION=Desktop (GNOME)/Libraries
-COMPONENT_LICENSE=      LGPLv2
+COMPONENT_LICENSE=	LGPL-2.0-only
 COMPONENT_LICENSE_FILE= COPYING
 
+include $(WS_MAKE_RULES)/gnome.mk
 include $(WS_MAKE_RULES)/common.mk
 
+# Testing needs GNU tools
 PATH= $(PATH.gnu)
 
-COMPONENT_BUILD_ENV += CC="$(CC)"
-COMPONENT_BUILD_ENV += CFLAGS="$(CFLAGS)"
+# Dynamic library version number
+SOVER := 0.$(shell printf '%s00.%s' $(wordlist 2,3,$(subst ., ,$(COMPONENT_VERSION))))
+SOVER_RE = $(subst .,\.,$(SOVER))
 
-COMPONENT_POST_INSTALL_ACTION = ( \
-	$(RM) -fr $(PROTO_DIR)/etc/$(MACH64)/pango && $(MKDIR) $(PROTO_DIR)/etc/$(MACH64)/pango &&\
-	$(ENV) LD_LIBRARY_PATH=$(PROTO_DIR)/usr/lib/$(MACH64) \
-	$(PROTO_DIR)/usr/bin/$(MACH64)/pango-querymodules \
-	  $(PROTO_DIR)/usr/lib/$(MACH64)/pango/*/modules/*.so | sed -e "s:$(PROTO_DIR)::" \
-	  > $(PROTO_DIR)/etc/$(MACH64)/pango/pango.modules )
+# Replace library version number by SOVER
+GENERATE_EXTRA_CMD += | $(GSED) -e 's/$(SOVER_RE)/$$(SOVER)/'
 
-# cp boundaries.utf8 to tests directory in the build area
-COMPONENT_PRE_TEST_ACTION += \
-	cp $(SOURCE_DIR)/tests/boundaries.utf8 $(BUILD_DIR_$(BITS))/tests/
-
-COMPONENT_TEST_TARGETS += ; cd tests; ./cxx-test; ./markup-parse; \
-	./test-break; ./test-converage; ./test-font ; ./test-ot-tags; \
-	./testboundaries; ./testcolor; ./testiter; ./testscript; \
-	./test-ellipsize; ./test-harfbuzz; ./test-itemize; ./test-layout; \
-	./test-pangocairo-threads; ./test-shape; ./testmisc; ./testattributes;
-
-COMPONENT_TEST_TRANSFORMS += \
-	'-e "s/      [0-9].[0-9][0-9]s//" ' \
-	'-e "s/      [0-9][0-9].[0-9][0-9]s//" ' \
-	'-e "s/[0-9]*\:[0-9]*\:[0-9]*\.[0-9]*//" ' \
-	'-e "s/test-layout\:[0-9]*/test-layout/" '
+# SOVER is needed for manifest processing
+PKG_MACROS += SOVER=$(SOVER)
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/c++/harfbuzz

--- a/components/library/pango/manifests/sample-manifest.p5m
+++ b/components/library/pango/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,7 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=etc/$(MACH64)/pango/pango.modules
 file path=usr/bin/pango-list
 file path=usr/bin/pango-segmentation
 file path=usr/bin/pango-view
@@ -72,20 +71,20 @@ file path=usr/lib/$(MACH64)/girepository-1.0/PangoFc-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/PangoOT-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/PangoXft-1.0.typelib
 link path=usr/lib/$(MACH64)/libpango-1.0.so target=libpango-1.0.so.0
-link path=usr/lib/$(MACH64)/libpango-1.0.so.0 target=libpango-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpango-1.0.so.0.5505.0
+link path=usr/lib/$(MACH64)/libpango-1.0.so.0 target=libpango-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpango-1.0.so.$(SOVER)
 link path=usr/lib/$(MACH64)/libpangocairo-1.0.so target=libpangocairo-1.0.so.0
 link path=usr/lib/$(MACH64)/libpangocairo-1.0.so.0 \
-    target=libpangocairo-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpangocairo-1.0.so.0.5505.0
+    target=libpangocairo-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpangocairo-1.0.so.$(SOVER)
 link path=usr/lib/$(MACH64)/libpangoft2-1.0.so target=libpangoft2-1.0.so.0
 link path=usr/lib/$(MACH64)/libpangoft2-1.0.so.0 \
-    target=libpangoft2-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpangoft2-1.0.so.0.5505.0
+    target=libpangoft2-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpangoft2-1.0.so.$(SOVER)
 link path=usr/lib/$(MACH64)/libpangoxft-1.0.so target=libpangoxft-1.0.so.0
 link path=usr/lib/$(MACH64)/libpangoxft-1.0.so.0 \
-    target=libpangoxft-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpangoxft-1.0.so.0.5505.0
+    target=libpangoxft-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpangoxft-1.0.so.$(SOVER)
 file path=usr/lib/$(MACH64)/pkgconfig/pango.pc
 file path=usr/lib/$(MACH64)/pkgconfig/pangocairo.pc
 file path=usr/lib/$(MACH64)/pkgconfig/pangofc.pc
@@ -98,4 +97,3 @@ file path=usr/share/gir-1.0/PangoFT2-1.0.gir
 file path=usr/share/gir-1.0/PangoFc-1.0.gir
 file path=usr/share/gir-1.0/PangoOT-1.0.gir
 file path=usr/share/gir-1.0/PangoXft-1.0.gir
-file path=usr/share/man/man1/pango-view.1

--- a/components/library/pango/pango.p5m
+++ b/components/library/pango/pango.p5m
@@ -25,9 +25,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-depend fmri=library/desktop/pangox-compat type=require
-
-file path=etc/$(MACH64)/pango/pango.modules
 file path=usr/bin/pango-list
 file path=usr/bin/pango-segmentation
 file path=usr/bin/pango-view
@@ -76,20 +73,20 @@ file path=usr/lib/$(MACH64)/girepository-1.0/PangoFc-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/PangoOT-1.0.typelib
 file path=usr/lib/$(MACH64)/girepository-1.0/PangoXft-1.0.typelib
 link path=usr/lib/$(MACH64)/libpango-1.0.so target=libpango-1.0.so.0
-link path=usr/lib/$(MACH64)/libpango-1.0.so.0 target=libpango-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpango-1.0.so.0.5505.0
+link path=usr/lib/$(MACH64)/libpango-1.0.so.0 target=libpango-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpango-1.0.so.$(SOVER)
 link path=usr/lib/$(MACH64)/libpangocairo-1.0.so target=libpangocairo-1.0.so.0
 link path=usr/lib/$(MACH64)/libpangocairo-1.0.so.0 \
-    target=libpangocairo-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpangocairo-1.0.so.0.5505.0
+    target=libpangocairo-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpangocairo-1.0.so.$(SOVER)
 link path=usr/lib/$(MACH64)/libpangoft2-1.0.so target=libpangoft2-1.0.so.0
 link path=usr/lib/$(MACH64)/libpangoft2-1.0.so.0 \
-    target=libpangoft2-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpangoft2-1.0.so.0.5505.0
+    target=libpangoft2-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpangoft2-1.0.so.$(SOVER)
 link path=usr/lib/$(MACH64)/libpangoxft-1.0.so target=libpangoxft-1.0.so.0
 link path=usr/lib/$(MACH64)/libpangoxft-1.0.so.0 \
-    target=libpangoxft-1.0.so.0.5505.0
-file path=usr/lib/$(MACH64)/libpangoxft-1.0.so.0.5505.0
+    target=libpangoxft-1.0.so.$(SOVER)
+file path=usr/lib/$(MACH64)/libpangoxft-1.0.so.$(SOVER)
 file path=usr/lib/$(MACH64)/pkgconfig/pango.pc
 file path=usr/lib/$(MACH64)/pkgconfig/pangocairo.pc
 file path=usr/lib/$(MACH64)/pkgconfig/pangofc.pc
@@ -102,4 +99,3 @@ file path=usr/share/gir-1.0/PangoFT2-1.0.gir
 file path=usr/share/gir-1.0/PangoFc-1.0.gir
 file path=usr/share/gir-1.0/PangoOT-1.0.gir
 file path=usr/share/gir-1.0/PangoXft-1.0.gir
-file path=usr/share/man/man1/pango-view.1

--- a/components/library/pango/patches/01-fix-includes.patch
+++ b/components/library/pango/patches/01-fix-includes.patch
@@ -1,7 +1,7 @@
 Our harfbuzz include files reside in a separate harfbuzz folder.
 
---- pango-1.48.0/pango/pango-font.h.orig	2020-11-08 15:25:10.861614200 +0000
-+++ pango-1.48.0/pango/pango-font.h	2021-01-09 20:46:35.715122334 +0000
+--- pango-1.56.0/pango/pango-font.h.orig
++++ pango-1.56.0/pango/pango-font.h
 @@ -26,7 +26,7 @@
  #include <pango/pango-types.h>
  
@@ -11,8 +11,8 @@ Our harfbuzz include files reside in a separate harfbuzz folder.
  
  G_BEGIN_DECLS
  
---- pango-1.48.0/pango/pango-coverage.h.orig	2020-11-08 15:25:10.861614200 +0000
-+++ pango-1.48.0/pango/pango-coverage.h	2021-01-09 20:46:58.516545730 +0000
+--- pango-1.56.0/pango/pango-coverage.h.orig
++++ pango-1.56.0/pango/pango-coverage.h
 @@ -25,7 +25,7 @@
  #include <glib-object.h>
  
@@ -22,8 +22,8 @@ Our harfbuzz include files reside in a separate harfbuzz folder.
  
  G_BEGIN_DECLS
  
---- pango-1.48.0/pango/pangofc-fontmap.h.orig	2020-11-08 15:25:10.870614300 +0000
-+++ pango-1.48.0/pango/pangofc-fontmap.h	2021-01-09 20:47:37.813385285 +0000
+--- pango-1.56.0/pango/pangofc-fontmap.h.orig
++++ pango-1.56.0/pango/pangofc-fontmap.h
 @@ -26,7 +26,7 @@
  #include <fontconfig/fontconfig.h>
  #include <pango/pangofc-decoder.h>

--- a/components/library/pango/test/results-all.master
+++ b/components/library/pango/test/results-all.master
@@ -1,10 +1,10 @@
 cxx-test                SKIP
 markup-parse            OK   122 subtests passed
-test-bidi               OK   7 subtests passed
+test-bidi               OK   8 subtests passed
 test-break              OK   17 subtests passed
 test-coverage           OK   2 subtests passed
 test-ellipsize          OK   3 subtests passed
-test-font               OK   21 subtests passed
+test-font               OK   24 subtests passed
 test-fonts              OK   4 subtests passed
 test-harfbuzz           OK   1 subtests passed
 test-itemize            SKIP   0 subtests passed


### PR DESCRIPTION
This also removes dependency on `library/desktop/pangox-compat` because I believe there is currently nothing in OpenIndiana that would need such a dependency here.