### PR TITLE
fix swipl-dev installation by disabling the userland-mangler for file…

### DIFF
--- a/components/prolog/swi-prolog-dev/Makefile
+++ b/components/prolog/swi-prolog-dev/Makefile
@@ -19,6 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		swipl
 COMPONENT_VERSION=	9.3.24
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Robust, mature, free. Prolog for the real world. This is the development version.
 COMPONENT_PROJECT_URL= https://www.swi-prolog.org
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/prolog/swi-prolog-dev/swipl.p5m
+++ b/components/prolog/swi-prolog-dev/swipl.p5m
@@ -28,6 +28,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 <transform file path=usr/lib/swipl-$(HUMAN_VERSION)/.* -> default pkg.linted.userland.action001.3 true>
 <transform file path=usr/lib/swipl-$(HUMAN_VERSION)/.* -> default pkg.linted.userland.action001.5 true>
 
+# We need to disable userland-mangler for files that are falsely identified as man pages
+# (just because they are located in a folder named man) by it:
+<transform file path=usr/lib/swipl-$(HUMAN_VERSION)/xpce/man/.* -> add mangler.bypass true>
+<transform file path=usr/lib/swipl-$(HUMAN_VERSION)/xpce/prolog/lib/man/.* -> add mangler.bypass true>
+
 link path=usr/bin/swipl \
     target=../lib/swipl-$(HUMAN_VERSION)/bin/amd64-sunos/swipl mediator=swi-prolog mediator-implementation=dev
 link path=usr/bin/swipl-ld \


### PR DESCRIPTION
…s that are falsely idenfied as man pages