### PR TITLE
cog-spur: update inisqueak to 6.1alpha 23193 image

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -44,7 +44,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		cog-spur
 COMPONENT_VERSION=	5.0.3504
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 GIT_TAG=		sun-v5.0.70
 PLUGIN_REV=		5.0-202501172014-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine

--- a/components/runtime/smalltalk/cog-spur/inisqueak5c
+++ b/components/runtime/smalltalk/cog-spur/inisqueak5c
@@ -77,7 +77,7 @@ while true; do
     -r) remote=true; shift;;
     -32) BIT=32;REMSUFFIX='-32bit'; shift;;
     -64) shift;;
-    -v6) MAJOR=6.0; MAJORV=60; VERSION=6.0-22104; shift ;;
+    -v6) MAJOR=6.1alpha; MAJORV=60; VERSION=6.1alpha-23193; shift ;;
     -R) remote=false; shift;;
     -b) batch=true; interactive=false; shift;;
     -h|-help|--help)

--- a/components/runtime/smalltalk/cog-spur/patches/05-sqUnixMain.patch
+++ b/components/runtime/smalltalk/cog-spur/patches/05-sqUnixMain.patch
@@ -1,0 +1,11 @@
+--- opensmalltalk-vm-sun-v5.0.70/platforms/unix/vm/sqUnixMain.c	Fri Jan 17 21:14:01 2025
++++ p0/opensmalltalk-vm-sun-v5.0.70/platforms/unix/vm/sqUnixMain.c	Sun Feb  2 09:59:54 2025
+@@ -2103,7 +2103,7 @@
+     struct stat sb;
+ 
+ 	// first check for an embedded image
+-	void *handle = dlopen(NULL, RTLD_NOW);
++	void *handle = NULL;
+ 	void *embeddedImage;
+ 	if (handle && (embeddedImage = dlsym(handle,"embeddedImage"))) {
+ 		strcpy(shortImageName,dlsym(handle,"embeddedImageName"));


### PR DESCRIPTION

Update inisqueak for the 6.1alpha image and tested this image.

The tests run OK (about 5000 tests) except for the ones in the TestWithinLimitFix which has to be deselected as test prior to running the V6.1 alpha testsuite.

Also disable a feature for builtin smalltalk images in the executable by adding the patch 05sqUnixMain.c which disables a piece of code which in my opinion is experimental code (I do not use smalltalk images attached to executables anyway).
