### PR TITLE
berkeley-db: fix configure silliness to allow build with gcc14

### DIFF
--- a/components/database/berkeleydb/Makefile
+++ b/components/database/berkeleydb/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		berkeleydb
 COMPONENT_VERSION=	5.3.28
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_SUMMARY=	Berkeley DB is a computer software library that provides a high-performance embedded database for key/value data
 COMPONENT_PROJECT_URL=	https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html
 COMPONENT_SRC_NAME=	db

--- a/components/database/berkeleydb/patches/configure.patch
+++ b/components/database/berkeleydb/patches/configure.patch
@@ -1,6 +1,126 @@
---- db-5.1.25/dist/configure.orig	2011-08-04 15:02:16.786577345 -0700
-+++ db-5.1.25/dist/configure	2011-08-04 15:02:45.349081448 -0700
-@@ -25858,7 +25858,7 @@
+--- db-5.3.28/dist/configure.orig	Mon Sep  9 15:35:02 2013
++++ db-5.3.28/dist/configure	Tue Mar 11 10:31:30 2025
+@@ -20611,6 +20611,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -20671,6 +20672,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_condattr_t condattr;
+@@ -20721,6 +20723,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_rwlock_t rwlock;
+ 	pthread_rwlockattr_t rwlockattr;
+@@ -20785,6 +20788,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -20845,6 +20849,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_condattr_t condattr;
+@@ -20895,6 +20900,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_rwlock_t rwlock;
+ 	pthread_rwlockattr_t rwlockattr;
+@@ -20960,6 +20966,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -21018,6 +21025,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_condattr_t condattr;
+@@ -21068,6 +21076,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_rwlock_t rwlock;
+ 	pthread_rwlockattr_t rwlockattr;
+@@ -21130,6 +21139,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_mutex_t mutex;
+@@ -21188,6 +21198,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_cond_t cond;
+ 	pthread_condattr_t condattr;
+@@ -21238,6 +21249,7 @@
+ 
+ #include <stdlib.h>
+ #include <pthread.h>
++int
+ main() {
+ 	pthread_rwlock_t rwlock;
+ 	pthread_rwlockattr_t rwlockattr;
+@@ -23456,6 +23468,7 @@
+ /* end confdefs.h.  */
+ 
+ #include <sys/time.h>
++int
+ main() {
+ 	struct timespec t;
+ 	return (clock_gettime(CLOCK_MONOTONIC, &t) != 0);
+@@ -24226,6 +24239,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
++		int
+ 		main() {
+ 			$db_cv_seq_type l;
+ 			unsigned $db_cv_seq_type u;
+@@ -24322,6 +24336,7 @@
+ 	    exit(1);
+     }
+ 
++    int
+     main() {
+ 	    const char *underlying;
+ 	    unsigned gapsize;
+@@ -27375,7 +27390,7 @@
    cd jdbc
    test ! -e Makefile.in.tmp && mv Makefile.in Makefile.in.tmp
    sed "s/@BDB_LIB@/$BDB_LIB/g" Makefile.in.tmp > Makefile.in


### PR DESCRIPTION
There are a number of little test programs embedded in the configure script that don't specify the return type of main(), leading to compilation failures and thus mis-detected features during configure.