### PR TITLE
ntp: Fix shake128 hashes after incompatible change in openssl 3.4

### DIFF
--- a/components/network/ntp/Makefile
+++ b/components/network/ntp/Makefile
@@ -31,7 +31,7 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		ntp
 HUMAN_VERSION=		4.2.8p18
 COMPONENT_VERSION=	$(subst p,.,$(HUMAN_VERSION))
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	Network Time Protocol Daemon v4
 COMPONENT_DESCRIPTION=	Network Time Protocol v4, NTP Daemon and Utilities
 COMPONENT_PROJECT_URL=	https://www.ntp.org/
@@ -54,7 +54,10 @@ include $(WS_MAKE_RULES)/common.mk
 # We modified configure.ac and m4 macros
 COMPONENT_PREP_ACTION = ( cd $(@D) && PATH="$(PATH)" ./bootstrap )
 
-CFLAGS += -D_XOPEN_SOURCE=600 -D__EXTENSIONS__
+CFLAGS += -D_XOPEN_SOURCE=800 -D__EXTENSIONS__
+
+# configure needs this for pthread_detach test to work
+CFLAGS += -Wno-error=int-conversion
 
 # This is needed to help debugging https://bugs.ntp.org/show_bug.cgi?id=3552
 # See also https://www.illumos.org/issues/15984#note-6

--- a/components/network/ntp/patches/40-openssl-shake-len.patch
+++ b/components/network/ntp/patches/40-openssl-shake-len.patch
@@ -1,0 +1,47 @@
+OpenSSL versions >= 3.4 removed the default digest length for
+SHAKE128; it must now be set as an additional context parameter. 
+
+--- sntp/crypto.c.~1~	Tue May  7 04:21:35 2024
++++ sntp/crypto.c	Sat May  3 12:37:48 2025
+@@ -91,6 +91,19 @@
+ 				macname);
+ 			goto mac_fail;
+ 		}
++#if OPENSSL_VERSION_NUMBER >= 0x30400000L
++		if (key_type == NID_shake128) {
++			OSSL_PARAM params[2];
++			static uint shakelen = SHAKE128_LENGTH;
++			params[0] = OSSL_PARAM_construct_uint("xoflen", &shakelen);
++			params[1] = OSSL_PARAM_construct_end();
++			if (!EVP_MD_CTX_set_params(ctx, params)) {
++				msyslog(LOG_ERR, "make_mac: MAC %s set_params failed.",
++				    macname);
++				goto mac_fail;
++			}
++		}
++#endif
+ 		if (!EVP_DigestUpdate(ctx, key_data, key_size)) {
+ 			msyslog(LOG_ERR, "make_mac: MAC %s Digest Update key failed.",
+ 				macname);
+--- libntp/a_md5encrypt.c.~1~	Tue May  7 04:21:31 2024
++++ libntp/a_md5encrypt.c	Sat May  3 12:56:01 2025
+@@ -65,6 +65,19 @@
+ 		return NULL;
+ 	}
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30400000L
++	if (nid == NID_shake128) {
++		OSSL_PARAM params[2];
++		static uint shakelen = SHAKE128_LENGTH;
++		params[0] = OSSL_PARAM_construct_uint("xoflen", &shakelen);
++		params[1] = OSSL_PARAM_construct_end();
++		if (!EVP_MD_CTX_set_params(digest_ctx, params)) {
++			msyslog(LOG_ERR, "get_md_ctx: MAC %s set_params failed.",
++			    "shake128");
++			return NULL;
++		}
++	}
++#endif
+ 	return digest_ctx;
+ #endif	/* OPENSSL */
+ }


### PR DESCRIPTION
This fixes the test failures that derailed #19993.
