### PR TITLE
squeak: patch for cmake 4.0.3 and disable OpenGL support

### DIFF
--- a/components/runtime/smalltalk/squeak/Makefile
+++ b/components/runtime/smalltalk/squeak/Makefile
@@ -71,7 +71,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.20.10
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -183,13 +183,12 @@ CLEAN_PATHS+= Cross
 CONFIGURE_SCRIPT= $(SOURCE_DIR_2)/cmake/configure
 CONFIGURE_OPTIONS +=	--src=$(SOURCE_DIR_0)
 CONFIGURE_OPTIONS +=    --link-shared-lib
+CONFIGURE_OPTIONS +=    --without-gl
 CONFIGURE_OPTIONS +=    --without-vm-sound-Sun
 CONFIGURE_OPTIONS +=    --without-RePlugin
 CONFIGURE_OPTIONS +=    --without-Mpeg3Plugin
 CONFIGURE_OPTIONS +=    --without-GStreamerPlugin
 CONFIGURE_OPTIONS +=    --without-ScratchPlugin
-# cmake 4.0.2 requires 09-Pluginscmake.patch 10-npsqueak.patch and this -D
-CONFIGURE_OPTIONS +=    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 # in the 64bit case the vm is called squeakvm64 (not squeakvm)
 # the plugin directory under usr/lib/squeak has a _64bit suffix
@@ -223,7 +222,8 @@ rebuild-manifests::
 # disable pkglint until we find solution for 64bit object in 32-bit path error
 PKGLINT= /bin/true
 
-REQUIRED_PACKAGES += x11/library/mesa
+# avoid mesa , use configure --without-gl
+# REQUIRED_PACKAGES += x11/library/mesa
 REQUIRED_PACKAGES += system/library/dbus
 
 # Auto-generated dependencies

--- a/components/runtime/smalltalk/squeak/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/squeak/manifests/sample-manifest.p5m
@@ -27,7 +27,6 @@ file path=usr/bin/squeak
 file path=usr/bin/squeak.sh
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3834_64bit/ckformat
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3834_64bit/so.AioPlugin
-file path=usr/lib/squeak/$(HUMAN_VERSION)-3834_64bit/so.B3DAcceleratorPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3834_64bit/so.CameraPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3834_64bit/so.ClipboardExtendedPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3834_64bit/so.DBusPlugin

--- a/components/runtime/smalltalk/squeak/manifests/squeak-display-X11.p5m
+++ b/components/runtime/smalltalk/squeak/manifests/squeak-display-X11.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2022, 2023 David Stes
+# Copyright 2020, 2021, 2022, 2023, 2025 David Stes
 #
 
 set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,7 +24,8 @@ set name=pkg.human-version value=$(HUMAN_VERSION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+# since 4.20.10 revision 4 configure --without-gl to avoid libGL
+# <transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
 # 32-bit objects in 64-bit multiarch build are rejected by lint
 <transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
 

--- a/components/runtime/smalltalk/squeak/patches/10-npsqueak.patch
+++ b/components/runtime/smalltalk/squeak/patches/10-npsqueak.patch
@@ -1,5 +1,18 @@
---- squeak-platforms-unix-3834/CMakeLists.txt	Mon Jun 16 08:44:36 2025
-+++ p0/squeak-platforms-unix-3834/CMakeLists.txt	Tue Jun 17 11:44:51 2025
+--- squeak-platforms-unix-3834/CMakeLists.txt	ma jun. 16 08:44:36 2025
++++ p0/squeak-platforms-unix-3834/CMakeLists.txt	za jul. 19 18:41:53 2025
+@@ -2,10 +2,10 @@
+ # 
+ # Last edited: 2013-12-06 14:09:50 by piumarta on emilia
+ 
++CMAKE_MINIMUM_REQUIRED (VERSION 4.0.2)
++
+ PROJECT (squeak)
+ 
+-CMAKE_MINIMUM_REQUIRED (VERSION 2.6.2)
+-
+ IF (NOT DEFINED VM_HOST OR NOT DEFINED VM_VERSION)
+   MESSAGE (FATAL_ERROR "
+     You MUST NOT run CMake directly the first time you configure a build.
 @@ -170,8 +170,6 @@
  
  BUILD_PLUGINS ()

--- a/components/runtime/smalltalk/squeak/pkg5
+++ b/components/runtime/smalltalk/squeak/pkg5
@@ -15,8 +15,7 @@
         "system/library/math",
         "x11/library/libx11",
         "x11/library/libxext",
-        "x11/library/libxrender",
-        "x11/library/mesa"
+        "x11/library/libxrender"
     ],
     "fmris": [
         "runtime/smalltalk/squeak",

--- a/components/runtime/smalltalk/squeak/squeak-display-X11.p5m
+++ b/components/runtime/smalltalk/squeak/squeak-display-X11.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2022, 2023 David Stes
+# Copyright 2020, 2021, 2022, 2023, 2025 David Stes
 #
 
 set name=pkg.fmri value=pkg:/runtime/smalltalk/squeak-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -24,7 +24,8 @@ set name=pkg.human-version value=$(HUMAN_VERSION)
 license squeak.license license='MIT'
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+# since 4.20.10 revision 4 configure --without-gl to avoid libGL
+# <transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
 # 32-bit objects in 64-bit multiarch build are rejected by lint
 <transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
 
@@ -35,7 +36,6 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 depend type=require fmri=pkg:/runtime/smalltalk/squeak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
 
-file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.B3DAcceleratorPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.B3DAcceleratorPlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.ClipboardExtendedPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.ClipboardExtendedPlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.HostWindowPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.HostWindowPlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.ImmX11Plugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.ImmX11Plugin


### PR DESCRIPTION

compile with the switch :   --without-gl

should investigate how to reenable OpenGL support in the future (add perhaps in a package or use a mediator)

also update /patch the CMakeLists.txt for cmake 4.0.3

should check upstream whether this change will be integrated in Squeak repository (a while ago, I submitted the cmake patches and I was told that the patch for cmake 4.0.3 was going to be integrated upstream)
