### PR TITLE
Add coherent_licensed Python project

### DIFF
--- a/components/python/coherent.licensed/.gitignore
+++ b/components/python/coherent.licensed/.gitignore
@@ -1,0 +1,1 @@
+/coherent_licensed-0.1.1/

--- a/components/python/coherent.licensed/Makefile
+++ b/components/python/coherent.licensed/Makefile
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project -d python/coherent.licensed coherent_licensed
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		coherent_licensed
+HUMAN_VERSION =			0.1.1
+COMPONENT_SUMMARY =		License management tooling for Coherent System and skeleton projects
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:04f52b4b7c827768cfa4a2d28bab2243174f9f1be5263b4d2bb9d4a94854d1dc
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE
+
+TEST_STYLE = none
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/flit-core
+PYTHON_REQUIRED_PACKAGES += library/python/requests
+PYTHON_REQUIRED_PACKAGES += runtime/python

--- a/components/python/coherent.licensed/coherent_licensed-PYVER.p5m
+++ b/components/python/coherent.licensed/coherent_licensed-PYVER.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent/licensed/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent/licensed/setuptools.py
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/entry_points.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/requests-$(PYV)

--- a/components/python/coherent.licensed/manifests/sample-manifest.p5m
+++ b/components/python/coherent.licensed/manifests/sample-manifest.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent/licensed/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent/licensed/setuptools.py
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/entry_points.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/coherent_licensed-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/requests-$(PYV)

--- a/components/python/coherent.licensed/pkg5
+++ b/components/python/coherent.licensed/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "library/python/flit-core-39",
+        "library/python/requests-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/coherent-licensed",
+        "library/python/coherent-licensed-39"
+    ],
+    "name": "coherent_licensed"
+}


### PR DESCRIPTION
New build dependency for jaraco.itertools 6.4.3.