### PR TITLE
libtasn1: update to 4.20.0; drop 32 bit

### DIFF
--- a/components/library/libtasn1/Makefile
+++ b/components/library/libtasn1/Makefile
@@ -11,18 +11,18 @@
 
 #
 # Copyright 2015 Alexander Pyhalov
-# Copyright 2021 Andreas Wacknitz
+# Copyright 2025 Andreas Wacknitz
 #
 
-BUILD_BITS= 64_and_32
+USE_DEFAULT_TEST_TRANSFORMS= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= libtasn1
-COMPONENT_VERSION= 4.19.0
+COMPONENT_VERSION= 4.20.0
 COMPONENT_SUMMARY= Tiny ASN.1 library
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:1613f0ac1cf484d6ec0ce3b8c06d56263cc7242f1c23b30d82d23de345a63f7a
+COMPONENT_ARCHIVE_HASH=	sha256:92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c
 COMPONENT_ARCHIVE_URL=	https://ftp.gnu.org/gnu/libtasn1/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL = https://www.gnu.org/software/libtasn1/
 COMPONENT_FMRI= library/libtasn1
@@ -31,24 +31,13 @@ COMPONENT_LICENSE = Library is LGPLv2.1, binaries are GPLv3
 
 include $(WS_MAKE_RULES)/common.mk
 
-PATH=$(PATH.gnu)
+PATH= $(PATH.gnu)
 
-CONFIGURE_OPTIONS += --sysconfdir=/etc
 CONFIGURE_OPTIONS += --disable-static
 CONFIGURE_OPTIONS += --enable-shared
 
-# Two tests fail otherwise
-unexport SHELLOPTS
-
-COMPONENT_TEST_TRANSFORMS= \
-  '-n ' \
-  '-e "/TOTAL/p" ' \
-  '-e "/PASS/p" '  \
-  '-e "/SKIP/p" '  \
-  '-e "/XFAIL/p" ' \
-  '-e "/FAIL/p" '  \
-  '-e "/XPASS/p" ' \
-  '-e "/ERROR/p" ' 
+# Remove info/dir
+COMPONENT_POST_INSTALL_ACTION += $(RM) $(PROTOUSRSHAREDIR)/info/dir ;
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/library/libtasn1/libtasn1.p5m
+++ b/components/library/libtasn1/libtasn1.p5m
@@ -27,22 +27,14 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=usr/share/info/dir -> drop>
 <transform path=usr/bin/$(MACH32) -> drop>
 
-file path=usr/bin/$(MACH32)/asn1Coding
-file path=usr/bin/$(MACH32)/asn1Decoding
-file path=usr/bin/$(MACH32)/asn1Parser
 file path=usr/bin/asn1Coding
 file path=usr/bin/asn1Decoding
 file path=usr/bin/asn1Parser
 file path=usr/include/libtasn1.h
-link path=usr/lib/$(MACH64)/libtasn1.so target=libtasn1.so.6.6.3
-link path=usr/lib/$(MACH64)/libtasn1.so.6 target=libtasn1.so.6.6.3
-file path=usr/lib/$(MACH64)/libtasn1.so.6.6.3
+link path=usr/lib/$(MACH64)/libtasn1.so target=libtasn1.so.6.6.4
+link path=usr/lib/$(MACH64)/libtasn1.so.6 target=libtasn1.so.6.6.4
+file path=usr/lib/$(MACH64)/libtasn1.so.6.6.4
 file path=usr/lib/$(MACH64)/pkgconfig/libtasn1.pc
-link path=usr/lib/libtasn1.so target=libtasn1.so.6.6.3
-link path=usr/lib/libtasn1.so.6 target=libtasn1.so.6.6.3
-file path=usr/lib/libtasn1.so.6.6.3
-file path=usr/lib/pkgconfig/libtasn1.pc
-file path=usr/share/info/dir
 file path=usr/share/info/libtasn1.info
 file path=usr/share/man/man1/asn1Coding.1
 file path=usr/share/man/man1/asn1Decoding.1

--- a/components/library/libtasn1/manifests/sample-manifest.p5m
+++ b/components/library/libtasn1/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,22 +23,14 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH32)/asn1Coding
-file path=usr/bin/$(MACH32)/asn1Decoding
-file path=usr/bin/$(MACH32)/asn1Parser
 file path=usr/bin/asn1Coding
 file path=usr/bin/asn1Decoding
 file path=usr/bin/asn1Parser
 file path=usr/include/libtasn1.h
-link path=usr/lib/$(MACH64)/libtasn1.so target=libtasn1.so.6.6.3
-link path=usr/lib/$(MACH64)/libtasn1.so.6 target=libtasn1.so.6.6.3
-file path=usr/lib/$(MACH64)/libtasn1.so.6.6.3
+link path=usr/lib/$(MACH64)/libtasn1.so target=libtasn1.so.6.6.4
+link path=usr/lib/$(MACH64)/libtasn1.so.6 target=libtasn1.so.6.6.4
+file path=usr/lib/$(MACH64)/libtasn1.so.6.6.4
 file path=usr/lib/$(MACH64)/pkgconfig/libtasn1.pc
-link path=usr/lib/libtasn1.so target=libtasn1.so.6.6.3
-link path=usr/lib/libtasn1.so.6 target=libtasn1.so.6.6.3
-file path=usr/lib/libtasn1.so.6.6.3
-file path=usr/lib/pkgconfig/libtasn1.pc
-file path=usr/share/info/dir
 file path=usr/share/info/libtasn1.info
 file path=usr/share/man/man1/asn1Coding.1
 file path=usr/share/man/man1/asn1Decoding.1

--- a/components/library/libtasn1/pkg5
+++ b/components/library/libtasn1/pkg5
@@ -1,7 +1,5 @@
 {
     "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
         "system/library"
     ],
     "fmris": [

--- a/components/library/libtasn1/test/results-all.master
+++ b/components/library/libtasn1/test/results-all.master
@@ -11,9 +11,7 @@ PASS: asn1_decode_simple_der_fuzzer
 # PASS:  9
 # SKIP:  0
 # XFAIL: 0
-# XFAIL: 0
 # FAIL:  0
-# XPASS: 0
 # XPASS: 0
 # ERROR: 0
 PASS: Test_parser
@@ -51,8 +49,6 @@ PASS: parser.sh
 # PASS:  31
 # SKIP:  0
 # XFAIL: 0
-# XFAIL: 0
 # FAIL:  0
-# XPASS: 0
 # XPASS: 0
 # ERROR: 0


### PR DESCRIPTION
32 bit can be dropped because all consumers are 64 bit only.