### PR TITLE
Add jaraco_services Python project

### DIFF
--- a/components/python/jaraco.services/.gitignore
+++ b/components/python/jaraco.services/.gitignore
@@ -1,0 +1,1 @@
+/jaraco_services-4.0.0/

--- a/components/python/jaraco.services/Makefile
+++ b/components/python/jaraco.services/Makefile
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project -d python/jaraco.services jaraco_services
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		jaraco_services
+HUMAN_VERSION =			4.0.0
+COMPONENT_SUMMARY =		Service orchestration and pytest plugins
+COMPONENT_PROJECT_URL =		https://github.com/jaraco/jaraco.services
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:2e4c7ff9716879911c145ad1cad5bfd22d3646c51e47b8e300c4c52c2797cef5
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/jaraco-classes
+PYTHON_REQUIRED_PACKAGES += library/python/path
+PYTHON_REQUIRED_PACKAGES += library/python/portend
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools-scm
+PYTHON_REQUIRED_PACKAGES += library/python/tempora
+PYTHON_REQUIRED_PACKAGES += runtime/python
+TEST_REQUIRED_PACKAGES.python += library/python/pytest
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-checkdocs
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-cov
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-enabler
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-mypy

--- a/components/python/jaraco.services/jaraco_services-PYVER.p5m
+++ b/components/python/jaraco.services/jaraco_services-PYVER.p5m
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/services/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/services/paths.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/jaraco-classes-$(PYV)
+depend type=require fmri=pkg:/library/python/path-$(PYV)
+depend type=require fmri=pkg:/library/python/portend-$(PYV)
+depend type=require fmri=pkg:/library/python/tempora-$(PYV)

--- a/components/python/jaraco.services/manifests/sample-manifest.p5m
+++ b/components/python/jaraco.services/manifests/sample-manifest.p5m
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/services/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/services/paths.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_services-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/jaraco-classes-$(PYV)
+depend type=require fmri=pkg:/library/python/path-$(PYV)
+depend type=require fmri=pkg:/library/python/portend-$(PYV)
+depend type=require fmri=pkg:/library/python/tempora-$(PYV)

--- a/components/python/jaraco.services/patches/01-no-ruff.patch
+++ b/components/python/jaraco.services/patches/01-no-ruff.patch
@@ -1,0 +1,13 @@
+We have no pytest-ruff support yet.
+see https://github.com/tikv/jemallocator/issues/58
+
+--- jaraco_services-4.0.0/pyproject.toml.orig
++++ jaraco_services-4.0.0/pyproject.toml
+@@ -36,7 +36,6 @@
+ 	"pytest-cov",
+ 	"pytest-mypy",
+ 	"pytest-enabler >= 2.2",
+-	"pytest-ruff >= 0.2.1",
+ 
+ 	# local
+ ]

--- a/components/python/jaraco.services/pkg5
+++ b/components/python/jaraco.services/pkg5
@@ -1,0 +1,16 @@
+{
+    "dependencies": [
+        "library/python/jaraco-classes-39",
+        "library/python/path-39",
+        "library/python/portend-39",
+        "library/python/setuptools-39",
+        "library/python/setuptools-scm-39",
+        "library/python/tempora-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/jaraco-services",
+        "library/python/jaraco-services-39"
+    ],
+    "name": "jaraco_services"
+}

--- a/components/python/jaraco.services/python-integrate-project.conf
+++ b/components/python/jaraco.services/python-integrate-project.conf
@@ -1,0 +1,16 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+%patch% 01-no-ruff.patch

--- a/components/python/jaraco.services/test/results-all.master
+++ b/components/python/jaraco.services/test/results-all.master
@@ -1,0 +1,43 @@
+py$(PYV): remove tox env folder $(@D)/.tox/py$(PYV)
+py$(PYV): commands[0]> python -m pytest
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(@D)/.tox/py$(PYV)/bin/python
+cachedir: .tox/py$(PYV)/.pytest_cache
+rootdir: $(@D)
+configfile: pytest.ini
+collecting ... collected 9 items
+
+docs/conf.py::mypy PASSED
+docs/conf.py::mypy-status PASSED
+jaraco/services/__init__.py::mypy PASSED
+jaraco/services/__init__.py::jaraco.services.Guard PASSED
+jaraco/services/paths.py::mypy PASSED
+.::project PASSED
+.::project PASSED
+tests/test_services.py::mypy PASSED
+tests/test_services.py::TestHTTPStatus::test_HTTPError PASSED
+
+=============================== warnings summary ===============================
+jaraco/services/__init__.py::jaraco.services.Guard
+jaraco/services/__init__.py::jaraco.services.Guard
+jaraco/services/__init__.py::jaraco.services.Guard
+  $(PYTHON_DIR)/doctest.py:1334: DeprecationWarning: Guard is deprecated. File an issue with jaraco.services if you encounter this message.
+    exec(compile(example.source, filename, "single",
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+===================================== mypy =====================================
+Success: no issues found in 4 source files
+================================ tests coverage ================================
+_______________ coverage: platform sunos5, python 3.9.21-final-0 _______________
+
+Name                          Stmts   Miss  Cover   Missing
+-----------------------------------------------------------
+docs/conf.py                      9      0   100%
+jaraco/services/__init__.py     155     77    50%   70, 93, 100, 109, 120, 123-127, 136-139, 142-147, 154-160, 163-171, 174-176, 180-184, 191, 194, 197, 200, 204-208, 222, 226, 230, 237-240, 246-248, 254-259, 262-264, 267-275
+jaraco/services/paths.py         31     13    58%   30, 34-38, 46, 50-55
+tests/test_services.py           18      0   100%
+-----------------------------------------------------------
+TOTAL                           213     90    58%
+======== 9 passed, 3 warnings ========
+  py$(PYV): OK
+  congratulations :)


### PR DESCRIPTION
This is runtime dependency for `jaraco.mongodb`.  The `jaraco.mongodb` is needed by `coherent.deps` which in turn is new runtime dependency for `pip-run` (version 16.0.0).