### PR TITLE
libodfgen: fix dependency for library/libxml2/32, remove CXXFLAGS for…

### DIFF
--- a/components/library/libodfgen/Makefile
+++ b/components/library/libodfgen/Makefile
@@ -25,7 +25,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		libodfgen
 COMPONENT_VERSION=	0.1.8
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=      libodfgen - ODF export library using librevenge
 COMPONENT_PROJECT_URL=	https://sourceforge.net/p/libwpd/wiki/libodfgen/
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -39,9 +39,6 @@ COMPONENT_LICENSE=      LGPLv2.1 MPLv2
 TEST_TARGET= $(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 
-# Fix threading detection issue with boost 1.64
-CXXFLAGS+= -pthread
-
 CONFIGURE_OPTIONS+=	--enable-shared
 CONFIGURE_OPTIONS+=	--disable-static
 
@@ -53,5 +50,6 @@ REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += $(GXX_RUNTIME_PKG)
 REQUIRED_PACKAGES += library/c++/librevenge
 REQUIRED_PACKAGES += library/libxml2
+REQUIRED_PACKAGES += library/libxml2/32
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/library/libodfgen/libodfgen.p5m
+++ b/components/library/libodfgen/libodfgen.p5m
@@ -42,6 +42,7 @@ file path=usr/share/doc/libodfgen/html/bc_s.png
 file path=usr/share/doc/libodfgen/html/bc_sd.png
 file path=usr/share/doc/libodfgen/html/closed.png
 file path=usr/share/doc/libodfgen/html/doxygen.css
+file path=usr/share/doc/libodfgen/html/doxygen_crawl.html
 file path=usr/share/doc/libodfgen/html/index.html
 file path=usr/share/doc/libodfgen/html/nav_f.png
 file path=usr/share/doc/libodfgen/html/nav_fd.png

--- a/components/library/libodfgen/manifests/sample-manifest.p5m
+++ b/components/library/libodfgen/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -42,6 +42,7 @@ file path=usr/share/doc/libodfgen/html/bc_s.png
 file path=usr/share/doc/libodfgen/html/bc_sd.png
 file path=usr/share/doc/libodfgen/html/closed.png
 file path=usr/share/doc/libodfgen/html/doxygen.css
+file path=usr/share/doc/libodfgen/html/doxygen_crawl.html
 file path=usr/share/doc/libodfgen/html/index.html
 file path=usr/share/doc/libodfgen/html/nav_f.png
 file path=usr/share/doc/libodfgen/html/nav_fd.png

--- a/components/library/libodfgen/pkg5
+++ b/components/library/libodfgen/pkg5
@@ -2,10 +2,11 @@
     "dependencies": [
         "library/c++/librevenge",
         "library/libxml2",
+        "library/libxml2/32",
         "system/library",
         "system/library/boost",
-        "system/library/g++-13-runtime",
-        "system/library/gcc-13-runtime",
+        "system/library/g++-14-runtime",
+        "system/library/gcc-14-runtime",
         "system/library/math"
     ],
     "fmris": [


### PR DESCRIPTION
… old boost-library.