### PR TITLE
x265-4.0-rebuild-cmake-patch

### DIFF
--- a/components/encumbered/x265-4.0/Makefile
+++ b/components/encumbered/x265-4.0/Makefile
@@ -19,6 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         x265
 COMPONENT_VERSION=      4.0
+COMPONENT_REVISION=     1
 COMPONENT_SUMMARY=	Runtime library for High Efficiency Video Coding (HEVC) version $(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  https://x265.org/
 COMPONENT_SRC=          $(COMPONENT_NAME)_$(COMPONENT_VERSION)

--- a/components/encumbered/x265-4.0/patches/02-cmake-4.0.patch
+++ b/components/encumbered/x265-4.0/patches/02-cmake-4.0.patch
@@ -1,0 +1,22 @@
+--- x265_4.1/source/CMakeLists.txt.old	2025-04-13 22:22:43.741477169 -0400
++++ x265_4.1/source/CMakeLists.txt	2025-04-13 22:23:47.866170392 -0400
+@@ -6,18 +6,12 @@
+         FORCE)
+ endif()
+ message(STATUS "cmake version ${CMAKE_VERSION}")
+-if(POLICY CMP0025)
+-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
+-endif()
+ if(POLICY CMP0042)
+     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+ endif()
+-if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
+-endif()
+ 
+ project (x265)
+-cmake_minimum_required (VERSION 2.8.8) # OBJECT libraries require 2.8.8
++cmake_minimum_required (VERSION 2.8.8...3.10) # OBJECT libraries require 2.8.8
+ include(CheckIncludeFiles)
+ include(CheckFunctionExists)
+ include(CheckSymbolExists)

--- a/components/encumbered/x265-4.0/pkg5
+++ b/components/encumbered/x265-4.0/pkg5
@@ -2,7 +2,7 @@
     "dependencies": [
         "developer/assembler/nasm",
         "system/library",
-        "system/library/g++-13-runtime",
+        "system/library/g++-14-runtime",
         "system/library/math"
     ],
     "fmris": [


### PR DESCRIPTION
Cherry pick cmake 4.0 patch from https://bitbucket.org/multicoreware/x265_git/commits/51ae8e922bcc4586ad4710812072289af91492a8