### PR TITLE
ibus-table : update to 1.17.12

### DIFF
--- a/components/inputmethod/ibus-table/Makefile
+++ b/components/inputmethod/ibus-table/Makefile
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=           ibus-table
+COMPONENT_VERSION=        1.17.12
+COMPONENT_SUMMARY=        ibus-table - The tables engines for IBus
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=        $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH=   sha256:e1eeee02362b091010851acdc278c05fba7d9840254c5c05eca050a6c10a4702
+COMPONENT_ARCHIVE_URL=    https://github.com/mike-fabian/$(COMPONENT_NAME)/releases/download/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
+COMPONENT_FMRI=           system/input-method/ibus/table
+COMPONENT_CLASSIFICATION= System/Localizations
+COMPONENT_LICENSE=        LGPLv2.1
+COMPONENT_LICENSE_FILE=   COPYING
+COMPONENT_PROJECT_URL=    https://github.com/mike-fabian/ibus-table
+
+TEST_TARGET= $(NO_TESTS)
+include $(WS_MAKE_RULES)/common.mk
+
+PATH= $(PATH.gnu)
+
+# Manually added build dependencies
+PYTHON_REQUIRED_PACKAGES += runtime/python
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += shell/ksh93

--- a/components/inputmethod/ibus-table/ibus-table.p5m
+++ b/components/inputmethod/ibus-table/ibus-table.p5m
@@ -1,0 +1,97 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/ibus-table-createdb
+file path=usr/lib/$(MACH64)/pkgconfig/ibus-table.pc
+file path=usr/libexec/ibus-engine-table
+file path=usr/libexec/ibus-setup-table
+file path=usr/share/applications/ibus-setup-table.desktop
+file path=usr/share/glib-2.0/schemas/org.freedesktop.ibus.engine.table.gschema.xml
+file path=usr/share/ibus-table/data/coin9.wav
+file path=usr/share/ibus-table/data/phrase.txt.bz2
+file path=usr/share/ibus-table/data/pinyin_table.txt.bz2
+file path=usr/share/ibus-table/engine/chinese_variants.py
+file path=usr/share/ibus-table/engine/factory.py
+file path=usr/share/ibus-table/engine/ibus_table_location.py
+file path=usr/share/ibus-table/engine/it_active_window.py
+file path=usr/share/ibus-table/engine/it_sound.py
+file path=usr/share/ibus-table/engine/it_util.py
+file path=usr/share/ibus-table/engine/main.py
+file path=usr/share/ibus-table/engine/tabcreatedb.py
+file path=usr/share/ibus-table/engine/table.py
+file path=usr/share/ibus-table/engine/tabsqlitedb.py
+file path=usr/share/ibus-table/engine/version.py
+file path=usr/share/ibus-table/icons/acommit.svg
+file path=usr/share/ibus-table/icons/cb-mode.svg
+file path=usr/share/ibus-table/icons/chinese.svg
+file path=usr/share/ibus-table/icons/english.svg
+file path=usr/share/ibus-table/icons/full-letter.svg
+file path=usr/share/ibus-table/icons/full-punct.svg
+file path=usr/share/ibus-table/icons/half-letter.svg
+file path=usr/share/ibus-table/icons/half-punct.svg
+file path=usr/share/ibus-table/icons/ibus-table.svg
+file path=usr/share/ibus-table/icons/ncommit.svg
+file path=usr/share/ibus-table/icons/onechar.svg
+file path=usr/share/ibus-table/icons/phrase.svg
+file path=usr/share/ibus-table/icons/py-mode.svg
+file path=usr/share/ibus-table/icons/sc-mode.svg
+file path=usr/share/ibus-table/icons/scb-mode.svg
+file path=usr/share/ibus-table/icons/tab-mode.svg
+file path=usr/share/ibus-table/icons/tc-mode.svg
+file path=usr/share/ibus-table/icons/tcb-mode.svg
+file path=usr/share/ibus-table/setup/i18n.py
+file path=usr/share/ibus-table/setup/main.py
+file path=usr/share/ibus-table/setup/version.py
+file path=usr/share/ibus-table/tables/template.txt
+file path=usr/share/ibus/component/table.xml
+file path=usr/share/icons/hicolor/128x128/apps/ibus-table.png
+file path=usr/share/icons/hicolor/16x16/apps/ibus-table.png
+file path=usr/share/icons/hicolor/22x22/apps/ibus-table.png
+file path=usr/share/icons/hicolor/256x256/apps/ibus-table.png
+file path=usr/share/icons/hicolor/32x32/apps/ibus-table.png
+file path=usr/share/icons/hicolor/48x48/apps/ibus-table.png
+file path=usr/share/icons/hicolor/64x64/apps/ibus-table.png
+file path=usr/share/icons/hicolor/scalable/apps/ibus-table.svg
+file path=usr/share/locale/ca/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/cs/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/de/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/el/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/es/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/fa/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/fr/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/ja/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/ka/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/kab/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/pt_PT/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/ru/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/si/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/tr/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/uk/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/ibus-table.mo
+file path=usr/share/man/man1/ibus-table-createdb.1
+file path=usr/share/metainfo/org.freedesktop.ibus.engine.table.metainfo.xml

--- a/components/inputmethod/ibus-table/manifests/sample-manifest.p5m
+++ b/components/inputmethod/ibus-table/manifests/sample-manifest.p5m
@@ -1,0 +1,125 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/ibus-table-createdb
+file path=usr/lib/$(MACH64)/pkgconfig/ibus-table.pc
+file path=usr/libexec/ibus-engine-table
+file path=usr/libexec/ibus-setup-table
+file path=usr/share/applications/ibus-setup-table.desktop
+file path=usr/share/glib-2.0/schemas/org.freedesktop.ibus.engine.table.gschema.xml
+file path=usr/share/ibus-table/data/coin9.wav
+file path=usr/share/ibus-table/data/phrase.txt.bz2
+file path=usr/share/ibus-table/data/pinyin_table.txt.bz2
+file path=usr/share/ibus-table/engine/__pycache__/chinese_variants.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/chinese_variants.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/factory.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/factory.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/ibus_table_location.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/ibus_table_location.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/it_active_window.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/it_active_window.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/it_sound.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/it_sound.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/it_util.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/it_util.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/main.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/main.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/tabcreatedb.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/tabcreatedb.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/table.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/table.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/tabsqlitedb.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/tabsqlitedb.cpython-39.pyc
+file path=usr/share/ibus-table/engine/__pycache__/version.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/engine/__pycache__/version.cpython-39.pyc
+file path=usr/share/ibus-table/engine/chinese_variants.py
+file path=usr/share/ibus-table/engine/factory.py
+file path=usr/share/ibus-table/engine/ibus_table_location.py
+file path=usr/share/ibus-table/engine/it_active_window.py
+file path=usr/share/ibus-table/engine/it_sound.py
+file path=usr/share/ibus-table/engine/it_util.py
+file path=usr/share/ibus-table/engine/main.py
+file path=usr/share/ibus-table/engine/tabcreatedb.py
+file path=usr/share/ibus-table/engine/table.py
+file path=usr/share/ibus-table/engine/tabsqlitedb.py
+file path=usr/share/ibus-table/engine/version.py
+file path=usr/share/ibus-table/icons/acommit.svg
+file path=usr/share/ibus-table/icons/cb-mode.svg
+file path=usr/share/ibus-table/icons/chinese.svg
+file path=usr/share/ibus-table/icons/english.svg
+file path=usr/share/ibus-table/icons/full-letter.svg
+file path=usr/share/ibus-table/icons/full-punct.svg
+file path=usr/share/ibus-table/icons/half-letter.svg
+file path=usr/share/ibus-table/icons/half-punct.svg
+file path=usr/share/ibus-table/icons/ibus-table.svg
+file path=usr/share/ibus-table/icons/ncommit.svg
+file path=usr/share/ibus-table/icons/onechar.svg
+file path=usr/share/ibus-table/icons/phrase.svg
+file path=usr/share/ibus-table/icons/py-mode.svg
+file path=usr/share/ibus-table/icons/sc-mode.svg
+file path=usr/share/ibus-table/icons/scb-mode.svg
+file path=usr/share/ibus-table/icons/tab-mode.svg
+file path=usr/share/ibus-table/icons/tc-mode.svg
+file path=usr/share/ibus-table/icons/tcb-mode.svg
+file path=usr/share/ibus-table/setup/__pycache__/i18n.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/setup/__pycache__/i18n.cpython-39.pyc
+file path=usr/share/ibus-table/setup/__pycache__/main.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/setup/__pycache__/main.cpython-39.pyc
+file path=usr/share/ibus-table/setup/__pycache__/version.cpython-39.opt-1.pyc
+file path=usr/share/ibus-table/setup/__pycache__/version.cpython-39.pyc
+file path=usr/share/ibus-table/setup/i18n.py
+file path=usr/share/ibus-table/setup/main.py
+file path=usr/share/ibus-table/setup/version.py
+file path=usr/share/ibus-table/tables/template.txt
+file path=usr/share/ibus/component/table.xml
+file path=usr/share/icons/hicolor/128x128/apps/ibus-table.png
+file path=usr/share/icons/hicolor/16x16/apps/ibus-table.png
+file path=usr/share/icons/hicolor/22x22/apps/ibus-table.png
+file path=usr/share/icons/hicolor/256x256/apps/ibus-table.png
+file path=usr/share/icons/hicolor/32x32/apps/ibus-table.png
+file path=usr/share/icons/hicolor/48x48/apps/ibus-table.png
+file path=usr/share/icons/hicolor/64x64/apps/ibus-table.png
+file path=usr/share/icons/hicolor/scalable/apps/ibus-table.svg
+file path=usr/share/locale/ca/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/cs/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/de/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/el/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/es/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/fa/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/fr/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/ja/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/ka/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/kab/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/pt_BR/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/pt_PT/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/ru/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/si/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/tr/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/uk/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/zh_CN/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/zh_HK/LC_MESSAGES/ibus-table.mo
+file path=usr/share/locale/zh_TW/LC_MESSAGES/ibus-table.mo
+file path=usr/share/man/man1/ibus-table-createdb.1
+file path=usr/share/metainfo/org.freedesktop.ibus.engine.table.metainfo.xml

--- a/components/inputmethod/ibus-table/pkg5
+++ b/components/inputmethod/ibus-table/pkg5
@@ -1,0 +1,10 @@
+{
+    "dependencies": [
+        "runtime/python-39",
+        "shell/ksh93"
+    ],
+    "fmris": [
+        "system/input-method/ibus/table"
+    ],
+    "name": "ibus-table"
+}


### PR DESCRIPTION
Currently, ibus/table's tables are splitted into several packages.
I suggest shipping only ibus-table-chinese and ibus-table-others and sunset old packages.

In this case, the following input engine will not be delivered:
ibus-table-ziranma
ibus-table-zhengma
ibus-table-xinhua

They are still on ibus Google Code, so anyone who needs it can install it themselves.
It is not shipped with most Linux distros too, might patent issue. (As far as I checked, they already expired.)
