### PR TITLE
components/x11/mesa: further fixes and enablement of dri (i915) and gallium (swrast, crocus, iris) drivers

### DIFF
--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -46,7 +46,7 @@ X11_SERVERLIBS_DIR= /usr/lib/xorg
 
 CONFIGURE_OPTIONS += --libdir='lib/mesa/amd64'
 
-PKG_HARDLINKS += usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
+#PKG_HARDLINKS += usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 
 # Command line options to GNU autoconf configure script
 CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, i915'
@@ -92,8 +92,10 @@ COMPONENT_POST_INSTALL_ACTION.64 += \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
 	  $(PROTOUSRLIBDIR)/mesa/$(MACH64)/$$f ; \
 	done ; \
+	for f in kms_swrast_dri.so i915_dri.so; do \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
-	  $(PROTOUSRLIBDIR)/xorg/modules/dri/$(MACH64)/i915_dri.so ; \
+	  $(PROTOUSRLIBDIR)/xorg/modules/dri/$(MACH64)/$$f ; \
+	done ; \
 	mv $(PROTOUSRDIR)/include/GL $(PROTOUSRDIR)/include/mesa
 
 # Manually added build dependencies

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -51,7 +51,7 @@ CONFIGURE_OPTIONS += --libdir='lib/mesa/amd64'
 #PKG_HARDLINKS += usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 
 # Command line options to GNU autoconf configure script
-CONFIGURE_OPTIONS += -Dgallium-drivers='swrast'
+CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, crocus, iris'
 CONFIGURE_OPTIONS += -Dvulkan-drivers=''
 CONFIGURE_OPTIONS += -Dgbm=enabled
 CONFIGURE_OPTIONS += -Dglvnd=false
@@ -70,6 +70,8 @@ CONFIGURE_OPTIONS += -Dgallium-xa=disabled
 CONFIGURE_OPTIONS += -Ddri-drivers='i915'
 CONFIGURE_OPTIONS += -Ddri-drivers-path='$(X11_SERVERMODS_DIR)/dri$(SERVERMOD_SUBDIR)'
 CONFIGURE_OPTIONS += -Delf-tls=false
+CONFIGURE_OPTIONS += -Dprefer-crocus=true
+CONFIGURE_OPTIONS += -Dprefer-iris=true
 
 CFLAGS += $(XPG7MODE)
 CFLAGS += -Wno-incompatible-pointer-types -D_POSIX_PTHREAD_SEMANTICS
@@ -94,7 +96,7 @@ COMPONENT_POST_INSTALL_ACTION.64 += \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR):${CLANG_LIBDIR}" \
 	  $(PROTOUSRLIBDIR)/mesa/$(MACH64)/$$f ; \
 	done ; \
-	for f in kms_swrast_dri.so i915_dri.so; do \
+	for f in kms_swrast_dri.so i915_dri.so crocus_dri.so iris_dri.so; do \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR):${CLANG_LIBDIR}" \
 	  $(PROTOUSRLIBDIR)/xorg/modules/dri/$(MACH64)/$$f ; \
 	done ; \

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -18,6 +18,8 @@ BUILD_BITS = 64
 BUILD_STYLE = meson
 include ../../../make-rules/shared-macros.mk
 
+CLANG_VERSION = 13
+
 COMPONENT_NAME= mesa
 COMPONENT_VERSION= 21.3.9
 COMPONENT_REVISION= 2
@@ -56,7 +58,7 @@ CONFIGURE_OPTIONS += -Dglvnd=false
 # Wayland currently requires linux specific socket options and epoll for events.
 CONFIGURE_OPTIONS += -Dplatforms='x11'
 # llvm is disabled due to requiring llvm 16 we do not have 16
-CONFIGURE_OPTIONS += -Dllvm=false
+CONFIGURE_OPTIONS += -Dllvm=enabled
 CONFIGURE_OPTIONS += -Dglx='auto'
 CONFIGURE_OPTIONS += -Degl=enabled
 CONFIGURE_OPTIONS += -Dgles1=enabled
@@ -88,12 +90,12 @@ CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
 # Add RPATH to xorg lib directory where is libdrm.
 
 COMPONENT_POST_INSTALL_ACTION.64 += \
-	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0; do \
-	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
+	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0 libOSMesa.so.8.0.0; do \
+	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR):${CLANG_LIBDIR}" \
 	  $(PROTOUSRLIBDIR)/mesa/$(MACH64)/$$f ; \
 	done ; \
 	for f in kms_swrast_dri.so i915_dri.so; do \
-	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
+	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR):${CLANG_LIBDIR}" \
 	  $(PROTOUSRLIBDIR)/xorg/modules/dri/$(MACH64)/$$f ; \
 	done ; \
 	mv $(PROTOUSRDIR)/include/GL $(PROTOUSRDIR)/include/mesa
@@ -107,6 +109,7 @@ REQUIRED_PACKAGES += library/graphics/libvdpau
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
+REQUIRED_PACKAGES += $(CLANG_RUNTIME_PKG)
 REQUIRED_PACKAGES += compress/zstd
 REQUIRED_PACKAGES += library/expat
 REQUIRED_PACKAGES += library/zlib

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -49,7 +49,7 @@ CONFIGURE_OPTIONS += --libdir='lib/mesa/amd64'
 #PKG_HARDLINKS += usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 
 # Command line options to GNU autoconf configure script
-CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, i915'
+CONFIGURE_OPTIONS += -Dgallium-drivers='swrast'
 CONFIGURE_OPTIONS += -Dvulkan-drivers=''
 CONFIGURE_OPTIONS += -Dgbm=enabled
 CONFIGURE_OPTIONS += -Dglvnd=false
@@ -64,8 +64,8 @@ CONFIGURE_OPTIONS += -Dgles2=enabled
 CONFIGURE_OPTIONS += -Dosmesa=true
 CONFIGURE_OPTIONS += -Dshared-glapi=enabled
 CONFIGURE_OPTIONS += -Dgallium-xvmc=disabled
-CONFIGURE_OPTIONS += -Dgallium-xa=enabled
-CONFIGURE_OPTIONS += -Ddri-drivers=''
+CONFIGURE_OPTIONS += -Dgallium-xa=disabled
+CONFIGURE_OPTIONS += -Ddri-drivers='i915'
 CONFIGURE_OPTIONS += -Ddri-drivers-path='$(X11_SERVERMODS_DIR)/dri$(SERVERMOD_SUBDIR)'
 CONFIGURE_OPTIONS += -Delf-tls=false
 
@@ -88,7 +88,7 @@ CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
 # Add RPATH to xorg lib directory where is libdrm.
 
 COMPONENT_POST_INSTALL_ACTION.64 += \
-	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0 libxatracker.so.2.5.0; do \
+	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0; do \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
 	  $(PROTOUSRLIBDIR)/mesa/$(MACH64)/$$f ; \
 	done ; \

--- a/components/x11/mesa/Makefile
+++ b/components/x11/mesa/Makefile
@@ -49,7 +49,7 @@ CONFIGURE_OPTIONS += --libdir='lib/mesa/amd64'
 PKG_HARDLINKS += usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 
 # Command line options to GNU autoconf configure script
-CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, i915, r600'
+CONFIGURE_OPTIONS += -Dgallium-drivers='swrast, i915'
 CONFIGURE_OPTIONS += -Dvulkan-drivers=''
 CONFIGURE_OPTIONS += -Dgbm=enabled
 CONFIGURE_OPTIONS += -Dglvnd=false
@@ -63,7 +63,7 @@ CONFIGURE_OPTIONS += -Dgles1=enabled
 CONFIGURE_OPTIONS += -Dgles2=enabled
 CONFIGURE_OPTIONS += -Dosmesa=true
 CONFIGURE_OPTIONS += -Dshared-glapi=enabled
-CONFIGURE_OPTIONS += -Dgallium-xvmc=enabled
+CONFIGURE_OPTIONS += -Dgallium-xvmc=disabled
 CONFIGURE_OPTIONS += -Dgallium-xa=enabled
 CONFIGURE_OPTIONS += -Ddri-drivers=''
 CONFIGURE_OPTIONS += -Ddri-drivers-path='$(X11_SERVERMODS_DIR)/dri$(SERVERMOD_SUBDIR)'
@@ -88,7 +88,7 @@ CONFIGURE_ENV += CPPFLAGS="$(CPPFLAGS)"
 # Add RPATH to xorg lib directory where is libdrm.
 
 COMPONENT_POST_INSTALL_ACTION.64 += \
-	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0 libxatracker.so.2.5.0 libXvMCr600.so.1.0.0 vdpau/libvdpau_r600.so.1.0.0; do \
+	for f in libgbm.so.1.0.0 libEGL.so.1.0.0 libGL.so.1.2.0 libxatracker.so.2.5.0; do \
 	elfedit -e "dyn:runpath /usr/lib/mesa/$(MACH64):/usr/lib/xorg/$(MACH64):$(GCC_LIBDIR)" \
 	  $(PROTOUSRLIBDIR)/mesa/$(MACH64)/$$f ; \
 	done ; \

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -89,5 +89,4 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64/i915_dri.so target=kms_swrast_dri.so
 file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
-hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so target=kms_swrast_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -52,9 +52,6 @@ file path=usr/include/mesa/internal/dri_interface.h
 link path=usr/include/GL/internal/dri_interface.h target=../../mesa/internal/dri_interface.h
 file path=usr/include/mesa/osmesa.h
 link path=usr/include/GL/osmesa.h target=../mesa/osmesa.h
-file path=usr/include/xa_composite.h
-file path=usr/include/xa_context.h
-file path=usr/include/xa_tracker.h
 link path=usr/lib/mesa/$(MACH64)/libEGL.so target=libEGL.so.1
 link path=usr/lib/mesa/$(MACH64)/libEGL.so.1 target=libEGL.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libEGL.so.1.0.0
@@ -76,9 +73,6 @@ file path=usr/lib/mesa/$(MACH64)/libgbm.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so target=libglapi.so.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so.0 target=libglapi.so.0.0.0
 file path=usr/lib/mesa/$(MACH64)/libglapi.so.0.0.0
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so target=libxatracker.so.2
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so.2 target=libxatracker.so.2.5.0
-file path=usr/lib/mesa/$(MACH64)/libxatracker.so.2.5.0
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/dri.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/egl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/gbm.pc
@@ -86,7 +80,6 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/gl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
-file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
-hardlink path=usr/lib/xorg/modules/dri/$(MACH64/i915_dri.so target=kms_swrast_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64/i915_dri.so
 file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -70,10 +70,6 @@ file path=usr/lib/mesa/$(MACH64)/libGLESv2.so.2.0.0
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so target=libOSMesa.so.8
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8 target=libOSMesa.so.8.0.0
 file path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1 target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0 target=libXvMCr600.so.1.0.0
-file path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libgbm.so target=libgbm.so.1
 link path=usr/lib/mesa/$(MACH64)/libgbm.so.1 target=libgbm.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libgbm.so.1.0.0
@@ -91,15 +87,7 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
-link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so \
-    target=libvdpau_r600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
-    target=libvdpau_r600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0 \
-    target=libvdpau_r600.so.1.0.0
-file path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0.0
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64/i915_dri.so target=kms_swrast_dri.so
 file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
-hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/r600_dri.so target=kms_swrast_dri.so
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so target=kms_swrast_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/manifests/sample-manifest.p5m
+++ b/components/x11/mesa/manifests/sample-manifest.p5m
@@ -82,4 +82,6 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
 file path=usr/lib/xorg/modules/dri/$(MACH64/i915_dri.so
 file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/crocus_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/iris_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -70,7 +70,6 @@ link path=usr/lib/$(MACH64)/pkgconfig/gl.pc target=../../mesa/$(MACH64)/pkgconfi
 link path=usr/lib/$(MACH64)/pkgconfig/glesv1_cm.pc target=../../mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 link path=usr/lib/$(MACH64)/pkgconfig/glesv2.pc target=../../mesa/$(MACH64)/pkgconfig/glesv2.pc
 link path=usr/lib/$(MACH64)/pkgconfig/osmesa.pc target=../../mesa/$(MACH64)/pkgconfig/osmesa.pc
-link path=usr/lib/$(MACH64)/pkgconfig/xatracker.pc target=../../mesa/$(MACH64)/pkgconfig/xatracker.pc
 
 file path=usr/include/EGL/egl.h
 file path=usr/include/EGL/eglext.h
@@ -101,9 +100,6 @@ file path=usr/include/mesa/internal/dri_interface.h
 link path=usr/include/GL/internal/dri_interface.h target=../../mesa/internal/dri_interface.h
 file path=usr/include/mesa/osmesa.h
 link path=usr/include/GL/osmesa.h target=../mesa/osmesa.h
-file path=usr/include/xa_composite.h
-file path=usr/include/xa_context.h
-file path=usr/include/xa_tracker.h
 link path=usr/lib/mesa/$(MACH64)/libEGL.so target=libEGL.so.1
 link path=usr/lib/mesa/$(MACH64)/libEGL.so.1 target=libEGL.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libEGL.so.1.0.0
@@ -125,9 +121,6 @@ file path=usr/lib/mesa/$(MACH64)/libgbm.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so target=libglapi.so.0
 link path=usr/lib/mesa/$(MACH64)/libglapi.so.0 target=libglapi.so.0.0.0
 file path=usr/lib/mesa/$(MACH64)/libglapi.so.0.0.0
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so target=libxatracker.so.2
-link path=usr/lib/mesa/$(MACH64)/libxatracker.so.2 target=libxatracker.so.2.5.0
-file path=usr/lib/mesa/$(MACH64)/libxatracker.so.2.5.0
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/dri.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/egl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/gbm.pc
@@ -135,7 +128,6 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/gl.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
-file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
 file path=usr/lib/xorg/modules/dri/$(MACH64)/i915_dri.so
 file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -137,6 +137,5 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
 file path=usr/lib/xorg/modules/dri/$(MACH64)/i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so target=i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so target=i915_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -119,10 +119,6 @@ file path=usr/lib/mesa/$(MACH64)/libGLESv2.so.2.0.0
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so target=libOSMesa.so.8
 link path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8 target=libOSMesa.so.8.0.0
 file path=usr/lib/mesa/$(MACH64)/libOSMesa.so.8.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1 target=libXvMCr600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0 target=libXvMCr600.so.1.0.0
-file path=usr/lib/mesa/$(MACH64)/libXvMCr600.so.1.0.0
 link path=usr/lib/mesa/$(MACH64)/libgbm.so target=libgbm.so.1
 link path=usr/lib/mesa/$(MACH64)/libgbm.so.1 target=libgbm.so.1.0.0
 file path=usr/lib/mesa/$(MACH64)/libgbm.so.1.0.0
@@ -140,15 +136,7 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv1_cm.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/xatracker.pc
-link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so \
-    target=libvdpau_r600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1 \
-    target=libvdpau_r600.so.1.0.0
-link path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0 \
-    target=libvdpau_r600.so.1.0.0
-file path=usr/lib/mesa/$(MACH64)/vdpau/libvdpau_r600.so.1.0.0
 file path=usr/lib/xorg/modules/dri/$(MACH64)/i915_dri.so
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so target=i915_dri.so
-hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/r600_dri.so target=i915_dri.so
 hardlink path=usr/lib/xorg/modules/dri/$(MACH64)/swrast_dri.so target=i915_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf

--- a/components/x11/mesa/mesa.p5m
+++ b/components/x11/mesa/mesa.p5m
@@ -130,4 +130,6 @@ file path=usr/lib/mesa/$(MACH64)/pkgconfig/glesv2.pc
 file path=usr/lib/mesa/$(MACH64)/pkgconfig/osmesa.pc
 file path=usr/lib/xorg/modules/dri/$(MACH64)/i915_dri.so
 file path=usr/lib/xorg/modules/dri/$(MACH64)/kms_swrast_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/crocus_dri.so
+file path=usr/lib/xorg/modules/dri/$(MACH64)/iris_dri.so
 file path=usr/share/drirc.d/00-mesa-defaults.conf


### PR DESCRIPTION
As per title.

These fixes in addition to the previous fixes I have contributed will result in an almost error free Xorg log. When starting xorg-server there is an error for no devices found. When poking further it is around device initialisation. I read this to be an error in libdrm, resulting from the update in 2024.

When trying to load a gallium driver there is an error. When poked further it leads to libGLESv2.

Outstanding TODO:
- Glamor needs to be enabled in xorg-server
- libdrm needs to be explicitly enabled in xorg-server
- we might need to explicitly enable dri3 in Mesa
- xa might need to be re-enabled in Mesa.
- XvMc will need to be re-enabled in Mesa when we start to add r300, r600, etc.

With this PR, someone should be able to tweak libdrm and get a working Intel dri setup, just like we had before.  Once the initial TODOs are complete i.e. Glamor enablement in xorg-server, we are not far away from a Mesa with working gallium drivers.