### PR TITLE
Mention the license in the README as required by the OpenSource Foundation for Fiscal hosting via OpenCollective.

### DIFF
--- a/README
+++ b/README
@@ -157,3 +157,9 @@ Building the Bits
 
     The gate should only incrementally build what it needs to based on what has
     changed since you last built it.
+
+License
+
+    All Code in this Repository is Licensed under CDDL 1.0
+    All code is owned by the Respective Authors. See the CDDL Header of each file.
+    You can find a Copy of the License here https://illumos.org/license/CDDL


### PR DESCRIPTION
I got requested to mention the license we use in a Central spot of the Repository so that we can have the  OpenSourceFoundation as Fiscal Host for our OpenCollective page.