### PR TITLE
Fix how variables are set in site startup file

### DIFF
--- a/components/editor/emacs/Makefile
+++ b/components/editor/emacs/Makefile
@@ -29,7 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         emacs
 COMPONENT_VERSION=      30.1
-COMPONENT_REVISION=	4
+COMPONENT_REVISION=	5
 COMPONENT_PROJECT_URL=  https://www.gnu.org/software/emacs/
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz

--- a/components/editor/emacs/augment/source.el
+++ b/components/editor/emacs/augment/source.el
@@ -1,6 +1,7 @@
 (set-variable 'find-program "/usr/gnu/bin/find")
-(set-variable 'Man-sed-program "/usr/gnu/bin/sed")
-(set-variable 'insert-directory-program "/usr/gnu/bin/ls")
+
+(setopt Man-sed-command "/usr/gnu/bin/sed"
+        insert-directory-program "/usr/gnu/bin/ls")
 
 ;;; Path to Emacs C Sources.
 (when (string-match (regexp-quote "COMPONENT_VERSION") emacs-version)


### PR DESCRIPTION
- `Man-sed-program` should be `Man-sed-command` (unfortunately in my testing of the previous commit, my `.emacs` set `Man-sed-command` so I didn't catch that `site-startup.el` was setting the wrong variable.  I tested this change with `emacs -q`)
- Use `setopt` instead of `set-variable` to take into account that they are variables declared with defcustom - this did not cause any breakage but is considered better style because `setopt` runs setters for custom variables when they are set.