### PR TITLE
history: rename mixlib-config-23

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -662,6 +662,7 @@ library/arcus@2.7.0,5.11-2023.0.0.3
 library/audio/audiofile@0.2.7,5.11-2022.1.0.3
 library/audio/gstreamer/plugin/gnonlin@0.10.17,5.11-2022.1.0.2
 library/ruby/bundler@1.13.6-2025.0.0.2
+library/ruby/mixlib-config-23@2.2.18,5.11-2020.0.1.1 library/ruby/mixlib-config
 library/c++/net6@1.3.14,5.11-2014.1.3.0
 library/c++/obby@0.4.7,5.11-2014.1.3.0
 library/c++/stdcxx@4.2.1,5.11-2014.1.3.0


### PR DESCRIPTION
The `mixlib-config` component switched from Ruby 2.3 to 3.2 in #21069 but the `library/ruby/mixlib-config-23` package got forgotten there.