### PR TITLE
Fix typo in tree sitter configure flag and fix indentation in a patch

### DIFF
--- a/components/editor/emacs/Makefile
+++ b/components/editor/emacs/Makefile
@@ -29,7 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         emacs
 COMPONENT_VERSION=      30.1
-COMPONENT_REVISION=		3
+COMPONENT_REVISION=	4
 COMPONENT_PROJECT_URL=  https://www.gnu.org/software/emacs/
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz
@@ -97,7 +97,7 @@ CONFIGURE_OPTIONS +=	--with-sqlite3
 CONFIGURE_OPTIONS +=	--with-tiff
 CONFIGURE_OPTIONS +=	--with-toolkit-scroll-bars
 CONFIGURE_OPTIONS +=	--with-webp
-CONFIGURE_OPTIONS +=	--with-treesitter
+CONFIGURE_OPTIONS +=	--with-tree-sitter
 CONFIGURE_OPTIONS +=	--with-sound=oss
 CONFIGURE_OPTIONS +=	ac_cv_sys_long_file_names=yes
 

--- a/components/editor/emacs/patches/05-exec-path.patch
+++ b/components/editor/emacs/patches/05-exec-path.patch
@@ -10,7 +10,7 @@ with things like GCC being referenced.
                            ((equal dump-mode "pbootstrap") "bootstrap-emacs.pdmp")
 -                          (t (error "Unrecognized dump mode %s" dump-mode)))))
 +                          (t (error "Unrecognized dump mode %s" dump-mode))))
-+                              (exec-path nil))
++            (exec-path nil))
          (when (and (featurep 'native-compile)
                     (equal dump-mode "pdump"))
            ;; Don't enable this before bootstrap is completed, as the


### PR DESCRIPTION
A typo in the flag for tree-sitter was causing it to operate incorrectly, and also fix indentation for a patch (the patch was still correct, but the wrong indentation made it easy to incorrectly read the elisp)