### PR TITLE
groovy-40: Add 4.0.25

### DIFF
--- a/components/developer/groovy-40/Makefile
+++ b/components/developer/groovy-40/Makefile
@@ -1,0 +1,52 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016-2017 Jim Klimov
+#
+
+BUILD_STYLE=justmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		groovy
+COMPONENT_MAJOR_VERSION=	4.0
+COMPONENT_MINOR_VERSION=	25
+COMPONENT_VERSION=	$(COMPONENT_MAJOR_VERSION).$(COMPONENT_MINOR_VERSION)
+COMPONENT_ARCHIVE=	apache-$(COMPONENT_NAME)-binary-$(COMPONENT_VERSION).zip
+COMPONENT_FMRI=		developer/groovy-40
+COMPONENT_CLASSIFICATION=	Development/Java
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL=	https://groovy-lang.org/
+COMPONENT_ARCHIVE_HASH=	\
+	sha256:822cad8e03388f23bf613d37f990b813bb4165fe389fd3fcc24f8b96476c30ef
+COMPONENT_ARCHIVE_URL=\
+	https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/$(COMPONENT_ARCHIVE)
+COMPONENT_LICENSE=		Apache-2.0, BSD, MIT, Eclipse 1.0, Eclipse 2.0, Public Domain, 3-clause BSD, JSR223
+COMPONENT_LICENSE_FILE= groovy.license
+COMPONENT_SUMMARY=	Groovy is a Java-based scripting language
+
+TEST_TARGET=$(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+
+PATH=$(PATH.gnu)
+
+COMPONENT_PREP_ACTION += ($(CP) $(COMPONENT_DIR)/files/Makefile $(SOURCE_DIR))
+
+COMPONENT_COPY_ACTION = $(CP) -r $(SOURCE_DIR)/* $(@D)/
+
+COMPONENT_INSTALL_ENV += GROOVY_MAJOR_VERSION=$(COMPONENT_MAJOR_VERSION)
+
+COMPONENT_POST_INSTALL_ACTION = $(FIND) $(PROTO_DIR) -name \*.bat -delete
+
+# JDK does not get picked up by gmake REQUIRED_PACKAGES
+REQUIRED_PACKAGES += runtime/java/openjdk21
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += SUNWcs

--- a/components/developer/groovy-40/files/Makefile
+++ b/components/developer/groovy-40/files/Makefile
@@ -1,0 +1,11 @@
+SUBDIRS=bin conf grooid lib
+GROOVY_MAJOR_VERSION ?= 4.0
+all: build
+
+build: 
+
+install: 
+	mkdir -p $(DESTDIR)/usr/share/groovy-$(GROOVY_MAJOR_VERSION)
+	mkdir -p $(DESTDIR)/usr/bin
+	cp -rf $(SUBDIRS) $(DESTDIR)/usr/share/groovy-$(GROOVY_MAJOR_VERSION)
+	ln -frs $(DESTDIR)/usr/share/groovy-$(GROOVY_MAJOR_VERSION)/bin/* $(DESTDIR)/usr/bin

--- a/components/developer/groovy-40/groovy-40.p5m
+++ b/components/developer/groovy-40/groovy-40.p5m
@@ -1,0 +1,130 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Jim Klimov
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/bin/grape target=../share/groovy-4.0/bin/grape mediator=groovy mediator-version=4.0
+link path=usr/bin/grape_completion \
+    target=../share/groovy-4.0/bin/grape_completion mediator=groovy mediator-version=4.0
+link path=usr/bin/groovy target=../share/groovy-4.0/bin/groovy mediator=groovy mediator-version=4.0
+link path=usr/bin/groovy.ico target=../share/groovy-4.0/bin/groovy.ico mediator=groovy mediator-version=4.0
+link path=usr/bin/groovyConsole target=../share/groovy-4.0/bin/groovyConsole mediator=groovy mediator-version=4.0
+link path=usr/bin/groovyConsole_completion \
+    target=../share/groovy-4.0/bin/groovyConsole_completion mediator=groovy mediator-version=4.0
+link path=usr/bin/groovy_completion \
+    target=../share/groovy-4.0/bin/groovy_completion mediator=groovy mediator-version=4.0
+link path=usr/bin/groovyc target=../share/groovy-4.0/bin/groovyc mediator=groovy mediator-version=4.0
+link path=usr/bin/groovyc_completion \
+    target=../share/groovy-4.0/bin/groovyc_completion mediator=groovy mediator-version=4.0
+link path=usr/bin/groovydoc target=../share/groovy-4.0/bin/groovydoc mediator=groovy mediator-version=4.0
+link path=usr/bin/groovydoc_completion \
+    target=../share/groovy-4.0/bin/groovydoc_completion mediator=groovy mediator-version=4.0
+link path=usr/bin/groovysh target=../share/groovy-4.0/bin/groovysh mediator=groovy mediator-version=4.0
+link path=usr/bin/groovysh_completion \
+    target=../share/groovy-4.0/bin/groovysh_completion mediator=groovy mediator-version=4.0
+link path=usr/bin/java2groovy target=../share/groovy-4.0/bin/java2groovy mediator=groovy mediator-version=4.0
+link path=usr/bin/startGroovy target=../share/groovy-4.0/bin/startGroovy mediator=groovy mediator-version=4.0
+
+file path=usr/share/groovy-4.0/bin/grape
+file path=usr/share/groovy-4.0/bin/grape_completion
+file path=usr/share/groovy-4.0/bin/groovy
+file path=usr/share/groovy-4.0/bin/groovy.ico
+file path=usr/share/groovy-4.0/bin/groovyConsole
+file path=usr/share/groovy-4.0/bin/groovyConsole_completion
+file path=usr/share/groovy-4.0/bin/groovy_completion
+file path=usr/share/groovy-4.0/bin/groovyc
+file path=usr/share/groovy-4.0/bin/groovyc_completion
+file path=usr/share/groovy-4.0/bin/groovydoc
+file path=usr/share/groovy-4.0/bin/groovydoc_completion
+file path=usr/share/groovy-4.0/bin/groovysh
+file path=usr/share/groovy-4.0/bin/groovysh_completion
+file path=usr/share/groovy-4.0/bin/java2groovy
+file path=usr/share/groovy-4.0/bin/startGroovy
+file path=usr/share/groovy-4.0/conf/groovy-starter.conf
+file path=usr/share/groovy-4.0/grooid/groovy-$(HUMAN_VERSION)-grooid.jar
+file path=usr/share/groovy-4.0/grooid/groovy-test-$(HUMAN_VERSION)-grooid.jar
+file path=usr/share/groovy-4.0/lib/ant-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/ant-antlr-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/ant-junit-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/ant-launcher-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/commons-cli-1.6.0.jar
+file path=usr/share/groovy-4.0/lib/gpars-1.2.1.jar
+file path=usr/share/groovy-4.0/lib/groovy-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-ant-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-astbuilder-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-cli-commons-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-cli-picocli-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-console-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-contracts-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-datetime-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-dateutil-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-docgenerator-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-ginq-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-groovydoc-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-groovysh-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-jmx-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-json-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-jsr223-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-macro-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-macro-library-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-nio-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-servlet-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-sql-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-swing-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-templates-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-test-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-test-junit5-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-testng-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-toml-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-typecheckers-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-xml-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-yaml-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy.icns
+file path=usr/share/groovy-4.0/lib/hamcrest-core-1.3.jar
+file path=usr/share/groovy-4.0/lib/ivy-2.5.3.jar
+file path=usr/share/groovy-4.0/lib/jackson-annotations-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-core-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-databind-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-dataformat-toml-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-dataformat-yaml-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jansi-2.4.1.jar
+file path=usr/share/groovy-4.0/lib/javaparser-core-3.26.3.jar
+file path=usr/share/groovy-4.0/lib/jcommander-1.78.jar
+file path=usr/share/groovy-4.0/lib/jline-2.14.6.jar
+file path=usr/share/groovy-4.0/lib/jquery-3.5.1.jar
+file path=usr/share/groovy-4.0/lib/jsr166y-1.7.0.jar
+file path=usr/share/groovy-4.0/lib/junit-4.13.2.jar
+file path=usr/share/groovy-4.0/lib/junit-jupiter-api-5.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-jupiter-engine-5.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-platform-commons-1.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-platform-engine-1.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-platform-launcher-1.11.4.jar
+file path=usr/share/groovy-4.0/lib/multiverse-core-0.7.0.jar
+file path=usr/share/groovy-4.0/lib/mxparser-1.2.2.jar
+file path=usr/share/groovy-4.0/lib/opentest4j-1.3.0.jar
+file path=usr/share/groovy-4.0/lib/org.abego.treelayout.core-1.0.3.jar
+file path=usr/share/groovy-4.0/lib/qdox-1.12.1.jar
+file path=usr/share/groovy-4.0/lib/slf4j-api-2.0.16.jar
+file path=usr/share/groovy-4.0/lib/snakeyaml-2.3.jar
+file path=usr/share/groovy-4.0/lib/testng-7.5.1.jar
+file path=usr/share/groovy-4.0/lib/xstream-1.4.21.jar

--- a/components/developer/groovy-40/groovy.license
+++ b/components/developer/groovy-40/groovy.license
@@ -1,0 +1,798 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------
+
+ANTLR 4 License
+
+Antlr4 is released under a BSD 3-clause license.
+See licenses/antlr4-license.txt for details.
+
+------------------------------------------------------------------------
+
+ASM License
+
+ASM uses a 3-clause BSD license. For details, see licenses/asm-license.txt.
+
+------------------------------------------------------------------------
+
+Hamcrest License (needed when using optional JUnit dependency)
+
+This product bundles the Hamcrest jar, which is available under a
+BSD license.  For details, see licenses/hamcrest-license.txt.
+
+------------------------------------------------------------------------
+
+JLine2 License (optional dependency used with groovysh)
+
+This product bundles the JLine2 jar, which is available under a
+BSD License.  For details, see licenses/jline2-license.txt.
+
+------------------------------------------------------------------------
+
+JSR166y License (optionally used by the optional GPars dependency)
+
+This product bundles the jsr166y jar (containing works from
+the JSR-166 EG, Doug Lea, and Jason T. Greene) made available in
+the public domain.  For details, see licenses/jsr166y-license.txt.
+
+------------------------------------------------------------------------
+
+JSR223 License
+
+The following classes within this product:
+
+    org.codehaus.groovy.jsr223.GroovyCompiledScript
+    org.codehaus.groovy.jsr223.GroovyScriptEngineFactory
+    org.codehaus.groovy.jsr223.GroovyScriptEngineImpl
+
+were derived from reference implementation files developed by Sun in
+collaboration with the Groovy community. The reference implementation
+has a BSD-style license. Details can be found in: licenses/jsr223-license.txt
+
+------------------------------------------------------------------------
+
+JUnit Licenses (optional dependencies when using Groovy for testing)
+
+This product bundles the JUnit 4 jar, which is available under the
+Eclipse Public License v1.0.  For details, see licenses/junit4-license.txt.
+
+This product bundles several JUnit 5 jars, which are available under the
+Eclipse Public License v2.0.  For details, see licenses/junit5-license.txt.
+
+------------------------------------------------------------------------
+
+normalize.css License
+
+The stylesheet.css file (originally normalize.css) is used by the
+groovydoc and docgenerator components for groovy-jdk/gapi documentation.
+It is made available under a MIT License:
+licenses/normalize-stylesheet-license.txt
+
+------------------------------------------------------------------------
+
+XStream License (optional dependency when serializing AST as XML)
+
+This product bundles the XStream jar, which is available under a
+"3-clause BSD" license.  For details, see licenses/xstream-license.txt.
+ANTLR 4 License
+
+[The "BSD 3-clause license"]
+Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ASM License
+
+ASM: a very small and fast Java bytecode manipulation framework
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+BSD License
+
+Copyright (c) 2000-2015 www.hamcrest.org
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+
+Neither the name of Hamcrest nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+Copyright (c) 2002-2012, the original author or authors.
+All rights reserved.
+
+http://www.opensource.org/licenses/bsd-license.php
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with
+the distribution.
+
+Neither the name of JLine nor the names of its contributors
+may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+The person or persons who have associated work with this document (the
+"Dedicator" or "Certifier") hereby either (a) certifies that, to the best of
+his knowledge, the work of authorship identified is in the public domain of
+the country from which the work is published, or (b) hereby dedicates whatever
+copyright the dedicators holds in the work of authorship identified below (the
+"Work") to the public domain. A certifier, moreover, dedicates any copyright
+interest he may have in the associated work, and for these purposes, is
+described as a "dedicator" below.
+
+A certifier has taken reasonable steps to verify the copyright status of this
+work. Certifier recognizes that his good faith efforts may not shield him from
+liability if in fact the work certified is not in the public domain.
+
+Dedicator makes this dedication for the benefit of the public at large and to
+the detriment of the Dedicator's heirs and successors. Dedicator intends this
+dedication to be an overt act of relinquishment in perpetuity of all present
+and future rights under copyright law, whether vested or contingent, in the
+Work. Dedicator understands that such relinquishment of all rights includes
+the relinquishment of all rights to enforce (by lawsuit or otherwise) those
+copyrights in the Work.
+
+Dedicator recognizes that, once placed in the public domain, the Work may be
+freely reproduced, distributed, transmitted, used, modified, built upon, or
+otherwise exploited by anyone for any purpose, commercial or non-commercial,
+and in any way, including by methods that have not yet been invented or
+conceived.
+Copyright (c) 2006, Sun Microsystems, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ - Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ - Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ - Neither the name of the Sun Microsystems, Inc. nor the names of
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+Eclipse Public License - v 1.0
+
+   THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+   PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF
+   THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+   1. DEFINITIONS
+
+   "Contribution" means:
+
+   a) in the case of the initial Contributor, the initial code and
+   documentation distributed under this Agreement, and
+
+   b) in the case of each subsequent Contributor:
+
+   i) changes to the Program, and
+
+   ii) additions to the Program;
+
+   where such changes and/or additions to the Program originate from and
+   are distributed by that particular Contributor. A Contribution
+   'originates' from a Contributor if it was added to the Program by such
+   Contributor itself or anyone acting on such Contributor's behalf.
+   Contributions do not include additions to the Program which: (i) are
+   separate modules of software distributed in conjunction with the
+   Program under their own license agreement, and (ii) are not derivative
+   works of the Program.
+
+   "Contributor" means any person or entity that distributes the Program.
+
+   "Licensed Patents" mean patent claims licensable by a Contributor which
+   are necessarily infringed by the use or sale of its Contribution alone
+   or when combined with the Program.
+
+   "Program" means the Contributions distributed in accordance with this
+   Agreement.
+
+   "Recipient" means anyone who receives the Program under this Agreement,
+   including all Contributors.
+
+   2. GRANT OF RIGHTS
+
+   a) Subject to the terms of this Agreement, each Contributor hereby
+   grants Recipient a non-exclusive, worldwide, royalty-free copyright
+   license to reproduce, prepare derivative works of, publicly display,
+   publicly perform, distribute and sublicense the Contribution of such
+   Contributor, if any, and such derivative works, in source code and
+   object code form.
+
+   b) Subject to the terms of this Agreement, each Contributor hereby
+   grants Recipient a non-exclusive, worldwide, royalty-free patent
+   license under Licensed Patents to make, use, sell, offer to sell,
+   import and otherwise transfer the Contribution of such Contributor, if
+   any, in source code and object code form. This patent license shall
+   apply to the combination of the Contribution and the Program if, at the
+   time the Contribution is added by the Contributor, such addition of the
+   Contribution causes such combination to be covered by the Licensed
+   Patents. The patent license shall not apply to any other combinations
+   which include the Contribution. No hardware per se is licensed
+   hereunder.
+
+   c) Recipient understands that although each Contributor grants the
+   licenses to its Contributions set forth herein, no assurances are
+   provided by any Contributor that the Program does not infringe the
+   patent or other intellectual property rights of any other entity. Each
+   Contributor disclaims any liability to Recipient for claims brought by
+   any other entity based on infringement of intellectual property rights
+   or otherwise. As a condition to exercising the rights and licenses
+   granted hereunder, each Recipient hereby assumes sole responsibility to
+   secure any other intellectual property rights needed, if any. For
+   example, if a third party patent license is required to allow Recipient
+   to distribute the Program, it is Recipient's responsibility to acquire
+   that license before distributing the Program.
+
+   d) Each Contributor represents that to its knowledge it has sufficient
+   copyright rights in its Contribution, if any, to grant the copyright
+   license set forth in this Agreement.
+
+   3. REQUIREMENTS
+
+   A Contributor may choose to distribute the Program in object code form
+   under its own license agreement, provided that:
+
+   a) it complies with the terms and conditions of this Agreement; and
+
+   b) its license agreement:
+
+   i) effectively disclaims on behalf of all Contributors all warranties
+   and conditions, express and implied, including warranties or conditions
+   of title and non-infringement, and implied warranties or conditions of
+   merchantability and fitness for a particular purpose;
+
+   ii) effectively excludes on behalf of all Contributors all liability
+   for damages, including direct, indirect, special, incidental and
+   consequential damages, such as lost profits;
+
+   iii) states that any provisions which differ from this Agreement are
+   offered by that Contributor alone and not by any other party; and
+
+   iv) states that source code for the Program is available from such
+   Contributor, and informs licensees how to obtain it in a reasonable
+   manner on or through a medium customarily used for software exchange.
+
+   When the Program is made available in source code form:
+
+   a) it must be made available under this Agreement; and
+
+   b) a copy of this Agreement must be included with each copy of the
+   Program.
+
+   Contributors may not remove or alter any copyright notices contained
+   within the Program.
+
+   Each Contributor must identify itself as the originator of its
+   Contribution, if any, in a manner that reasonably allows subsequent
+   Recipients to identify the originator of the Contribution.
+
+   4. COMMERCIAL DISTRIBUTION
+
+   Commercial distributors of software may accept certain responsibilities
+   with respect to end users, business partners and the like. While this
+   license is intended to facilitate the commercial use of the Program,
+   the Contributor who includes the Program in a commercial product
+   offering should do so in a manner which does not create potential
+   liability for other Contributors. Therefore, if a Contributor includes
+   the Program in a commercial product offering, such Contributor
+   ("Commercial Contributor") hereby agrees to defend and indemnify every
+   other Contributor ("Indemnified Contributor") against any losses,
+   damages and costs (collectively "Losses") arising from claims, lawsuits
+   and other legal actions brought by a third party against the
+   Indemnified Contributor to the extent caused by the acts or omissions
+   of such Commercial Contributor in connection with its distribution of
+   the Program in a commercial product offering. The obligations in this
+   section do not apply to any claims or Losses relating to any actual or
+   alleged intellectual property infringement. In order to qualify, an
+   Indemnified Contributor must: a) promptly notify the Commercial
+   Contributor in writing of such claim, and b) allow the Commercial
+   Contributor to control, and cooperate with the Commercial Contributor
+   in, the defense and any related settlement negotiations. The
+   Indemnified Contributor may participate in any such claim at its own
+   expense.
+
+   For example, a Contributor might include the Program in a commercial
+   product offering, Product X. That Contributor is then a Commercial
+   Contributor. If that Commercial Contributor then makes performance
+   claims, or offers warranties related to Product X, those performance
+   claims and warranties are such Commercial Contributor's responsibility
+   alone. Under this section, the Commercial Contributor would have to
+   defend claims against the other Contributors related to those
+   performance claims and warranties, and if a court requires any other
+   Contributor to pay any damages as a result, the Commercial Contributor
+   must pay those damages.
+
+   5. NO WARRANTY
+
+   EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+   PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY
+   WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR
+   FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible
+   for determining the appropriateness of using and distributing the
+   Program and assumes all risks associated with its exercise of rights
+   under this Agreement , including but not limited to the risks and costs
+   of program errors, compliance with applicable laws, damage to or loss
+   of data, programs or equipment, and unavailability or interruption of
+   operations.
+
+   6. DISCLAIMER OF LIABILITY
+
+   EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR
+   ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+   WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+   DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+   HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+   7. GENERAL
+
+   If any provision of this Agreement is invalid or unenforceable under
+   applicable law, it shall not affect the validity or enforceability of
+   the remainder of the terms of this Agreement, and without further
+   action by the parties hereto, such provision shall be reformed to the
+   minimum extent necessary to make such provision valid and enforceable.
+
+   If Recipient institutes patent litigation against any entity (including
+   a cross-claim or counterclaim in a lawsuit) alleging that the Program
+   itself (excluding combinations of the Program with other software or
+   hardware) infringes such Recipient's patent(s), then such Recipient's
+   rights granted under Section 2(b) shall terminate as of the date such
+   litigation is filed.
+
+   All Recipient's rights under this Agreement shall terminate if it fails
+   to comply with any of the material terms or conditions of this
+   Agreement and does not cure such failure in a reasonable period of time
+   after becoming aware of such noncompliance. If all Recipient's rights
+   under this Agreement terminate, Recipient agrees to cease use and
+   distribution of the Program as soon as reasonably practicable. However,
+   Recipient's obligations under this Agreement and any licenses granted
+   by Recipient relating to the Program shall continue and survive.
+
+   Everyone is permitted to copy and distribute copies of this Agreement,
+   but in order to avoid inconsistency the Agreement is copyrighted and
+   may only be modified in the following manner. The Agreement Steward
+   reserves the right to publish new versions (including revisions) of
+   this Agreement from time to time. No one other than the Agreement
+   Steward has the right to modify this Agreement. The Eclipse Foundation
+   is the initial Agreement Steward. The Eclipse Foundation may assign the
+   responsibility to serve as the Agreement Steward to a suitable separate
+   entity. Each new version of the Agreement will be given a
+   distinguishing version number. The Program (including Contributions)
+   may always be distributed subject to the version of the Agreement under
+   which it was received. In addition, after a new version of the
+   Agreement is published, Contributor may elect to distribute the Program
+   (including its Contributions) under the new version. Except as
+   expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
+   rights or licenses to the intellectual property of any Contributor
+   under this Agreement, whether expressly, by implication, estoppel or
+   otherwise. All rights in the Program not expressly granted under this
+   Agreement are reserved.
+
+   This Agreement is governed by the laws of the State of New York and the
+   intellectual property laws of the United States of America. No party to
+   this Agreement will bring a legal action under this Agreement more than
+   one year after the cause of action arose. Each party waives its rights
+   to a jury trial in any resulting litigation.
+Eclipse Public License - v 2.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. Definitions
+“Contribution” means:
+
+a) in the case of the initial Contributor, the initial content Distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program; where such changes and/or additions to the Program originate from and are Distributed by that particular Contributor. A Contribution “originates” from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include changes or additions to the Program that are not Modified Works.
+“Contributor” means any person or entity that Distributes the Program.
+
+“Licensed Patents” mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+“Program” means the Contributions Distributed in accordance with this Agreement.
+
+“Recipient” means anyone who receives the Program under this Agreement or any Secondary License (as applicable), including Contributors.
+
+“Derivative Works” shall mean any work, whether in Source Code or other form, that is based on (or derived from) the Program and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship.
+
+“Modified Works” shall mean any work in Source Code or other form that results from an addition to, deletion from, or modification of the contents of the Program, including, for purposes of clarity any new file in Source Code form that contains any contents of the Program. Modified Works shall not include works that contain only declarations, interfaces, types, classes, structures, or files of the Program solely in each case in order to link to, bind by name, or subclass the Program or Modified Works thereof.
+
+“Distribute” means the acts of a) distributing or b) making available in any manner that enables the transfer of a copy.
+
+“Source Code” means the form of a Program preferred for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+“Secondary License” means either the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
+
+2. Grant of Rights
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, Distribute and sublicense the Contribution of such Contributor, if any, and such Derivative Works.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in Source Code or other form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to Distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+
+e) Notwithstanding the terms of any Secondary License, no Contributor makes additional grants to any Recipient (other than those set forth in this Agreement) as a result of such Recipient's receipt of the Program under the terms of a Secondary License (if permitted under the terms of Section 3).
+
+3. Requirements
+3.1 If a Contributor Distributes the Program in any form, then:
+
+a) the Program must also be made available as Source Code, in accordance with section 3.2, and the Contributor must accompany the Program with a statement that the Source Code for the Program is available under this Agreement, and informs Recipients how to obtain it in a reasonable manner on or through a medium customarily used for software exchange; and
+
+b) the Contributor may Distribute the Program under a license different than this Agreement, provided that such license:
+
+i) effectively disclaims on behalf of all other Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all other Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) does not attempt to limit or alter the recipients' rights in the Source Code under section 3.2; and
+iv) requires any subsequent distribution of the Program by any party to be under a license that satisfies the requirements of this section 3.
+3.2 When the Program is Distributed as Source Code:
+
+a) it must be made available under this Agreement, or if the Program (i) is combined with other material in a separate file or files made available under a Secondary License, and (ii) the initial Contributor attached to the Source Code the notice described in Exhibit A of this Agreement, then the Program may be made available under the terms of such Secondary Licenses, and
+b) a copy of this Agreement must be included with each copy of the Program.
+3.3 Contributors may not remove or alter any copyright, patent, trademark, attribution notices, disclaimers of warranty, or limitations of liability (“notices”) contained within the Program from any copy of the Program which they Distribute, provided that Contributors may add their own appropriate notices.
+
+4. Commercial Distribution
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (“Commercial Contributor”) hereby agrees to defend and indemnify every other Contributor (“Indemnified Contributor”) against any losses, damages and costs (collectively “Losses”) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+5. No Warranty
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+6. Disclaimer of Liability
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. General
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be Distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to Distribute the Program (including its Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved. Nothing in this Agreement is intended to be enforceable by any entity that is not a Contributor or Recipient. No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+“This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: {name license(s), version(s), and exceptions or additional permissions here}.”
+
+Simply including a copy of this Agreement, including this Exhibit A is not sufficient to license the Source Code under Secondary Licenses.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+Copyright (c) 2003-2006, Joe Walnes
+Copyright (c) 2006-2009, 2011 XStream Committers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of XStream nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/components/developer/groovy-40/manifests/sample-manifest.p5m
+++ b/components/developer/groovy-40/manifests/sample-manifest.p5m
@@ -1,0 +1,129 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/bin/grape target=../share/groovy-4.0/bin/grape
+link path=usr/bin/grape_completion \
+    target=../share/groovy-4.0/bin/grape_completion
+link path=usr/bin/groovy target=../share/groovy-4.0/bin/groovy
+link path=usr/bin/groovy.ico target=../share/groovy-4.0/bin/groovy.ico
+link path=usr/bin/groovyConsole target=../share/groovy-4.0/bin/groovyConsole
+link path=usr/bin/groovyConsole_completion \
+    target=../share/groovy-4.0/bin/groovyConsole_completion
+link path=usr/bin/groovy_completion \
+    target=../share/groovy-4.0/bin/groovy_completion
+link path=usr/bin/groovyc target=../share/groovy-4.0/bin/groovyc
+link path=usr/bin/groovyc_completion \
+    target=../share/groovy-4.0/bin/groovyc_completion
+link path=usr/bin/groovydoc target=../share/groovy-4.0/bin/groovydoc
+link path=usr/bin/groovydoc_completion \
+    target=../share/groovy-4.0/bin/groovydoc_completion
+link path=usr/bin/groovysh target=../share/groovy-4.0/bin/groovysh
+link path=usr/bin/groovysh_completion \
+    target=../share/groovy-4.0/bin/groovysh_completion
+link path=usr/bin/java2groovy target=../share/groovy-4.0/bin/java2groovy
+link path=usr/bin/startGroovy target=../share/groovy-4.0/bin/startGroovy
+file path=usr/share/groovy-4.0/bin/grape
+file path=usr/share/groovy-4.0/bin/grape_completion
+file path=usr/share/groovy-4.0/bin/groovy
+file path=usr/share/groovy-4.0/bin/groovy.ico
+file path=usr/share/groovy-4.0/bin/groovyConsole
+file path=usr/share/groovy-4.0/bin/groovyConsole_completion
+file path=usr/share/groovy-4.0/bin/groovy_completion
+file path=usr/share/groovy-4.0/bin/groovyc
+file path=usr/share/groovy-4.0/bin/groovyc_completion
+file path=usr/share/groovy-4.0/bin/groovydoc
+file path=usr/share/groovy-4.0/bin/groovydoc_completion
+file path=usr/share/groovy-4.0/bin/groovysh
+file path=usr/share/groovy-4.0/bin/groovysh_completion
+file path=usr/share/groovy-4.0/bin/java2groovy
+file path=usr/share/groovy-4.0/bin/startGroovy
+file path=usr/share/groovy-4.0/conf/groovy-starter.conf
+file path=usr/share/groovy-4.0/grooid/groovy-$(HUMAN_VERSION)-grooid.jar
+file path=usr/share/groovy-4.0/grooid/groovy-test-$(HUMAN_VERSION)-grooid.jar
+file path=usr/share/groovy-4.0/lib/ant-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/ant-antlr-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/ant-junit-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/ant-launcher-1.10.15.jar
+file path=usr/share/groovy-4.0/lib/commons-cli-1.6.0.jar
+file path=usr/share/groovy-4.0/lib/gpars-1.2.1.jar
+file path=usr/share/groovy-4.0/lib/groovy-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-ant-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-astbuilder-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-cli-commons-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-cli-picocli-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-console-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-contracts-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-datetime-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-dateutil-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-docgenerator-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-ginq-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-groovydoc-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-groovysh-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-jmx-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-json-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-jsr223-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-macro-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-macro-library-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-nio-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-servlet-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-sql-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-swing-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-templates-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-test-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-test-junit5-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-testng-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-toml-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-typecheckers-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-xml-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy-yaml-$(HUMAN_VERSION).jar
+file path=usr/share/groovy-4.0/lib/groovy.icns
+file path=usr/share/groovy-4.0/lib/hamcrest-core-1.3.jar
+file path=usr/share/groovy-4.0/lib/ivy-2.5.3.jar
+file path=usr/share/groovy-4.0/lib/jackson-annotations-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-core-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-databind-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-dataformat-toml-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jackson-dataformat-yaml-2.18.2.jar
+file path=usr/share/groovy-4.0/lib/jansi-2.4.1.jar
+file path=usr/share/groovy-4.0/lib/javaparser-core-3.26.3.jar
+file path=usr/share/groovy-4.0/lib/jcommander-1.78.jar
+file path=usr/share/groovy-4.0/lib/jline-2.14.6.jar
+file path=usr/share/groovy-4.0/lib/jquery-3.5.1.jar
+file path=usr/share/groovy-4.0/lib/jsr166y-1.7.0.jar
+file path=usr/share/groovy-4.0/lib/junit-4.13.2.jar
+file path=usr/share/groovy-4.0/lib/junit-jupiter-api-5.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-jupiter-engine-5.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-platform-commons-1.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-platform-engine-1.11.4.jar
+file path=usr/share/groovy-4.0/lib/junit-platform-launcher-1.11.4.jar
+file path=usr/share/groovy-4.0/lib/multiverse-core-0.7.0.jar
+file path=usr/share/groovy-4.0/lib/mxparser-1.2.2.jar
+file path=usr/share/groovy-4.0/lib/opentest4j-1.3.0.jar
+file path=usr/share/groovy-4.0/lib/org.abego.treelayout.core-1.0.3.jar
+file path=usr/share/groovy-4.0/lib/qdox-1.12.1.jar
+file path=usr/share/groovy-4.0/lib/slf4j-api-2.0.16.jar
+file path=usr/share/groovy-4.0/lib/snakeyaml-2.3.jar
+file path=usr/share/groovy-4.0/lib/testng-7.5.1.jar
+file path=usr/share/groovy-4.0/lib/xstream-1.4.21.jar

--- a/components/developer/groovy-40/pkg5
+++ b/components/developer/groovy-40/pkg5
@@ -1,0 +1,10 @@
+{
+    "dependencies": [
+        "SUNWcs",
+        "runtime/java/openjdk21"
+    ],
+    "fmris": [
+        "developer/groovy-40"
+    ],
+    "name": "groovy"
+}


### PR DESCRIPTION
Add groovy 4.0 branch to prepare to replace groovy 2.4 branch.  Build recipe based on method used in groovy-24.