### PR TITLE
lz4: fix pkgconfig file

### DIFF
--- a/components/library/lz4/Makefile
+++ b/components/library/lz4/Makefile
@@ -15,36 +15,54 @@
 #
 
 BUILD_STYLE= justmake
-DROP_STATIC_LIBRARIES= yes
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		lz4
 COMPONENT_VERSION=	1.10.0
+COMPONENT_REVISION=	1
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_SUMMARY=	Extremely Fast Compression algorithm
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= sha256:537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
 COMPONENT_ARCHIVE_URL=	https://github.com/lz4/lz4/archive/v$(COMPONENT_VERSION).tar.gz
-COMPONENT_PROJECT_URL=	https://lz4.github.io/lz4/
+COMPONENT_PROJECT_URL=	https://lz4.org/
 COMPONENT_FMRI=		library/lz4
-COMPONENT_LICENSE=	BSD,GPLv2
+COMPONENT_LICENSE=	BSD-2-Clause AND GPL-2.0-or-later
 COMPONENT_LICENSE_FILE=	lz4.license
 COMPONENT_CLASSIFICATION= System/Libraries
 
 include $(WS_MAKE_RULES)/common.mk
 
+# helper target
+update-license-file: patch
+	( \
+		$(CAT) $(SOURCE_DIR)/LICENSE ; \
+		printf '\n\n--- lib/LICENSE -----------------------------------------------------------\n\n' ; \
+		$(CAT) $(SOURCE_DIR)/lib/LICENSE ; \
+		printf '\n\n--- programs/COPYING ------------------------------------------------------\n\n' ; \
+		$(CAT) $(SOURCE_DIR)/programs/COPYING \
+	) > $(COMPONENT_DIR)/$(COMPONENT_LICENSE_FILE)
+
 PATH= $(PATH.gnu)
 
 # Tests require the full copy of source dir.
-COMPONENT_PRE_CONFIGURE_ACTION= ( CLONEY_MODE=copy $(CLONEY) $(SOURCE_DIR) $(@D) )
+CLONEY_MODE=copy
+
+# Do not build static library
+COMPONENT_COMMON_ARGS += BUILD_STATIC=no
+# PREFIX and libdir are needed for the pkgconfig file generation
+COMPONENT_COMMON_ARGS += PREFIX=$(USRDIR)
+COMPONENT_COMMON_ARGS += libdir=$(USRLIBDIR.$(BITS))
+
+# Common args used for build and install
+COMPONENT_BUILD_ARGS += $(COMPONENT_COMMON_ARGS)
+COMPONENT_INSTALL_ARGS += $(COMPONENT_COMMON_ARGS)
 
 # Verbose compilation output
 COMPONENT_BUILD_ARGS += Q=
 
 COMPONENT_BUILD_ARGS += CFLAGS='$(CFLAGS)'
-
-COMPONENT_INSTALL_ENV += PREFIX=$(USRDIR)
-COMPONENT_INSTALL_ENV += LIBDIR=$(USRLIBDIR64)
 
 # The test results differ for x86 and SPARC
 COMPONENT_TEST_MASTER = $(COMPONENT_TEST_RESULTS_DIR)/results-$(MACH$(BITS)).master

--- a/components/library/lz4/lz4.license
+++ b/components/library/lz4/lz4.license
@@ -12,8 +12,8 @@ are intended to be used "as is", as part of their intended scenarios,
 with no intention to support 3rd party integration use cases.
 
 
-lib/LICENSE File
-------------------
+--- lib/LICENSE -----------------------------------------------------------
+
 LZ4 Library
 Copyright (c) 2011-2020, Yann Collet
 All rights reserved.
@@ -39,10 +39,9 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
--------------------------------------------------------------------------------------------------------------------
 
-programs/COPYING
------------------------
+--- programs/COPYING ------------------------------------------------------
+
 Full name:
 GNU General Public License v2.0 or later
 

--- a/components/library/lz4/lz4.p5m
+++ b/components/library/lz4/lz4.p5m
@@ -28,9 +28,7 @@ link path=usr/bin/lz4c target=lz4
 link path=usr/bin/lz4cat target=lz4
 link path=usr/bin/unlz4 target=lz4
 file path=usr/include/lz4.h
-file path=usr/include/lz4file.h
 file path=usr/include/lz4frame.h
-file path=usr/include/lz4frame_static.h
 file path=usr/include/lz4hc.h
 link path=usr/lib/$(MACH64)/liblz4.so target=liblz4.so.$(HUMAN_VERSION)
 file path=usr/lib/$(MACH64)/liblz4.so.$(HUMAN_VERSION)

--- a/components/library/lz4/manifests/sample-manifest.p5m
+++ b/components/library/lz4/manifests/sample-manifest.p5m
@@ -28,9 +28,7 @@ link path=usr/bin/lz4c target=lz4
 link path=usr/bin/lz4cat target=lz4
 link path=usr/bin/unlz4 target=lz4
 file path=usr/include/lz4.h
-file path=usr/include/lz4file.h
 file path=usr/include/lz4frame.h
-file path=usr/include/lz4frame_static.h
 file path=usr/include/lz4hc.h
 link path=usr/lib/$(MACH64)/liblz4.so target=liblz4.so.$(HUMAN_VERSION)
 file path=usr/lib/$(MACH64)/liblz4.so.$(HUMAN_VERSION)

--- a/components/library/lz4/patches/02_lz4io.c.patch
+++ b/components/library/lz4/patches/02_lz4io.c.patch
@@ -6,8 +6,8 @@ a pipe.
 
 This is Solaris specific patch but can be offered also upstream. 
 
---- lz4-1.10.0/programs/lz4io.c.orig	2024-09-20 17:10:38.794388179 +0200
-+++ lz4-1.10.0/programs/lz4io.c	2024-09-20 17:20:06.362595010 +0200
+--- lz4-1.10.0/programs/lz4io.c.orig
++++ lz4-1.10.0/programs/lz4io.c
 @@ -2320,14 +2320,21 @@
  {
      const unsigned stepMax = 1U << 30;

--- a/components/library/lz4/patches/test.patch
+++ b/components/library/lz4/patches/test.patch
@@ -3,9 +3,9 @@ get reproducible test results.
 
 Solaris UL specific. Not suitable for upstream.
 
---- lz4-1.10.0/examples/Makefile
+--- lz4-1.10.0/examples/Makefile.orig
 +++ lz4-1.10.0/examples/Makefile
-@@ -86,8 +86,6 @@ $(LZ4) -vt $(TESTFILE).lz4
+@@ -86,8 +86,6 @@
  	@echo "\n=== file compression ==="
  	./fileCompress$(EXT) $(TESTFILE)
  	$(LZ4) -vt $(TESTFILE).lz4
@@ -14,9 +14,9 @@ Solaris UL specific. Not suitable for upstream.
  
  .PHONY: clean
  clean:
---- lz4-1.10.0/tests/Makefile
+--- lz4-1.10.0/tests/Makefile.orig
 +++ lz4-1.10.0/tests/Makefile
-@@ -314,7 +314,6 @@ $(QEMU_SYS) $(DATAGEN) -g3GB   | $(QEMU_
+@@ -314,7 +314,6 @@
  endif
  
  test-fullbench: fullbench
@@ -24,9 +24,9 @@ Solaris UL specific. Not suitable for upstream.
  
  test-fullbench32: CFLAGS += -m32
  test-fullbench32: test-fullbench
---- lz4-1.10.0/tests/fuzzer.c
+--- lz4-1.10.0/tests/fuzzer.c.orig
 +++ lz4-1.10.0/tests/fuzzer.c
-@@ -1053,11 +1053,12 @@ }
+@@ -1053,11 +1053,12 @@
  
      if (nbCycles<=1) nbCycles = cycleNb;   /* end by time */
      bytes += !bytes;   /* avoid division by 0 */
@@ -40,9 +40,9 @@ Solaris UL specific. Not suitable for upstream.
  
      /* release memory */
      free(CNBuffer);
---- lz4-1.10.0/tests/test-lz4-basic.sh
+--- lz4-1.10.0/tests/test-lz4-basic.sh.orig
 +++ lz4-1.10.0/tests/test-lz4-basic.sh
-@@ -62,7 +62,8 @@ lz4 -f $FPREFIX-hw                    #
+@@ -62,7 +62,8 @@
  lz4 --list $FPREFIX-hw.lz4            # test --list on valid single-frame file
  lz4 --list < $FPREFIX-hw.lz4          # test --list from stdin (file only)
  cat $FPREFIX-hw >> $FPREFIX-hw.lz4
@@ -52,9 +52,9 @@ Solaris UL specific. Not suitable for upstream.
  lz4 -BX $FPREFIX-hw -c -q | lz4 -tv   # test block checksum
  # datagen -g20KB generates the same file every single time
  # cannot save output of datagen -g20KB as input file to lz4 because the following shell commands are run before datagen -g20KB
---- lz4-1.10.0/tests/test-lz4-dict.sh
+--- lz4-1.10.0/tests/test-lz4-dict.sh.orig
 +++ lz4-1.10.0/tests/test-lz4-dict.sh
-@@ -37,10 +37,11 @@ lz4 -bi0 -D $FPREFIX $FPREFIX-sample-32k
+@@ -37,10 +37,11 @@
  
  echo "---- test lz4 dictionary loading ----"
  datagen -g128KB > $FPREFIX-data-128KB
@@ -70,9 +70,9 @@ Solaris UL specific. Not suitable for upstream.
 +    < $FPREFIX-${MYPID}l      lz4 -D stdin $FPREFIX-data-128KB -c | lz4 -dD $FPREFIX-${MYPID}l-tail | diff - $FPREFIX-data-128KB; \
 +    < $FPREFIX-${MYPID}l-tail lz4 -D stdin $FPREFIX-data-128KB -c | lz4 -dD $FPREFIX-${MYPID}l      | diff - $FPREFIX-data-128KB; \
  done
---- lz4-1.10.0/tests/test-lz4-fast-hugefile.sh
+--- lz4-1.10.0/tests/test-lz4-fast-hugefile.sh.orig
 +++ lz4-1.10.0/tests/test-lz4-fast-hugefile.sh
-@@ -15,7 +15,7 @@ set -x
+@@ -15,7 +15,7 @@
  datagen -g6GB    | lz4 -vB5 | lz4 -qt
  # test large file size [2-4] GB
  datagen -g3G -P100 | lz4 -vv | lz4 --decompress --force --sparse - ${FPREFIX}1
@@ -82,7 +82,7 @@ Solaris UL specific. Not suitable for upstream.
 -ls -ls ${FPREFIX}2
 +ls -ls ${FPREFIX}2 | awk '{printf "%10.d\t%s\n", $6, $10}'
  diff -s ${FPREFIX}1 ${FPREFIX}2
---- lz4-1.10.0/tests/test-lz4-sparse.sh
+--- lz4-1.10.0/tests/test-lz4-sparse.sh.orig
 +++ lz4-1.10.0/tests/test-lz4-sparse.sh
 @@ -1,4 +1,4 @@
 -#!/bin/sh
@@ -90,7 +90,7 @@ Solaris UL specific. Not suitable for upstream.
  
  FPREFIX="tmp-tls"
  
-@@ -23,10 +23,10 @@ lz4 -B7D ${FPREFIX}dg5M -c | lz4 -dv --s
+@@ -23,10 +23,10 @@
  diff -s ${FPREFIX}dg5M ${FPREFIX}cB7
  lz4 ${FPREFIX}dg5M -c | lz4 -dv --no-sparse > ${FPREFIX}nosparse
  diff -s ${FPREFIX}dg5M ${FPREFIX}nosparse
@@ -103,16 +103,16 @@ Solaris UL specific. Not suitable for upstream.
  rm $FPREFIX*
  printf "\n Compatibility with Console :"
  echo "Hello World 1 !" | lz4 | lz4 -d -c
-@@ -38,5 +38,5 @@ cat ${FPREFIX}dg1M ${FPREFIX}dg1M > ${FP
+@@ -38,5 +38,5 @@
  lz4 -B5 -v ${FPREFIX}dg1M ${FPREFIX}c
  lz4 -d -v ${FPREFIX}c ${FPREFIX}r
  lz4 -d -v ${FPREFIX}c -c >> ${FPREFIX}r
 -ls -ls $FPREFIX*
 +ls -1s $FPREFIX*
  diff ${FPREFIX}2M ${FPREFIX}r
---- lz4-1.10.0/tests/test_custom_block_sizes.sh
+--- lz4-1.10.0/tests/test_custom_block_sizes.sh.orig
 +++ lz4-1.10.0/tests/test_custom_block_sizes.sh
-@@ -7,9 +7,9 @@ DATAGEN=./datagen
+@@ -7,9 +7,9 @@
  
  failures=""
  


### PR DESCRIPTION
This fixes incorrect `prefix` and `libdir` in the `liblz4.pc` file.  Namely it does this:

```
$ diff /usr/lib/amd64/pkgconfig/liblz4.pc build/prototype/i386/usr/lib/amd64/pkgconfig/liblz4.pc 
5,6c5,6
< prefix=/usr/local
< libdir=${prefix}/lib
---
> prefix=/usr
> libdir=${prefix}/lib/amd64
$
```