### PR TITLE
components/x11/mesa: link additional (currently missing) GL headers

### DIFF
--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= mesa
 COMPONENT_VERSION= 21.3.9
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= The Mesa 3-D Graphics Library
 COMPONENT_SRC= mesa-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= mesa-$(COMPONENT_VERSION).tar.xz

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -44,11 +44,14 @@ file path=usr/include/KHR/khrplatform.h
 file path=usr/include/gbm.h
 file path=usr/include/mesa/gl.h
 file path=usr/include/mesa/glcorearb.h
+link path=usr/include/GL/glcorearb.h target=../mesa/glcorearb.h
 file path=usr/include/mesa/glext.h
 file path=usr/include/mesa/glx.h
 file path=usr/include/mesa/glxext.h
 file path=usr/include/mesa/internal/dri_interface.h
+link path=usr/include/GL/internal/dri_interface.h target=../../mesa/internal/dri_interface.h
 file path=usr/include/mesa/osmesa.h
+link path=usr/include/GL/osmesa.h target=../mesa/osmesa.h
 file path=usr/include/xa_composite.h
 file path=usr/include/xa_context.h
 file path=usr/include/xa_tracker.h

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -93,11 +93,14 @@ file path=usr/include/KHR/khrplatform.h
 file path=usr/include/gbm.h
 file path=usr/include/mesa/gl.h
 file path=usr/include/mesa/glcorearb.h
+link path=usr/include/GL/glcorearb.h target=../mesa/glcorearb.h
 file path=usr/include/mesa/glext.h
 file path=usr/include/mesa/glx.h
 file path=usr/include/mesa/glxext.h
 file path=usr/include/mesa/internal/dri_interface.h
+link path=usr/include/GL/internal/dri_interface.h target=../../mesa/internal/dri_interface.h
 file path=usr/include/mesa/osmesa.h
+link path=usr/include/GL/osmesa.h target=../mesa/osmesa.h
 file path=usr/include/xa_composite.h
 file path=usr/include/xa_context.h
 file path=usr/include/xa_tracker.h


### PR DESCRIPTION
These GL headers are currently missing from /usr/include/GL, yet are expected by e.g. xorg-server during build.

Currently the headers stored /usr/include/GL are symlinks created at runtime via ogl-select. This has been the case since ye olde days.

I don't particularly want to add further headers to ogl-select, especially when the current supported method of doing this is via libglvnd which actually supports multiple libgl implementations on a single system.

Once mesa is in a better working state, I will proceed with enabling libglvnd and we can retire ogl-select, and remove the links created in this package.