### PR TITLE
Packages for database-specific drivers for libdbi.  

### DIFF
--- a/components/library/libdbi-drivers/Makefile
+++ b/components/library/libdbi-drivers/Makefile
@@ -1,0 +1,72 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Bill Sommerfeld
+#
+
+DROP_STATIC_LIBRARIES= yes
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= libdbi-drivers
+COMPONENT_VERSION= 0.9.0
+COMPONENT_SUMMARY= Database access drivers for libdbi
+COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_PROJECT_URL= http://libdbi-drivers.sourceforge.net/
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:43d2eacd573a4faff296fa925dd97fbf2aedbf1ae35c6263478210c61004c854
+
+COMPONENT_ARCHIVE_URL= https://sourceforge.net/projects/$(COMPONENT_NAME)/files/$(COMPONENT_NAME)/$(COMPONENT_NAME)-$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+
+COMPONENT_CLASSIFICATION=System/Libraries
+
+COMPONENT_FMRI.sqlite3= library/libdbi/sqlite3
+COMPONENT_FMRI.mysql= library/libdbi/mysql
+COMPONENT_FMRI.pgsql= library/libdbi/pgsql
+
+COMPONENT_LICENSE= LGPLv2.1
+COMPONENT_LICENSE_FILE= COPYING
+
+# tests exist but don't compile with modern compiler
+# and require running database instances
+COMPONENT_TEST_TARGETS=
+
+CONFIGURE_OPTIONS += --enable-docs=no
+CONFIGURE_OPTIONS += --with-dbi-libdir=/usr/lib/$(MACH64)
+
+CONFIGURE_OPTIONS += --with-sqlite3
+
+CONFIGURE_OPTIONS += --with-mysql --with-mysql-libdir=$(MYSQL_LIBDIR)
+CONFIGURE_OPTIONS += --with-pgsql --with-pgsql-libdir=$(PG_LIBDIR)
+
+# Borrowed from library/opendbx:
+# RPATH needed to make 'make REQUIRED_PACKAGES' happy
+COMPONENT_POST_CONFIGURE_ACTION= \
+        (cd $(@D) ; \
+	$(GSED) -i -e 's:^LDFLAGS = .*:LDFLAGS = -m64 -Wl,-rpath=$(MYSQL_LIBDIR):' drivers/mysql/Makefile; \
+	$(GSED) -i -e 's:^LDFLAGS = .*:LDFLAGS = -m64 -Wl,-rpath=$(PG_LIBDIR):' drivers/pgsql/Makefile )
+
+include $(WS_MAKE_RULES)/common.mk
+
+CFLAGS += -std=c99 $(CPP_XPG6MODE)
+# tests need this (and need more work)
+CFLAGS += -Wno-error=int-conversion
+
+# Manually added
+REQUIRED_PACKAGES += $(MYSQL_CLIENT_PKG)
+REQUIRED_PACKAGES += $(PG_DEVELOPER_PKG)
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(MYSQL_LIBRARY_PKG)
+REQUIRED_PACKAGES += $(PG_LIBRARY_PKG)
+REQUIRED_PACKAGES += database/sqlite-3
+REQUIRED_PACKAGES += library/libdbi
+REQUIRED_PACKAGES += system/library

--- a/components/library/libdbi-drivers/manifests/sample-manifest.p5m
+++ b/components/library/libdbi-drivers/manifests/sample-manifest.p5m
@@ -1,0 +1,28 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/$(MACH64)/dbd/libdbdmysql.so
+file path=usr/lib/$(MACH64)/dbd/libdbdpgsql.so
+file path=usr/lib/$(MACH64)/dbd/libdbdsqlite3.so

--- a/components/library/libdbi-drivers/mysql.p5m
+++ b/components/library/libdbi-drivers/mysql.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Bill Sommerfeld
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/$(MACH64)/dbd/libdbdmysql.so

--- a/components/library/libdbi-drivers/patches/01-cgreen-includes.patch
+++ b/components/library/libdbi-drivers/patches/01-cgreen-includes.patch
@@ -1,0 +1,13 @@
+Fix build with separate build tree.
+
+--- libdbi-drivers-0.9.0/tests/cgreen/Makefile.in.~1~	Mon Mar 11 16:52:12 2013
++++ libdbi-drivers-0.9.0/tests/cgreen/Makefile.in	Wed Apr 30 16:57:34 2025
+@@ -268,7 +268,7 @@
+ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = foreign
+ noinst_LIBRARIES = libcgreen.a
+-INCLUDES = -Iinclude
++INCLUDES = -I$(srcdir)/include
+ libcgreen_a_SOURCES = src/unit.c src/messaging.c src/breadcrumb.c src/reporter.c src/assertions.c src/vector.c src/mocks.c src/constraint.c src/parameters.c src/text_reporter.c src/cdash_reporter.c 
+ EXTRA_DIST = AUTHORS ChangeLog CMakeLists.txt ConfigureChecks.cmake COPYING CTestConfig.cmake DefineOptions.cmake INSTALL LICENSE NEWS README README.osx README.win32 TODO VERSION config.h.cmake cmake contrib doc include samples tests
+ all: all-am

--- a/components/library/libdbi-drivers/patches/02-cgreen-constraint-cast.patch
+++ b/components/library/libdbi-drivers/patches/02-cgreen-constraint-cast.patch
@@ -1,0 +1,24 @@
+Add casts to silence complaints from gcc-14
+
+--- libdbi-drivers-0.9.0/tests/cgreen/src/constraint.c.~1~	Mon Jul 19 14:49:44 2010
++++ libdbi-drivers-0.9.0/tests/cgreen/src/constraint.c	Wed Apr 30 17:04:33 2025
+@@ -101,7 +101,7 @@
+ 
+     constraint->parameter = parameter;
+     constraint->compare = &compare_using_matcher;
+-    constraint->test = &test_with_matcher;
++    constraint->test = (void (*)(Constraint *, const char *, intptr_t, const char *, int, TestReporter *))&test_with_matcher;
+     constraint->name = matcher_name;
+     constraint->expected = (intptr_t)matcher_function;
+     return constraint;
+@@ -164,8 +164,8 @@
+ }
+ 
+ static int compare_using_matcher(Constraint *constraint, intptr_t actual) {
+-	int (*matches)(const void*) = constraint->expected;
+-    return matches(actual);
++	int (*matches)(const void*) = (int (*)(const void*))(constraint->expected);
++	return matches((const void *)actual);
+ }
+ 
+ static void test_with_matcher(Constraint *constraint, const char *function, const char* matcher_name, intptr_t matcher_function, const char *test_file, int test_line, TestReporter *reporter) {

--- a/components/library/libdbi-drivers/pgsql.p5m
+++ b/components/library/libdbi-drivers/pgsql.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/$(MACH64)/dbd/libdbdpgsql.so

--- a/components/library/libdbi-drivers/pkg5
+++ b/components/library/libdbi-drivers/pkg5
@@ -1,0 +1,17 @@
+{
+    "dependencies": [
+        "database/mariadb-106/client",
+        "database/mariadb-106/library",
+        "database/postgres-16/developer",
+        "database/postgres-16/library",
+        "database/sqlite-3",
+        "library/libdbi",
+        "system/library"
+    ],
+    "fmris": [
+        "library/libdbi/mysql",
+        "library/libdbi/pgsql",
+        "library/libdbi/sqlite3"
+    ],
+    "name": "libdbi-drivers"
+}

--- a/components/library/libdbi-drivers/sqlite3.p5m
+++ b/components/library/libdbi-drivers/sqlite3.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Bill Sommerfeld
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+dir path=usr/lib/$(MACH64)/dbd
+file path=usr/lib/$(MACH64)/dbd/libdbdsqlite3.so


### PR DESCRIPTION
Note that this package includes tests but they don't build cleanly with gcc-14 and they require manual configuration (to point at a running database instance of each type).