### PR TITLE
cog-spur: rebuild with gcc 14.2

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -36,14 +36,6 @@ USE_OPENSSL10=yes
 # the default OpenIndiana JPEG_IMPLEM at time of writing is libjpeg8-turbo
 JPEG_IMPLEM=libjpeg8-turbo
 
-# problems OpenSmalltalk and gcc
-# the default gcc_OPT flags with -O2 do not work (see below)
-# this has been the case for many years
-# extra problems with gcc 14.2 
-# gcc_OPT+=		-Wno-error=implicit-function-declaration
-# problem with iconv and restrict keyword
-GCC_VERSION=	13
-
 include ../../../../make-rules/shared-macros.mk
 
 # there is no official triplet version for opensmalltalk-vm
@@ -52,7 +44,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.3504
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 GIT_TAG=		sun-v5.0.70
 PLUGIN_REV=		5.0-202501172014-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine
@@ -118,7 +110,12 @@ LIBS = "-lmapmalloc"
 
 # the default CFLAGS.gcc will be -m64 -O3 but this does not work for us
 # opensmalltalk code is not compatible with the gcc optimizer -O2 or higher
+# for gcc 14.2 add -Wno-error options
 gcc_OPT=		-DAIO_DEBUG -DNDEBUG -DDEBUGVM=0 -DCOGMTVM=0
+gcc_OPT+=		-Wno-error=implicit-function-declaration
+gcc_OPT+=		-Wno-error=incompatible-pointer-types
+gcc_OPT+=		-Wno-error=return-mismatch
+gcc_OPT+=		-Wno-error=int-to-pointer-cast
 
 CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/config/configure
 CONFIGURE_OPTIONS +=	--without-npsqueak
@@ -167,7 +164,6 @@ rebuild-manifests::
 
 REQUIRED_PACKAGES += x11/library/mesa
 REQUIRED_PACKAGES += system/library/dbus
-REQUIRED_PACKAGES += library/audio/gstreamer
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += system/library/freetype-2
 

--- a/components/runtime/smalltalk/cog-spur/pkg5
+++ b/components/runtime/smalltalk/cog-spur/pkg5
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "library/audio/gstreamer",
         "library/audio/pulseaudio",
         "library/desktop/cairo",
         "library/desktop/pango",


### PR DESCRIPTION

Remove dependency gstreamer for GStreamerPlugin (which was not packaged in the case of stack-spur)
