### PR TITLE
Add DateTime-Format-RFC3339 Perl distribution

### DIFF
--- a/components/perl/DateTime-Format-RFC3339/.gitignore
+++ b/components/perl/DateTime-Format-RFC3339/.gitignore
@@ -1,0 +1,1 @@
+/DateTime-Format-RFC3339-v1.10.0/

--- a/components/perl/DateTime-Format-RFC3339/DateTime-Format-RFC3339-PERLVER.p5m
+++ b/components/perl/DateTime-Format-RFC3339/DateTime-Format-RFC3339-PERLVER.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::RFC3339.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/RFC3339.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/datetime-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/version-$(PLV)

--- a/components/perl/DateTime-Format-RFC3339/DateTime-Format-RFC3339.license
+++ b/components/perl/DateTime-Format-RFC3339/DateTime-Format-RFC3339.license
@@ -1,0 +1,13 @@
+
+No rights reserved.
+
+The author has dedicated the work to the Commons by waiving all of his
+or her rights to the work worldwide under copyright law and all related or
+neighboring legal rights he or she had in the work, to the extent allowable by
+law.
+
+Works under CC0 do not require attribution. When citing the work, you should
+not imply endorsement by the author.
+
+===========================================================================
+

--- a/components/perl/DateTime-Format-RFC3339/Makefile
+++ b/components/perl/DateTime-Format-RFC3339/Makefile
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module DateTime-Format-RFC3339
+#
+
+BUILD_STYLE = makemaker
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		DateTime-Format-RFC3339
+HUMAN_VERSION =			v1.10.0
+COMPONENT_SUMMARY =		Parse and format RFC3339 datetime strings
+COMPONENT_CPAN_AUTHOR =		IKEGAMI
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:3a5e64e7beaafd2c64a12109e3cc0fed3db3f893b0323b43b52964fc2c0c8496
+COMPONENT_LICENSE =		CC0-1.0
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += library/perl-5/datetime
+PERL_REQUIRED_PACKAGES += library/perl-5/extutils-makemaker
+PERL_REQUIRED_PACKAGES += library/perl-5/version
+PERL_REQUIRED_PACKAGES += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-pod
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/DateTime-Format-RFC3339/manifests/sample-manifest.p5m
+++ b/components/perl/DateTime-Format-RFC3339/manifests/sample-manifest.p5m
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::RFC3339.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/RFC3339.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/datetime-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/version-$(PLV)

--- a/components/perl/DateTime-Format-RFC3339/perl-integrate-module.conf
+++ b/components/perl/DateTime-Format-RFC3339/perl-integrate-module.conf
@@ -1,0 +1,18 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+%hook-no-license%
+LICENSE='CC0-1.0'
+USE_DEFAULT_PERL_LICENSE=0

--- a/components/perl/DateTime-Format-RFC3339/pkg5
+++ b/components/perl/DateTime-Format-RFC3339/pkg5
@@ -1,0 +1,23 @@
+{
+    "dependencies": [
+        "library/perl-5/datetime-536",
+        "library/perl-5/datetime-538",
+        "library/perl-5/datetime-540",
+        "library/perl-5/extutils-makemaker-536",
+        "library/perl-5/extutils-makemaker-538",
+        "library/perl-5/extutils-makemaker-540",
+        "library/perl-5/version-536",
+        "library/perl-5/version-538",
+        "library/perl-5/version-540",
+        "runtime/perl-536",
+        "runtime/perl-538",
+        "runtime/perl-540"
+    ],
+    "fmris": [
+        "library/perl-5/datetime-format-rfc3339",
+        "library/perl-5/datetime-format-rfc3339-536",
+        "library/perl-5/datetime-format-rfc3339-538",
+        "library/perl-5/datetime-format-rfc3339-540"
+    ],
+    "name": "DateTime-Format-RFC3339"
+}

--- a/components/perl/DateTime-Format-RFC3339/test/results-all.master
+++ b/components/perl/DateTime-Format-RFC3339/test/results-all.master
@@ -1,0 +1,12 @@
+t/00_load.t ................. ok
+t/01_devel_mark_check.t ..... skipped: Mark checks are only performed when DEVEL_TESTS=1
+t/02_devel_version_check.t .. skipped: Version checks are only performed when DEVEL_TESTS=1
+t/03_devel_whitespace.t ..... skipped: Whitespace checks are only performed when DEVEL_TESTS=1
+t/04_devel_permissions.t .... skipped: Permission checks are only performed when DEVEL_TESTS=1
+t/05_pod.t .................. ok
+t/06_devel_pod_coverage.t ... skipped: Pod coverage is only tested when DEVEL_TESTS=1
+t/07_parsing.t .............. ok
+t/08_formatting.t ........... ok
+All tests successful.
+Files=9, Tests=33
+Result: PASS


### PR DESCRIPTION
This is needed by `TOML-Tiny` and `TOML-Tiny` is needed by `zadm`.