### PR TITLE
unrar: update to 7.1.6; fix alignment

### DIFF
--- a/components/archiver/unrar/Makefile
+++ b/components/archiver/unrar/Makefile
@@ -23,16 +23,17 @@
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2018, Michal Nowak
 #
+
 BUILD_STYLE= justmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=			unrar
-COMPONENT_VERSION=		7.1.4
+COMPONENT_VERSION=		7.1.6
 COMPONENT_SUMMARY=		Rar archives extractor utility
 COMPONENT_SRC=			$(COMPONENT_NAME)
 COMPONENT_PROJECT_URL=	https://www.rarlabs.com/rar_add.htm
 COMPONENT_ARCHIVE=		$(COMPONENT_NAME)src-$(COMPONENT_VERSION).tar.gz
-COMPONENT_ARCHIVE_HASH= sha256:7f3decbcbf71704ffb3726b9c4e2222f055953310042a9ba0f96b3fb2209971f
+COMPONENT_ARCHIVE_HASH= sha256:ca5e1da37dd6fa1b78bb5ed675486413f79e4a917709744aa04b6f93dfd914f0
 COMPONENT_ARCHIVE_URL=	https://www.rarlab.com/rar/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=			archiver/unrar
 COMPONENT_CLASSIFICATION= Applications/System Utilities

--- a/components/archiver/unrar/patches/02-disallow-unalign.patch
+++ b/components/archiver/unrar/patches/02-disallow-unalign.patch
@@ -1,0 +1,14 @@
+Something happended with illumos/OpenIndiana between 8 April 2025 and
+3 May 2025 where ALLOW_MISALIGNED now can not be defined
+
+--- unrar/os.hpp.~1~	2025-03-20 06:03:14.000000000 -0400
++++ unrar/os.hpp	2025-05-04 11:54:46.039645743 -0400
+@@ -263,7 +263,7 @@
+   #endif
+ #endif
+ 
+-#if !defined(BIG_ENDIAN) && defined(_WIN_ALL) || defined(__i386__) || defined(__x86_64__) || defined(__aarch64__)
++#if !defined (__illumos__) && ( !defined(BIG_ENDIAN) && defined(_WIN_ALL) || defined(__i386__) || defined(__x86_64__) || defined(__aarch64__) )
+ // Allow unaligned integer access, increases speed in some operations.
+ #define ALLOW_MISALIGNED
+ #endif


### PR DESCRIPTION
disabled define ALLOW_MISALIGNED since its usage stopped working some time after 8 April 2025.