### PR TITLE
desktop-cache: fix gio-module-cache.sh script again.

### DIFF
--- a/components/desktop/desktop-cache/Makefile
+++ b/components/desktop/desktop-cache/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= desktop-cache
 COMPONENT_VERSION= 0.2.2
-COMPONENT_REVISION= 19
+COMPONENT_REVISION= 20
 COMPONENT_SUMMARY= desktop-cache is a set of SMF services used to update the various GNOME desktop caches.
 COMPONENT_SRC= desktop-cache-smf-services-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2

--- a/components/desktop/desktop-cache/files/gio-module-cache.sh
+++ b/components/desktop/desktop-cache/files/gio-module-cache.sh
@@ -72,7 +72,7 @@ NEED_COMPILE=0
 # make sure cache file can be written, needed during install.
 RDONLY=`/usr/sbin/mount | grep "/usr" | grep -c "read only"`
 if [ "$RDONLY" -eq "1" ]; then
-	MODULE_DIR="/tmp"
+	MODULE_DIR="/tmp/gio"
 else
 	MODULE_DIR="/usr/lib/64/gio/modules"
 fi


### PR DESCRIPTION
Sorry for bumping this again, this time it is tested out using a new ISO on SPARC and it works.
To be able to test again on x86_64, I need this to be merged, so I can rebuild the ISO on x86_64 to test on that platform again.
Thanks so much in advance.