### PR TITLE
x11/components/mesa: fix erroneous dri-drivers-path

### DIFF
--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= mesa
 COMPONENT_VERSION= 21.3.9
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= The Mesa 3-D Graphics Library
 COMPONENT_SRC= mesa-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= mesa-$(COMPONENT_VERSION).tar.xz
@@ -66,7 +66,7 @@ CONFIGURE_OPTIONS += -Dshared-glapi=enabled
 CONFIGURE_OPTIONS += -Dgallium-xvmc=enabled
 CONFIGURE_OPTIONS += -Dgallium-xa=enabled
 CONFIGURE_OPTIONS += -Ddri-drivers=''
-CONFIGURE_OPTIONS += -Ddri-drivers-path=$(X11_SERVERMODS_DIR)/dri
+CONFIGURE_OPTIONS += -Ddri-drivers-path='$(X11_SERVERMODS_DIR)/dri$(SERVERMOD_SUBDIR)'
 CONFIGURE_OPTIONS += -Delf-tls=false
 
 CFLAGS += $(XPG7MODE)
@@ -93,7 +93,7 @@ COMPONENT_POST_INSTALL_ACTION.64 += \
 	  $(PROTOUSRLIBDIR)/mesa/$(MACH64)/$$f ; \
 	done ; \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
-	  $(PROTOUSRLIBDIR)/xorg/modules/dri/i915_dri.so ; \
+	  $(PROTOUSRLIBDIR)/xorg/modules/dri/$(MACH64)/i915_dri.so ; \
 	mv $(PROTOUSRDIR)/include/GL $(PROTOUSRDIR)/include/mesa
 
 # Manually added build dependencies

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -46,7 +46,7 @@ X11_SERVERLIBS_DIR= /usr/lib/xorg
 
 CONFIGURE_OPTIONS += --libdir='lib/mesa/amd64'
 
-PKG_HARDLINKS += usr/lib/xorg/modules/dri/kms_swrast_dri.so
+PKG_HARDLINKS += usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 
 # Command line options to GNU autoconf configure script
 CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, i915, r600'

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -98,8 +98,8 @@ link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0 \
     target=libvdpau_r600.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0.0
-hardlink path=usr/lib/xorg/modules/dri/i915_dri.so target=kms_swrast_dri.so
-file path=usr/lib/xorg/modules/dri/kms_swrast_dri.so
-hardlink path=usr/lib/xorg/modules/dri/r600_dri.so target=kms_swrast_dri.so
-hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=kms_swrast_dri.so
+hardlink path=usr/lib/xorg/modules/dri/$(MACH64/i915_dri.so target=kms_swrast_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
+hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/r600_dri.so target=kms_swrast_dri.so
+hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so target=kms_swrast_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -147,8 +147,8 @@ link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
 link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0 \
     target=libvdpau_r600.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0.0
-file path=usr/lib/xorg/modules/dri/i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/kms_swrast_dri.so target=i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/r600_dri.so target=i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/swrast_dri.so target=i915_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/i915_dri.so
+hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so target=i915_dri.so
+hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/r600_dri.so target=i915_dri.so
+hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so target=i915_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf


### PR DESCRIPTION
Xorg expects /usr/lib/xorg/modules/dri/amd64 , and previous versions of Mesa provided this path. With the version update to v21.3.9 this changed to /usr/lib/xorg/modules/dri , which causes problems, i.e. as previously described with Xorg expecting /usr/lib/xorg/modules/dri/amd64 , which is defined in x11.mk along with drivers, extensions, input and multimedia paths for Xorg.