### PR TITLE
ibus-chewing : update to 2.1.4

### DIFF
--- a/components/inputmethod/ibus-chewing/Makefile
+++ b/components/inputmethod/ibus-chewing/Makefile
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+BUILD_STYLE= cmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           ibus-chewing
+COMPONENT_VERSION=        2.1.4
+COMPONENT_SUMMARY=        ibus-chewing - The Chewing engine for IBus
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)-Source
+COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.xz
+COMPONENT_ARCHIVE_HASH=   sha256:dfa73f177c059280609174d7bdac9a90fe87a46a0d3d1b2b4ab8500f3013a29e
+COMPONENT_ARCHIVE_URL=    https://github.com/chewing/$(COMPONENT_NAME)/releases/download/v$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+
+COMPONENT_FMRI=           system/input-method/ibus/chewing
+COMPONENT_CLASSIFICATION= System/Localizations
+COMPONENT_LICENSE=        GPL v2
+COMPONENT_LICENSE_FILE=   COPYING
+COMPONENT_PROJECT_URL=    https://github.com/chewing/ibus-chewing
+
+TEST_TARGET= $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+
+PATH= $(PATH.gnu)
+
+CMAKE_OPTIONS += -DCMAKE_BUILD_TYPE=Release
+
+#To prevent git describe --dirty
+COMPONENT_PREP_ACTION= ( sed -i 's/find_package(Git)/\#find_package(Git)/g'  $(SOURCE_DIR)/CMakeLists.txt) ;
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/desktop/gtk4
+REQUIRED_PACKAGES += library/desktop/libadwaita
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += system/input-method/ibus
+REQUIRED_PACKAGES += system/input-method/library/libchewing
+REQUIRED_PACKAGES += system/library

--- a/components/inputmethod/ibus-chewing/ibus-chewing.p5m
+++ b/components/inputmethod/ibus-chewing/ibus-chewing.p5m
@@ -1,0 +1,54 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/libexec/ibus-engine-chewing
+file path=usr/libexec/ibus-setup-chewing
+file path=usr/share/applications/ibus-setup-chewing.desktop
+file path=usr/share/doc/ibus-chewing/AUTHORS
+file path=usr/share/doc/ibus-chewing/CHANGELOG.md
+file path=usr/share/doc/ibus-chewing/COPYING
+file path=usr/share/doc/ibus-chewing/ChangeLog-1.x
+file path=usr/share/doc/ibus-chewing/README.md
+file path=usr/share/doc/ibus-chewing/USER-GUIDE
+file path=usr/share/glib-2.0/schemas/org.freedesktop.IBus.Chewing.gschema.xml
+file path=usr/share/ibus-chewing/icons/ibus-chewing.png
+file path=usr/share/ibus-chewing/icons/ibus-setup-chewing.png
+file path=usr/share/ibus-chewing/icons/org.freedesktop.IBus.Chewing.Setup.svg
+file path=usr/share/ibus/component/chewing.xml
+file path=usr/share/icons/hicolor/scalable/apps/org.freedesktop.IBus.Chewing.Setup.svg
+file path=usr/share/locale/ca/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/cs/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/de/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/es/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/fr/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/it/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/ja/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/ko/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/pa/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/pl/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/uk/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/ibus-chewing.mo

--- a/components/inputmethod/ibus-chewing/manifests/sample-manifest.p5m
+++ b/components/inputmethod/ibus-chewing/manifests/sample-manifest.p5m
@@ -1,0 +1,54 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/libexec/ibus-engine-chewing
+file path=usr/libexec/ibus-setup-chewing
+file path=usr/share/applications/ibus-setup-chewing.desktop
+file path=usr/share/doc/ibus-chewing/AUTHORS
+file path=usr/share/doc/ibus-chewing/CHANGELOG.md
+file path=usr/share/doc/ibus-chewing/COPYING
+file path=usr/share/doc/ibus-chewing/ChangeLog-1.x
+file path=usr/share/doc/ibus-chewing/README.md
+file path=usr/share/doc/ibus-chewing/USER-GUIDE
+file path=usr/share/glib-2.0/schemas/org.freedesktop.IBus.Chewing.gschema.xml
+file path=usr/share/ibus-chewing/icons/ibus-chewing.png
+file path=usr/share/ibus-chewing/icons/ibus-setup-chewing.png
+file path=usr/share/ibus-chewing/icons/org.freedesktop.IBus.Chewing.Setup.svg
+file path=usr/share/ibus/component/chewing.xml
+file path=usr/share/icons/hicolor/scalable/apps/org.freedesktop.IBus.Chewing.Setup.svg
+file path=usr/share/locale/ca/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/cs/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/de/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/es/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/fr/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/it/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/ja/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/ko/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/pa/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/pl/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/uk/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/ibus-chewing.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/ibus-chewing.mo

--- a/components/inputmethod/ibus-chewing/pkg5
+++ b/components/inputmethod/ibus-chewing/pkg5
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        "library/desktop/gtk4",
+        "library/desktop/libadwaita",
+        "library/glib2",
+        "system/input-method/ibus",
+        "system/input-method/library/libchewing",
+        "system/library"
+    ],
+    "fmris": [
+        "system/input-method/ibus/chewing"
+    ],
+    "name": "ibus-chewing"
+}


### PR DESCRIPTION
Sorry for the bother again.
There can be duplicate features, but I want to replace all ibus-* packages with new one that openindiana is delivering.
I've verified that it works, as follows
https://fedoraproject.org/wiki/QA:Chewing