### PR TITLE
ibus-hangul: fix ibus/hangul fmri name

### DIFF
--- a/components/inputmethod/ibus-hangul/Makefile
+++ b/components/inputmethod/ibus-hangul/Makefile
@@ -16,12 +16,12 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           ibus-hangul
 COMPONENT_VERSION=        1.5.5
-COMPONENT_SUMMARY=        libhangul - The hangul engine for IBus
+COMPONENT_SUMMARY=        ibus-hangul - The hangul engine for IBus
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.xz
 COMPONENT_ARCHIVE_HASH=   sha256:a5aac88286cd18960229860e3e1a778978a7aeaa484ad9acfa48284b87fdc3bb
 COMPONENT_ARCHIVE_URL=    https://github.com/libhangul/$(COMPONENT_NAME)/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
-COMPONENT_FMRI=           system/input-method/library/ibus/hangul
+COMPONENT_FMRI=           system/input-method/ibus/hangul
 COMPONENT_CLASSIFICATION= System/Localizations
 COMPONENT_LICENSE=        GPL v2
 COMPONENT_LICENSE_FILE=   COPYING

--- a/components/inputmethod/ibus-hangul/history
+++ b/components/inputmethod/ibus-hangul/history
@@ -1,0 +1,1 @@
+system/input-method/library/ibus/hangul@1.5.5,5.11-2025.0.0.1 system/input-method/ibus/hangul

--- a/components/inputmethod/ibus-hangul/pkg5
+++ b/components/inputmethod/ibus-hangul/pkg5
@@ -8,7 +8,7 @@
         "system/library"
     ],
     "fmris": [
-        "system/input-method/library/ibus/hangul"
+        "system/input-method/ibus/hangul"
     ],
     "name": "ibus-hangul"
 }


### PR DESCRIPTION
I'm really sorry. I made a big mistake.
I just found out that the package name is wrong.
I’m not sure if there’s a mechanism in place to roll back an already released package.

I think I fell asleep for a moment before sending the PR....
I apologize again.