### PR TITLE
history: do not incorporate library/libmediainfo

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -766,7 +766,7 @@ library/libcroco@0.6.13,5.11-2022.1.0.2
 library/libevent@1.4.15-2023.0.0.2
 library/libgee@0.20.1,5.11-2018.0.0.1
 library/libinfinity@0.5.5,5.11-2017.0.0.2
-library/libmediainfo@24.4,5.11-2024.0.0.1
+library/libmediainfo@24.4,5.11-2024.0.0.2 noincorporate
 library/libosip2@3.3.0,5.11-2013.0.0.1
 library/libproxy/libproxy-mozjs@0.3.1,5.11-2014.0.1.1
 library/libunique@1.1.6,5.11-2017.0.0.1


### PR DESCRIPTION
Packages [moved to encumbered](https://github.com/OpenIndiana/oi-userland/pull/19639) should never be incorporated because otherwise the `userland-incorporation` will prevent their installation from the encumbered repo.

See also #14164.