### PR TITLE
firefox: update to 136.0

### DIFF
--- a/components/web/firefox/Makefile
+++ b/components/web/firefox/Makefile
@@ -30,13 +30,13 @@ ESR =
 # CANDIDATE_NIGHTLY is the nightly release hosted on github
 # USE_HG_REPO is to use mozilla's hg source repo nstead of github
 # Do not define any for final release build.
-# CANDIDATE_BUILD=1
+# CANDIDATE_BUILD=3
 # CANDIDATE_BETA=9
 # CANDIDATE_NIGHTLY=1
 # USE_HG_REPO=1
 
 COMPONENT_NAME =	firefox
-COMPONENT_VERSION =	135.0.1
+COMPONENT_VERSION =	136.0
 COMPONENT_SUMMARY=      Mozilla Firefox Web browser
 COMPONENT_PROJECT_URL =	https://www.mozilla.com/firefox
 COMPONENT_SRC_NAME =	$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -49,7 +49,7 @@ COMPONENT_ARCHIVE =	$(COMPONENT_SRC_NAME)$(ESR).source.tar.xz
 endif
 
 ifdef CANDIDATE_NIGHTLY
-COMPONENT_GIT_HASH=     827e12a962ef47511089af4498f65ebf42fa57ca31db790bfd7e9a820d16b960
+COMPONENT_GIT_HASH=     0299b6544c93b13c8c6c85457d0d3bad1d11963b
 COMPONENT_SRC=          gecko-dev-$(COMPONENT_GIT_HASH)
 COMPONENT_ARCHIVE=      $(COMPONENT_GIT_HASH).tar.gz
 COMPONENT_ARCHIVE_URL=  https://github.com/mozilla/gecko-dev/archive/$(COMPONENT_ARCHIVE)
@@ -73,11 +73,11 @@ COMPONENT_SRC = 	$(COMPONENT_SRC_NAME)
 COMPONENT_ARCHIVE_URL =	$(MOZILLA_FTP)/source/$(COMPONENT_ARCHIVE)
 endif
 
-COMPONENT_ARCHIVE_HASH= sha256:74fbdfddce3be390f3f03194a4e398b30d0a69754e1542a59d7f2b38bac37906
+COMPONENT_ARCHIVE_HASH= sha256:3bee314eb7934451be4e2c7ecac38b382f8422fed8287e05be26fe94dd286f57
 COMPONENT_PROJECT_URL = https://www.mozilla.com/en-US/firefox/
 COMPONENT_FMRI=		web/browser/firefox
 
-RUST_VERSION = 1.83.0
+RUST_VERSION = 1.84.0
 
 # TODO: use remote hashfile to verify
 ALLOW_UNVERIFIED_DOWNLOADS=yes
@@ -271,7 +271,6 @@ PYTHON_REQUIRED_PACKAGES += runtime/python
 REQUIRED_PACKAGES += database/sqlite-3
 REQUIRED_PACKAGES += developer/build/autoconf-213
 REQUIRED_PACKAGES += developer/lang/rustc
-REQUIRED_PACKAGES += gnome/config/gconf
 REQUIRED_PACKAGES += library/audio/pulseaudio
 REQUIRED_PACKAGES += library/http-parser
 REQUIRED_PACKAGES += runtime/nodejs-22

--- a/components/web/firefox/pkg5
+++ b/components/web/firefox/pkg5
@@ -4,7 +4,6 @@
         "developer/build/autoconf-213",
         "developer/lang/rustc",
         "gnome/accessibility/at-spi2-core",
-        "gnome/config/gconf",
         "library/audio/pulseaudio",
         "library/c++/harfbuzz",
         "library/desktop/cairo",


### PR DESCRIPTION
Drop dependency for gnome/config/gconf since firefox doesn't need it.