### PR TITLE
font-cronyx-cyrillic: update to 1.0.4

### DIFF
--- a/components/fonts/font-cronyx-cyrillic/Makefile
+++ b/components/fonts/font-cronyx-cyrillic/Makefile
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+BUILD_STYLE = configure
+FONT_TYPE = X11
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		font-cronyx-cyrillic
+COMPONENT_VERSION =		1.0.4
+COMPONENT_SUMMARY =		Cyrillic bitmap fonts from X.Org Foundation
+COMPONENT_ARCHIVE_EXTENSION =	.tar.xz
+COMPONENT_ARCHIVE_HASH =	sha256:dc0781ce0dcbffdbf6aae1a00173a13403f92b0de925bca5a9e117e4e2d6b789
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	COPYING
+
+include $(WS_MAKE_RULES)/font.mk
+
+FONT_SUBDIR = cronyx-cyrillic
+
+CONFIGURE_OPTIONS += --with-fontdir=$(USRSHAREX11FONTSDIR)/$(FONT_SUBDIR)
+
+COMPONENT_POST_INSTALL_ACTION += \
+	$(call create-symlinks,$(USRSHAREX11FONTSDIR)/$(FONT_SUBDIR),$(ETCDIR)/X11/fontpath.d) ; \
+	$(MV) $(PROTOETCDIR)/X11/fontpath.d/$(FONT_SUBDIR) \
+	      $(PROTOETCDIR)/X11/fontpath.d/$(FONT_SUBDIR):pri=75 ;
+
+# Auto-generated dependencies

--- a/components/fonts/font-cronyx-cyrillic/font-cronyx-cyrillic.p5m
+++ b/components/fonts/font-cronyx-cyrillic/font-cronyx-cyrillic.p5m
@@ -1,0 +1,92 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=etc/X11/fontpath.d/cronyx-cyrillic:pri=75 \
+    target=../../../usr/share/fonts/X11/cronyx-cyrillic
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1c.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1cb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1cbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1co.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2c.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2cb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2cbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2co.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3c.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3cb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3cbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3co.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/fonts.dir
+file path=usr/share/fonts/X11/cronyx-cyrillic/koi10x16b.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/koi10x20.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/koi6x10.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/koinil2.pcf

--- a/components/fonts/font-cronyx-cyrillic/manifests/sample-manifest.p5m
+++ b/components/fonts/font-cronyx-cyrillic/manifests/sample-manifest.p5m
@@ -1,0 +1,92 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+link path=etc/X11/fontpath.d/cronyx-cyrillic:pri=75 \
+    target=../../../usr/share/fonts/X11/cronyx-cyrillic
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1c.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1cb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1cbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1co.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox1to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2c.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2cb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2cbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2co.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox2to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3c.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3cb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3cbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3co.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox3to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox4to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox5to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6h.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6hb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6hbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6ho.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6t.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6tb.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6tbo.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/crox6to.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/fonts.dir
+file path=usr/share/fonts/X11/cronyx-cyrillic/koi10x16b.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/koi10x20.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/koi6x10.pcf
+file path=usr/share/fonts/X11/cronyx-cyrillic/koinil2.pcf

--- a/components/fonts/font-cronyx-cyrillic/pkg5
+++ b/components/fonts/font-cronyx-cyrillic/pkg5
@@ -1,0 +1,7 @@
+{
+    "dependencies": [],
+    "fmris": [
+        "system/font/xorg/font-cronyx-cyrillic"
+    ],
+    "name": "font-cronyx-cyrillic"
+}

--- a/components/fonts/xorg-cyrillic/Makefile
+++ b/components/fonts/xorg-cyrillic/Makefile
@@ -29,13 +29,9 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		font-misc-cyrillic
 COMPONENT_VERSION= 	1.0.3
+COMPONENT_REVISION=	1
 COMPONENT_ARCHIVE_HASH=	\
 	sha256:e40fe3e3323c62b738550795457ad555c70c008aa91b5912dfd46f8e745f5e60
-
-COMPONENT_NAME_1=	font-cronyx-cyrillic
-COMPONENT_VERSION_1= 	1.0.3
-COMPONENT_ARCHIVE_HASH_1=	\
-	sha256:6e8631936157677c77ba032b5c7b1fb3cb2ee872dbcea0444f12cd602cd9212a
 
 COMPONENT_NAME_2=	font-screen-cyrillic
 COMPONENT_VERSION_2= 	1.0.4
@@ -50,7 +46,7 @@ COMPONENT_ARCHIVE_HASH_3=	\
 # Use font-screen-cyrillic version number as solaris-userland does
 IPS_COMPONENT_VERSION=$(COMPONENT_VERSION_2)
 
-LIST = 1 2 3
+LIST = 2 3
 
 BUILD_TARGET = $(BUILD_$(MK_BITS))
 INSTALL_TARGET = $(INSTALL_$(MK_BITS))
@@ -66,13 +62,13 @@ $(foreach n, $(LIST), \
     $(eval BUILD_DIR_$(n) += $(BUILD_DIR_NO_ARCH)_$(n)) \
     $(eval CONFIGURE_NO_ARCH += $(BUILD_DIR_$(n))/.configured) \
     $(eval BUILD_NO_ARCH_$(n) += $(BUILD_DIR_$(n))/.built) \
+    $(eval $(BUILD_DIR_$(n))/.built: BITS=$(PREFERRED_BITS)) \
     $(eval BUILD_TARGET += $(BUILD_NO_ARCH_$(n))) \
     $(eval INSTALL_NO_ARCH_$(n) += $(BUILD_DIR_$(n))/.installed) \
     $(eval INSTALL_TARGET += $(INSTALL_NO_ARCH_$(n))) \
     $(eval $(call extra-target-rules,$(n))) \
 )
 
-include $(WS_MAKE_RULES)/x11.mk
 include $(WS_MAKE_RULES)/font.mk
 
 CYRILLIC_FONT_DIR = $(USRSHAREX11FONTSDIR)/cyrillic
@@ -80,4 +76,4 @@ CYRILLIC_FONT_DIR = $(USRSHAREX11FONTSDIR)/cyrillic
 # Install to separate directory for easier packaging
 CONFIGURE_OPTIONS += --with-fontdir=$(CYRILLIC_FONT_DIR)
 
-include $(WS_MAKE_RULES)/common.mk
+# Auto-generated dependencies

--- a/components/fonts/xorg-cyrillic/manifests/sample-manifest.p5m
+++ b/components/fonts/xorg-cyrillic/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -22,73 +23,10 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/share/fonts/X11/cyrillic/crox1c.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1cb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1cbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1co.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2c.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2cb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2cbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2co.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3c.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3cb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3cbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3co.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6to.pcf
 file path=usr/share/fonts/X11/cyrillic/fonts.dir
-file path=usr/share/fonts/X11/cyrillic/koi10x16b.pcf
-file path=usr/share/fonts/X11/cyrillic/koi10x20.pcf
 file path=usr/share/fonts/X11/cyrillic/koi12x24.pcf
 file path=usr/share/fonts/X11/cyrillic/koi12x24b.pcf
 file path=usr/share/fonts/X11/cyrillic/koi5x8.pcf
-file path=usr/share/fonts/X11/cyrillic/koi6x10.pcf
 file path=usr/share/fonts/X11/cyrillic/koi6x13.pcf
 file path=usr/share/fonts/X11/cyrillic/koi6x13b.pcf
 file path=usr/share/fonts/X11/cyrillic/koi6x9.pcf
@@ -101,7 +39,6 @@ file path=usr/share/fonts/X11/cyrillic/koi9x15.pcf
 file path=usr/share/fonts/X11/cyrillic/koi9x15b.pcf
 file path=usr/share/fonts/X11/cyrillic/koi9x18.pcf
 file path=usr/share/fonts/X11/cyrillic/koi9x18b.pcf
-file path=usr/share/fonts/X11/cyrillic/koinil2.pcf
 file path=usr/share/fonts/X11/cyrillic/proof9x16.pcf
 file path=usr/share/fonts/X11/cyrillic/screen8x16.pcf
 file path=usr/share/fonts/X11/cyrillic/screen8x16b.pcf

--- a/components/fonts/xorg-cyrillic/pkg5
+++ b/components/fonts/xorg-cyrillic/pkg5
@@ -1,12 +1,5 @@
 {
-    "dependencies": [
-        "SUNWcs",
-        "developer/build/autoconf/xorg-macros",
-        "system/library",
-        "system/library/fontconfig",
-        "x11/font-utilities",
-        "x11/header/x11-protocols"
-    ],
+    "dependencies": [],
     "fmris": [
         "system/font/xorg/cyrillic"
     ],

--- a/components/fonts/xorg-cyrillic/xorg-cyrillic.license
+++ b/components/fonts/xorg-cyrillic/xorg-cyrillic.license
@@ -31,20 +31,6 @@ X Window System is a trademark of X Consortium, Inc.
 Additional terms and/or notices apply to certain fonts within the X11 Fonts
 as follows:
 
-This package contains the set of russian fonts for X11 Release 6.
-Copyright (C) 1994-1995 Cronyx Ltd.
-Changes Copyright (C) 1996 by Andrey A. Chernov, Moscow, Russia.
-
-Version: 1.0
-
-This software may be used, modified, copied, distributed, and sold,
-in both source and binary form provided that the above copyright
-and these terms are retained. Under no circumstances is the author
-responsible for the proper functioning of this software, nor does
-the author assume any responsibility for damages incurred with its use.
-
-  ------------------------------------------------------------------------
-
 koi12x24b.bdf, koi8x16b.bdf and koi8x16.bdf:
 --------------------------------------------
 May be distributed and modified without restrictions.

--- a/components/fonts/xorg-cyrillic/xorg-cyrillic.p5m
+++ b/components/fonts/xorg-cyrillic/xorg-cyrillic.p5m
@@ -27,86 +27,24 @@
 # one, while others all are behind by one.
 set name=pkg.fmri \
     value=pkg:/system/font/xorg/cyrillic@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="Cyrillic bitmap fonts from X.Org Foundation"
 set name=pkg.description \
     value="X Window System font files for Cyrillic scripts from X.Org Foundation open source release"
 set name=com.oracle.info.description value="the xorg-cyrillic fonts"
 set name=info.classification value=org.opensolaris.category.2008:System/Fonts
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL) \
-    value=$(COMPONENT_ARCHIVE_URL_1) value=$(COMPONENT_ARCHIVE_URL_2) \
+    value=$(COMPONENT_ARCHIVE_URL_2) \
     value=$(COMPONENT_ARCHIVE_URL_3)
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=org.opensolaris.arc-caseid value=PSARC/2009/482
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 link path=etc/X11/fontpath.d/cyrillic:pri=75 \
     target=../../../usr/share/fonts/X11/cyrillic
-file path=usr/share/fonts/X11/cyrillic/crox1c.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1cb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1cbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1co.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox1to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2c.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2cb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2cbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2co.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox2to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3c.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3cb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3cbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3co.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox3to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox4to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox5to.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6h.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6hb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6hbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6ho.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6t.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6tb.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6tbo.pcf
-file path=usr/share/fonts/X11/cyrillic/crox6to.pcf
 file path=usr/share/fonts/X11/cyrillic/fonts.dir
-file path=usr/share/fonts/X11/cyrillic/koi10x16b.pcf
-file path=usr/share/fonts/X11/cyrillic/koi10x20.pcf
 file path=usr/share/fonts/X11/cyrillic/koi12x24.pcf
 file path=usr/share/fonts/X11/cyrillic/koi12x24b.pcf
 file path=usr/share/fonts/X11/cyrillic/koi5x8.pcf
-file path=usr/share/fonts/X11/cyrillic/koi6x10.pcf
 file path=usr/share/fonts/X11/cyrillic/koi6x13.pcf
 file path=usr/share/fonts/X11/cyrillic/koi6x13b.pcf
 file path=usr/share/fonts/X11/cyrillic/koi6x9.pcf
@@ -119,8 +57,10 @@ file path=usr/share/fonts/X11/cyrillic/koi9x15.pcf
 file path=usr/share/fonts/X11/cyrillic/koi9x15b.pcf
 file path=usr/share/fonts/X11/cyrillic/koi9x18.pcf
 file path=usr/share/fonts/X11/cyrillic/koi9x18b.pcf
-file path=usr/share/fonts/X11/cyrillic/koinil2.pcf
 file path=usr/share/fonts/X11/cyrillic/proof9x16.pcf
 file path=usr/share/fonts/X11/cyrillic/screen8x16.pcf
 file path=usr/share/fonts/X11/cyrillic/screen8x16b.pcf
 license xorg-cyrillic.license license=MIT
+
+# The font-cronyx-cyrillic fonts used to live in this package
+depend type=require fmri=system/font/xorg/font-cronyx-cyrillic


### PR DESCRIPTION
This also moves the `font-cronyx-cyrillic` fonts out of the monolithic `system/font/xorg/cyrillic` package to decrease confusion and improve maintainability.