### PR TITLE
ibus : export QT_IM_MODULE in ibus-xinput

### DIFF
--- a/components/inputmethod/ibus/Makefile
+++ b/components/inputmethod/ibus/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         ibus
 COMPONENT_VERSION=      1.5.29
+COMPONENT_REVISION=      1
 COMPONENT_SUMMARY=      iBus - Intelligent Input Bus
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz

--- a/components/inputmethod/ibus/files/ibus-xinput
+++ b/components/inputmethod/ibus/files/ibus-xinput
@@ -43,6 +43,8 @@ esac
 if [ -x /usr/bin/ibus-daemon ]; then
     GTK_IM_MODULE='ibus'
     export GTK_IM_MODULE
+    QT_IM_MODULE='ibus'
+    export QT_IM_MODULE
     XMODIFIERS='@im=ibus'
     export XMODIFIERS
 


### PR DESCRIPTION
It is necessary to input using ibus in Qt program.
Manually disable and enable in imf-selector is required to take effect.