### PR TITLE
mate_install: replace ogg-vorbis by libogg and libvorbis

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	18
+COMPONENT_VERSION =	19
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/desktop_common
+++ b/components/meta-packages/install-types/includes/desktop_common
@@ -2,7 +2,6 @@ depend type=require fmri=audio/audio-utilities
 depend type=require fmri=benchmark/x11perf
 depend type=require fmri=codec/flac
 depend type=require fmri=codec/libtheora
-depend type=require fmri=codec/ogg-vorbis
 depend type=require fmri=codec/speex
 depend type=require fmri=communication/im/pidgin
 depend type=require fmri=crypto/gnupg
@@ -52,6 +51,8 @@ depend type=require fmri=library/desktop/desktop-file-utils
 depend type=require fmri=library/desktop/gtk3
 depend type=require fmri=library/glib-networking
 depend type=require fmri=library/gnome/gvfs
+depend type=require fmri=library/libogg
+depend type=require fmri=library/libvorbis
 depend type=require fmri=library/xdg/consolekit
 depend type=require fmri=library/xdg/xdg-user-dirs
 depend type=require fmri=mail/thunderbird


### PR DESCRIPTION
The `codec/ogg-vorbis` package is a metapackage that depends on `libogg` and `libvorbis` only.  It does have a strange GNOME2-like version number (2.30.1) that's unrelated to neither `libogg` (the latest is 1.3.5) nor `libvorbis` (the latest is 1.3.7).  This changes the `mate_install` metapackage to directly depend on `libogg` and `libvorbis` instead.