### PR TITLE
orc: update to 0.4.41; drop 32-bit

### DIFF
--- a/components/library/orc/Makefile
+++ b/components/library/orc/Makefile
@@ -13,13 +13,12 @@
 #
 
 BUILD_STYLE = meson
-BUILD_BITS = 64_and_32
 USE_DEFAULT_TEST_TRANSFORMS = yes
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         orc
-COMPONENT_VERSION=	0.4.40
+COMPONENT_VERSION=	0.4.41
 COMPONENT_FMRI=		library/orc
 COMPONENT_PROJECT_URL=	https://gstreamer.freedesktop.org/projects/orc.html
 COMPONENT_SUMMARY=	The Optimized Inner Loop Runtime Compiler for SIMD array operations
@@ -27,16 +26,13 @@ COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	sha256:3fc2bee78dfb7c41fd9605061fc69138db7df007eae2f669a1f56e8bacef74ab
+	sha256:cb1bfd4f655289cd39bc04642d597be9de5427623f0861c1fc19c08d98467fa2
 COMPONENT_ARCHIVE_URL=  \
 	http://gstreamer.freedesktop.org/src/$(COMPONENT_NAME)/$(COMPONENT_ARCHIVE)
 COMPONENT_LICENSE=	BSD-2-Clause AND BSD-3-Clause
 COMPONENT_LICENSE_FILE=	COPYING
 
 include $(WS_MAKE_RULES)/common.mk
-
-# Heals libgstvideoscale (from gstreamer 0.10) core dump
-gcc_OPT = -O2
 
 # Dynamic library version number
 SOVER = 0.$(word 3,$(subst ., ,$(COMPONENT_VERSION))).0

--- a/components/library/orc/manifests/sample-manifest.p5m
+++ b/components/library/orc/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,8 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH32)/orc-bugreport
-file path=usr/bin/$(MACH32)/orcc
 file path=usr/bin/orc-bugreport
 file path=usr/bin/orcc
 file path=usr/include/orc-0.4/orc-test/orcarray.h
@@ -42,11 +40,9 @@ file path=usr/include/orc-0.4/orc/orccompiler.h
 file path=usr/include/orc-0.4/orc/orcconstant.h
 file path=usr/include/orc-0.4/orc/orccpu.h
 file path=usr/include/orc-0.4/orc/orcdebug.h
-file path=usr/include/orc-0.4/orc/orcemulateopcodes.h
 file path=usr/include/orc-0.4/orc/orcexecutor.h
 file path=usr/include/orc-0.4/orc/orcfunctions.h
 file path=usr/include/orc-0.4/orc/orcinstruction.h
-file path=usr/include/orc-0.4/orc/orcinternal.h
 file path=usr/include/orc-0.4/orc/orclimits.h
 file path=usr/include/orc-0.4/orc/orcmips.h
 file path=usr/include/orc-0.4/orc/orcmmx.h
@@ -72,14 +68,6 @@ link path=usr/lib/$(MACH64)/liborc-test-0.4.so.0 \
 file path=usr/lib/$(MACH64)/liborc-test-0.4.so.$(SOVER)
 file path=usr/lib/$(MACH64)/pkgconfig/orc-0.4.pc
 file path=usr/lib/$(MACH64)/pkgconfig/orc-test-0.4.pc
-link path=usr/lib/liborc-0.4.so target=liborc-0.4.so.0
-link path=usr/lib/liborc-0.4.so.0 target=liborc-0.4.so.$(SOVER)
-file path=usr/lib/liborc-0.4.so.$(SOVER)
-link path=usr/lib/liborc-test-0.4.so target=liborc-test-0.4.so.0
-link path=usr/lib/liborc-test-0.4.so.0 target=liborc-test-0.4.so.$(SOVER)
-file path=usr/lib/liborc-test-0.4.so.$(SOVER)
-file path=usr/lib/pkgconfig/orc-0.4.pc
-file path=usr/lib/pkgconfig/orc-test-0.4.pc
 file path=usr/share/gtk-doc/html/orc/ch01.html
 file path=usr/share/gtk-doc/html/orc/ch02.html
 file path=usr/share/gtk-doc/html/orc/ch03.html

--- a/components/library/orc/orc.p5m
+++ b/components/library/orc/orc.p5m
@@ -23,8 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH32)/orc-bugreport
-file path=usr/bin/$(MACH32)/orcc
 file path=usr/bin/orc-bugreport
 file path=usr/bin/orcc
 file path=usr/include/orc-0.4/orc-test/orcarray.h
@@ -42,11 +40,9 @@ file path=usr/include/orc-0.4/orc/orccompiler.h
 file path=usr/include/orc-0.4/orc/orcconstant.h
 file path=usr/include/orc-0.4/orc/orccpu.h
 file path=usr/include/orc-0.4/orc/orcdebug.h
-file path=usr/include/orc-0.4/orc/orcemulateopcodes.h
 file path=usr/include/orc-0.4/orc/orcexecutor.h
 file path=usr/include/orc-0.4/orc/orcfunctions.h
 file path=usr/include/orc-0.4/orc/orcinstruction.h
-file path=usr/include/orc-0.4/orc/orcinternal.h
 file path=usr/include/orc-0.4/orc/orclimits.h
 file path=usr/include/orc-0.4/orc/orcmips.h
 file path=usr/include/orc-0.4/orc/orcmmx.h
@@ -72,14 +68,6 @@ link path=usr/lib/$(MACH64)/liborc-test-0.4.so.0 \
 file path=usr/lib/$(MACH64)/liborc-test-0.4.so.$(SOVER)
 file path=usr/lib/$(MACH64)/pkgconfig/orc-0.4.pc
 file path=usr/lib/$(MACH64)/pkgconfig/orc-test-0.4.pc
-link path=usr/lib/liborc-0.4.so target=liborc-0.4.so.0
-link path=usr/lib/liborc-0.4.so.0 target=liborc-0.4.so.$(SOVER)
-file path=usr/lib/liborc-0.4.so.$(SOVER)
-link path=usr/lib/liborc-test-0.4.so target=liborc-test-0.4.so.0
-link path=usr/lib/liborc-test-0.4.so.0 target=liborc-test-0.4.so.$(SOVER)
-file path=usr/lib/liborc-test-0.4.so.$(SOVER)
-file path=usr/lib/pkgconfig/orc-0.4.pc
-file path=usr/lib/pkgconfig/orc-test-0.4.pc
 file path=usr/share/gtk-doc/html/orc/ch01.html
 file path=usr/share/gtk-doc/html/orc/ch02.html
 file path=usr/share/gtk-doc/html/orc/ch03.html

--- a/components/library/orc/test/results-all.master
+++ b/components/library/orc/test/results-all.master
@@ -1,6 +1,41 @@
+orc / orc_test                 OK
+orc / test2                    OK
+orc / test3                    OK
+orc:default / abi              OK
+orc:default / exec_opcodes_sys OK
+orc:default / exec_parse       OK
+orc:default / memcpy_speed     OK
+orc:default / perf_opcodes_sys OK
+orc:default / perf_parse       OK
+orc:default / test-limits      OK
+orc:default / test-schro       OK
+orc:default / test_accsadubl   OK
+orc:default / test_parse       OK
+orc:mmx / abi                  OK
+orc:mmx / exec_opcodes_sys     OK
+orc:mmx / exec_parse           OK
+orc:mmx / memcpy_speed         OK
+orc:mmx / perf_opcodes_sys     OK
+orc:mmx / perf_parse           OK
+orc:mmx / test-limits          OK
+orc:mmx / test-schro           OK
+orc:mmx / test_accsadubl       OK
+orc:mmx / test_parse           OK
+orc:sse / abi                  OK
+orc:sse / exec_opcodes_sys     OK
+orc:sse / exec_parse           OK
+orc:sse / memcpy_speed         OK
+orc:sse / perf_opcodes_sys     OK
+orc:sse / perf_parse           OK
+orc:sse / test-limits          OK
+orc:sse / test-schro           OK
+orc:sse / test_accsadubl       OK
+orc:sse / test_parse           OK
+
 Ok:                 33  
 Expected Fail:      0   
 Fail:               0   
 Unexpected Pass:    0   
 Skipped:            0   
 Timeout:            0   
+


### PR DESCRIPTION
Following components depends on `orc`:

- `desktop/pulseaudio`
- `encumbered/gst-plugins-bad`
- `encumbered/gst-plugins-ugly`
- `library/schroedinger`
- `multimedia/gst-plugins-base`
- `multimedia/gst-plugins-good`

and all of them are 64-bit only, so we are safe to drop 32-bit support here too.