### PR TITLE
mpg123: add 32 bit library package

### DIFF
--- a/components/multimedia/mpg123/Makefile
+++ b/components/multimedia/mpg123/Makefile
@@ -14,11 +14,13 @@
 # Copyright 2021,2024 Andreas Wacknitz
 #
 
+BUILD_BITS=64_and_32
 USE_DEFAULT_TEST_TRANSFORMS= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= mpg123
 COMPONENT_VERSION= 1.32.10
+COMPONENT_REVISON= 1
 COMPONENT_SUMMARY= Fast console MPEG Audio Player and decoder library
 COMPONENT_PROJECT_URL= https://mpg123.org
 COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
@@ -44,13 +46,17 @@ CONFIGURE_OPTIONS += --enable-network
 CONFIGURE_OPTIONS += --enable-ipv6=yes
 CONFIGURE_OPTIONS += --with-optimization=3
 ifeq ($(strip $(MACH)),i386)
-CONFIGURE_OPTIONS += --with-cpu=x86-64
+CONFIGURE_OPTIONS.64 += --with-cpu=x86-64
+CONFIGURE_OPTIONS.32 += --with-cpu=x86
 endif
 CONFIGURE_OPTIONS += --with-default-audio=pulse
+CONFIGURE_OPTIONS += $(CONFIGURE_OPTIONS.$(BITS))
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += library/audio/openal
 REQUIRED_PACKAGES += library/audio/pulseaudio
+REQUIRED_PACKAGES += library/audio/pulseaudio/32
 REQUIRED_PACKAGES += library/sdl2
+REQUIRED_PACKAGES += library/sdl2/32
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math

--- a/components/multimedia/mpg123/manifests/sample-manifest.p5m
+++ b/components/multimedia/mpg123/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,6 +23,10 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+file path=usr/bin/$(MACH32)/mpg123
+file path=usr/bin/$(MACH32)/mpg123-id3dump
+file path=usr/bin/$(MACH32)/mpg123-strip
+file path=usr/bin/$(MACH32)/out123
 file path=usr/bin/mpg123
 file path=usr/bin/mpg123-id3dump
 file path=usr/bin/mpg123-strip
@@ -49,5 +53,23 @@ file path=usr/lib/$(MACH64)/mpg123/output_sun.so
 file path=usr/lib/$(MACH64)/pkgconfig/libmpg123.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libout123.pc
 file path=usr/lib/$(MACH64)/pkgconfig/libsyn123.pc
+link path=usr/lib/libmpg123.so target=libmpg123.so.0.48.3
+link path=usr/lib/libmpg123.so.0 target=libmpg123.so.0.48.3
+file path=usr/lib/libmpg123.so.0.48.3
+link path=usr/lib/libout123.so target=libout123.so.0.5.1
+link path=usr/lib/libout123.so.0 target=libout123.so.0.5.1
+file path=usr/lib/libout123.so.0.5.1
+link path=usr/lib/libsyn123.so target=libsyn123.so.0.2.3
+link path=usr/lib/libsyn123.so.0 target=libsyn123.so.0.2.3
+file path=usr/lib/libsyn123.so.0.2.3
+file path=usr/lib/mpg123/output_dummy.so
+file path=usr/lib/mpg123/output_openal.so
+file path=usr/lib/mpg123/output_oss.so
+file path=usr/lib/mpg123/output_pulse.so
+file path=usr/lib/mpg123/output_sdl.so
+file path=usr/lib/mpg123/output_sun.so
+file path=usr/lib/pkgconfig/libmpg123.pc
+file path=usr/lib/pkgconfig/libout123.pc
+file path=usr/lib/pkgconfig/libsyn123.pc
 file path=usr/share/man/man1/mpg123.1
 file path=usr/share/man/man1/out123.1

--- a/components/multimedia/mpg123/mpg123-32.p5m
+++ b/components/multimedia/mpg123/mpg123-32.p5m
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Carsten Grzemba
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)/32@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) library (32-bit)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=usr/lib/libmpg123.so target=libmpg123.so.0.48.3
+link path=usr/lib/libmpg123.so.0 target=libmpg123.so.0.48.3
+file path=usr/lib/libmpg123.so.0.48.3
+link path=usr/lib/libout123.so target=libout123.so.0.5.1
+link path=usr/lib/libout123.so.0 target=libout123.so.0.5.1
+file path=usr/lib/libout123.so.0.5.1
+link path=usr/lib/libsyn123.so target=libsyn123.so.0.2.3
+link path=usr/lib/libsyn123.so.0 target=libsyn123.so.0.2.3
+file path=usr/lib/libsyn123.so.0.2.3
+file path=usr/lib/pkgconfig/libmpg123.pc
+file path=usr/lib/pkgconfig/libout123.pc
+file path=usr/lib/pkgconfig/libsyn123.pc

--- a/components/multimedia/mpg123/pkg5
+++ b/components/multimedia/mpg123/pkg5
@@ -2,12 +2,15 @@
     "dependencies": [
         "library/audio/openal",
         "library/audio/pulseaudio",
+        "library/audio/pulseaudio/32",
         "library/sdl2",
+        "library/sdl2/32",
         "system/library",
         "system/library/math"
     ],
     "fmris": [
-        "audio/mpg123"
+        "audio/mpg123",
+        "audio/mpg123/32"
     ],
     "name": "mpg123"
 }


### PR DESCRIPTION
this PR adds the 32-bit library package necessary for sunray-essential 