### PR TITLE
shared-macros.mk: drop support for 32 bit mysql

### DIFF
--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1011,11 +1011,6 @@ PKG_MACROS +=   PG_BASEPKG=$(PG_BASEPKG)
 MYSQL_VERSION ?=   10.6
 MYSQL_IMPLEM ?=    mariadb
 MYSQL_VERNUM =     $(subst .,,$(MYSQL_VERSION))
-MYSQL_MINOR =      $(word 2,$(subst .,$(space),$(MYSQL_VERSION)))
-# Beginning with mariadb 10.6 we only ship 64 bit versions. That changes the paths.
-$(if $(shell [ $(MYSQL_MINOR) -ge 6 ] && echo "OK"), \
-    $(eval MYSQL_64_BIT_ONLY := true), \
-    $(eval MYSQL_64_BIT_ONLY := false))
 # For dependencies, including REQUIRED_PACKAGES if needed
 MYSQL_BASEPKG =    database/$(MYSQL_IMPLEM)-$(MYSQL_VERNUM)
 MYSQL_CLIENT_PKG = $(MYSQL_BASEPKG)/client
@@ -1027,13 +1022,11 @@ REQUIRED_PACKAGES_SUBST+= MYSQL_DEVELOPER_PKG
 REQUIRED_PACKAGES_SUBST+= MYSQL_LIBRARY_PKG
 
 MYSQL_HOME =       $(USRDIR)/$(MYSQL_IMPLEM)/$(MYSQL_VERSION)
-ifeq ($(strip $(MYSQL_64_BIT_ONLY)),false)
-MYSQL_BINDIR.32 =  $(MYSQL_HOME)/bin
-MYSQL_BINDIR.64 =  $(MYSQL_HOME)/bin/$(MACH64)
-else
-MYSQL_BINDIR.64 =  $(MYSQL_HOME)/bin
-endif
-MYSQL_BINDIR =     $(MYSQL_BINDIR.$(BITS))
+MYSQL_BINDIR =		$(MYSQL_HOME)/bin
+# The MYSQL_BINDIR.64 variable is set for compatibility with some components
+# that still use $(MYSQL_BINDIR.$(BITS)) or $(MYSQL_BINDIR.64).  Once they are
+# converted to plain $(MYSQL_BINDIR) we should remove the MYSQL_BINDIR.64 here.
+MYSQL_BINDIR.64 =	$(MYSQL_BINDIR)
 MYSQL_INCDIR =     $(MYSQL_HOME)/include
 MYSQL_MANDIR =     $(MYSQL_HOME)/man
 MYSQL_SHAREDIR =   $(MYSQL_HOME)/share


### PR DESCRIPTION
All mysql/mariadb versions we do ship is 64 bit only so there is no reason to keep the 32 bit support in `shared-macros.mk`.  This will also save a shell spawn with every `gmake` invocation.