### PR TITLE
openssl-1.1: fix CVE-2024-13176

### DIFF
--- a/components/library/openssl/openssl-1.1/Makefile
+++ b/components/library/openssl/openssl-1.1/Makefile
@@ -31,7 +31,7 @@ COMPONENT_NAME=	openssl-$(COMPONENT_VERSION_SHORT)
 # and HUMAN_VERSION.
 COMPONENT_VERSION=	1.1.1.23
 HUMAN_VERSION=		1.1.1w
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_SUMMARY=	OpenSSL - a Toolkit for Transport Layer (TLS v1+) protocols and general purpose cryptographic library
 COMPONENT_PROJECT_URL=	https://www.openssl.org/
 COMPONENT_SRC=		openssl-$(HUMAN_VERSION)
@@ -46,12 +46,15 @@ COMPONENT_LICENSE=	OpenSSL, SSLeay
 # COPY_COMMON_FILES is there so that the copy is called as soon as
 # the Makefile is parsed.
 PATCH_DIR=patches-all
-COPY_COMMON_FILES:= rm -rf $(PATCH_DIR) && $(shell rsync -ac patches/ $(PATCH_DIR) && \
+COPY_COMMON_FILES:= $(RM) -rf $(PATCH_DIR) && $(shell rsync -ac patches/ $(PATCH_DIR) && \
 	cp -p ../common/patches/043-x86_asm_illegal_subtraction.patch $(PATCH_DIR))
 
 include $(WS_MAKE_RULES)/common.mk
 
 PATH= $(GCC_ROOT)/bin:$(PATH.illumos)
+
+# fix error: implicit declaration of function 'bn_mod_exp_mont_fixed_top'; did you mean 'BN_mod_exp_mont_word'? [-Wimplicit-function-declaration]
+CFLAGS += -Wno-error=implicit-function-declaration
 
 # OpenSSL does not use autoconf but its own configure system.
 CONFIGURE_SCRIPT = $(SOURCE_DIR)/Configure
@@ -156,6 +159,9 @@ COMPONENT_TEST_TRANSFORMS = \
         '-e "/skipped/p" ' \
         '-e "/ok/p" ' \
         '-e "/success/p" '
+
+clean::
+	$(RM) -rf $(PATCH_DIR)
 
 REQUIRED_PACKAGES += developer/build/makedepend
 

--- a/components/library/openssl/openssl-1.1/manifests/sample-manifest.p5m
+++ b/components/library/openssl/openssl-1.1/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/library/openssl/openssl-1.1/patches/CVE-2024-13176.patch
+++ b/components/library/openssl/openssl-1.1/patches/CVE-2024-13176.patch
@@ -1,0 +1,96 @@
+From 2a3058269d854754b66ef8bdaefb7820bd8c0908 Mon Sep 17 00:00:00 2001
+From: Ken Zalewski <ken.zalewski@gmail.com>
+Date: Sun, 9 Feb 2025 11:47:12 -0500
+Subject: [PATCH] Patch to openssl-1.1.1zb p2.  This version addresses one
+ vulnerability:  CVE-2024-13176
+
+---
+ crypto/bn/bn_exp.c         | 21 +++++++++++++++------
+ crypto/ec/ec_lib.c         |  6 +++---
+ include/crypto/bn.h        |  3 +++
+
+diff --git a/crypto/bn/bn_exp.c b/crypto/bn/bn_exp.c
+index 517e3c2..0489658 100644
+--- a/crypto/bn/bn_exp.c
++++ b/crypto/bn/bn_exp.c
+@@ -601,7 +601,7 @@ static int MOD_EXP_CTIME_COPY_FROM_PREBUF(BIGNUM *b, int top,
+  * out by Colin Percival,
+  * http://www.daemonology.net/hyperthreading-considered-harmful/)
+  */
+-int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
++int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                               const BIGNUM *m, BN_CTX *ctx,
+                               BN_MONT_CTX *in_mont)
+ {
+@@ -618,10 +618,6 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+     unsigned int t4 = 0;
+ #endif
+ 
+-    bn_check_top(a);
+-    bn_check_top(p);
+-    bn_check_top(m);
+-
+     if (!BN_is_odd(m)) {
+         BNerr(BN_F_BN_MOD_EXP_MONT_CONSTTIME, BN_R_CALLED_WITH_EVEN_MODULUS);
+         return 0;
+@@ -1141,7 +1137,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+             goto err;
+     } else
+ #endif
+-    if (!BN_from_montgomery(rr, &tmp, mont, ctx))
++    if (!bn_from_mont_fixed_top(rr, &tmp, mont, ctx))
+         goto err;
+     ret = 1;
+  err:
+@@ -1155,6 +1151,19 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+     return ret;
+ }
+ 
++int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
++                              const BIGNUM *m, BN_CTX *ctx,
++                              BN_MONT_CTX *in_mont)
++{
++    bn_check_top(a);
++    bn_check_top(p);
++    bn_check_top(m);
++    if (!bn_mod_exp_mont_fixed_top(rr, a, p, m, ctx, in_mont))
++        return 0;
++    bn_correct_top(rr);
++    return 1;
++}
++
+ int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,
+                          const BIGNUM *m, BN_CTX *ctx, BN_MONT_CTX *in_mont)
+ {
+diff --git a/crypto/ec/ec_lib.c b/crypto/ec/ec_lib.c
+index 08db89f..fef0c2f 100644
+--- a/crypto/ec/ec_lib.c
++++ b/crypto/ec/ec_lib.c
+@@ -1155,10 +1155,10 @@ static int ec_field_inverse_mod_ord(const EC_GROUP *group, BIGNUM *r,
+     if (!BN_sub(e, group->order, e))
+         goto err;
+     /*-
+-     * Exponent e is public.
+-     * No need for scatter-gather or BN_FLG_CONSTTIME.
++     * Although the exponent is public we want the result to be
++     * fixed top.
+      */
+-    if (!BN_mod_exp_mont(r, x, e, group->order, ctx, group->mont_data))
++    if (!bn_mod_exp_mont_fixed_top(r, x, e, group->order, ctx, group->mont_data))
+         goto err;
+ 
+     ret = 1;
+diff --git a/include/crypto/bn.h b/include/crypto/bn.h
+index 250914c..10cfc84 100644
+--- a/include/crypto/bn.h
++++ b/include/crypto/bn.h
+@@ -72,6 +72,9 @@ int bn_set_words(BIGNUM *a, const BN_ULONG *words, int num_words);
+  */
+ int bn_mul_mont_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
+                           BN_MONT_CTX *mont, BN_CTX *ctx);
++int bn_mode_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
++                               const BIGNUM *m, BN_CTX *ctx,
++                               BN_MONT_CTX *in_mont);
+ int bn_to_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,
+                          BN_CTX *ctx);
+ int bn_from_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,


### PR DESCRIPTION
Make sure contents of patches-all directory get removed during gmake clean .

New CVE-2024-13176 patch also needs CFLAGS += -Wno-error=implicit-function-declaration