### PR TITLE
tools: drop support for pypi_url

### DIFF
--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -669,10 +669,5 @@ endif
 clean::
 	$(RM) -r $(SOURCE_DIR) $(BUILD_DIR)
 
-# Make it easy to construct a URL for a pypi source download.
-pypi_url_multi = pypi:///$(COMPONENT_NAME_$(1))==$(COMPONENT_VERSION_$(1))
-pypi_url_single = pypi:///$(COMPONENT_NAME)==$(COMPONENT_VERSION)
-pypi_url = $(if $(COMPONENT_NAME_$(1)),$(pypi_url_multi),$(pypi_url_single))
-
 # Use common rules
 USE_COMMON_RULES = yes

--- a/tools/bass/makefiles.py
+++ b/tools/bass/makefiles.py
@@ -377,7 +377,7 @@ class Makefile(object):
             return False
         is_py = (self.build_style() == 'setup.py')
         urlnone = (not self.has_variable('COMPONENT_ARCHIVE_URL'))
-        urlpipy = urlnone or (self.variable('COMPONENT_ARCHIVE_URL').value() == '$(call pypi_url)')
+        urlpipy = urlnone
         return is_py and urlpipy
 
     def get_pypi_data(self):

--- a/tools/userland-fetch
+++ b/tools/userland-fetch
@@ -32,7 +32,6 @@ import errno
 import os
 import sys
 import shutil
-import json
 import subprocess
 import re
 import gzip
@@ -348,8 +347,6 @@ def download_paths(search, filenames, url):
         parse_result = urlparse(url)
         scheme = parse_result.scheme
         path = parse_result.path
-        if scheme == "pypi":
-            url = pypi_url(url, os.path.basename(filename))
         if url != None and url not in urls:
             urls.append(url)
 
@@ -371,68 +368,6 @@ def download_paths(search, filenames, url):
             remote_urls.append(entry)
     return local_urls + remote_urls
 
-
-def pypi_url(url, filename):
-	"""Given a pypi: URL, return the real URL for that component/version.
-
-	The pypi scheme has a host (with an empty host defaulting to
-	pypi.python.org), and a path that should be of the form
-	"component==version".  Other specs could be supported, but == is the
-	only thing that makes sense in this context.
-
-	The filename argument is the name of the expected file to download, so
-	that when pypi gives us multiple archives to choose from, we can pick
-	the right one.
-	"""
-
-        
-	parse_result = urlparse(url)
-	host = parse_result.netloc
-	path = parse_result.path
-
-	# We have to use ==; anything fancier would require pkg_resources, but
-	# really that's the only thing that makes sense in this context.
-	try:
-	        name, version = re.match("/(.*)==(.*)$", path).groups()
-	except AttributeError:
-		print("PyPI URLs must be of the form 'pypi:///component==version'")
-		return None
-
-	if not host:
-		jsurl = "https://pypi.python.org/pypi/%s/json" % name
-	else:
-		jsurl = "https://%s/pypi/%s/json" % (host, name)
-
-	try:
-		f = urlopen(jsurl, data=None)
-	except HTTPError as e:
-		if e.getcode() == 404:
-			print("Unknown component '%s'" % name)
-		else:
-			printIOError(e, "Can't open PyPI JSON url %s" % url)
-		return None
-	except IOError as e:
-		printIOError(e, "Can't open PyPI JSON url %s" % url)
-		return None
-	content = f.read().decode("utf-8")
-	js = json.loads(content)
-	try:
-		verblock = js["releases"][version]
-	except KeyError:
-		print("Unknown version '%s'" % version)
-		return None
-
-	urls = [ d["url"] for d in verblock ]
-	for archiveurl in urls:
-		if archiveurl.endswith("/%s" % filename):
-			return archiveurl
-
-	if urls:
-		print("None of the following URLs delivers '%s':" % filename)
-		print("  " + "\n  ".join(urls))
-	else:
-		print("Couldn't find any suitable URLs")
-	return None
 
 def download_from_paths(search_list, file_arg, url, link_arg, quiet=False,get_signature=False,download_dir=None):
     """Attempts to download a file from a number of possible locations.


### PR DESCRIPTION
This is no longer used and it is wrong by design because it produces confusing urls in a form of `pypi:///component==version`.