### PR TITLE
Add backports_datetime_fromisoformat Python project

### DIFF
--- a/components/python/backports-datetime-fromisoformat/.gitignore
+++ b/components/python/backports-datetime-fromisoformat/.gitignore
@@ -1,0 +1,1 @@
+/backports_datetime_fromisoformat-2.0.3/

--- a/components/python/backports-datetime-fromisoformat/Makefile
+++ b/components/python/backports-datetime-fromisoformat/Makefile
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project -d python/backports-datetime-fromisoformat backports_datetime_fromisoformat
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		backports_datetime_fromisoformat
+HUMAN_VERSION =			2.0.3
+COMPONENT_SUMMARY =		Backport of Python 3.11's datetime.fromisoformat
+COMPONENT_PROJECT_URL =		https://github.com/movermeyer/backports.datetime_fromisoformat
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:b58edc8f517b66b397abc250ecc737969486703a66eb97e01e6d51291b1a139d
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE
+
+TEST_STYLE = pytest
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools
+PYTHON_REQUIRED_PACKAGES += runtime/python
+REQUIRED_PACKAGES += system/library

--- a/components/python/backports-datetime-fromisoformat/backports_datetime_fromisoformat-PYVER.p5m
+++ b/components/python/backports-datetime-fromisoformat/backports_datetime_fromisoformat-PYVER.p5m
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/_datetime_fromisoformat.cpython-$(PYV).so
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/_datetimemodule.c
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/_datetimemodule.h
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/module.c
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/timezone.c
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/timezone.h
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/backports-datetime-fromisoformat/manifests/sample-manifest.p5m
+++ b/components/python/backports-datetime-fromisoformat/manifests/sample-manifest.p5m
@@ -1,0 +1,42 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/_datetime_fromisoformat.cpython-$(PYV).so
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/_datetimemodule.c
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/_datetimemodule.h
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/module.c
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/timezone.c
+file path=usr/lib/python$(PYVER)/vendor-packages/backports/datetime_fromisoformat/timezone.h
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/backports_datetime_fromisoformat-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/backports-datetime-fromisoformat/pkg5
+++ b/components/python/backports-datetime-fromisoformat/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "library/python/setuptools-39",
+        "runtime/python-39",
+        "system/library"
+    ],
+    "fmris": [
+        "library/python/backports-datetime-fromisoformat",
+        "library/python/backports-datetime-fromisoformat-39"
+    ],
+    "name": "backports_datetime_fromisoformat"
+}

--- a/components/python/backports-datetime-fromisoformat/test/results-all.master
+++ b/components/python/backports-datetime-fromisoformat/test/results-all.master
@@ -1,0 +1,30 @@
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(PYTHON)
+cachedir: .pytest_cache
+rootdir: $(@D)
+configfile: pyproject.toml
+collecting ... collected 21 items
+
+tests/test_basics.py::TestFromIsoFormat::test_basic_naive_parse PASSED
+tests/test_basics.py::TestsFromCPython::test_datetime_fromisoformat_fails_surrogate PASSED
+tests/test_basics.py::TestsFromCPython::test_datetime_fromisoformat_timezone PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_ambiguous PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_datetime PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_datetime_examples PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_examples PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_fails PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_fails_datetime PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_fails_typeerror PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_separators PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_time_examples PASSED
+tests/test_basics.py::TestsFromCPython::test_fromisoformat_timespecs PASSED
+tests/test_basics.py::TestsFromCPython::test_time_fromisoformat PASSED
+tests/test_basics.py::TestsFromCPython::test_time_fromisoformat_fails PASSED
+tests/test_basics.py::TestsFromCPython::test_time_fromisoformat_fails_typeerror PASSED
+tests/test_basics.py::TestsFromCPython::test_time_fromisoformat_fractions PASSED
+tests/test_basics.py::TestsFromCPython::test_time_fromisoformat_timespecs PASSED
+tests/test_basics.py::TestsFromCPython::test_time_fromisoformat_timezone PASSED
+tests/test_basics.py::TestCopy::test_basic_pickle_and_copy PASSED
+
+======== 21 passed ========


### PR DESCRIPTION
This is needed for marshmallow 4.0.0.