### PR TITLE
mate_install: do not depend on deprecated GStreamer 0.10

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	16
+COMPONENT_VERSION =	17
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -49,7 +49,6 @@ depend type=require fmri=gnome/theme/tango-icon-theme
 depend type=require fmri=gnome/zenity
 depend type=require fmri=image/dcraw
 depend type=require fmri=image/scanner/xsane/sane-backends
-depend type=require fmri=library/audio/gstreamer
 depend type=require fmri=library/desktop/desktop-file-utils
 depend type=require fmri=library/desktop/gtk3
 depend type=require fmri=library/glib-networking


### PR DESCRIPTION
GStreamer 0.10 is deprecated for almost 13 years now so there is no reason to bring it to new installations.