### PR TITLE
vrtualbox: 7.1.8 fix postinstall error

### DIFF
--- a/components/sysutils/virtualbox/Makefile
+++ b/components/sysutils/virtualbox/Makefile
@@ -21,7 +21,7 @@ gcc_OPT =
 
 COMPONENT_NAME=         VirtualBox
 COMPONENT_VERSION=      7.1.8
-COMPONENT_REVISION=	0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=      VirtualBox - general-purpose full virtualizer
 COMPONENT_PROJECT_URL=  https://www.virtualbox.org/
 COMPONENT_DOWNLOAD_URL= https://download.virtualbox.org/virtualbox/$(COMPONENT_VERSION)

--- a/components/sysutils/virtualbox/files/run-once.sh
+++ b/components/sysutils/virtualbox/files/run-once.sh
@@ -112,6 +112,10 @@ fi
 # Run the pkginstall.sh --ips
 echo "--PKGINSTALL virtualbox/run-once"
 /opt/VirtualBox/pkginstall.sh --ips
+if [ $? -ne 0 ]; then
+        errorprint "pkginstall.sh failed"
+	abort_error
+fi
 svccfg -s $SMF_FMRI setprop config/assembled = true
 svccfg -s $SMF_FMRI refresh
 echo "--DONE virtualbox/run-once"

--- a/components/sysutils/virtualbox/patches/28-vboxconfig.sh.patch
+++ b/components/sysutils/virtualbox/patches/28-vboxconfig.sh.patch
@@ -1,0 +1,23 @@
+modunload fails because
+$ modinfo | grep vboxflt
+delivers two lines:
+
+root@notebookcg2:~# modinfo | grep vboxflt
+262 fffffffff529a000   7bd8 309   1  vboxflt (VirtualBox NetDrv 7.1.8r168469)
+262 fffffffff529a000   7bd8   -   1  vboxflt (VirtualBox NetMod 7.1.8r168469)
+
+this leads to a non working modunload option list. The mod_id's are the same, so take the last.
+
+diff --git a/src/VBox/Installer/solaris/vboxconfig.sh b/src/VBox/Installer/solaris/vboxconfig.sh
+index cfb3f58..fe56316 100755
+--- a/src/VBox/Installer/solaris/vboxconfig.sh
++++ b/src/VBox/Installer/solaris/vboxconfig.sh
+@@ -576,7 +576,7 @@ unload_module()
+     moddesc=$2
+     retry=$3
+     fatal=$4
+-    modid=`$BIN_MODINFO | grep "$modname " | cut -f 1 -d ' ' `
++    modid=`$BIN_MODINFO | grep "$modname " | cut -f 1 -d ' ' | tail -1`
+     if test -n "$modid"; then
+         $BIN_MODUNLOAD -i $modid
+         if test "$?" -eq 0; then


### PR DESCRIPTION
This PR fixes the postinstall scrip vboxconfig.sh, where the driver unload - reinstall procedure is not working
If already version 7.1.8 is installed, for fix broken installation it is necessary to run manually:

# /opt/VirtualBox/pkginstall.sh --ips