### PR TITLE
install-types: fix cdrtools package name

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	15
+COMPONENT_VERSION =	16
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -57,7 +57,7 @@ depend type=require fmri=library/gnome/gvfs
 depend type=require fmri=library/xdg/consolekit
 depend type=require fmri=library/xdg/xdg-user-dirs
 depend type=require fmri=mail/thunderbird
-depend type=require fmri=mail/cdrtools
+depend type=require fmri=media/cdrtools
 depend type=require fmri=network/ftp/ncftp
 depend type=require fmri=print/cups/system-config-printer
 depend type=require fmri=print/filter/ghostscript

--- a/components/meta-packages/install-types/manifests/sample-manifest.p5m
+++ b/components/meta-packages/install-types/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)


### PR DESCRIPTION
This fixes typo introduced in #20471.