### PR TITLE
python/cryptography: do not warn on certificates with zero serial number

### DIFF
--- a/components/python/cryptography/Makefile
+++ b/components/python/cryptography/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		cryptography
 HUMAN_VERSION =			45.0.2
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		cryptography is a package which provides cryptographic recipes and primitives to Python developers.
 COMPONENT_PROJECT_URL =		https://github.com/pyca/cryptography
 COMPONENT_ARCHIVE_HASH =	\

--- a/components/python/cryptography/patches/01-zero-serial-number.patch
+++ b/components/python/cryptography/patches/01-zero-serial-number.patch
@@ -1,0 +1,33 @@
+This partially reverts https://github.com/pyca/cryptography/pull/12853 because
+the warning on zero serial numbers causes the pkg(1) command to print it
+annoyingly (e.g. pkg update -n).
+
+See also https://github.com/pyca/cryptography/issues/12948
+
+As of 2025-05-22 we do have following certificates with zero serial number:
+
+$ for c in $(ls /etc/certs/CA) ; do openssl x509 -serial -noout < /etc/certs/CA/$c | grep -q '^serial=00$' && echo $c ; done
+Go_Daddy_Class_2_CA.pem
+Go_Daddy_Root_Certificate_Authority_-_G2.pem
+Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.pem
+Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem
+Security_Communication_RootCA2.pem
+Starfield_Class_2_CA.pem
+Starfield_Root_Certificate_Authority_-_G2.pem
+Starfield_Services_Root_Certificate_Authority_-_G2.pem
+$
+
+--- cryptography-45.0.2/src/rust/src/x509/certificate.rs.orig
++++ cryptography-45.0.2/src/rust/src/x509/certificate.rs
+@@ -437,9 +437,9 @@
+ }
+ 
+ fn warn_if_not_positive(py: pyo3::Python<'_>, bytes: &[u8]) -> pyo3::PyResult<()> {
+-    if bytes[0] & 0x80 != 0 || bytes == [0] {
++    if bytes[0] & 0x80 != 0 {
+         let warning_cls = types::DEPRECATED_IN_36.get(py)?;
+-        let message = cstr_from_literal!("Parsed a serial number which wasn't positive (i.e., it was negative or zero), which is disallowed by RFC 5280. Loading this certificate will cause an exception in a future release of cryptography.");
++        let message = cstr_from_literal!("Parsed a negative serial number, which is disallowed by RFC 5280. Loading this certificate will cause an exception in a future release of cryptography.");
+         pyo3::PyErr::warn(py, &warning_cls, message, 1)?;
+     }
+     Ok(())

--- a/components/python/cryptography/python-integrate-project.conf
+++ b/components/python/cryptography/python-integrate-project.conf
@@ -13,6 +13,8 @@
 # Copyright 2023 Marcel Telka
 #
 
+%patch% 01-zero-serial-number.patch
+
 %include-3%
 # https://www.illumos.org/issues/15767
 LD_Z_IGNORE=

--- a/components/python/cryptography/test/results-all.master
+++ b/components/python/cryptography/test/results-all.master
@@ -3548,12 +3548,5 @@ tests/x509/verification/test_verification.py::TestCustomExtensionPolicies::test_
 tests/x509/verification/test_verification.py::TestCustomExtensionPolicies::test_ca_ext_policy_must_require_basic_constraints PASSED
 tests/x509/verification/test_verification.py::TestCustomExtensionPolicies::test_wrong_subject_alt_name PASSED
 
-=============================== warnings summary ===============================
-tests/x509/test_x509.py::TestECDSACertificate::test_load_ecdsa_no_named_curve
-tests/x509/test_x509_ext.py::TestRSASubjectAlternativeNameExtension::test_registered_id
-  $(@D)/tests/x509/test_x509.py:86: CryptographyDeprecationWarning: Parsed a serial number which wasn't positive (i.e., it was negative or zero), which is disallowed by RFC 5280. Loading this certificate will cause an exception in a future release of cryptography.
-    loader=lambda pemfile: loader(pemfile.read()),
-
--- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 =========================== short test summary info ============================
-======== 3368 passed, 171 skipped, 2 warnings ========
+======== 3368 passed, 171 skipped ========


### PR DESCRIPTION
This is to make the `pkg(1)` command to do not warn during regular operation because we still do have few certs with zero serial number.

See also https://github.com/pyca/cryptography/issues/12948