### PR TITLE
Add TOML-Parser Perl distribution

### DIFF
--- a/components/perl/TOML-Parser/.gitignore
+++ b/components/perl/TOML-Parser/.gitignore
@@ -1,0 +1,1 @@
+/TOML-Parser-0.91/

--- a/components/perl/TOML-Parser/Makefile
+++ b/components/perl/TOML-Parser/Makefile
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module TOML-Parser
+#
+
+BUILD_STYLE = modulebuild
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		TOML-Parser
+HUMAN_VERSION =			0.91
+COMPONENT_SUMMARY =		simple toml parser
+COMPONENT_CPAN_AUTHOR =		KARUPA
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:2a8513b904e377e0cae726910be676f4ff96bd960001c358dd66dc7c37aa9a8e
+COMPONENT_LICENSE =		Artistic-1.0 OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PERL_REQUIRED_PACKAGES += library/perl-5/encode
+PERL_REQUIRED_PACKAGES += library/perl-5/module-build-tiny
+PERL_REQUIRED_PACKAGES += library/perl-5/parent
+PERL_REQUIRED_PACKAGES += library/perl-5/types-serialiser
+PERL_REQUIRED_PACKAGES += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/mime-base64
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-deep
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-deep-fuzzy
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/TOML-Parser/TOML-Parser-PERLVER.p5m
+++ b/components/perl/TOML-Parser/TOML-Parser-PERLVER.p5m
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/TOML::Parser.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser/Tokenizer.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser/Tokenizer/Strict.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser/Util.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/encode-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/types-serialiser-$(PLV)

--- a/components/perl/TOML-Parser/manifests/sample-manifest.p5m
+++ b/components/perl/TOML-Parser/manifests/sample-manifest.p5m
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/TOML::Parser.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser/Tokenizer.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser/Tokenizer/Strict.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/TOML/Parser/Util.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/encode-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/types-serialiser-$(PLV)

--- a/components/perl/TOML-Parser/pkg5
+++ b/components/perl/TOML-Parser/pkg5
@@ -1,0 +1,26 @@
+{
+    "dependencies": [
+        "library/perl-5/encode-536",
+        "library/perl-5/encode-538",
+        "library/perl-5/encode-540",
+        "library/perl-5/module-build-tiny-536",
+        "library/perl-5/module-build-tiny-538",
+        "library/perl-5/module-build-tiny-540",
+        "library/perl-5/parent-536",
+        "library/perl-5/parent-538",
+        "library/perl-5/parent-540",
+        "library/perl-5/types-serialiser-536",
+        "library/perl-5/types-serialiser-538",
+        "library/perl-5/types-serialiser-540",
+        "runtime/perl-536",
+        "runtime/perl-538",
+        "runtime/perl-540"
+    ],
+    "fmris": [
+        "library/perl-5/toml-parser",
+        "library/perl-5/toml-parser-536",
+        "library/perl-5/toml-parser-538",
+        "library/perl-5/toml-parser-540"
+    ],
+    "name": "TOML-Parser"
+}

--- a/components/perl/TOML-Parser/test/results-all.master
+++ b/components/perl/TOML-Parser/test/results-all.master
@@ -1,0 +1,23 @@
+t/000_compile.t ............................. ok
+t/001_parser/broken.t ....................... ok
+t/001_parser/comma_at_last_of_array.t ....... ok
+t/001_parser/dot_in_key.t ................... ok
+t/001_parser/duplicate_key.t ................ ok
+t/001_parser/empty_array.t .................. ok
+t/001_parser/empty_comment.t ................ ok
+t/001_parser/empty_string.t ................. ok
+t/001_parser/equal_in_key_with_no_spaces.t .. ok
+t/001_parser/escape.t ....................... ok
+t/001_parser/example.t ...................... ok
+t/001_parser/example_fruit.t ................ ok
+t/001_parser/float.t ........................ ok
+t/001_parser/hard_example.t ................. ok
+t/001_parser/inline_table.t ................. ok
+t/001_parser/integer.t ...................... ok
+t/001_parser/multi_line_string.t ............ ok
+t/001_parser/single_quote.t ................. ok
+t/001_parser/string_zero.t .................. ok
+t/001_parser/table.t ........................ ok
+All tests successful.
+Files=20, Tests=59
+Result: PASS


### PR DESCRIPTION
Transitional dependency of `zadm`.  The full dependency chain is: `zadm` -> `TOML-Tiny` -> `TOML-Parser`.