### PR TITLE
tdb: drop 32 bit

### DIFF
--- a/components/library/tdb/Makefile
+++ b/components/library/tdb/Makefile
@@ -14,12 +14,12 @@
 # Copyright (c) 2022, Friedrich Kink
 #
 
-BUILD_BITS= 64_and_32
 BUILD_STYLE= waf
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= tdb
 COMPONENT_VERSION= 1.4.12
+COMPONENT_REVISION= 1
 COMPONENT_SUMMARY= Trivial Database Library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz

--- a/components/library/tdb/manifests/sample-manifest.p5m
+++ b/components/library/tdb/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,10 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH32)/tdbbackup
-file path=usr/bin/$(MACH32)/tdbdump
-file path=usr/bin/$(MACH32)/tdbrestore
-file path=usr/bin/$(MACH32)/tdbtool
 file path=usr/bin/tdbbackup
 file path=usr/bin/tdbdump
 file path=usr/bin/tdbrestore
@@ -36,7 +32,3 @@ link path=usr/lib/$(MACH64)/libtdb.so target=libtdb.so.$(HUMAN_VERSION)
 file path=usr/lib/$(MACH64)/libtdb.so.$(HUMAN_VERSION)
 link path=usr/lib/$(MACH64)/libtdb.so.1 target=libtdb.so.$(HUMAN_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/tdb.pc
-link path=usr/lib/libtdb.so target=libtdb.so.$(HUMAN_VERSION)
-file path=usr/lib/libtdb.so.$(HUMAN_VERSION)
-link path=usr/lib/libtdb.so.1 target=libtdb.so.$(HUMAN_VERSION)
-file path=usr/lib/pkgconfig/tdb.pc

--- a/components/library/tdb/tdb.p5m
+++ b/components/library/tdb/tdb.p5m
@@ -26,10 +26,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 # We don't deliver binaries
 <transform path=usr/bin -> drop>
 
-file path=usr/bin/$(MACH32)/tdbbackup
-file path=usr/bin/$(MACH32)/tdbdump
-file path=usr/bin/$(MACH32)/tdbrestore
-file path=usr/bin/$(MACH32)/tdbtool
 file path=usr/bin/tdbbackup
 file path=usr/bin/tdbdump
 file path=usr/bin/tdbrestore
@@ -39,7 +35,3 @@ link path=usr/lib/$(MACH64)/libtdb.so target=libtdb.so.$(HUMAN_VERSION)
 file path=usr/lib/$(MACH64)/libtdb.so.$(HUMAN_VERSION)
 link path=usr/lib/$(MACH64)/libtdb.so.1 target=libtdb.so.$(HUMAN_VERSION)
 file path=usr/lib/$(MACH64)/pkgconfig/tdb.pc
-link path=usr/lib/libtdb.so target=libtdb.so.$(HUMAN_VERSION)
-file path=usr/lib/libtdb.so.$(HUMAN_VERSION)
-link path=usr/lib/libtdb.so.1 target=libtdb.so.$(HUMAN_VERSION)
-file path=usr/lib/pkgconfig/tdb.pc


### PR DESCRIPTION
`tdb` is currently used by the following three components only: `library/libcanberra`, `multimedia/rhythmbox`, `web/squid`.  Since all of them are built 64 bit only then we can safely drop 32 bit support in `tdb`.