### PR TITLE
Add jaraco.logging Python project

### DIFF
--- a/components/python/jaraco.logging/.gitignore
+++ b/components/python/jaraco.logging/.gitignore
@@ -1,0 +1,1 @@
+/jaraco.logging-3.3.0/

--- a/components/python/jaraco.logging/Makefile
+++ b/components/python/jaraco.logging/Makefile
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project jaraco.logging
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		jaraco.logging
+HUMAN_VERSION =			3.3.0
+COMPONENT_SUMMARY =		Support for Python logging facility
+COMPONENT_PROJECT_URL =		https://github.com/jaraco/jaraco.logging
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:f4a7cfbacb86a834c2886c01a3b52bc4cde2728c1d9717c49d4dce1d6248f07b
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools-scm
+PYTHON_REQUIRED_PACKAGES += runtime/python

--- a/components/python/jaraco.logging/jaraco.logging-PYVER.p5m
+++ b/components/python/jaraco.logging/jaraco.logging-PYVER.p5m
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/logging.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/jaraco.logging/manifests/sample-manifest.p5m
+++ b/components/python/jaraco.logging/manifests/sample-manifest.p5m
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/logging.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_logging-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/jaraco.logging/pkg5
+++ b/components/python/jaraco.logging/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "library/python/setuptools-39",
+        "library/python/setuptools-scm-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/jaraco-logging",
+        "library/python/jaraco-logging-39"
+    ],
+    "name": "jaraco.logging"
+}

--- a/components/python/jaraco.logging/test/results-all.master
+++ b/components/python/jaraco.logging/test/results-all.master
@@ -1,0 +1,17 @@
+py$(PYV): remove tox env folder $(@D)/.tox/py$(PYV)
+py$(PYV): commands[0]> python -m pytest
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(@D)/.tox/py$(PYV)/bin/python
+cachedir: .tox/py$(PYV)/.pytest_cache
+rootdir: $(@D)
+configfile: pytest.ini
+collecting ... collected 4 items
+
+jaraco/logging.py::jaraco.logging.add_arguments PASSED
+jaraco/logging.py::jaraco.logging.log_level PASSED
+jaraco/logging.py::jaraco.logging.setup PASSED
+jaraco/logging.py::jaraco.logging.setup_requests_logging PASSED
+
+======== 4 passed ========
+  py$(PYV): OK
+  congratulations :)


### PR DESCRIPTION
This is runtime dependency for `jaraco.mongodb`.  The `jaraco.mongodb` is needed by `coherent.deps` which in turn is new runtime dependency for `pip-run` (version 16.0.0).