### PR TITLE
Add DateTime-Format-ISO8601 Perl distribution

### DIFF
--- a/components/perl/DateTime-Format-ISO8601/.gitignore
+++ b/components/perl/DateTime-Format-ISO8601/.gitignore
@@ -1,0 +1,1 @@
+/DateTime-Format-ISO8601-0.17/

--- a/components/perl/DateTime-Format-ISO8601/DateTime-Format-ISO8601-PERLVER.p5m
+++ b/components/perl/DateTime-Format-ISO8601/DateTime-Format-ISO8601-PERLVER.p5m
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::ISO8601.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::ISO8601::Types.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/ISO8601.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/ISO8601/Types.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/datetime-$(PLV)@1.45
+depend type=require fmri=pkg:/library/perl-5/datetime-format-builder-$(PLV)@0.77
+depend type=require fmri=pkg:/library/perl-5/namespace-autoclean-$(PLV)
+depend type=require \
+    fmri=pkg:/library/perl-5/params-validationcompiler-$(PLV)@0.26
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/specio-$(PLV)@0.18

--- a/components/perl/DateTime-Format-ISO8601/Makefile
+++ b/components/perl/DateTime-Format-ISO8601/Makefile
@@ -1,0 +1,43 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module DateTime-Format-ISO8601
+#
+
+BUILD_STYLE = makemaker
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		DateTime-Format-ISO8601
+HUMAN_VERSION =			0.17
+COMPONENT_SUMMARY =		Parses ISO8601 formats
+COMPONENT_CPAN_AUTHOR =		DROLSKY
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:04899f3b1896b2e0933a1d728b3094ccd2f7d09e434c4eac2696cd931bbf0551
+COMPONENT_LICENSE =		Artistic-1.0-Perl OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += library/perl-5/datetime
+PERL_REQUIRED_PACKAGES += library/perl-5/datetime-format-builder
+PERL_REQUIRED_PACKAGES += library/perl-5/extutils-makemaker
+PERL_REQUIRED_PACKAGES += library/perl-5/namespace-autoclean
+PERL_REQUIRED_PACKAGES += library/perl-5/params-validationcompiler
+PERL_REQUIRED_PACKAGES += library/perl-5/parent
+PERL_REQUIRED_PACKAGES += library/perl-5/specio
+PERL_REQUIRED_PACKAGES += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/cpan-meta
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/extutils-makemaker
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/DateTime-Format-ISO8601/manifests/sample-manifest.p5m
+++ b/components/perl/DateTime-Format-ISO8601/manifests/sample-manifest.p5m
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::ISO8601.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/DateTime::Format::ISO8601::Types.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/ISO8601.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/DateTime/Format/ISO8601/Types.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/datetime-$(PLV)@1.45
+depend type=require fmri=pkg:/library/perl-5/datetime-format-builder-$(PLV)@0.77
+depend type=require fmri=pkg:/library/perl-5/namespace-autoclean-$(PLV)
+depend type=require \
+    fmri=pkg:/library/perl-5/params-validationcompiler-$(PLV)@0.26
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/specio-$(PLV)@0.18

--- a/components/perl/DateTime-Format-ISO8601/pkg5
+++ b/components/perl/DateTime-Format-ISO8601/pkg5
@@ -1,0 +1,35 @@
+{
+    "dependencies": [
+        "library/perl-5/datetime-536",
+        "library/perl-5/datetime-538",
+        "library/perl-5/datetime-540",
+        "library/perl-5/datetime-format-builder-536",
+        "library/perl-5/datetime-format-builder-538",
+        "library/perl-5/datetime-format-builder-540",
+        "library/perl-5/extutils-makemaker-536",
+        "library/perl-5/extutils-makemaker-538",
+        "library/perl-5/extutils-makemaker-540",
+        "library/perl-5/namespace-autoclean-536",
+        "library/perl-5/namespace-autoclean-538",
+        "library/perl-5/namespace-autoclean-540",
+        "library/perl-5/params-validationcompiler-536",
+        "library/perl-5/params-validationcompiler-538",
+        "library/perl-5/params-validationcompiler-540",
+        "library/perl-5/parent-536",
+        "library/perl-5/parent-538",
+        "library/perl-5/parent-540",
+        "library/perl-5/specio-536",
+        "library/perl-5/specio-538",
+        "library/perl-5/specio-540",
+        "runtime/perl-536",
+        "runtime/perl-538",
+        "runtime/perl-540"
+    ],
+    "fmris": [
+        "library/perl-5/datetime-format-iso8601",
+        "library/perl-5/datetime-format-iso8601-536",
+        "library/perl-5/datetime-format-iso8601-538",
+        "library/perl-5/datetime-format-iso8601-540"
+    ],
+    "name": "DateTime-Format-ISO8601"
+}

--- a/components/perl/DateTime-Format-ISO8601/test/results-all.master
+++ b/components/perl/DateTime-Format-ISO8601/test/results-all.master
@@ -1,0 +1,12 @@
+t/00-report-prereqs.t .. ok
+t/bad-formats.t ........ ok
+t/base-datetime.t ...... ok
+t/cut-off-year.t ....... ok
+t/date.t ............... ok
+t/datetime.t ........... ok
+t/format-datetime.t .... ok
+t/legacy-year.t ........ ok
+t/time.t ............... ok
+All tests successful.
+Files=9, Tests=21608
+Result: PASS


### PR DESCRIPTION
Transitional dependency of `zadm`.  The full dependency chain is: `zadm` -> `TOML-Tiny` -> `DateTime-Format-ISO8601`.