### PR TITLE
Add jaraco_compat Python project

### DIFF
--- a/components/python/jaraco.compat/.gitignore
+++ b/components/python/jaraco.compat/.gitignore
@@ -1,0 +1,1 @@
+/jaraco_compat-4.3.1/

--- a/components/python/jaraco.compat/Makefile
+++ b/components/python/jaraco.compat/Makefile
@@ -1,0 +1,39 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project -d python/jaraco.compat jaraco_compat
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		jaraco_compat
+HUMAN_VERSION =			4.3.1
+COMPONENT_SUMMARY =		Modules providing forward compatibility across Python versions
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:8be915cbf8f696edf75377796e552e0c4e765226dde48ae15d9fb648161c39c8
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools
+PYTHON_REQUIRED_PACKAGES += library/python/setuptools-scm
+PYTHON_REQUIRED_PACKAGES += runtime/python
+TEST_REQUIRED_PACKAGES.python += library/python/pytest
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-checkdocs
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-cov
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-enabler
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-mypy

--- a/components/python/jaraco.compat/jaraco_compat-PYVER.p5m
+++ b/components/python/jaraco.compat/jaraco_compat-PYVER.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/compat/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/compat/py310/safe_path.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/compat/py38.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/jaraco.compat/manifests/sample-manifest.p5m
+++ b/components/python/jaraco.compat/manifests/sample-manifest.p5m
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/compat/py.typed
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/compat/py310/safe_path.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco/compat/py38.py
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/licenses/LICENSE
+file path=usr/lib/python$(PYVER)/vendor-packages/jaraco_compat-$(HUMAN_VERSION).dist-info/top_level.txt
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/python/jaraco.compat/patches/01-license.patch
+++ b/components/python/jaraco.compat/patches/01-license.patch
@@ -1,0 +1,22 @@
+https://github.com/jaraco/jaraco.compat/issues/4
+
+--- /dev/null
++++ jaraco_compat-4.3.1/LICENSE
+@@ -0,0 +1,17 @@
++Permission is hereby granted, free of charge, to any person obtaining a copy
++of this software and associated documentation files (the "Software"), to
++deal in the Software without restriction, including without limitation the
++rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++sell copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in
++all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
++IN THE SOFTWARE.

--- a/components/python/jaraco.compat/patches/02-no-ruff.patch
+++ b/components/python/jaraco.compat/patches/02-no-ruff.patch
@@ -1,0 +1,13 @@
+We have no pytest-ruff support yet.
+see https://github.com/tikv/jemallocator/issues/58
+
+--- jaraco_compat-4.3.1/pyproject.toml.orig
++++ jaraco_compat-4.3.1/pyproject.toml
+@@ -45,7 +45,6 @@
+ 
+ check = [
+ 	"pytest-checkdocs >= 2.4",
+-	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
+ ]
+ 
+ cover = [

--- a/components/python/jaraco.compat/pkg5
+++ b/components/python/jaraco.compat/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "library/python/setuptools-39",
+        "library/python/setuptools-scm-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/jaraco-compat",
+        "library/python/jaraco-compat-39"
+    ],
+    "name": "jaraco_compat"
+}

--- a/components/python/jaraco.compat/python-integrate-project.conf
+++ b/components/python/jaraco.compat/python-integrate-project.conf
@@ -1,0 +1,17 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+%patch% 01-license.patch
+%patch% 02-no-ruff.patch

--- a/components/python/jaraco.compat/test/results-all.master
+++ b/components/python/jaraco.compat/test/results-all.master
@@ -1,0 +1,33 @@
+py$(PYV): remove tox env folder $(@D)/.tox/py$(PYV)
+py$(PYV): commands[0]> python -m pytest
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(@D)/.tox/py$(PYV)/bin/python
+cachedir: .tox/py$(PYV)/.pytest_cache
+rootdir: $(@D)
+configfile: pytest.ini
+collecting ... collected 8 items
+
+docs/conf.py::mypy PASSED
+docs/conf.py::mypy-status PASSED
+jaraco/compat/py310/safe_path.py::mypy PASSED
+jaraco/compat/py310/safe_path.py::jaraco.compat.py310.safe_path.ensure_safe_path PASSED
+jaraco/compat/py38.py::mypy PASSED
+jaraco/compat/py38.py::jaraco.compat.py38 PASSED
+.::project PASSED
+.::project PASSED
+===================================== mypy =====================================
+
+Success: no issues found in 3 source files
+================================ tests coverage ================================
+_______________ coverage: platform sunos5, python 3.9.21-final-0 _______________
+
+Name                               Stmts   Miss  Cover   Missing
+----------------------------------------------------------------
+docs/conf.py                          14      0   100%
+jaraco/compat/py38.py                  8      0   100%
+jaraco/compat/py310/safe_path.py       8      0   100%
+----------------------------------------------------------------
+TOTAL                                 30      0   100%
+======== 8 passed ========
+  py$(PYV): OK
+  congratulations :)


### PR DESCRIPTION
This is runtime dependency for `coherent.deps` which in turn is new runtime dependency for `pip-run` (version 16.0.0).