### PR TITLE
gst-devtools: enable gst-dots-viewer

### DIFF
--- a/components/encumbered/gst-devtools/Makefile
+++ b/components/encumbered/gst-devtools/Makefile
@@ -34,10 +34,8 @@ COMPONENT_LICENSE_FILE=	validate/COPYING
 include $(WS_MAKE_RULES)/encumbered.mk
 include $(WS_MAKE_RULES)/common.mk
 
-# dots_viewer fails to compile due to missing illumos support in
-# the single-instance crate.
-# https://github.com/WLBF/single-instance/issues/18
-CONFIGURE_OPTIONS += -Ddots_viewer=disabled
+# Need to compile dynamic rust crates. See https://www.illumos.org/issues/15767
+LD_Z_IGNORE=
 
 PYTHON_SCRIPTS += usr/bin/gst-validate-launcher
 
@@ -55,11 +53,22 @@ GENERATE_EXTRA_CMD += | $(GSED) -e 's/$(SOVER_RE)/$$(SOVER)/'
 # SOVER is needed for manifest processing
 PKG_MACROS += SOVER=$(SOVER)
 
+# Need to patch single-instance dependency crate since it does not have
+# Illumos support.
+# Download all dependency crates and then apply patch.
+CRATE_PATCH_FLAG = --backup --version-control=numbered -p0
+COMPONENT_PRE_BUILD_ACTION= \
+	CARGO_HOME=$(@D)/.cargo cargo fetch --manifest-path $(SOURCE_DIR)/dots-viewer/Cargo.toml ; \
+	for patchfile in patches-crate/*.patch; do \
+ 		gpatch $(CRATE_PATCH_FLAG) < $$patchfile ; \
+ 	done ;
+
 # build dependency not detected by REQUIRED_PACKAGES
 REQUIRED_PACKAGES += system/header/header-audio
 
 # Auto-generated dependencies
 PYTHON_REQUIRED_PACKAGES += runtime/python
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
 REQUIRED_PACKAGES += library/audio/gstreamer
 REQUIRED_PACKAGES += library/audio/gstreamer/plugin/bad
 REQUIRED_PACKAGES += library/audio/gstreamer/plugin/base

--- a/components/encumbered/gst-devtools/gst-devtools.p5m
+++ b/components/encumbered/gst-devtools/gst-devtools.p5m
@@ -23,6 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=usr/bin/gst-dots-viewer
 file path=usr/bin/gst-validate-1.0
 file path=usr/bin/gst-validate-images-check-1.0
 file path=usr/bin/gst-validate-launcher

--- a/components/encumbered/gst-devtools/manifests/sample-manifest.p5m
+++ b/components/encumbered/gst-devtools/manifests/sample-manifest.p5m
@@ -23,6 +23,7 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=usr/bin/gst-dots-viewer
 file path=usr/bin/gst-validate-1.0
 file path=usr/bin/gst-validate-images-check-1.0
 file path=usr/bin/gst-validate-launcher

--- a/components/encumbered/gst-devtools/patches-crate/01-single-instance-illumos-support.patch
+++ b/components/encumbered/gst-devtools/patches-crate/01-single-instance-illumos-support.patch
@@ -1,0 +1,76 @@
+--- build/amd64/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/single-instance-0.3.3/src/lib.rs.orig	1973-11-29 16:33:09.000000000 -0500
++++ build/amd64/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/single-instance-0.3.3/src/lib.rs	2025-04-03 16:53:11.007308785 -0400
+@@ -22,7 +22,7 @@
+ 
+ pub mod error;
+ 
+-#[cfg(target_os = "macos")]
++#[cfg(any(target_os = "macos", target_os = "illumos"))]
+ extern crate libc;
+ #[cfg(target_os = "linux")]
+ extern crate nix;
+@@ -169,6 +169,46 @@
+                 Ok(Self {
+                     _file: file,
+                     is_single,
++                })
++            }
++        }
++
++        /// Returns whether this instance is single.
++        pub fn is_single(&self) -> bool {
++            self.is_single
++        }
++    }
++}
++
++#[cfg(target_os = "illumos")]
++mod inner {
++    use error::Result;
++    use libc::{___errno, flock, EWOULDBLOCK, LOCK_EX, LOCK_NB};
++    use std::fs::File;
++    use std::os::unix::io::AsRawFd;
++    use std::path::Path;
++
++    /// A struct representing one running instance.
++    pub struct SingleInstance {
++        _file: File,
++        is_single: bool,
++    }
++
++    impl SingleInstance {
++        /// Returns a new SingleInstance object.
++        pub fn new(name: &str) -> Result<Self> {
++            let path = Path::new(name);
++            let file = if path.exists() {
++                File::open(path)?
++            } else {
++                File::create(path)?
++            };
++            unsafe {
++                let rc = flock(file.as_raw_fd(), LOCK_EX | LOCK_NB);
++                let is_single = rc == 0 || EWOULDBLOCK != *___errno();
++                Ok(Self {
++                    _file: file,
++                    is_single,
+                 })
+             }
+         }
+--- build/amd64/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/single-instance-0.3.3/src/error.rs.orig	1973-11-29 16:33:09.000000000 -0500
++++ build/amd64/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/single-instance-0.3.3/src/error.rs	2025-04-03 16:19:56.443021509 -0400
+@@ -6,7 +6,7 @@
+     #[error("new abstract addr error")]
+     Nix(#[from] nix::Error),
+ 
+-    #[cfg(target_os = "macos")]
++    #[cfg(any(target_os = "macos", target_os = "illumos"))]
+     #[error("file open or create error")]
+     Io(#[from] std::io::Error),
+ 
+@@ -19,4 +19,4 @@
+     MutexError(u32),
+ }
+ 
+-pub type Result<T> = std::result::Result<T, SingleInstanceError>;
+\ No newline at end of file
++pub type Result<T> = std::result::Result<T, SingleInstanceError>;

--- a/components/encumbered/gst-devtools/pkg5
+++ b/components/encumbered/gst-devtools/pkg5
@@ -11,6 +11,7 @@
         "runtime/python-39",
         "system/header/header-audio",
         "system/library",
+        "system/library/gcc-14-runtime",
         "system/library/math"
     ],
     "fmris": [


### PR DESCRIPTION
Patch single-instance rust crate (dependency) to add Illumos support.   Since the single-instance crate source  is not in gsts-devtools, it needs to be downloaded after gst-devtools is extracted.  The crate patch gets applied after configure stage, but before build stage.

The Linux inner code in the crate can't be used on Illumos since there is no support for abstract sockets.  Instead, copy/paste macos inner code.  Illumos doesn't have __error so replace with ___errno . Does any rust coders want to verify that this looks good?

I have no idea how to test gst-dots-viewer to determine if this works.  The code compiles.  The web server starts.  Connecting to server with a web client gets some text.