### PR TITLE
python/coherent.licensed: drop the unnecessary warning

### DIFF
--- a/components/python/coherent.licensed/Makefile
+++ b/components/python/coherent.licensed/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		coherent_licensed
 HUMAN_VERSION =			0.4.1
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		License management tooling for Coherent System and skeleton projects
 COMPONENT_ARCHIVE_HASH =	\
 	sha256:8ce06acba9cc78726ab9a46977212b10c982a306083e688d19717383144c04b7

--- a/components/python/coherent.licensed/patches/01-no-avoid-warning.patch
+++ b/components/python/coherent.licensed/patches/01-no-avoid-warning.patch
@@ -1,0 +1,17 @@
+Drop the unnecessary warning.  It causes many tests to fail.  We found no other
+way how to disable it reliably.
+
+See also https://github.com/coherent-oss/coherent.licensed/issues/6
+
+--- coherent_licensed-0.4.1/coherent/licensed/setuptools.py.orig
++++ coherent_licensed-0.4.1/coherent/licensed/setuptools.py
+@@ -8,9 +8,6 @@
+ 
+ 
+ def warn_if_false(enabled):
+-    enabled or warnings.warn(
+-        "Avoid installing this plugin for projects that don't depend on it."
+-    )
+     return enabled
+ 
+ 

--- a/components/python/coherent.licensed/python-integrate-project.conf
+++ b/components/python/coherent.licensed/python-integrate-project.conf
@@ -1,0 +1,16 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Marcel Telka
+#
+
+%patch% 01-no-avoid-warning.patch

--- a/make-rules/setup.py.mk
+++ b/make-rules/setup.py.mk
@@ -500,11 +500,6 @@ PYTEST_ADDOPTS += $(PYTEST_FASTFAIL)
 PYTEST_TRACEBACK = --tb=line
 PYTEST_ADDOPTS += $(PYTEST_TRACEBACK)
 
-# Suppress the unnecessary warning that pollutes the test results and is
-# causing many tests to fail.
-# See also https://github.com/coherent-oss/coherent.licensed/issues/6
-PYTEST_ADDOPTS += -W "ignore:Avoid installing this plugin for projects that don't depend on it.::coherent.licensed.setuptools"
-
 # Normalize pytest test results.  The pytest framework could be used either
 # directly or via tox or setup.py so add these transforms for all test styles
 # unconditionally.


### PR DESCRIPTION
This solves https://github.com/coherent-oss/coherent.licensed/issues/6 for us.