### PR TITLE
install-types: move components media/cdrtools and runtime/tk-8 from c…

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -10,7 +10,7 @@
 
 #
 # Copyright 2011 EveryCity Ltd. All rights reserved.
-# Copyright 2024 Klaus Ziegler
+# Copyright 2025 Klaus Ziegler
 #
 
 BUILD_STYLE = pkg
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	14
+COMPONENT_VERSION =	15
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/core
+++ b/components/meta-packages/install-types/includes/core
@@ -12,11 +12,9 @@ depend type=require fmri=compress/bzip2
 depend type=require fmri=compress/p7zip
 depend type=require fmri=compress/unzip
 depend type=require fmri=compress/zip
-depend type=require fmri=media/cdrtools
 depend type=require fmri=network/rsync
 depend type=require fmri=network/telnet
 depend type=require fmri=runtime/tcl-8
-depend type=require fmri=runtime/tk-8
 depend type=require fmri=service/hal
 depend type=require fmri=service/network/dns/mdns
 depend type=require fmri=service/network/network-clients

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -57,6 +57,7 @@ depend type=require fmri=library/gnome/gvfs
 depend type=require fmri=library/xdg/consolekit
 depend type=require fmri=library/xdg/xdg-user-dirs
 depend type=require fmri=mail/thunderbird
+depend type=require fmri=mail/cdrtools
 depend type=require fmri=network/ftp/ncftp
 depend type=require fmri=print/cups/system-config-printer
 depend type=require fmri=print/filter/ghostscript
@@ -65,6 +66,7 @@ depend type=require fmri=print/filter/ghostscript/fonts/gnu-gs-fonts-std
 depend type=require fmri=print/filter/gutenprint
 depend type=require fmri=print/filter/hplip
 depend type=require fmri=release/os-welcome
+depend type=require fmri=runtime/tk-8
 depend type=require fmri=service/gnome/desktop-cache
 depend type=require fmri=system/display-manager/desktop-startup
 depend type=require fmri=system/file-system/ntfsprogs


### PR DESCRIPTION
…ore profile to desktop_common, in order to provide a small ISO image which fits onto a CDROM again.