### PR TITLE
Add fakeroot

### DIFF
--- a/components/sysutils/fakeroot/Makefile
+++ b/components/sysutils/fakeroot/Makefile
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+USE_DEFAULT_TEST_TRANSFORMS = yes
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=			fakeroot
+COMPONENT_VERSION=		1.31
+COMPONENT_SUMMARY=		Tool for simulating superuser privileges
+COMPONENT_PROJECT_URL=		https://tracker.debian.org/pkg/fakeroot
+COMPONENT_FMRI=			developer/fakeroot
+COMPONENT_CLASSIFICATION=	Applications/System Utilities
+COMPONENT_SRC=			$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=		$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=		http://deb.debian.org/debian/pool/main/f/$(COMPONENT_NAME)/$(COMPONENT_NAME)_$(COMPONENT_VERSION).orig.tar.gz
+COMPONENT_ARCHIVE_HASH=		sha256:63886d41e11c56c7170b9d9331cca086421b350d257338ef14daad98f77e202f
+COMPONENT_LICENSE=		GPL-3.0-only
+COMPONENT_LICENSE_FILE=		COPYING
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Testing expects GNU tools
+PATH = $(PATH.gnu)
+
+CONFIGURE_OPTIONS += --disable-static
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += shell/bash
+REQUIRED_PACKAGES += system/library

--- a/components/sysutils/fakeroot/fakeroot.p5m
+++ b/components/sysutils/fakeroot/fakeroot.p5m
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/faked
+file path=usr/bin/fakeroot
+file path=usr/lib/$(MACH64)/libfakeroot-0.so
+link path=usr/lib/$(MACH64)/libfakeroot.so target=libfakeroot-0.so
+file path=usr/share/man/de/man1/faked.1
+file path=usr/share/man/de/man1/fakeroot.1
+file path=usr/share/man/es/man1/faked.1
+file path=usr/share/man/es/man1/fakeroot.1
+file path=usr/share/man/fr/man1/faked.1
+file path=usr/share/man/fr/man1/fakeroot.1
+file path=usr/share/man/man1/faked.1
+file path=usr/share/man/man1/fakeroot.1
+file path=usr/share/man/nl/man1/faked.1
+file path=usr/share/man/nl/man1/fakeroot.1
+file path=usr/share/man/pt/man1/faked.1
+file path=usr/share/man/pt/man1/fakeroot.1
+file path=usr/share/man/sv/man1/faked.1
+file path=usr/share/man/sv/man1/fakeroot.1

--- a/components/sysutils/fakeroot/manifests/sample-manifest.p5m
+++ b/components/sysutils/fakeroot/manifests/sample-manifest.p5m
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/faked
+file path=usr/bin/fakeroot
+file path=usr/lib/$(MACH64)/libfakeroot-0.so
+link path=usr/lib/$(MACH64)/libfakeroot.so target=libfakeroot-0.so
+file path=usr/share/man/de/man1/faked.1
+file path=usr/share/man/de/man1/fakeroot.1
+file path=usr/share/man/es/man1/faked.1
+file path=usr/share/man/es/man1/fakeroot.1
+file path=usr/share/man/fr/man1/faked.1
+file path=usr/share/man/fr/man1/fakeroot.1
+file path=usr/share/man/man1/faked.1
+file path=usr/share/man/man1/fakeroot.1
+file path=usr/share/man/nl/man1/faked.1
+file path=usr/share/man/nl/man1/fakeroot.1
+file path=usr/share/man/pt/man1/faked.1
+file path=usr/share/man/pt/man1/fakeroot.1
+file path=usr/share/man/sv/man1/faked.1
+file path=usr/share/man/sv/man1/fakeroot.1

--- a/components/sysutils/fakeroot/patches/01-test-bash.patch
+++ b/components/sysutils/fakeroot/patches/01-test-bash.patch
@@ -1,0 +1,32 @@
+Some tests expects bash instead of POSIX shell.
+
+--- fakeroot-1.31/test/echo_arg.orig
++++ fakeroot-1.31/test/echo_arg
+@@ -1,2 +1,2 @@
+-#!/bin/sh
++#!/bin/bash
+ eval echo \$$1
+--- fakeroot-1.31/test/cp-atest.orig
++++ fakeroot-1.31/test/cp-atest
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ set -e
+ echo cp-atest:
+ TMP="$tmp"
+--- fakeroot-1.31/test/tartest.orig
++++ fakeroot-1.31/test/tartest
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ set -e
+ echo tartest:
+ TMP="$tmp"
+--- fakeroot-1.31/test/compare-tar.orig
++++ fakeroot-1.31/test/compare-tar
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ ROOTGROUP=root
+ 
+ SYSNAME="`uname -s 2>/dev/null`"

--- a/components/sysutils/fakeroot/patches/02-test-uudecode.patch
+++ b/components/sysutils/fakeroot/patches/02-test-uudecode.patch
@@ -1,0 +1,13 @@
+uudecode is 32-bit and so we cannot preload the 64-bit libfakeroot there.
+
+--- fakeroot-1.31/test/tartest.orig
++++ fakeroot-1.31/test/tartest
+@@ -75,7 +75,7 @@
+ 
+ 
+ rm -f tartest.tar.gz
+-uudecode ${SRCDIR}/tartest.tar.gz.uue
++LD_PRELOAD= uudecode ${SRCDIR}/tartest.tar.gz.uue
+ 
+ tar -cf - tar | gzip -9 > faketar.tar.gz
+ 

--- a/components/sysutils/fakeroot/pkg5
+++ b/components/sysutils/fakeroot/pkg5
@@ -1,0 +1,10 @@
+{
+    "dependencies": [
+        "shell/bash",
+        "system/library"
+    ],
+    "fmris": [
+        "developer/fakeroot"
+    ],
+    "name": "fakeroot"
+}

--- a/components/sysutils/fakeroot/test/results-all.master
+++ b/components/sysutils/fakeroot/test/results-all.master
@@ -1,0 +1,20 @@
+PASS: t.chmod_dev
+PASS: t.chown
+PASS: t.cp-a
+PASS: t.echoarg
+PASS: t.falsereturn
+PASS: t.mknod
+PASS: t.no_ld_preload
+PASS: t.no_ld_preload_link
+PASS: t.option
+PASS: t.tar
+PASS: t.touchinstall
+PASS: t.truereturn
+SKIP: t.xattr
+# TOTAL: 13
+# PASS:  12
+# SKIP:  1
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0


### PR DESCRIPTION
We already do have `fakeroot` packaged:
```
$ pkg list -afv developer/fakeroot
FMRI                                                                         IFO
pkg://openindiana.org/developer/fakeroot@1.11-2013.0.0.0:20151027T061704Z    i--
$
```
but we do miss the build recipe for it.  Here it is.