### PR TITLE
install-types: twm is not needed for mate_install

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	17
+COMPONENT_VERSION =	18
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -17,7 +17,6 @@ depend type=require fmri=desktop/gksu
 depend type=require fmri=desktop/paprefs
 depend type=require fmri=desktop/remote-desktop/tigervnc
 depend type=require fmri=desktop/time-slider
-depend type=require fmri=desktop/window-manager/twm
 depend type=require fmri=desktop/xdg/xdg-user-dirs-gtk
 depend type=require fmri=desktop/xdg/xdg-utils
 depend type=require fmri=diagnostic/ddu


### PR DESCRIPTION
`twm` is alternative window manager (to MATE) so I believe it makes no sense to bring it automatically with the `mate_install` meta package.