### PR TITLE
Add DateTime-Format-Builder Perl distribution

### DIFF
--- a/components/perl/DateTime-Format-Builder/.gitignore
+++ b/components/perl/DateTime-Format-Builder/.gitignore
@@ -1,0 +1,1 @@
+/DateTime-Format-Builder-0.83/

--- a/components/perl/DateTime-Format-Builder/DateTime-Format-Builder-PERLVER.p5m
+++ b/components/perl/DateTime-Format-Builder/DateTime-Format-Builder-PERLVER.p5m
@@ -1,0 +1,52 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Dispatch.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Quick.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Regex.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Strptime.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::generic.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Tutorial.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Dispatch.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Quick.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Regex.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Strptime.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/generic.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Tutorial.pod
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/datetime-$(PLV)@1.0
+depend type=require fmri=pkg:/library/perl-5/datetime-format-strptime-$(PLV)@1.4
+depend type=require fmri=pkg:/library/perl-5/params-validate-$(PLV)@0.72
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/scalar-list-utils-$(PLV)

--- a/components/perl/DateTime-Format-Builder/Makefile
+++ b/components/perl/DateTime-Format-Builder/Makefile
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module DateTime-Format-Builder
+#
+
+BUILD_STYLE = makemaker
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		DateTime-Format-Builder
+HUMAN_VERSION =			0.83
+COMPONENT_SUMMARY =		Create DateTime parser classes and objects.
+COMPONENT_CPAN_AUTHOR =		DROLSKY
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:61ffb23d85b3ca1786b2da3289e99b57e0625fe0e49db02a6dc0cb62c689e2f2
+COMPONENT_LICENSE =		Artistic-2.0
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += library/perl-5/datetime
+PERL_REQUIRED_PACKAGES += library/perl-5/datetime-format-strptime
+PERL_REQUIRED_PACKAGES += library/perl-5/extutils-makemaker
+PERL_REQUIRED_PACKAGES += library/perl-5/params-validate
+PERL_REQUIRED_PACKAGES += library/perl-5/parent
+PERL_REQUIRED_PACKAGES += library/perl-5/scalar-list-utils
+PERL_REQUIRED_PACKAGES += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/cpan-meta
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/extutils-makemaker
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/DateTime-Format-Builder/manifests/sample-manifest.p5m
+++ b/components/perl/DateTime-Format-Builder/manifests/sample-manifest.p5m
@@ -1,0 +1,52 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Dispatch.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Quick.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Regex.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::Strptime.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Parser::generic.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::Builder::Tutorial.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Dispatch.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Quick.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Regex.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/Strptime.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Parser/generic.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/Builder/Tutorial.pod
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/datetime-$(PLV)@1.0
+depend type=require fmri=pkg:/library/perl-5/datetime-format-strptime-$(PLV)@1.4
+depend type=require fmri=pkg:/library/perl-5/params-validate-$(PLV)@0.72
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/scalar-list-utils-$(PLV)

--- a/components/perl/DateTime-Format-Builder/pkg5
+++ b/components/perl/DateTime-Format-Builder/pkg5
@@ -1,0 +1,32 @@
+{
+    "dependencies": [
+        "library/perl-5/datetime-536",
+        "library/perl-5/datetime-538",
+        "library/perl-5/datetime-540",
+        "library/perl-5/datetime-format-strptime-536",
+        "library/perl-5/datetime-format-strptime-538",
+        "library/perl-5/datetime-format-strptime-540",
+        "library/perl-5/extutils-makemaker-536",
+        "library/perl-5/extutils-makemaker-538",
+        "library/perl-5/extutils-makemaker-540",
+        "library/perl-5/params-validate-536",
+        "library/perl-5/params-validate-538",
+        "library/perl-5/params-validate-540",
+        "library/perl-5/parent-536",
+        "library/perl-5/parent-538",
+        "library/perl-5/parent-540",
+        "library/perl-5/scalar-list-utils-536",
+        "library/perl-5/scalar-list-utils-538",
+        "library/perl-5/scalar-list-utils-540",
+        "runtime/perl-536",
+        "runtime/perl-538",
+        "runtime/perl-540"
+    ],
+    "fmris": [
+        "library/perl-5/datetime-format-builder",
+        "library/perl-5/datetime-format-builder-536",
+        "library/perl-5/datetime-format-builder-538",
+        "library/perl-5/datetime-format-builder-540"
+    ],
+    "name": "DateTime-Format-Builder"
+}

--- a/components/perl/DateTime-Format-Builder/test/results-all.master
+++ b/components/perl/DateTime-Format-Builder/test/results-all.master
@@ -1,0 +1,29 @@
+t/00-report-prereqs.t .. ok
+t/99pod.t .............. ok
+t/altcon.t ............. ok
+t/basic.t .............. ok
+t/clone.t .............. ok
+t/create.t ............. ok
+t/dispatch.t ........... ok
+t/extra.t .............. ok
+t/fall.t ............... ok
+t/import.t ............. ok
+t/lengths.t ............ ok
+t/memory-cycle.t ....... skipped: These tests require Test::Memory::Cycle and a working Devel::Cycle (> 1.07).
+t/mergecb.t ............ ok
+t/newclass.t ........... ok
+t/nocon.t .............. ok
+t/noredef.t ............ ok
+t/on_fail.t ............ ok
+t/on_fail_regex.t ...... ok
+t/on_fail_sub.t ........ ok
+t/param.t .............. ok
+t/quick.t .............. ok
+t/self.t ............... ok
+t/strptime.t ........... ok
+t/taint.t .............. ok
+t/verbose.t ............ ok
+t/wholeclass.t ......... ok
+All tests successful.
+Files=26, Tests=226
+Result: PASS


### PR DESCRIPTION
Transitional dependency of `zadm`.  The full dependency chain is: `zadm` -> `TOML-Tiny` -> `DateTime-Format-ISO8601` -> `DateTime-Format-Builder`.