### PR TITLE
gdb: disable libbfd installation

### DIFF
--- a/components/developer/gdb/Makefile
+++ b/components/developer/gdb/Makefile
@@ -26,16 +26,13 @@
 # Copyright 2023 Carsten Grzemba
 #
 
-# There are a large number of macros in the GDB code written
-# specifically for GCC's preprocessor. Studio does not expand
-# these macros the same way GCC does, and the resulting gdb is
-# not usable. Building gdb with a GCC >= 4.7.2 produces very
-# good results, even on SPARC.
+USE_PARALLEL_BUILD = yes
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         gdb
 COMPONENT_VERSION=      14.2
-COMPONENT_REVISION=	0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=      GDB: The GNU Project Debugger
 COMPONENT_CLASSIFICATION=Development/System
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -121,6 +118,8 @@ CONFIGURE_OPTIONS += --with-libexpat-prefix=/usr/lib
 CONFIGURE_OPTIONS += --infodir=$(CONFIGURE_INFODIR)
 CONFIGURE_OPTIONS += --with-system-zlib
 CONFIGURE_OPTIONS += --without-guile
+# libbfd is provided by binutils
+CONFIGURE_OPTIONS += --disable-install-libbfd
 
 COMPONENT_BUILD_ENV += $(CONFIGURE_ENV)
 

--- a/components/developer/gdb/Solaris/gen_syscall_table.sh
+++ b/components/developer/gdb/Solaris/gen_syscall_table.sh
@@ -48,9 +48,10 @@ EOM
         sed < $TMPDIR/offsets32.h 's/\t0x/_32&/'
         sed < $TMPDIR/offsets64.h 's/\t0x/_64&/'
         $EGREP $'define\tPR(FN|ARG)SZ' /usr/include/sys/old_procfs.h
-    } | tee illumos-offsets.h > ${SOURCE_DIR}/bfd/illumos-offsets.h
+    } > ${SOURCE_DIR}/bfd/illumos-offsets.h
 
 }
 
 [ ! -d ${TMPDIR} ] && mkdir ${TMPDIR}
 generate
+rm -rf ${TMPDIR}

--- a/components/developer/gdb/gdb.p5m
+++ b/components/developer/gdb/gdb.p5m
@@ -25,7 +25,6 @@
 # Copyright 2023 Carsten Grzemba
 #
 
-<transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
 set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
@@ -40,18 +39,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 file path=usr/bin/gdb
 file path=usr/bin/gdb-add-index
 file path=usr/bin/gdbtui
-file path=usr/include/ansidecl.h
-file path=usr/include/bfd.h
-file path=usr/include/bfdlink.h
-file path=usr/include/ctf-api.h
-file path=usr/include/ctf.h
-file path=usr/include/diagnostics.h
-file path=usr/include/dis-asm.h
 file path=usr/include/gdb/jit-reader.h
-file path=usr/include/plugin-api.h
-file path=usr/include/sframe-api.h
-file path=usr/include/sframe.h
-file path=usr/include/symcat.h
 file path=usr/share/gdb/python/gdb/FrameDecorator.py
 file path=usr/share/gdb/python/gdb/FrameIterator.py
 file path=usr/share/gdb/python/gdb/__init__.py

--- a/components/developer/gdb/manifests/sample-manifest.p5m
+++ b/components/developer/gdb/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,23 +27,7 @@ file path=usr/bin/gcore
 file path=usr/bin/gdb
 file path=usr/bin/gdb-add-index
 file path=usr/bin/gdbtui
-file path=usr/include/ansidecl.h
-file path=usr/include/bfd.h
-file path=usr/include/bfdlink.h
-file path=usr/include/ctf-api.h
-file path=usr/include/ctf.h
-file path=usr/include/diagnostics.h
-file path=usr/include/dis-asm.h
 file path=usr/include/gdb/jit-reader.h
-file path=usr/include/plugin-api.h
-file path=usr/include/sframe-api.h
-file path=usr/include/sframe.h
-file path=usr/include/symcat.h
-file path=usr/lib/$(MACH64)/libbfd.a
-file path=usr/lib/$(MACH64)/libctf-nobfd.a
-file path=usr/lib/$(MACH64)/libctf.a
-file path=usr/lib/$(MACH64)/libopcodes.a
-file path=usr/lib/$(MACH64)/libsframe.a
 file path=usr/share/gdb/python/gdb/FrameDecorator.py
 file path=usr/share/gdb/python/gdb/FrameIterator.py
 file path=usr/share/gdb/python/gdb/__init__.py

--- a/components/developer/gdb/patches/features-i386.patch
+++ b/components/developer/gdb/patches/features-i386.patch
@@ -1,7 +1,6 @@
-diff -wpruN '--exclude=*.orig' a~/gdb/features/Makefile a/gdb/features/Makefile
---- a~/gdb/features/Makefile	1970-01-01 00:00:00
-+++ a/gdb/features/Makefile	1970-01-01 00:00:00
-@@ -99,6 +99,11 @@ OUTPUTS = $(patsubst %,$(outdir)/%.dat,$
+--- gdb-14.2/gdb/features/Makefile.orig
++++ gdb-14.2/gdb/features/Makefile
+@@ -100,6 +100,11 @@
  # --enable-targets=all GDB.  You can override this by passing XMLTOC
  # to make on the command line.
  XMLTOC = \
@@ -13,18 +12,17 @@ diff -wpruN '--exclude=*.orig' a~/gdb/features/Makefile a/gdb/features/Makefile
  	microblaze-with-stack-protect.xml \
  	microblaze.xml \
  	mips-dsp-linux.xml \
-@@ -227,6 +232,8 @@ FEATURE_XMLFILES = aarch64-core.xml \
- 	i386/64bit-pkeys.xml \
+@@ -234,6 +239,8 @@
  	i386/64bit-sse.xml \
+ 	i386/pkeys.xml \
  	i386/x32-core.xml \
 +	i386/32bit-illumos.xml \
 +	i386/64bit-illumos.xml \
  	loongarch/base32.xml \
  	loongarch/base64.xml \
- 	riscv/rv32e-xregs.xml \
-diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/32bit-illumos.xml a/gdb/features/i386/32bit-illumos.xml
---- a~/gdb/features/i386/32bit-illumos.xml	1970-01-01 00:00:00
-+++ a/gdb/features/i386/32bit-illumos.xml	1970-01-01 00:00:00
+ 	loongarch/fpu.xml \
+--- /dev/null
++++ gdb-14.2/gdb/features/i386/32bit-illumos.xml
 @@ -0,0 +1,11 @@
 +<?xml version="1.0"?>
 +<!-- Copyright (C) 2010-2013 Free Software Foundation, Inc.
@@ -37,9 +35,8 @@ diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/32bit-illumos.xml a/gdb/feat
 +<feature name="org.gnu.gdb.i386.illumos">
 +  <reg name="orig_eax" bitsize="32" type="int" regnum="41"/>
 +</feature>
-diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/64bit-illumos.xml a/gdb/features/i386/64bit-illumos.xml
---- a~/gdb/features/i386/64bit-illumos.xml	1970-01-01 00:00:00
-+++ a/gdb/features/i386/64bit-illumos.xml	1970-01-01 00:00:00
+--- /dev/null
++++ gdb-14.2/gdb/features/i386/64bit-illumos.xml
 @@ -0,0 +1,11 @@
 +<?xml version="1.0"?>
 +<!-- Copyright (C) 2010-2013 Free Software Foundation, Inc.
@@ -52,9 +49,8 @@ diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/64bit-illumos.xml a/gdb/feat
 +<feature name="org.gnu.gdb.i386.illumos">
 +  <reg name="orig_rax" bitsize="64" type="int" regnum="57"/>
 +</feature>
-diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/amd64-avx-illumos.xml a/gdb/features/i386/amd64-avx-illumos.xml
---- a~/gdb/features/i386/amd64-avx-illumos.xml	1970-01-01 00:00:00
-+++ a/gdb/features/i386/amd64-avx-illumos.xml	1970-01-01 00:00:00
+--- /dev/null
++++ gdb-14.2/gdb/features/i386/amd64-avx-illumos.xml
 @@ -0,0 +1,18 @@
 +<?xml version="1.0"?>
 +<!-- Copyright (C) 2010-2013 Free Software Foundation, Inc.
@@ -74,9 +70,8 @@ diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/amd64-avx-illumos.xml a/gdb/
 +  <xi:include href="64bit-illumos.xml"/>
 +  <xi:include href="64bit-avx.xml"/>
 +</target>
-diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/amd64-illumos.xml a/gdb/features/i386/amd64-illumos.xml
---- a~/gdb/features/i386/amd64-illumos.xml	1970-01-01 00:00:00
-+++ a/gdb/features/i386/amd64-illumos.xml	1970-01-01 00:00:00
+--- /dev/null
++++ gdb-14.2/gdb/features/i386/amd64-illumos.xml
 @@ -0,0 +1,17 @@
 +<?xml version="1.0"?>
 +<!-- Copyright (C) 2010-2013 Free Software Foundation, Inc.
@@ -95,9 +90,8 @@ diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/amd64-illumos.xml a/gdb/feat
 +  <xi:include href="64bit-sse.xml"/>
 +  <xi:include href="64bit-illumos.xml"/>
 +</target>
-diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/i386-avx-illumos.xml a/gdb/features/i386/i386-avx-illumos.xml
---- a~/gdb/features/i386/i386-avx-illumos.xml	1970-01-01 00:00:00
-+++ a/gdb/features/i386/i386-avx-illumos.xml	1970-01-01 00:00:00
+--- /dev/null
++++ gdb-14.2/gdb/features/i386/i386-avx-illumos.xml
 @@ -0,0 +1,18 @@
 +<?xml version="1.0"?>
 +<!-- Copyright (C) 2010-2013 Free Software Foundation, Inc.
@@ -117,9 +111,8 @@ diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/i386-avx-illumos.xml a/gdb/f
 +  <xi:include href="32bit-illumos.xml"/>
 +  <xi:include href="32bit-avx.xml"/>
 +</target>
-diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/i386-illumos.xml a/gdb/features/i386/i386-illumos.xml
---- a~/gdb/features/i386/i386-illumos.xml	1970-01-01 00:00:00
-+++ a/gdb/features/i386/i386-illumos.xml	1970-01-01 00:00:00
+--- /dev/null
++++ gdb-14.2/gdb/features/i386/i386-illumos.xml
 @@ -0,0 +1,17 @@
 +<?xml version="1.0"?>
 +<!-- Copyright (C) 2010-2013 Free Software Foundation, Inc.
@@ -138,9 +131,8 @@ diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/i386-illumos.xml a/gdb/featu
 +  <xi:include href="32bit-illumos.xml"/>
 +  <xi:include href="32bit-sse.xml"/>
 +</target>
-diff -wpruN '--exclude=*.orig' a~/gdb/features/i386/i386-mmx-illumos.xml a/gdb/features/i386/i386-mmx-illumos.xml
---- a~/gdb/features/i386/i386-mmx-illumos.xml	1970-01-01 00:00:00
-+++ a/gdb/features/i386/i386-mmx-illumos.xml	1970-01-01 00:00:00
+--- /dev/null
++++ gdb-14.2/gdb/features/i386/i386-mmx-illumos.xml
 @@ -0,0 +1,16 @@
 +<?xml version="1.0"?>
 +<!-- Copyright (C) 2010-2013 Free Software Foundation, Inc.

--- a/components/developer/gdb/patches/fix-attach.patch
+++ b/components/developer/gdb/patches/fix-attach.patch
@@ -5,10 +5,9 @@ the issue, we extract a valid stratum from the current inferior.
 
 Will be sent to upstream.
 
-diff -wpruN '--exclude=*.orig' a~/gdb/procfs.c a/gdb/procfs.c
---- a~/gdb/procfs.c	1970-01-01 00:00:00
-+++ a/gdb/procfs.c	1970-01-01 00:00:00
-@@ -1863,7 +1863,7 @@ do_attach (ptid_t ptid)
+--- gdb-14.2/gdb/procfs.c.orig
++++ gdb-14.2/gdb/procfs.c
+@@ -1863,7 +1863,7 @@
  
    /* Add it to gdb's thread list.  */
    ptid = ptid_t (pi->pid, lwpid, 0);

--- a/components/developer/gdb/patches/fix-null-ptr.patch
+++ b/components/developer/gdb/patches/fix-null-ptr.patch
@@ -1,7 +1,6 @@
-diff -wpruN '--exclude=*.orig' a~/gdb/osabi.c a/gdb/osabi.c
---- a~/gdb/osabi.c	1970-01-01 00:00:00
-+++ a/gdb/osabi.c	1970-01-01 00:00:00
-@@ -64,7 +64,7 @@ static const struct osabi_names gdb_osab
+--- gdb-14.2/gdb/osabi.c.orig
++++ gdb-14.2/gdb/osabi.c
+@@ -64,7 +64,7 @@
  
    { "SVR4", NULL },
    { "GNU/Hurd", NULL },

--- a/components/developer/gdb/patches/force-bash.patch
+++ b/components/developer/gdb/patches/force-bash.patch
@@ -5,10 +5,9 @@ we force GDB to internally use well-tested bash shell.
 
 Not suitable for upstream.
 
-diff -wpruN '--exclude=*.orig' a~/gdbsupport/pathstuff.cc a/gdbsupport/pathstuff.cc
---- a~/gdbsupport/pathstuff.cc	1970-01-01 00:00:00
-+++ a/gdbsupport/pathstuff.cc	1970-01-01 00:00:00
-@@ -358,11 +358,7 @@ find_gdb_home_config_file (const char *n
+--- gdb-14.2/gdbsupport/pathstuff.cc.orig
++++ gdb-14.2/gdbsupport/pathstuff.cc
+@@ -373,11 +373,7 @@
  const char *
  get_shell ()
  {

--- a/components/developer/gdb/patches/no-build-id.patch
+++ b/components/developer/gdb/patches/no-build-id.patch
@@ -1,7 +1,7 @@
 illumos ld have no support for --build-id option.
 
---- gdb-13.2/libbacktrace/Makefile.in.orig
-+++ gdb-13.2/libbacktrace/Makefile.in
+--- gdb-14.2/libbacktrace/Makefile.in.orig
++++ gdb-14.2/libbacktrace/Makefile.in
 @@ -135,8 +135,6 @@
  @NATIVE_TRUE@@USE_DSYMUTIL_TRUE@	btest.dSYM btest_alloc.dSYM \
  @NATIVE_TRUE@@USE_DSYMUTIL_TRUE@	stest.dSYM stest_alloc.dSYM \

--- a/components/developer/gdb/patches/remove-core-warning.patch
+++ b/components/developer/gdb/patches/remove-core-warning.patch
@@ -4,10 +4,9 @@
 # Note: this patch may not be appropriate for upstream;
 # it may eventually be removed.
 
-diff -wpruN '--exclude=*.orig' a~/gdb/corelow.c a/gdb/corelow.c
---- a~/gdb/corelow.c	1970-01-01 00:00:00
-+++ a/gdb/corelow.c	1970-01-01 00:00:00
-@@ -863,11 +863,14 @@ core_target::get_core_register_section (
+--- gdb-14.2/gdb/corelow.c.orig
++++ gdb-14.2/gdb/corelow.c
+@@ -863,11 +863,14 @@
  	       section_name.c_str ());
        return;
      }

--- a/components/developer/gdb/patches/syscalls.patch
+++ b/components/developer/gdb/patches/syscalls.patch
@@ -1,10 +1,9 @@
 
 The XML representation of the illumos system calls is generated in ../build.sh
 
-diff -wpruN '--exclude=*.orig' a~/gdb/data-directory/Makefile.in a/gdb/data-directory/Makefile.in
---- a~/gdb/data-directory/Makefile.in	1970-01-01 00:00:00
-+++ a/gdb/data-directory/Makefile.in	1970-01-01 00:00:00
-@@ -51,8 +51,10 @@ SYSCALLS_INSTALL_DIR = $(DESTDIR)$(GDB_D
+--- gdb-14.2/gdb/data-directory/Makefile.in.orig
++++ gdb-14.2/gdb/data-directory/Makefile.in
+@@ -51,8 +51,10 @@
  GEN_SYSCALLS_FILES = \
  	aarch64-linux.xml \
  	amd64-linux.xml \

--- a/components/developer/gdb/pkg5
+++ b/components/developer/gdb/pkg5
@@ -12,8 +12,8 @@
         "runtime/python-39",
         "shell/ksh93",
         "system/library",
-        "system/library/g++-13-runtime",
-        "system/library/gcc-13-runtime",
+        "system/library/g++-14-runtime",
+        "system/library/gcc-14-runtime",
         "system/library/math"
     ],
     "fmris": [


### PR DESCRIPTION
Please note that testing fails early and so the stored test results does not match the actual results.  I suspect testing was not run while the `gdb` update to 14.2 in #17276.