### PR TITLE
thunderbird: update to 128.9.2

### DIFF
--- a/components/mail/thunderbird/Makefile
+++ b/components/mail/thunderbird/Makefile
@@ -38,13 +38,13 @@ ESR = esr
 # CANDIDATE_BUILD= 2
 
 COMPONENT_NAME =	thunderbird
-COMPONENT_VERSION =	128.9.1
+COMPONENT_VERSION =	128.9.2
 COMPONENT_SUMMARY = Mozilla Thunderbird Email Application
 COMPONENT_PROJECT_URL =	https://www.thunderbird.net/
 COMPONENT_SRC = $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE = 	$(COMPONENT_SRC)$(ESR).source.tar.xz
 COMPONENT_ARCHIVE_HASH= \
-	 sha256:2d6caeb9c958d89d9a789eeaf0e41064f4a8678b493452e89a244f5dc60e952d
+	 sha256:21cbdc12fd2a5c79ce3ae3f23b5c334160b4380858aaa8a92fc1d9c9acfdd5fb
 ifndef CANDIDATE_BUILD
 MOZILLA_FTP = 		https://ftp.mozilla.org/pub/$(COMPONENT_NAME)/releases/$(COMPONENT_VERSION)$(ESR)
 else
@@ -210,7 +210,6 @@ COMPONENT_POST_INSTALL_ACTION += \
 
 # copy distribution.ini to install staging area
 COMPONENT_POST_INSTALL_ACTION += \
-   mkdir $(PROTO_DIR)$(THUNDERBIRD_LIBDIR)/thunderbird/distribution ; \
    $(CP) $(COMPONENT_DIR)/files/distribution.ini $(PROTO_DIR)$(THUNDERBIRD_LIBDIR)/thunderbird/distribution/distribution.ini ;
 
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-$(MACH).master

--- a/components/mail/thunderbird/manifests/sample-manifest.p5m
+++ b/components/mail/thunderbird/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -110,6 +110,7 @@ file path=usr/lib/$(MACH64)/thunderbird/distribution/extensions/langpack-vi@thun
 file path=usr/lib/$(MACH64)/thunderbird/distribution/extensions/langpack-zh-CN@thunderbird.mozilla.org.xpi
 file path=usr/lib/$(MACH64)/thunderbird/distribution/extensions/langpack-zh-TW@thunderbird.mozilla.org.xpi
 file path=usr/lib/$(MACH64)/thunderbird/glxtest
+file path=usr/lib/$(MACH64)/thunderbird/interesting_serverknobs.json
 file path=usr/lib/$(MACH64)/thunderbird/isp/Bogofilter.sfd
 file path=usr/lib/$(MACH64)/thunderbird/isp/DSPAM.sfd
 file path=usr/lib/$(MACH64)/thunderbird/isp/POPFile.sfd

--- a/components/mail/thunderbird/thunderbird.p5m
+++ b/components/mail/thunderbird/thunderbird.p5m
@@ -59,6 +59,7 @@ file path=usr/lib/$(MACH64)/thunderbird/defaults/pref/channel-prefs.js
 file path=usr/lib/$(MACH64)/thunderbird/dependentlibs.list
 file path=usr/lib/$(MACH64)/thunderbird/distribution/distribution.ini
 file path=usr/lib/$(MACH64)/thunderbird/glxtest mode=0555
+file path=usr/lib/$(MACH64)/thunderbird/interesting_serverknobs.json
 file path=usr/lib/$(MACH64)/thunderbird/isp/Bogofilter.sfd
 file path=usr/lib/$(MACH64)/thunderbird/isp/DSPAM.sfd
 file path=usr/lib/$(MACH64)/thunderbird/isp/POPFile.sfd


### PR DESCRIPTION
Add missing file /usr/lib/$(MACH64)/thunderbird/interesting_serverknobs.json
Remove unnecessary `mkdir $(PROTO_DIR)$(THUNDERBIRD_LIBDIR)/thunderbird/distribution` since this gets handled by `$(MKDIR) $(PROTO_DIR)$(THUNDERBIRD_LIBDIR)/thunderbird/distribution/extensions/`