### PR TITLE
schroedinger: drop 32-bit

### DIFF
--- a/components/library/schroedinger/Makefile
+++ b/components/library/schroedinger/Makefile
@@ -13,12 +13,11 @@
 # Copyright 2015 Alexander Pyhalov
 #
 
-BUILD_BITS= 64_and_32
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= schroedinger
 COMPONENT_VERSION= 1.0.11
-COMPONENT_REVISION= 2
+COMPONENT_REVISION= 3
 COMPONENT_SUMMARY= Library for decoding and encoding video in the Dirac format
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
@@ -32,11 +31,6 @@ COMPONENT_LICENSE_FILE= COPYING.LGPL
 
 TEST_TARGET= $(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
-
-# Build can't create generated sources without this
-COMPONENT_PRE_CONFIGURE_ACTION= ( $(CLONEY) $(SOURCE_DIR) $(@D) )
-
-CONFIGURE_SCRIPT= $(@D)/configure
 
 CONFIGURE_OPTIONS += --disable-gtk-doc
 CONFIGURE_OPTIONS += --enable-shared

--- a/components/library/schroedinger/libschroedinger.p5m
+++ b/components/library/schroedinger/libschroedinger.p5m
@@ -67,10 +67,6 @@ link path=usr/lib/$(MACH64)/libschroedinger-1.0.so.0 \
     target=libschroedinger-1.0.so.0.11.0
 file path=usr/lib/$(MACH64)/libschroedinger-1.0.so.0.11.0
 file path=usr/lib/$(MACH64)/pkgconfig/schroedinger-1.0.pc
-link path=usr/lib/libschroedinger-1.0.so target=libschroedinger-1.0.so.0.11.0
-link path=usr/lib/libschroedinger-1.0.so.0 target=libschroedinger-1.0.so.0.11.0
-file path=usr/lib/libschroedinger-1.0.so.0.11.0
-file path=usr/lib/pkgconfig/schroedinger-1.0.pc
 file path=usr/share/gtk-doc/html/schroedinger/home.png
 file path=usr/share/gtk-doc/html/schroedinger/index.html
 file path=usr/share/gtk-doc/html/schroedinger/index.sgml

--- a/components/library/schroedinger/manifests/sample-manifest.p5m
+++ b/components/library/schroedinger/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -64,10 +64,6 @@ link path=usr/lib/$(MACH64)/libschroedinger-1.0.so.0 \
     target=libschroedinger-1.0.so.0.11.0
 file path=usr/lib/$(MACH64)/libschroedinger-1.0.so.0.11.0
 file path=usr/lib/$(MACH64)/pkgconfig/schroedinger-1.0.pc
-link path=usr/lib/libschroedinger-1.0.so target=libschroedinger-1.0.so.0.11.0
-link path=usr/lib/libschroedinger-1.0.so.0 target=libschroedinger-1.0.so.0.11.0
-file path=usr/lib/libschroedinger-1.0.so.0.11.0
-file path=usr/lib/pkgconfig/schroedinger-1.0.pc
 file path=usr/share/gtk-doc/html/schroedinger/home.png
 file path=usr/share/gtk-doc/html/schroedinger/index.html
 file path=usr/share/gtk-doc/html/schroedinger/index.sgml

--- a/components/library/schroedinger/patches/01-return.patch
+++ b/components/library/schroedinger/patches/01-return.patch
@@ -1,5 +1,5 @@
---- schroedinger-1.0.11/schroedinger/schrolowdelay.c	Tue Jan 24 20:26:20 2012
-+++ schroedinger-1.0.11/schroedinger/schrolowdelay.c	Tue Jan 24 20:25:30 2012
+--- schroedinger-1.0.11/schroedinger/schrolowdelay.c.orig
++++ schroedinger-1.0.11/schroedinger/schrolowdelay.c
 @@ -750,14 +750,14 @@
  
    if (SCHRO_FRAME_FORMAT_DEPTH (picture->transform_frame->format) ==

--- a/components/library/schroedinger/patches/02-testsuite.patch
+++ b/components/library/schroedinger/patches/02-testsuite.patch
@@ -1,6 +1,6 @@
---- schroedinger-1.0.10/Makefile.in	2011-10-17 09:17:07.054927065 +0200
-+++ schroedinger-1.0.10/Makefile.in	2010-10-08 03:28:38.000000000 +0200
-@@ -290,7 +290,7 @@
+--- schroedinger-1.0.11/Makefile.in.orig
++++ schroedinger-1.0.11/Makefile.in
+@@ -291,7 +291,7 @@
  top_builddir = @top_builddir@
  top_srcdir = @top_srcdir@
  AUTOMAKE_OPTIONS = foreign


### PR DESCRIPTION
The only known consumer for this - `vlc` - is 64-bit only.