### PR TITLE
desktop-cache: fix sparcv7 pixbuf-installer

### DIFF
--- a/components/desktop/desktop-cache/Makefile
+++ b/components/desktop/desktop-cache/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= desktop-cache
 COMPONENT_VERSION= 0.2.2
-COMPONENT_REVISION= 21
+COMPONENT_REVISION= 22
 COMPONENT_SUMMARY= desktop-cache is a set of SMF services used to update the various GNOME desktop caches.
 COMPONENT_SRC= desktop-cache-smf-services-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.bz2

--- a/components/desktop/desktop-cache/patches/10-sparcv7.patch
+++ b/components/desktop/desktop-cache/patches/10-sparcv7.patch
@@ -1,0 +1,10 @@
+--- desktop-cache-smf-services-0.2.2/pixbuf-loaders/pixbuf-loaders-installer.orig	2025-06-14 14:21:46.618482739 +0300
++++ desktop-cache-smf-services-0.2.2/pixbuf-loaders/pixbuf-loaders-installer	2025-06-14 14:22:16.967290852 +0300
+@@ -58,6 +58,7 @@
+   BINDIR='/usr/bin'
+   DIR="$ARCH"
+   [ "$ARCH" == "i386" ] && BINDIR='/usr/bin/i86' && DIR=''
++  [ "$ARCH" == "sparc" ] && BINDIR='/usr/bin/sparcv7' && DIR=''
+ 
+   test -x $BINDIR/gdk-pixbuf-query-loaders || {
+       echo "gdk-pixbuf-query-loaders not installed"


### PR DESCRIPTION
Sorry, this one got lost by the cleanup, but it does not influence building i386 install images.