### PR TITLE
Add Test-Deep-Fuzzy Perl distribution

### DIFF
--- a/components/perl/Test-Deep-Fuzzy/.gitignore
+++ b/components/perl/Test-Deep-Fuzzy/.gitignore
@@ -1,0 +1,1 @@
+/Test-Deep-Fuzzy-0.01/

--- a/components/perl/Test-Deep-Fuzzy/Makefile
+++ b/components/perl/Test-Deep-Fuzzy/Makefile
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module Test-Deep-Fuzzy
+#
+
+BUILD_STYLE = modulebuild
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		Test-Deep-Fuzzy
+HUMAN_VERSION =			0.01
+COMPONENT_SUMMARY =		fuzzy number comparison with Test::Deep
+COMPONENT_CPAN_AUTHOR =		KARUPA
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:f5c94fdd836b0d07187e297556986b0888d2cd5d136251962eed427580394daf
+COMPONENT_LICENSE =		Artistic-1.0 OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += library/perl-5/math-round
+PERL_REQUIRED_PACKAGES += library/perl-5/module-build-tiny
+PERL_REQUIRED_PACKAGES += library/perl-5/scalar-list-utils
+PERL_REQUIRED_PACKAGES += library/perl-5/test-deep
+PERL_REQUIRED_PACKAGES += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-deep
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/Test-Deep-Fuzzy/Test-Deep-Fuzzy-PERLVER.p5m
+++ b/components/perl/Test-Deep-Fuzzy/Test-Deep-Fuzzy-PERLVER.p5m
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Test::Deep::Fuzzy.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/Test/Deep/Fuzzy.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Test/Deep/Fuzzy/Number.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/math-round-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/scalar-list-utils-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/test-deep-$(PLV)

--- a/components/perl/Test-Deep-Fuzzy/manifests/sample-manifest.p5m
+++ b/components/perl/Test-Deep-Fuzzy/manifests/sample-manifest.p5m
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Test::Deep::Fuzzy.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/Test/Deep/Fuzzy.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/Test/Deep/Fuzzy/Number.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/math-round-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/scalar-list-utils-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/test-deep-$(PLV)

--- a/components/perl/Test-Deep-Fuzzy/pkg5
+++ b/components/perl/Test-Deep-Fuzzy/pkg5
@@ -1,0 +1,26 @@
+{
+    "dependencies": [
+        "library/perl-5/math-round-536",
+        "library/perl-5/math-round-538",
+        "library/perl-5/math-round-540",
+        "library/perl-5/module-build-tiny-536",
+        "library/perl-5/module-build-tiny-538",
+        "library/perl-5/module-build-tiny-540",
+        "library/perl-5/scalar-list-utils-536",
+        "library/perl-5/scalar-list-utils-538",
+        "library/perl-5/scalar-list-utils-540",
+        "library/perl-5/test-deep-536",
+        "library/perl-5/test-deep-538",
+        "library/perl-5/test-deep-540",
+        "runtime/perl-536",
+        "runtime/perl-538",
+        "runtime/perl-540"
+    ],
+    "fmris": [
+        "library/perl-5/test-deep-fuzzy",
+        "library/perl-5/test-deep-fuzzy-536",
+        "library/perl-5/test-deep-fuzzy-538",
+        "library/perl-5/test-deep-fuzzy-540"
+    ],
+    "name": "Test-Deep-Fuzzy"
+}

--- a/components/perl/Test-Deep-Fuzzy/test/results-all.master
+++ b/components/perl/Test-Deep-Fuzzy/test/results-all.master
@@ -1,0 +1,5 @@
+t/00_compile.t .. ok
+t/01_number.t ... ok
+All tests successful.
+Files=2, Tests=12
+Result: PASS


### PR DESCRIPTION
Transitional dependency of `zadm`.  The full dependency chain is: `zadm` -> `TOML-Tiny` -> `TOML-Parser` -> `Test-Deep-Fuzzy`.