### PR TITLE
nimbus : fix dark-nimbus and light-nimbus theme

### DIFF
--- a/components/desktop/nimbus/Makefile
+++ b/components/desktop/nimbus/Makefile
@@ -12,27 +12,27 @@
 # Copyright 2018 Alexander Pyhalov
 #
 
+USE_PARALLEL_BUILD= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		nimbus
 COMPONENT_VERSION=	1.0
-COMPONENT_REVISION=	4
-COMPONENT_COMMIT=	172733afb6156c59fcd57484854090b798460fd9
+COMPONENT_REVISION=	5
+COMPONENT_COMMIT=	e865d724c11d992b95385fa884df5adc6e1d0506
 COMPONENT_PROJECT_URL=	https://openindiana.org
 COMPONENT_SUMMARY=	Engine for Nimbus GTK2/3 Theme
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_COMMIT)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH=	\
-    sha256:6815b90625b283a7f6af8763a7e27a182ec11017a825dc0a60ce59589ef747f5
+    sha256:04c71ac54a99d41c4b9538ee49c2abce9800caf680cef22e76bda716e0f58aad
 COMPONENT_ARCHIVE_URL=	https://github.com/OpenIndiana/nimbus/archive/$(COMPONENT_COMMIT).tar.gz
 COMPONENT_FMRI=		gnome/theme/nimbus
 COMPONENT_CLASSIFICATION= Desktop (GNOME)/Theming
 COMPONENT_LICENSE = LGPLv2
 COMPONENT_LICENSE_FILE = COPYING
 
-include $(WS_MAKE_RULES)/prep.mk
-include $(WS_MAKE_RULES)/configure.mk
-include $(WS_MAKE_RULES)/ips.mk
+TEST_TARGET= $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
 
 PATH=$(PATH.gnu)
 
@@ -53,13 +53,13 @@ CONFIGURE_SCRIPT=$(SOURCE_DIR)/autogen.sh
 
 CONFIGURE_OPTIONS += --sysconfdir=/etc
 
-# common targets
-build:		$(BUILD_32_and_64)
+# Manually added build dependencies
+REQUIRED_PACKAGES += developer/build/automake-115
+REQUIRED_PACKAGES += library/desktop/xdg/icon-naming-utils
+PERL_REQUIRED_PACKAGES += runtime/perl
+PERL_REQUIRED_PACKAGES += library/perl-5/xml-simple
 
-install:	$(INSTALL_32_and_64)
-
-test:		$(NO_TESTS)
-
+# Auto-generated dependencies
 REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
 REQUIRED_PACKAGES += library/desktop/gtk2
 REQUIRED_PACKAGES += library/glib2

--- a/components/desktop/nimbus/manifests/sample-manifest.p5m
+++ b/components/desktop/nimbus/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -24,8 +25,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/lib/$(MACH64)/gtk-2.0/2.10.0/engines/libnimbus.a
 file path=usr/lib/$(MACH64)/gtk-2.0/2.10.0/engines/libnimbus.so
-file path=usr/lib/gtk-2.0/2.10.0/engines/libnimbus.a
-file path=usr/lib/gtk-2.0/2.10.0/engines/libnimbus.so
 file path=usr/share/icons/nimbus/12x12/actions/info.png
 link path=usr/share/icons/nimbus/12x12/apps/gnome-help.png \
     target=help-browser.png
@@ -277,8 +276,7 @@ link path=usr/share/icons/nimbus/16x16/actions/gtk-unindent-ltr.png \
     target=format-indent-less.png
 link path=usr/share/icons/nimbus/16x16/actions/gtk-unindent-rtl.png \
     target=format-indent-more.png
-link \
-    path=usr/share/icons/nimbus/16x16/actions/gtk-zoom-$(COMPONENT_VERSION).png \
+link path=usr/share/icons/nimbus/16x16/actions/gtk-zoom-100.png \
     target=zoom-original.png
 link path=usr/share/icons/nimbus/16x16/actions/gtk-zoom-in.png \
     target=zoom-in.png
@@ -2053,8 +2051,7 @@ link path=usr/share/icons/nimbus/24x24/actions/gtk-unindent-ltr.png \
     target=format-indent-less.png
 link path=usr/share/icons/nimbus/24x24/actions/gtk-unindent-rtl.png \
     target=format-indent-more.png
-link \
-    path=usr/share/icons/nimbus/24x24/actions/gtk-zoom-$(COMPONENT_VERSION).png \
+link path=usr/share/icons/nimbus/24x24/actions/gtk-zoom-100.png \
     target=zoom-original.png
 link path=usr/share/icons/nimbus/24x24/actions/gtk-zoom-in.png \
     target=zoom-in.png
@@ -2784,7 +2781,7 @@ link path=usr/share/icons/nimbus/24x24/status/error.png target=dialog-error.png
 file path=usr/share/icons/nimbus/24x24/status/gnome-netstatus-0-24.png
 file path=usr/share/icons/nimbus/24x24/status/gnome-netstatus-25-49.png
 file path=usr/share/icons/nimbus/24x24/status/gnome-netstatus-50-74.png
-file path=usr/share/icons/nimbus/24x24/status/gnome-netstatus-75-$(COMPONENT_VERSION).png
+file path=usr/share/icons/nimbus/24x24/status/gnome-netstatus-75-100.png
 link path=usr/share/icons/nimbus/24x24/status/gnome-netstatus-disconn.png \
     target=network-offline.png
 link path=usr/share/icons/nimbus/24x24/status/gnome-netstatus-error.png \
@@ -2839,7 +2836,7 @@ link path=usr/share/icons/nimbus/24x24/status/nm-no-connection.png \
 file path=usr/share/icons/nimbus/24x24/status/nwam-wireless-0-24.png
 file path=usr/share/icons/nimbus/24x24/status/nwam-wireless-25-49.png
 file path=usr/share/icons/nimbus/24x24/status/nwam-wireless-50-74.png
-file path=usr/share/icons/nimbus/24x24/status/nwam-wireless-75-$(COMPONENT_VERSION).png
+file path=usr/share/icons/nimbus/24x24/status/nwam-wireless-75-100.png
 file path=usr/share/icons/nimbus/24x24/status/nwam-wireless-nosignal.png
 link path=usr/share/icons/nimbus/24x24/status/stock_dialog-error.png \
     target=dialog-error.png
@@ -3533,7 +3530,7 @@ link path=usr/share/icons/nimbus/32x32/status/error.png target=dialog-error.png
 file path=usr/share/icons/nimbus/32x32/status/gnome-netstatus-0-24.png
 file path=usr/share/icons/nimbus/32x32/status/gnome-netstatus-25-49.png
 file path=usr/share/icons/nimbus/32x32/status/gnome-netstatus-50-74.png
-file path=usr/share/icons/nimbus/32x32/status/gnome-netstatus-75-$(COMPONENT_VERSION).png
+file path=usr/share/icons/nimbus/32x32/status/gnome-netstatus-75-100.png
 link path=usr/share/icons/nimbus/32x32/status/gnome-netstatus-disconn.png \
     target=network-offline.png
 link path=usr/share/icons/nimbus/32x32/status/gnome-netstatus-error.png \
@@ -3584,7 +3581,7 @@ link path=usr/share/icons/nimbus/32x32/status/nm-no-connection.png \
 file path=usr/share/icons/nimbus/32x32/status/nwam-wireless-0-24.png
 file path=usr/share/icons/nimbus/32x32/status/nwam-wireless-25-49.png
 file path=usr/share/icons/nimbus/32x32/status/nwam-wireless-50-74.png
-file path=usr/share/icons/nimbus/32x32/status/nwam-wireless-75-$(COMPONENT_VERSION).png
+file path=usr/share/icons/nimbus/32x32/status/nwam-wireless-75-100.png
 file path=usr/share/icons/nimbus/32x32/status/nwam-wireless-nosignal.png
 link path=usr/share/icons/nimbus/32x32/status/stock_dialog-error.png \
     target=dialog-error.png
@@ -5867,6 +5864,104 @@ link path=usr/share/themes/dark-nimbus/gtk-2.0/zoom-original.png \
     target=../../nimbus/gtk-2.0/zoom-original.png
 link path=usr/share/themes/dark-nimbus/gtk-2.0/zoom-out.png \
     target=../../nimbus/gtk-2.0/zoom-out.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/budgie.css \
+    target=../../../nimbus/gtk-3.0/apps/budgie.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/desktop.css \
+    target=../../../nimbus/gtk-3.0/apps/desktop.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/gnome-flashback.css \
+    target=../../../nimbus/gtk-3.0/apps/gnome-flashback.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/gnome-terminal.css \
+    target=../../../nimbus/gtk-3.0/apps/gnome-terminal.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/libreoffice.css \
+    target=../../../nimbus/gtk-3.0/apps/libreoffice.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/mate.css \
+    target=../../../nimbus/gtk-3.0/apps/mate.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/synaptic.css \
+    target=../../../nimbus/gtk-3.0/apps/synaptic.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/unity.css \
+    target=../../../nimbus/gtk-3.0/apps/unity.css
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked-active.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked-active.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked-hover.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-active.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-hover.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked-active.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-active.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-active.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-hover.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-symbolic.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-symbolic.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected-active.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected-hover.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected-active.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected-active.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected-hover.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected.png
+link \
+    path=usr/share/themes/dark-nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png \
+    target=../../../nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/scrollbar-slider.png \
+    target=../../../nimbus/gtk-3.0/assets/scrollbar-slider.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/gtk-widgets-assets.css \
+    target=../../nimbus/gtk-3.0/gtk-widgets-assets.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/gtk-widgets.css \
+    target=../../nimbus/gtk-3.0/gtk-widgets.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/gtk.css \
+    target=../../nimbus/gtk-3.0/gtk.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/settings.ini \
+    target=../../nimbus/gtk-3.0/settings.ini
+link path=usr/share/themes/dark-nimbus/gtk-3.0/thumbnail.png \
+    target=../../nimbus/gtk-3.0/thumbnail.png
 file path=usr/share/themes/dark-nimbus/index.theme
 link \
     path=usr/share/themes/dark-nimbus/metacity-1/button-close-icon-prelight.png \
@@ -6116,6 +6211,107 @@ link path=usr/share/themes/light-nimbus/gtk-2.0/zoom-original.png \
     target=../../nimbus/gtk-2.0/zoom-original.png
 link path=usr/share/themes/light-nimbus/gtk-2.0/zoom-out.png \
     target=../../nimbus/gtk-2.0/zoom-out.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/budgie.css \
+    target=../../../nimbus/gtk-3.0/apps/budgie.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/desktop.css \
+    target=../../../nimbus/gtk-3.0/apps/desktop.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/gnome-flashback.css \
+    target=../../../nimbus/gtk-3.0/apps/gnome-flashback.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/gnome-terminal.css \
+    target=../../../nimbus/gtk-3.0/apps/gnome-terminal.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/libreoffice.css \
+    target=../../../nimbus/gtk-3.0/apps/libreoffice.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/mate.css \
+    target=../../../nimbus/gtk-3.0/apps/mate.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/synaptic.css \
+    target=../../../nimbus/gtk-3.0/apps/synaptic.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/unity.css \
+    target=../../../nimbus/gtk-3.0/apps/unity.css
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked-active.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked-active.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked-hover.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-checked.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-active.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-active.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-hover.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-mixed.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked-active.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-active.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked.png \
+    target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-active.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-active.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-hover.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-insensitive.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-symbolic.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed-symbolic.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-mixed.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected-active.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected-active.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected-hover.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-selected.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected-active.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected-active.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected-hover.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected-hover.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected-insensitive.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected.png \
+    target=../../../nimbus/gtk-3.0/assets/radio-unselected.png
+link \
+    path=usr/share/themes/light-nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png \
+    target=../../../nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/scrollbar-slider.png \
+    target=../../../nimbus/gtk-3.0/assets/scrollbar-slider.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/gtk-widgets-assets.css \
+    target=../../nimbus/gtk-3.0/gtk-widgets-assets.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/gtk-widgets.css \
+    target=../../nimbus/gtk-3.0/gtk-widgets.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/gtk.css \
+    target=../../nimbus/gtk-3.0/gtk.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/settings.ini \
+    target=../../nimbus/gtk-3.0/settings.ini
+link path=usr/share/themes/light-nimbus/gtk-3.0/thumbnail.png \
+    target=../../nimbus/gtk-3.0/thumbnail.png
 file path=usr/share/themes/light-nimbus/index.theme
 link \
     path=usr/share/themes/light-nimbus/metacity-1/button-close-icon-prelight.png \

--- a/components/desktop/nimbus/nimbus.p5m
+++ b/components/desktop/nimbus/nimbus.p5m
@@ -25,7 +25,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 depend type=require fmri=gnome/theme/tango-icon-theme
 
 file path=usr/lib/$(MACH64)/gtk-2.0/2.10.0/engines/libnimbus.so
-file path=usr/lib/gtk-2.0/2.10.0/engines/libnimbus.so
 file path=usr/share/icons/nimbus/12x12/actions/info.png
 link path=usr/share/icons/nimbus/12x12/apps/gnome-help.png \
     target=help-browser.png
@@ -5081,3 +5080,85 @@ file path=usr/share/themes/nimbus/metacity-1/button-unmax-icon-pressed.png
 file path=usr/share/themes/nimbus/metacity-1/button-unmax-icon-unfocused.png
 file path=usr/share/themes/nimbus/metacity-1/button-unmax-icon.png
 file path=usr/share/themes/nimbus/metacity-1/metacity-theme-1.xml
+link path=usr/share/themes/light-nimbus/gtk-3.0/settings.ini target=../../nimbus/gtk-3.0/settings.ini
+link path=usr/share/themes/light-nimbus/gtk-3.0/gtk-widgets.css target=../../nimbus/gtk-3.0/gtk-widgets.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/gtk.css target=../../nimbus/gtk-3.0/gtk.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/gtk-widgets-assets.css target=../../nimbus/gtk-3.0/gtk-widgets-assets.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/thumbnail.png target=../../nimbus/gtk-3.0/thumbnail.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed.png target=../../../nimbus/gtk-3.0/assets/radio-mixed.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-active.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-active.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected.png target=../../../nimbus/gtk-3.0/assets/radio-unselected.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected-insensitive.png target=../../../nimbus/gtk-3.0/assets/radio-unselected-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected-active.png target=../../../nimbus/gtk-3.0/assets/radio-unselected-active.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-active.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-active.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked-hover.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked-hover.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png target=../../../nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked-active.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked-active.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/scrollbar-slider.png target=../../../nimbus/gtk-3.0/assets/scrollbar-slider.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected-active.png target=../../../nimbus/gtk-3.0/assets/radio-selected-active.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-hover.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-hover.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-hover.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-hover.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected-insensitive.png target=../../../nimbus/gtk-3.0/assets/radio-selected-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-symbolic.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-symbolic.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-checked.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked-active.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-active.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected.png target=../../../nimbus/gtk-3.0/assets/radio-selected.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-unselected-hover.png target=../../../nimbus/gtk-3.0/assets/radio-unselected-hover.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-selected-hover.png target=../../../nimbus/gtk-3.0/assets/radio-selected-hover.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/assets/radio-mixed-insensitive.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-insensitive.png
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/synaptic.css target=../../../nimbus/gtk-3.0/apps/synaptic.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/desktop.css target=../../../nimbus/gtk-3.0/apps/desktop.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/gnome-flashback.css target=../../../nimbus/gtk-3.0/apps/gnome-flashback.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/budgie.css target=../../../nimbus/gtk-3.0/apps/budgie.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/mate.css target=../../../nimbus/gtk-3.0/apps/mate.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/unity.css target=../../../nimbus/gtk-3.0/apps/unity.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/libreoffice.css target=../../../nimbus/gtk-3.0/apps/libreoffice.css
+link path=usr/share/themes/light-nimbus/gtk-3.0/apps/gnome-terminal.css target=../../../nimbus/gtk-3.0/apps/gnome-terminal.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/gtk-widgets.css target=../../nimbus/gtk-3.0/gtk-widgets.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/thumbnail.png target=../../nimbus/gtk-3.0/thumbnail.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/gtk.css target=../../nimbus/gtk-3.0/gtk.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/gtk-widgets-assets.css target=../../nimbus/gtk-3.0/gtk-widgets-assets.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/settings.ini target=../../nimbus/gtk-3.0/settings.ini
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/gnome-terminal.css target=../../../nimbus/gtk-3.0/apps/gnome-terminal.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/synaptic.css target=../../../nimbus/gtk-3.0/apps/synaptic.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/mate.css target=../../../nimbus/gtk-3.0/apps/mate.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/unity.css target=../../../nimbus/gtk-3.0/apps/unity.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/budgie.css target=../../../nimbus/gtk-3.0/apps/budgie.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/libreoffice.css target=../../../nimbus/gtk-3.0/apps/libreoffice.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/gnome-flashback.css target=../../../nimbus/gtk-3.0/apps/gnome-flashback.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/apps/desktop.css target=../../../nimbus/gtk-3.0/apps/desktop.css
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-hover.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-hover.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked-active.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-hover.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked-active.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png target=../../../nimbus/gtk-3.0/assets/checkbox-unchecked-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed.png target=../../../nimbus/gtk-3.0/assets/radio-mixed.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected-active.png target=../../../nimbus/gtk-3.0/assets/radio-selected-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected-active.png target=../../../nimbus/gtk-3.0/assets/radio-unselected-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected-hover.png target=../../../nimbus/gtk-3.0/assets/radio-unselected-hover.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-symbolic.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-symbolic.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected-insensitive.png target=../../../nimbus/gtk-3.0/assets/radio-unselected-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-symbolic.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-hover.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-hover.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-insensitive.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-mixed-active.png target=../../../nimbus/gtk-3.0/assets/checkbox-mixed-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked-hover.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked-hover.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-unselected.png target=../../../nimbus/gtk-3.0/assets/radio-unselected.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-mixed-active.png target=../../../nimbus/gtk-3.0/assets/radio-mixed-active.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected-hover.png target=../../../nimbus/gtk-3.0/assets/radio-selected-hover.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/scrollbar-slider.png target=../../../nimbus/gtk-3.0/assets/scrollbar-slider.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png target=../../../nimbus/gtk-3.0/assets/scrollbar-slider-horiz.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected.png target=../../../nimbus/gtk-3.0/assets/radio-selected.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png target=../../../nimbus/gtk-3.0/assets/checkbox-checked-insensitive.png
+link path=usr/share/themes/dark-nimbus/gtk-3.0/assets/radio-selected-insensitive.png target=../../../nimbus/gtk-3.0/assets/radio-selected-insensitive.png


### PR DESCRIPTION
Fixes nimbus-light and nimbus-dark themes not working properly due to missing gtk 3.0 folder.

There are some unexpected changes.  I can't sure if this is the right change.

- Added some build dependencies.

- path=usr/lib/gtk-2.0/2.10.0/engines/libnimbus.so is deleted from nimbus.p5m. It seems like the 32bit dependency is gone.
- Replaced gnome-autogen.sh to mate-autogen. There is a stupid automake version check in gnome-autogen.sh and automake version was 1.16. I considered patching gnome-common to support 1.16, but It seems more common to use mate-common instead.
- Modified some makefile.am for make install to ensure the path is set properly.

