### PR TITLE
rtmpdump: fix git repo handling

### DIFF
--- a/components/encumbered/rtmpdump/Makefile
+++ b/components/encumbered/rtmpdump/Makefile
@@ -14,37 +14,30 @@
 #
 
 BUILD_STYLE=justmake
+DROP_STATIC_LIBRARIES = yes
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         rtmpdump
 COMPONENT_VERSION=      2.6
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=      RTMPdump -- a toolkit for RTMP streams
-COMPONENT_SRC=          $(COMPONENT_NAME)
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  http://rtmpdump.mplayerhq.hu/
 COMPONENT_LICENSE=      GPLv2,LGPLv2
 COMPONENT_LICENSE_FILE= rtmpdump.license
 COMPONENT_CLASSIFICATION=Applications/Sound and Video
 COMPONENT_FMRI=         video/rtmpdump
 
+# This project does not do release tarballs.  It even does not use git tags so
+# we need to pin to the desired commit explicitly.
 GIT_REPO=https://git.ffmpeg.org/rtmpdump
-GIT_BRANCH=master
-# mtekla identified that GIT_COMMIT_ID should be used to specify cloning
-# the git repo by a specific commmit number, as per discussion in
-# https://github.com/OpenIndiana/oi-userland/pull/20822
-# Not certain if this commit ID is being used since gmake download shows this:
-#  * branch            HEAD       -> FETCH_HEAD
 GIT_COMMIT_ID=6f6bb1353fc84f4cc37138baa99f586750028a01
+GIT_HASH = sha256:627ea7b61a14ae5820d3ab164c2e7ce3331a1dd362d8b5b8017bd217b1952743
 
-COMPONENT_PREP_GIT=no
+TEST_TARGET = $(NO_TESTS)
 
 include $(WS_MAKE_RULES)/encumbered.mk
-
-# copied from sysding Makefile:
-# The ugly hack with update-publish target is necessary to update
-# source from git repository on each "gmake publish".
-# publish: target should appear before inclusion of ips.mk/common.mk
-publish: update-publish
-
 include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_ENV += CC="$(CC)"
@@ -58,33 +51,7 @@ COMPONENT_INSTALL_ENV.64 = ARCH=/$(MACH64)
 COMPONENT_INSTALL_ENV += $(COMPONENT_ENV)
 COMPONENT_INSTALL_ENV += $(COMPONENT_INSTALL_ENV.$(BITS))
 
-# download source from git and then build it using method found in sysding Makefile recipe
-$(SOURCE_DIR)/.downloaded: $(ARCHIVES:%=$(USERLAND_ARCHIVES)%)
-	@[ -d $(SOURCE_DIR) ] || \
-	$(GIT) clone -b $(GIT_BRANCH) $(GIT_REPO) $(SOURCE_DIR)
-	@cd $(SOURCE_DIR) ; $(GIT) checkout $(GIT_BRANCH) ; $(GIT) pull \
-	  $(GIT_REPO) ; $(GIT) log -1 --format=%H > .downloaded
-
-update-publish:
-	@[ -d $(SOURCE_DIR) ] || \
-	$(GIT) clone -b $(GIT_BRANCH) $(GIT_REPO) $(SOURCE_DIR)
-	cd $(SOURCE_DIR) ; $(GIT) pull $(GIT_REPO) ; \
-	  [ "$$($(GIT) log -1 --format=%H)" == "$$(cat .downloaded)" ] || \
-	  ( $(GIT) log -1 --format=%H > .downloaded && $(MAKE) -C $$OLDPWD publish )
-
 COMPONENT_BUILD_TARGETS = all
-
-$(SOURCE_DIR)/.prep: $(SOURCE_DIR)/.downloaded Makefile
-
-build: $(BUILD_64)
-
-install: $(INSTALL_64)
-
-download:: $(SOURCE_DIR)/.downloaded
-
-# Erase source code during gmake clean.   Fixes error if patches tried to get reapplied during gmake build .
-clean::
-	$(RM) -rf rtmpdump
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(OPENSSL_PKG)

--- a/components/encumbered/rtmpdump/manifests/sample-manifest.p5m
+++ b/components/encumbered/rtmpdump/manifests/sample-manifest.p5m
@@ -31,7 +31,6 @@ file path=usr/include/librtmp/amf.h
 file path=usr/include/librtmp/http.h
 file path=usr/include/librtmp/log.h
 file path=usr/include/librtmp/rtmp.h
-file path=usr/lib/$(MACH64)/librtmp.a
 link path=usr/lib/$(MACH64)/librtmp.so target=librtmp.so.1
 file path=usr/lib/$(MACH64)/librtmp.so.1
 file path=usr/lib/$(MACH64)/pkgconfig/librtmp.pc

--- a/components/encumbered/rtmpdump/patches/01-build.patch
+++ b/components/encumbered/rtmpdump/patches/01-build.patch
@@ -1,5 +1,5 @@
---- rtmpdump/Makefile.~1~	2011-07-12 04:24:33.000000000 +0400
-+++ rtmpdump/Makefile	2015-07-21 10:13:56.339356942 +0300
+--- rtmpdump-2.6/Makefile.orig
++++ rtmpdump-2.6/Makefile
 @@ -1,9 +1,9 @@
  VERSION=v2.4
  
@@ -41,8 +41,8 @@
  	cp rtmpdump.1 $(MANDIR)/man1
  	cp rtmpgw.8 $(MANDIR)/man8
  	@cd librtmp; $(MAKE) install
---- rtmpdump/librtmp/Makefile.~1~	2011-07-12 04:24:33.000000000 +0400
-+++ rtmpdump/librtmp/Makefile	2015-07-21 10:16:43.481708226 +0300
+--- rtmpdump-2.6/librtmp/Makefile.orig
++++ rtmpdump-2.6/librtmp/Makefile
 @@ -1,18 +1,18 @@
  VERSION=v2.4
  

--- a/components/encumbered/rtmpdump/rtmpdump.p5m
+++ b/components/encumbered/rtmpdump/rtmpdump.p5m
@@ -18,7 +18,7 @@ set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
-set name=info.source-url value=https://git.ffmpeg.org/rtmpdump
+set name=info.source-url value=$(GIT_REPO)
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
@@ -31,7 +31,6 @@ file path=usr/include/librtmp/amf.h
 file path=usr/include/librtmp/http.h
 file path=usr/include/librtmp/log.h
 file path=usr/include/librtmp/rtmp.h
-#file path=usr/lib/$(MACH64)/librtmp.a
 link path=usr/lib/$(MACH64)/librtmp.so target=librtmp.so.1
 file path=usr/lib/$(MACH64)/librtmp.so.1
 file path=usr/lib/$(MACH64)/pkgconfig/librtmp.pc


### PR DESCRIPTION
This should also stop the continuous `rtmpdump` rebuild during every jenkins job run.

I honestly do not understand why people tend to use very complex (and non-working) ways to do things...