### PR TITLE
make-rules: BOOTSTRAP_SKIP_REQUIRED_PACKAGES support

### DIFF
--- a/make-rules/environment.mk
+++ b/make-rules/environment.mk
@@ -44,14 +44,16 @@ component-environment-check::
 	@/usr/sbin/psrinfo -vp
 	@/usr/sbin/ipadm show-addr
 	$(call separator-line,Required Packages)
-	@/usr/bin/pkg list -vH $(USERLAND_REQUIRED_PACKAGES:%=/%) $(REQUIRED_PACKAGES:%=/%)
+	@/usr/bin/pkg list -vH $(USERLAND_REQUIRED_PACKAGES:%=/%) \
+		$(filter-out $(if $(strip $(BOOTSTRAP)),$(BOOTSTRAP_SKIP_REQUIRED_PACKAGES:%=/%),),$(REQUIRED_PACKAGES:%=/%))
 	$(call separator-line)
 
 component-environment-prep::
 	@/usr/bin/pkg list -vH $(USERLAND_REQUIRED_PACKAGES:%=/%) $(REQUIRED_PACKAGES:%=/%) >/dev/null || \
 		{ echo "Adding required packages to build environment..."; \
 		while true ; do \
-		  $(PFEXEC) /usr/bin/pkg install --accept -v $(USERLAND_REQUIRED_PACKAGES:%=/%) $(REQUIRED_PACKAGES:%=/%) ; \
+		  $(PFEXEC) /usr/bin/pkg install --accept -v $(USERLAND_REQUIRED_PACKAGES:%=/%) \
+			$(filter-out $(if $(strip $(BOOTSTRAP)),$(BOOTSTRAP_SKIP_REQUIRED_PACKAGES:%=/%),),$(REQUIRED_PACKAGES:%=/%)) ; \
 		  RETVAL=$$? ; \
 		  [ $$RETVAL -eq 0 ] && break; \
 		  [ $$RETVAL -eq 4 ] && break; \

--- a/make-rules/shared-macros.mk
+++ b/make-rules/shared-macros.mk
@@ -1569,11 +1569,13 @@ REQUIRED_PACKAGES_SUBST+= GOBJC_RUNTIME_PKG
 # Generate requirements on all built python version variants for given packages
 USERLAND_REQUIRED_PACKAGES += $(foreach ver,$(PYTHON_VERSIONS),$(USERLAND_REQUIRED_PACKAGES.python:%=%-$(subst .,,$(ver))))
 REQUIRED_PACKAGES += $(foreach ver,$(PYTHON_VERSIONS),$(PYTHON_REQUIRED_PACKAGES:%=%-$(subst .,,$(ver))))
+BOOTSTRAP_SKIP_REQUIRED_PACKAGES += $(foreach ver,$(PYTHON_VERSIONS),$(BOOTSTRAP_SKIP_REQUIRED_PACKAGES.python:%=%-$(subst .,,$(ver))))
 TEST_REQUIRED_PACKAGES += $(foreach ver,$(PYTHON_VERSIONS),$(TEST_REQUIRED_PACKAGES.python:%=%-$(subst .,,$(ver))))
 
 # Generate requirements on all built perl version variants for given packages
 USERLAND_REQUIRED_PACKAGES += $(foreach ver,$(PERL_VERSIONS),$(USERLAND_REQUIRED_PACKAGES.perl:%=%-$(subst .,,$(ver))))
 REQUIRED_PACKAGES += $(foreach ver,$(PERL_VERSIONS),$(PERL_REQUIRED_PACKAGES:%=%-$(subst .,,$(ver))))
+BOOTSTRAP_SKIP_REQUIRED_PACKAGES += $(foreach ver,$(PERL_VERSIONS),$(BOOTSTRAP_SKIP_REQUIRED_PACKAGES.perl:%=%-$(subst .,,$(ver))))
 TEST_REQUIRED_PACKAGES += $(foreach ver,$(PERL_VERSIONS),$(TEST_REQUIRED_PACKAGES.perl:%=%-$(subst .,,$(ver))))
 
 # Generate conflicting packages for all built python version variants for given package


### PR DESCRIPTION
This will make the bootstrapping of new Perl versions a bit easier and faster for cases with circular runtime dependencies.  The support is generic (including special handling for Python), but there are currently no known other possible consumers except few Perl distributions.

To fully utilise this we will need to update `perl-integrate-module` to use this feature.  This will be done later.