### PR TITLE
stack-spur: rebuild with gcc 14.2

### DIFF
--- a/components/runtime/smalltalk/stack-spur/Makefile
+++ b/components/runtime/smalltalk/stack-spur/Makefile
@@ -9,7 +9,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2022, 2023, 2024 David Stes
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025 David Stes
 #
 
 
@@ -27,7 +27,7 @@
 # the driver script checks (with ckformat) the Smalltalk image
 # image format 6521 or 7033 : start VM 32bit  (not included any longer)
 # image format 68021 or 68533 : start VM 64bit
-BUILD_BITS=64
+
 USE_COMMON_TEST_MASTER= no
 
 # the SSL module is supporting 1.1 and 3.x but SUnit testframework is not
@@ -49,9 +49,9 @@ include ../../../../make-rules/shared-macros.mk
 # sometimes the Stack VM is generated from a different VMMaker as the Cog VM
 
 COMPONENT_NAME=		stack-spur
-COMPONENT_VERSION=	5.0.3475
-GIT_TAG=		sun-v5.0.69
-PLUGIN_REV=		5.0-202412141720
+COMPONENT_VERSION=	5.0.3504
+GIT_TAG=		sun-v5.0.70
+PLUGIN_REV=		5.0-202501172014
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_FMRI=		runtime/smalltalk/stack-spur
@@ -65,7 +65,7 @@ COMPONENT_LICENSE_FILE=	squeak5.license
 
 COMPONENT_SRC=		opensmalltalk-vm-$(GIT_TAG)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:4bf8791bea40ed4f730e23286d7357abee1a26f0a3c8d2dbef29431fbfebe79c
+COMPONENT_ARCHIVE_HASH=	sha256:31eb43ecea76728b4a83ed8cebdcf70f9adeea324e990895e7c134a8cb91854c
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 # run SUnit tests in the build directories on 32bit and 64bit Squeak images
@@ -114,7 +114,12 @@ LIBS = "-lmapmalloc"
 
 # the default CFLAGS.gcc will be -m64 -O3 but this does not work for us
 # opensmalltalk code is not compatible with the gcc optimizer -O2 or higher
+# for gcc 14.2 add -Wno-error options
 gcc_OPT=		-DAIO_DEBUG -DNDEBUG -DDEBUGVM=0
+gcc_OPT+=		-Wno-error=implicit-function-declaration
+gcc_OPT+=		-Wno-error=incompatible-pointer-types
+gcc_OPT+=		-Wno-error=return-mismatch
+gcc_OPT+=		-Wno-error=int-to-pointer-cast
 
 CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/config/configure
 CONFIGURE_OPTIONS +=	--with-vmversion=5.0
@@ -165,7 +170,6 @@ rebuild-manifests::
 
 REQUIRED_PACKAGES += x11/library/mesa
 REQUIRED_PACKAGES += system/library/dbus
-REQUIRED_PACKAGES += library/audio/gstreamer
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += system/library/freetype-2
 

--- a/components/runtime/smalltalk/stack-spur/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -31,29 +31,29 @@ file path=usr/doc/squeak/LICENSE
 file path=usr/doc/squeak/README.Contributing
 file path=usr/doc/squeak/README.Keyboard
 file path=usr/doc/squeak/README.Sound
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/B3DAcceleratorPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/ClipboardExtendedPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/DESPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/ImmX11Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/MD5Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/SHA2Plugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/UnixOSProcessPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/VectorEnginePlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/XDisplayControlPlugin.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/squeak
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/vm-display-X11.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/vm-display-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/vm-sound-OSS.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/vm-sound-Sun.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/vm-sound-null.so
-file path=usr/lib/$(MACH64)/squeak/5.0-202412141720-64bit/vm-sound-pulse.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/ClipboardExtendedPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/VectorEnginePlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/squeak
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/vm-sound-OSS.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/vm-sound-Sun.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/5.0-202501172014-64bit/vm-sound-pulse.so
 hardlink path=usr/share/man/man1/inisqueak.1 target=squeak.1
 file path=usr/share/man/man1/squeak.1
 file path=usr/squeak

--- a/components/runtime/smalltalk/stack-spur/patches/02-sqSCCSVersion.patch
+++ b/components/runtime/smalltalk/stack-spur/patches/02-sqSCCSVersion.patch
@@ -1,15 +1,15 @@
---- opensmalltalk-vm-sun-v5.0.69/platforms/Cross/vm/sqSCCSVersion.h	Sat Dec 14 18:20:36 2024
-+++ p0/opensmalltalk-vm-sun-v5.0.69/platforms/Cross/vm/sqSCCSVersion.h	Sun Dec 15 16:21:13 2024
+--- opensmalltalk-vm-sun-v5.0.70/platforms/Cross/vm/sqSCCSVersion.h	Fri Jan 17 21:14:01 2025
++++ p0/opensmalltalk-vm-sun-v5.0.70/platforms/Cross/vm/sqSCCSVersion.h	Sat Jan 18 12:03:09 2025
 @@ -30,13 +30,13 @@
  
  #if SUBVERSION
  # define PREFIX "r"
 -static char SvnRawRevisionString[] = "$Rev$";
-+static char SvnRawRevisionString[] = "$Rev: 202412141720 $";
++static char SvnRawRevisionString[] = "$Rev: 202501172014 $";
  # define REV_START (SvnRawRevisionString + 6)
  
 -static char SvnRawRevisionDate[] = "$Date$";
-+static char SvnRawRevisionDate[] = "$Date: Sat Dec 14 18:20:36 2024 +0100 $";
++static char SvnRawRevisionDate[] = "$Date: Fri Jan 17 21:14:01 2025 +0100 $";
  # define DATE_START (SvnRawRevisionDate + 7)
  
 -static char SvnRawRepositoryURL[] = "$URL$";
@@ -22,12 +22,12 @@
  #elif GIT
  # define PREFIX ""
 -static char GitRawRevisionString[] = "$Rev$";
-+static char GitRawRevisionString[] = "$Rev: 202412141720 $";
++static char GitRawRevisionString[] = "$Rev: 202501172014 $";
  # define REV_START (GitRawRevisionString + 6)
  # define REV_TIME_START (GitRawRevisionString + 14)
  
 -static char GitRawRevisionDate[] = "$Date$";
-+static char GitRawRevisionDate[] = "$Date: Sat Dec 14 18:20:36 2024 +0100 $";
++static char GitRawRevisionDate[] = "$Date: Fri Jan 17 21:14:01 2025 +0100 $";
  # define DATE_START (GitRawRevisionDate + 7)
  
 -static char GitRawRepositoryURL[] = "$URL$";
@@ -35,7 +35,7 @@
  # define URL_START (GitRawRepositoryURL + 6)
  
 -static char GitRawRevisionShortHash[] = "$CommitHash$";
-+static char GitRawRevisionShortHash[] = "$CommitHash: a8ec45a72 $";
++static char GitRawRevisionShortHash[] = "$CommitHash: bd8fe13a7 $";
  # define SHORTHASH_START (GitRawRevisionShortHash + 13)
  
  static char *

--- a/components/runtime/smalltalk/stack-spur/patches/03-sqPluginsSCCSVersion.patch
+++ b/components/runtime/smalltalk/stack-spur/patches/03-sqPluginsSCCSVersion.patch
@@ -1,11 +1,11 @@
---- opensmalltalk-vm-sun-v5.0.69/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sat Dec 14 18:20:36 2024
-+++ p0/opensmalltalk-vm-sun-v5.0.69/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sun Dec 15 16:21:13 2024
+--- opensmalltalk-vm-sun-v5.0.70/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri Jan 17 21:14:01 2025
++++ p0/opensmalltalk-vm-sun-v5.0.70/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sat Jan 18 12:03:09 2025
 @@ -9,10 +9,10 @@
   */
  
  #if SUBVERSION
 -static char SvnRawPluginsRevisionString[] = "$Rev$";
-+static char SvnRawPluginsRevisionString[] = "$Rev: 202412141720 $";
++static char SvnRawPluginsRevisionString[] = "$Rev: 202501172014 $";
  # define PLUGINS_REV_START (SvnRawPluginsRevisionString + 6)
  
 -static char SvnRawPluginsRepositoryURL[] = "$URL$";
@@ -18,7 +18,7 @@
  # undef URL_START
  #elif GIT
 -static char GitRawPluginsRevisionString[] = "$Rev$";
-+static char GitRawPluginsRevisionString[] = "$Rev: 202412141720 $";
++static char GitRawPluginsRevisionString[] = "$Rev: 202501172014 $";
  # define PLUGINS_REV_START (GitRawPluginsRevisionString + 6)
  
 -static char GitRawPluginsRepositoryURL[] = "$URL$";

--- a/components/runtime/smalltalk/stack-spur/pkg5
+++ b/components/runtime/smalltalk/stack-spur/pkg5
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "library/audio/gstreamer",
         "library/audio/pulseaudio",
         "library/desktop/cairo",
         "library/desktop/pango",

--- a/components/runtime/smalltalk/stack-spur/squeak.ips
+++ b/components/runtime/smalltalk/stack-spur/squeak.ips
@@ -6,7 +6,7 @@
 # Last edited: 2013-11-13 19:51:35 by piumarta on emilia
 
 PATH=/usr/bin:/bin
-PLUGIN_REV=5.0-202412141720
+PLUGIN_REV=5.0-202501172014
 
 realpath () {
     path="$1"

--- a/components/runtime/smalltalk/stack-spur/test/results-64.master
+++ b/components/runtime/smalltalk/stack-spur/test/results-64.master
@@ -1,7 +1,7 @@
 SUnit Results
 Squeak5.3
 solaris2.11
-Open Smalltalk Stack VM [StackInterpreterPrimitives VMMaker.oscog-eem.3475]
+Open Smalltalk Stack VM [StackInterpreterPrimitives VMMaker.oscog-eem.3504]
 Failed Tests
 'BorderedMorphTests>>#test01OldInstVarRefs'
 'OrderedDictionaryTest>>#testGrow'


### PR DESCRIPTION

Remove dependency gstreamer for GStreamerPlugin (which was not packaged in the case of stack-spur)
