### PR TITLE
Add pytimeparse Python project

### DIFF
--- a/components/python/pytimeparse/.gitignore
+++ b/components/python/pytimeparse/.gitignore
@@ -1,0 +1,1 @@
+/pytimeparse-1.1.8/

--- a/components/python/pytimeparse/Makefile
+++ b/components/python/pytimeparse/Makefile
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project pytimeparse
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		pytimeparse
+HUMAN_VERSION =			1.1.8
+COMPONENT_SUMMARY =		Time expression parser
+COMPONENT_PROJECT_URL =		https://github.com/wroberts/pytimeparse
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE.rst
+
+TEST_STYLE = unittest
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools
+PYTHON_REQUIRED_PACKAGES += runtime/python

--- a/components/python/pytimeparse/manifests/sample-manifest.p5m
+++ b/components/python/pytimeparse/manifests/sample-manifest.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/VERSION
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/tests/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/tests/testtimeparse.py
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/timeparse.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/pytimeparse/patches/01-no-shebang.patch
+++ b/components/python/pytimeparse/patches/01-no-shebang.patch
@@ -1,0 +1,16 @@
+https://github.com/wroberts/pytimeparse/issues/28
+
+--- pytimeparse-1.1.8/pytimeparse/__init__.py.orig
++++ pytimeparse-1.1.8/pytimeparse/__init__.py
+@@ -1,4 +1,3 @@
+-#!/usr/bin/env python
+ # -*- coding: utf-8 -*-
+ 
+ '''
+--- pytimeparse-1.1.8/pytimeparse/tests/testtimeparse.py.orig
++++ pytimeparse-1.1.8/pytimeparse/tests/testtimeparse.py
+@@ -1,4 +1,3 @@
+-#!/usr/bin/env python
+ # -*- coding: utf-8 -*-
+ 
+ '''

--- a/components/python/pytimeparse/pkg5
+++ b/components/python/pytimeparse/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "library/python/setuptools-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/pytimeparse",
+        "library/python/pytimeparse-39"
+    ],
+    "name": "pytimeparse"
+}

--- a/components/python/pytimeparse/python-integrate-project.conf
+++ b/components/python/pytimeparse/python-integrate-project.conf
@@ -1,0 +1,20 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+%patch% 01-no-shebang.patch
+
+# Pytest is unable to find tests so force unittest test style
+%include-2%
+TEST_STYLE = unittest

--- a/components/python/pytimeparse/pytimeparse-PYVER.p5m
+++ b/components/python/pytimeparse/pytimeparse-PYVER.p5m
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse-$(HUMAN_VERSION).dist-info/top_level.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/VERSION
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/tests/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/tests/testtimeparse.py
+file path=usr/lib/python$(PYVER)/vendor-packages/pytimeparse/timeparse.py
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/pytimeparse/test/results-all.master
+++ b/components/python/pytimeparse/test/results-all.master
@@ -1,0 +1,103 @@
+test_doctest (pytimeparse.tests.testtimeparse.TestTimeparse)
+Run timeparse doctests. ... ok
+test_hrs (pytimeparse.tests.testtimeparse.TestTimeparse)
+Test parsing hours. ... ok
+test_mins (pytimeparse.tests.testtimeparse.TestTimeparse)
+Test parsing minutes. ... ok
+test_time (pytimeparse.tests.testtimeparse.TestTimeparse)
+Test parsing time expression. ... ok
+test_timeparse_1 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 1. ... ok
+test_timeparse_10 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 10. ... ok
+test_timeparse_11 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 11. ... ok
+test_timeparse_12 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 12. ... ok
+test_timeparse_13 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 13. ... ok
+test_timeparse_14 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 14. ... ok
+test_timeparse_15 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 15. ... ok
+test_timeparse_16 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 16. ... ok
+test_timeparse_16b (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 16b. ... ok
+test_timeparse_16c (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 16c. ... ok
+test_timeparse_16d (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 16d. ... ok
+test_timeparse_16e (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 16e. ... ok
+test_timeparse_16f (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 16f. ... ok
+test_timeparse_17 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 17. ... ok
+test_timeparse_18 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 18. ... ok
+test_timeparse_19 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 19. ... ok
+test_timeparse_2 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 2. ... ok
+test_timeparse_20 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 20. ... ok
+test_timeparse_21 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 21. ... ok
+test_timeparse_22 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 22. ... ok
+test_timeparse_23 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 23. ... ok
+test_timeparse_24 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 24. ... ok
+test_timeparse_25 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 25. ... ok
+test_timeparse_26 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 26. ... ok
+test_timeparse_27 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 27. ... ok
+test_timeparse_28 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 28. ... ok
+test_timeparse_29 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 29. ... ok
+test_timeparse_3 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 3. ... ok
+test_timeparse_30 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 30. ... ok
+test_timeparse_31 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 31. ... ok
+test_timeparse_32 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 32. ... ok
+test_timeparse_33 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 33. ... ok
+test_timeparse_4 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 4. ... ok
+test_timeparse_5 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 5. ... ok
+test_timeparse_6 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 6. ... ok
+test_timeparse_7 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 7. ... ok
+test_timeparse_8 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 8. ... ok
+test_timeparse_9 (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test case 9. ... ok
+test_timeparse_bare_seconds (pytimeparse.tests.testtimeparse.TestTimeparse)
+timeparse test bare seconds, without minutes. ... ok
+test_timeparse_granularity_1 (pytimeparse.tests.testtimeparse.TestTimeparse)
+Check that minute-level granularity applies correctly. ... ok
+test_timeparse_granularity_2 (pytimeparse.tests.testtimeparse.TestTimeparse)
+Check that minute-level granularity does not apply inappropriately. ... ok
+test_timeparse_granularity_3 (pytimeparse.tests.testtimeparse.TestTimeparse)
+Check that minute-level granularity does not apply inappropriately. ... ok
+test_timeparse_granularity_4 (pytimeparse.tests.testtimeparse.TestTimeparse)
+Check that minute-level granularity does not apply inappropriately. ... ok
+test_timeparse_multipliers (pytimeparse.tests.testtimeparse.TestTimeparse)
+Test parsing time unit multipliers. ... ok
+test_timeparse_signs (pytimeparse.tests.testtimeparse.TestTimeparse)
+Test parsing time signs. ... ok
+
+----------------------------------------------------------------------
+Ran 49 tests
+
+OK


### PR DESCRIPTION
This is runtime dependency for `jaraco.mongodb`.  The `jaraco.mongodb` is needed by `coherent.deps` which in turn is new runtime dependency for `pip-run` (version 16.0.0).