### PR TITLE
ibus-pinyin : dependency update

### DIFF
--- a/components/inputmethod/ibus-pinyin/Makefile
+++ b/components/inputmethod/ibus-pinyin/Makefile
@@ -40,6 +40,7 @@ CONFIGURE_OPTIONS += --disable-lua-extension
 # Manually added build dependencies
 PYTHON_REQUIRED_PACKAGES += runtime/python
 REQUIRED_PACKAGES += developer/build/automake-115
+REQUIRED_PACKAGES += system/library/iconv/utf-8
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)

--- a/components/inputmethod/ibus-pinyin/pkg5
+++ b/components/inputmethod/ibus-pinyin/pkg5
@@ -9,7 +9,8 @@
         "system/input-method/library/pyzy",
         "system/library",
         "system/library/g++-14-runtime",
-        "system/library/gcc-14-runtime"
+        "system/library/gcc-14-runtime",
+        "system/library/iconv/utf-8"
     ],
     "fmris": [
         "system/input-method/ibus/pinyin"


### PR DESCRIPTION
It seems like the ibus/pinyin package isn't published.
If my guess is correct, gnu msgfmt(text/gnu-gettext) depends on iconv for non ascii-encoding, but the build system doesn't have system/library/iconv/utf-8.
Let's check...