### PR TITLE
Add toml_fmt_common Python project

### DIFF
--- a/components/python/toml-fmt-common/.gitignore
+++ b/components/python/toml-fmt-common/.gitignore
@@ -1,0 +1,1 @@
+/toml_fmt_common-1.0.1/

--- a/components/python/toml-fmt-common/Makefile
+++ b/components/python/toml-fmt-common/Makefile
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/python-integrate-project -d python/toml-fmt-common toml_fmt_common
+#
+
+BUILD_STYLE = pyproject
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		toml_fmt_common
+HUMAN_VERSION =			1.0.1
+COMPONENT_SUMMARY =		Common logic to the TOML formatter.
+COMPONENT_PROJECT_URL =		https://github.com/tox-dev/toml-fmt-common
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:7a29e99e527ffac456043296a0f1d8c03aaa1b06167bd39ad5e3cc5041f31c17
+COMPONENT_LICENSE =		MIT
+COMPONENT_LICENSE_FILE =	LICENSE.txt
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+PYTHON_REQUIRED_PACKAGES += library/python/hatch-vcs
+PYTHON_REQUIRED_PACKAGES += library/python/hatchling
+PYTHON_REQUIRED_PACKAGES += library/python/tomli
+PYTHON_REQUIRED_PACKAGES += runtime/python
+TEST_REQUIRED_PACKAGES.python += library/python/covdefaults
+TEST_REQUIRED_PACKAGES.python += library/python/pytest
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-cov
+TEST_REQUIRED_PACKAGES.python += library/python/pytest-mock

--- a/components/python/toml-fmt-common/manifests/sample-manifest.p5m
+++ b/components/python/toml-fmt-common/manifests/sample-manifest.p5m
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common-$(HUMAN_VERSION).dist-info/licenses/LICENSE.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common/py.typed
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/tomli-$(PYV)

--- a/components/python/toml-fmt-common/pkg5
+++ b/components/python/toml-fmt-common/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "library/python/hatch-vcs-39",
+        "library/python/hatchling-39",
+        "library/python/tomli-39",
+        "runtime/python-39"
+    ],
+    "fmris": [
+        "library/python/toml-fmt-common",
+        "library/python/toml-fmt-common-39"
+    ],
+    "name": "toml_fmt_common"
+}

--- a/components/python/toml-fmt-common/test/results-all.master
+++ b/components/python/toml-fmt-common/test/results-all.master
@@ -1,0 +1,43 @@
+$(PYTHON_DIR)/vendor-packages/coherent/licensed/setuptools.py:11: UserWarning: Avoid installing this plugin for projects that don't depend on it.
+  enabled or warnings.warn(
+py$(PYV): remove tox env folder $(@D)/.tox/py$(PYV)
+py$(PYV): commands[0]> pytest --durations 5 --junitxml $(@D)/.tox/junit.py$(PYV).xml --no-cov-on-fail --cov $(PYTHON_DIR)/site-packages/toml_fmt_common --cov $(@D)/tests --cov-config $(@D)/pyproject.toml --cov-context test --cov-report term-missing:skip-covered --cov-report html:$(@D)/.tox/py$(PYV)/tmp/htmlcov --cov-report xml:$(@D)/.tox/coverage.py$(PYV).xml tests
+============================= test session starts ==============================
+platform sunos5 -- Python $(PYTHON_VERSION).X -- $(PYTHON)
+cachedir: .tox/py$(PYV)/.pytest_cache
+rootdir: $(@D)
+configfile: pyproject.toml
+collecting ... collected 13 items
+
+tests/test_app.py::test_dumb_help PASSED
+tests/test_app.py::test_dumb_format_with_override PASSED
+tests/test_app.py::test_dumb_format_with_override_custom_type PASSED
+tests/test_app.py::test_dumb_format_no_print_diff PASSED
+tests/test_app.py::test_dumb_format_already_good PASSED
+tests/test_app.py::test_dumb_format_via_folder PASSED
+tests/test_app.py::test_dumb_format_override_non_dict_result PASSED
+tests/test_app.py::test_dumb_format_override_non_dict_part PASSED
+tests/test_app.py::test_dumb_stdin PASSED
+tests/test_app.py::test_dumb_path_missing PASSED
+tests/test_app.py::test_dumb_path_is_folder PASSED
+tests/test_app.py::test_dumb_path_no_read PASSED
+$(PYTHON_DIR)/vendor-packages/coverage/inorout.py:509: CoverageWarning: Module $(PYTHON_DIR)/site-packages/toml_fmt_common was never imported. (module-not-imported)
+  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
+tests/test_app.py::test_dumb_path_no_write PASSED
+
+- generated xml file: $(@D)/.tox/junit.py$(PYV).xml -
+================================ tests coverage ================================
+_______________ coverage: platform sunos5, python 3.9.21-final-0 _______________
+
+Name    Stmts   Miss Branch BrPart  Cover   Missing
+---------------------------------------------------
+TOTAL     146      0      2      0   100%
+
+1 file skipped due to complete coverage.
+Coverage HTML written to dir $(@D)/.tox/py$(PYV)/tmp/htmlcov
+Coverage XML written to file $(@D)/.tox/coverage.py$(PYV).xml
+Required test coverage of 100.0% reached. Total coverage: 100.00%
+============================= slowest 5 durations ==============================
+======== 13 passed ========
+  py$(PYV): OK
+  congratulations :)

--- a/components/python/toml-fmt-common/toml_fmt_common-PYVER.p5m
+++ b/components/python/toml-fmt-common/toml_fmt_common-PYVER.p5m
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using python-integrate-project
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common-$(HUMAN_VERSION).dist-info/METADATA
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common-$(HUMAN_VERSION).dist-info/WHEEL
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common-$(HUMAN_VERSION).dist-info/licenses/LICENSE.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common/__init__.py
+file path=usr/lib/python$(PYVER)/vendor-packages/toml_fmt_common/py.typed
+
+# python modules are unusable without python runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=python$(PYVER) \
+    pkg.debug.depend.path=usr/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/python/tomli-$(PYV)


### PR DESCRIPTION
This is new runtime dependency for `pyproject_fmt`.