### PR TITLE
Add libmediaart

### DIFF
--- a/components/desktop/gnome/libmediaart/Makefile
+++ b/components/desktop/gnome/libmediaart/Makefile
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+BUILD_STYLE = meson
+USE_DEFAULT_TEST_TRANSFORMS = yes
+
+include ../../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=			libmediaart
+HUMAN_VERSION=			1.9.6
+COMPONENT_SUMMARY=		Library tasked with managing, extracting and handling media art caches
+COMPONENT_ARCHIVE_HASH=		sha256:c3bc5025d7db380587f9c8eb800c611f6b5a16d6b4b78fcff93f62876a677f17
+COMPONENT_FMRI=			library/gnome/libmediaart
+COMPONENT_CLASSIFICATION=	Desktop (GNOME)/Libraries
+COMPONENT_LICENSE=		LGPL-2.1-only
+COMPONENT_LICENSE_FILE=		COPYING.LESSER
+
+include $(WS_MAKE_RULES)/gnome.mk
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += system/library

--- a/components/desktop/gnome/libmediaart/libmediaart.p5m
+++ b/components/desktop/gnome/libmediaart/libmediaart.p5m
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/libmediaart-2.0/libmediaart/cache.h
+file path=usr/include/libmediaart-2.0/libmediaart/extract.h
+file path=usr/include/libmediaart-2.0/libmediaart/extractgeneric.h
+file path=usr/include/libmediaart-2.0/libmediaart/mediaart-macros.h
+file path=usr/include/libmediaart-2.0/libmediaart/mediaart.h
+file path=usr/lib/$(MACH64)/girepository-1.0/MediaArt-2.0.typelib
+link path=usr/lib/$(MACH64)/libmediaart-2.0.so target=libmediaart-2.0.so.0
+link path=usr/lib/$(MACH64)/libmediaart-2.0.so.0 \
+    target=libmediaart-2.0.so.0.906.0
+file path=usr/lib/$(MACH64)/libmediaart-2.0.so.0.906.0
+file path=usr/lib/$(MACH64)/pkgconfig/libmediaart-2.0.pc
+file path=usr/share/gir-1.0/MediaArt-2.0.gir
+file path=usr/share/vala/vapi/libmediaart-2.0.deps
+file path=usr/share/vala/vapi/libmediaart-2.0.vapi

--- a/components/desktop/gnome/libmediaart/manifests/sample-manifest.p5m
+++ b/components/desktop/gnome/libmediaart/manifests/sample-manifest.p5m
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/include/libmediaart-2.0/libmediaart/cache.h
+file path=usr/include/libmediaart-2.0/libmediaart/extract.h
+file path=usr/include/libmediaart-2.0/libmediaart/extractgeneric.h
+file path=usr/include/libmediaart-2.0/libmediaart/mediaart-macros.h
+file path=usr/include/libmediaart-2.0/libmediaart/mediaart.h
+file path=usr/lib/$(MACH64)/girepository-1.0/MediaArt-2.0.typelib
+link path=usr/lib/$(MACH64)/libmediaart-2.0.so target=libmediaart-2.0.so.0
+link path=usr/lib/$(MACH64)/libmediaart-2.0.so.0 \
+    target=libmediaart-2.0.so.0.906.0
+file path=usr/lib/$(MACH64)/libmediaart-2.0.so.0.906.0
+file path=usr/lib/$(MACH64)/pkgconfig/libmediaart-2.0.pc
+file path=usr/share/gir-1.0/MediaArt-2.0.gir
+file path=usr/share/vala/vapi/libmediaart-2.0.deps
+file path=usr/share/vala/vapi/libmediaart-2.0.vapi

--- a/components/desktop/gnome/libmediaart/pkg5
+++ b/components/desktop/gnome/libmediaart/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "library/desktop/gdk-pixbuf",
+        "library/glib2",
+        "system/library"
+    ],
+    "fmris": [
+        "library/gnome/libmediaart"
+    ],
+    "name": "libmediaart"
+}

--- a/components/desktop/gnome/libmediaart/test/results-all.master
+++ b/components/desktop/gnome/libmediaart/test/results-all.master
@@ -1,0 +1,9 @@
+mediaart OK
+
+Ok:                 1   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   
+


### PR DESCRIPTION
`libmediaart` is needed for `grl-local-metadata` plugin in `grilo-plugins`.  The `grl-local-metadata` grilo plugin is a runtime dependency for Totem - see https://github.com/OpenIndiana/oi-userland/pull/20531#issuecomment-2617959653.