### PR TITLE
m17n-lib : update to 1.8.5

### DIFF
--- a/components/inputmethod/m17n-lib/Makefile
+++ b/components/inputmethod/m17n-lib/Makefile
@@ -1,0 +1,48 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           m17n-lib
+COMPONENT_VERSION=        1.8.5
+COMPONENT_SUMMARY=        m17n-lib - The m17n library is to support various aspects (e.g. input methods, layout engines) of multi-lingual text processing.
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=   sha256:7b6c425f792d06d14e4f5b17204d3627e2c8ebb423ebdae92c0c646710d3d6c7
+COMPONENT_ARCHIVE_URL=    https://download.savannah.nongnu.org/releases/m17n/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=           system/input-method/library/m17n
+COMPONENT_CLASSIFICATION= System/Localizations
+COMPONENT_LICENSE=        LGPLv2.1
+COMPONENT_LICENSE_FILE=   COPYING
+COMPONENT_PROJECT_URL=    https://www.nongnu.org/m17n/
+
+TEST_TARGET= $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+
+PATH= $(PATH.gnu)
+
+CONFIGURE_OPTIONS += --disable-static
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += library/fribidi
+REQUIRED_PACKAGES += library/libxml2
+REQUIRED_PACKAGES += system/input-method/library/libanthy
+REQUIRED_PACKAGES += system/input-method/library/libthai
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/fontconfig
+REQUIRED_PACKAGES += system/library/freetype-2
+REQUIRED_PACKAGES += x11/library/libx11
+REQUIRED_PACKAGES += x11/library/libxft
+REQUIRED_PACKAGES += x11/library/toolkit/libxaw7
+REQUIRED_PACKAGES += x11/library/toolkit/libxt

--- a/components/inputmethod/m17n-lib/m17n-lib.p5m
+++ b/components/inputmethod/m17n-lib/m17n-lib.p5m
@@ -1,0 +1,58 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+depend type=require fmri=system/input-method/library/m17n/db
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/m17n-conv
+file path=usr/bin/m17n-date
+file path=usr/bin/m17n-dump
+file path=usr/bin/m17n-edit
+file path=usr/bin/m17n-view
+file path=usr/include/m17n-X.h
+file path=usr/include/m17n-core.h
+file path=usr/include/m17n-flt.h
+file path=usr/include/m17n-gui.h
+file path=usr/include/m17n-misc.h
+file path=usr/include/m17n.h
+link path=usr/lib/$(MACH64)/libm17n-core.so target=libm17n-core.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-core.so.0 target=libm17n-core.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n-core.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-flt.so target=libm17n-flt.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-flt.so.0 target=libm17n-flt.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n-flt.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-gui.so target=libm17n-gui.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-gui.so.0 target=libm17n-gui.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n-gui.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n.so target=libm17n.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n.so.0 target=libm17n.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n.so.0.4.2
+file path=usr/lib/$(MACH64)/m17n/1.0/libm17n-X.so
+file path=usr/lib/$(MACH64)/m17n/1.0/libm17n-gd.so
+file path=usr/lib/$(MACH64)/m17n/1.0/libmimx-anthy.so
+file path=usr/lib/$(MACH64)/m17n/1.0/libmimx-ispell.so
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-core.pc
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-flt.pc
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-gui.pc
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-shell.pc

--- a/components/inputmethod/m17n-lib/manifests/sample-manifest.p5m
+++ b/components/inputmethod/m17n-lib/manifests/sample-manifest.p5m
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/m17n-conv
+file path=usr/bin/m17n-date
+file path=usr/bin/m17n-dump
+file path=usr/bin/m17n-edit
+file path=usr/bin/m17n-view
+file path=usr/include/m17n-X.h
+file path=usr/include/m17n-core.h
+file path=usr/include/m17n-flt.h
+file path=usr/include/m17n-gui.h
+file path=usr/include/m17n-misc.h
+file path=usr/include/m17n.h
+link path=usr/lib/$(MACH64)/libm17n-core.so target=libm17n-core.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-core.so.0 target=libm17n-core.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n-core.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-flt.so target=libm17n-flt.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-flt.so.0 target=libm17n-flt.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n-flt.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-gui.so target=libm17n-gui.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n-gui.so.0 target=libm17n-gui.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n-gui.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n.so target=libm17n.so.0.4.2
+link path=usr/lib/$(MACH64)/libm17n.so.0 target=libm17n.so.0.4.2
+file path=usr/lib/$(MACH64)/libm17n.so.0.4.2
+file path=usr/lib/$(MACH64)/m17n/1.0/libm17n-X.so
+file path=usr/lib/$(MACH64)/m17n/1.0/libm17n-gd.so
+file path=usr/lib/$(MACH64)/m17n/1.0/libmimx-anthy.so
+file path=usr/lib/$(MACH64)/m17n/1.0/libmimx-ispell.so
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-core.pc
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-flt.pc
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-gui.pc
+file path=usr/lib/$(MACH64)/pkgconfig/m17n-shell.pc

--- a/components/inputmethod/m17n-lib/patches/m17n-lib.patch
+++ b/components/inputmethod/m17n-lib/patches/m17n-lib.patch
@@ -1,0 +1,19 @@
+--- a/config.h.in
++++ b/config.h.in
+@@ -604,3 +604,6 @@
+ #define glthread_once_call            libintl_once_call
+ #define glthread_once_singlethreaded  libintl_once_singlethreaded
+ 
++#if HAVE_ALLOCA_H
++#include <alloca.h>
++#endif
+--- a/example/medit.c
++++ b/example/medit.c
+@@ -119,6 +119,7 @@
+ #include <X11/Xaw/SmeBSB.h>
+ #include <X11/Xaw/SmeLine.h>
+ #include <X11/Xaw/MenuButton.h>
++#include <alloca.h>
+ 
+ /* Global variables.  */
+ 

--- a/components/inputmethod/m17n-lib/pkg5
+++ b/components/inputmethod/m17n-lib/pkg5
@@ -1,0 +1,19 @@
+{
+    "dependencies": [
+        "library/fribidi",
+        "library/libxml2",
+        "system/input-method/library/libanthy",
+        "system/input-method/library/libthai",
+        "system/library",
+        "system/library/fontconfig",
+        "system/library/freetype-2",
+        "x11/library/libx11",
+        "x11/library/libxft",
+        "x11/library/toolkit/libxaw7",
+        "x11/library/toolkit/libxt"
+    ],
+    "fmris": [
+        "system/input-method/library/m17n"
+    ],
+    "name": "m17n-lib"
+}


### PR DESCRIPTION
Actually, it has no dependency on m17n-db, but it should be installed together.