### PR TITLE
Add gom

### DIFF
--- a/components/desktop/gnome/gom/Makefile
+++ b/components/desktop/gnome/gom/Makefile
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+BUILD_STYLE = meson
+USE_DEFAULT_TEST_TRANSFORMS = yes
+
+include ../../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=			gom
+HUMAN_VERSION=			0.5.3
+COMPONENT_SUMMARY=		GObject Data Mapper
+COMPONENT_ARCHIVE_HASH=		sha256:069d0909fbdc6b4d27edf7a879366194e3ab508b03548bf5b89ff63546d20177
+COMPONENT_FMRI=			library/gnome/libgom
+COMPONENT_CLASSIFICATION=	Desktop (GNOME)/Libraries
+COMPONENT_LICENSE=		LGPL-2.1-only
+COMPONENT_LICENSE_FILE=		COPYING
+
+include $(WS_MAKE_RULES)/gnome.mk
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += database/sqlite-3
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += system/library

--- a/components/desktop/gnome/gom/gom.p5m
+++ b/components/desktop/gnome/gom/gom.p5m
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/gom-1.0/gom/gom-adapter.h
+file path=usr/include/gom-1.0/gom/gom-autocleanups.h
+file path=usr/include/gom-1.0/gom/gom-command-builder.h
+file path=usr/include/gom-1.0/gom/gom-command.h
+file path=usr/include/gom-1.0/gom/gom-cursor.h
+file path=usr/include/gom-1.0/gom/gom-error.h
+file path=usr/include/gom-1.0/gom/gom-filter.h
+file path=usr/include/gom-1.0/gom/gom-repository.h
+file path=usr/include/gom-1.0/gom/gom-resource-group.h
+file path=usr/include/gom-1.0/gom/gom-resource.h
+file path=usr/include/gom-1.0/gom/gom-sorting.h
+file path=usr/include/gom-1.0/gom/gom.h
+file path=usr/lib/$(MACH64)/girepository-1.0/Gom-1.0.typelib
+link path=usr/lib/$(MACH64)/libgom-1.0.so target=libgom-1.0.so.0
+link path=usr/lib/$(MACH64)/libgom-1.0.so.0 target=libgom-1.0.so.0.1.0
+file path=usr/lib/$(MACH64)/libgom-1.0.so.0.1.0
+file path=usr/lib/$(MACH64)/pkgconfig/gom-1.0.pc
+file path=usr/lib/$(MACH64)/python3.9/vendor-packages/gi/overrides/Gom.py
+file path=usr/share/gir-1.0/Gom-1.0.gir

--- a/components/desktop/gnome/gom/manifests/sample-manifest.p5m
+++ b/components/desktop/gnome/gom/manifests/sample-manifest.p5m
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/gom-1.0/gom/gom-adapter.h
+file path=usr/include/gom-1.0/gom/gom-autocleanups.h
+file path=usr/include/gom-1.0/gom/gom-command-builder.h
+file path=usr/include/gom-1.0/gom/gom-command.h
+file path=usr/include/gom-1.0/gom/gom-cursor.h
+file path=usr/include/gom-1.0/gom/gom-error.h
+file path=usr/include/gom-1.0/gom/gom-filter.h
+file path=usr/include/gom-1.0/gom/gom-repository.h
+file path=usr/include/gom-1.0/gom/gom-resource-group.h
+file path=usr/include/gom-1.0/gom/gom-resource.h
+file path=usr/include/gom-1.0/gom/gom-sorting.h
+file path=usr/include/gom-1.0/gom/gom.h
+file path=usr/lib/$(MACH64)/girepository-1.0/Gom-1.0.typelib
+link path=usr/lib/$(MACH64)/libgom-1.0.so target=libgom-1.0.so.0
+link path=usr/lib/$(MACH64)/libgom-1.0.so.0 target=libgom-1.0.so.0.1.0
+file path=usr/lib/$(MACH64)/libgom-1.0.so.0.1.0
+file path=usr/lib/$(MACH64)/pkgconfig/gom-1.0.pc
+file path=usr/lib/$(MACH64)/python3.9/vendor-packages/gi/overrides/Gom.py
+file path=usr/share/gir-1.0/Gom-1.0.gir

--- a/components/desktop/gnome/gom/pkg5
+++ b/components/desktop/gnome/gom/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "database/sqlite-3",
+        "library/glib2",
+        "system/library"
+    ],
+    "fmris": [
+        "library/gnome/libgom"
+    ],
+    "name": "gom"
+}

--- a/components/desktop/gnome/gom/test/results-all.master
+++ b/components/desktop/gnome/gom/test/results-all.master
@@ -1,0 +1,21 @@
+test-gom-adapter       OK
+test-gom-constraints   OK
+test-gom-datetime      OK
+test-gom-find          OK
+test-gom-find-specific OK
+test-gom-insert        OK
+test-gom-migration     OK
+test-gom-repository    OK
+test-gom-sorting       OK
+test-gom-stress        OK
+test-gom-table-name    OK
+test-gom-transform     OK
+test-gom-update        OK
+
+Ok:                 13  
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   
+


### PR DESCRIPTION
The GObject Data Mapper (`gom`) is needed for `grl-bookmarks` plugin in `grilo-plugins`.  The `grl-bookmarks` grilo plugin is a runtime dependency for Totem - see https://github.com/OpenIndiana/oi-userland/pull/20531#issuecomment-2617959653.