### PR TITLE
python/sphinx: switch to roman-numerals

### DIFF
--- a/components/python/sphinx/Makefile
+++ b/components/python/sphinx/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME =		sphinx
 HUMAN_VERSION =			7.4.7
+COMPONENT_REVISION =		1
 COMPONENT_SUMMARY =		Python documentation generator
 COMPONENT_PROJECT_URL =		https://www.sphinx-doc.org/
 COMPONENT_ARCHIVE_HASH =	\
@@ -43,6 +44,7 @@ PYTHON_REQUIRED_PACKAGES += library/python/jinja2
 PYTHON_REQUIRED_PACKAGES += library/python/packaging
 PYTHON_REQUIRED_PACKAGES += library/python/pygments
 PYTHON_REQUIRED_PACKAGES += library/python/requests
+PYTHON_REQUIRED_PACKAGES += library/python/roman-numerals
 PYTHON_REQUIRED_PACKAGES += library/python/snowballstemmer
 PYTHON_REQUIRED_PACKAGES += library/python/sphinxcontrib-applehelp
 PYTHON_REQUIRED_PACKAGES += library/python/sphinxcontrib-devhelp

--- a/components/python/sphinx/manifests/sample-manifest.p5m
+++ b/components/python/sphinx/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PYV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -27,10 +27,10 @@ file path=usr/bin/sphinx-apidoc-$(PYVER)
 file path=usr/bin/sphinx-autogen-$(PYVER)
 file path=usr/bin/sphinx-build-$(PYVER)
 file path=usr/bin/sphinx-quickstart-$(PYVER)
-file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/LICENSE.rst
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/METADATA
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/WHEEL
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/entry_points.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/licenses/LICENSE.rst
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx/__main__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx/_cli/__init__.py
@@ -632,6 +632,7 @@ depend type=require fmri=pkg:/library/python/jinja2-$(PYV)
 depend type=require fmri=pkg:/library/python/packaging-$(PYV)
 depend type=require fmri=pkg:/library/python/pygments-$(PYV)
 depend type=require fmri=pkg:/library/python/requests-$(PYV)
+depend type=require fmri=pkg:/library/python/roman-numerals-$(PYV)
 depend type=require fmri=pkg:/library/python/snowballstemmer-$(PYV)
 depend type=require fmri=pkg:/library/python/sphinxcontrib-applehelp-$(PYV)
 depend type=require fmri=pkg:/library/python/sphinxcontrib-devhelp-$(PYV)

--- a/components/python/sphinx/patches/01-roman-numerals-py.patch
+++ b/components/python/sphinx/patches/01-roman-numerals-py.patch
@@ -1,0 +1,47 @@
+https://github.com/sphinx-doc/sphinx/pull/13131
+
+--- sphinx-7.4.7/pyproject.toml.orig
++++ sphinx-7.4.7/pyproject.toml
+@@ -70,6 +70,7 @@
+     "alabaster~=0.7.14",
+     "imagesize>=1.3",
+     "requests>=2.30.0",
++    "roman-numerals-py>=1.0.0",
+     "packaging>=23.0",
+     "importlib-metadata>=6.0; python_version < '3.10'",
+     "tomli>=2; python_version < '3.11'",
+--- sphinx-7.4.7/sphinx/writers/latex.py.orig
++++ sphinx-7.4.7/sphinx/writers/latex.py
+@@ -13,6 +13,7 @@
+ from typing import TYPE_CHECKING, Any, cast
+ 
+ from docutils import nodes, writers
++from roman_numerals import RomanNumeral
+ 
+ from sphinx import addnodes, highlighting
+ from sphinx.domains.std import StandardDomain
+@@ -25,12 +26,6 @@
+ from sphinx.util.template import LaTeXRenderer
+ from sphinx.util.texescape import tex_replace_map
+ 
+-try:
+-    from docutils.utils.roman import toRoman
+-except ImportError:
+-    # In Debian/Ubuntu, roman package is provided as roman, not as docutils.utils.roman
+-    from roman import toRoman  # type: ignore[no-redef, import-not-found]
+-
+ if TYPE_CHECKING:
+     from docutils.nodes import Element, Node, Text
+ 
+@@ -1276,8 +1271,9 @@
+             else:
+                 return get_nested_level(node.parent)
+ 
+-        enum = "enum%s" % toRoman(get_nested_level(node)).lower()
+-        enumnext = "enum%s" % toRoman(get_nested_level(node) + 1).lower()
++        nested_level = get_nested_level(node)
++        enum = f'enum{RomanNumeral(nested_level).to_lowercase()}'
++        enumnext = f'enum{RomanNumeral(nested_level + 1).to_lowercase()}'
+         style = ENUMERATE_LIST_STYLE.get(get_enumtype(node))
+         prefix = node.get('prefix', '')
+         suffix = node.get('suffix', '.')

--- a/components/python/sphinx/patches/04-roman-numerals.patch
+++ b/components/python/sphinx/patches/04-roman-numerals.patch
@@ -1,0 +1,13 @@
+https://github.com/sphinx-doc/sphinx/issues/13825
+
+--- sphinx-7.4.7/pyproject.toml.orig
++++ sphinx-7.4.7/pyproject.toml
+@@ -70,7 +70,7 @@
+     "alabaster~=0.7.14",
+     "imagesize>=1.3",
+     "requests>=2.30.0",
+-    "roman-numerals-py>=1.0.0",
++    "roman-numerals>=1.0.0",
+     "packaging>=23.0",
+     "importlib-metadata>=6.0; python_version < '3.10'",
+     "tomli>=2; python_version < '3.11'",

--- a/components/python/sphinx/patches/05-alabaster.patch
+++ b/components/python/sphinx/patches/05-alabaster.patch
@@ -1,0 +1,39 @@
+https://github.com/sphinx-doc/sphinx/commit/5f110f0fa05ce7db3de9773e7c2423a73bf12633
+
+--- sphinx-7.4.7/tests/test_builders/test_build_html.py.orig
++++ sphinx-7.4.7/tests/test_builders/test_build_html.py
+@@ -240,7 +240,18 @@
+             not in result)
+ 
+ 
+-@pytest.mark.sphinx('html', testroot='basic')
++@pytest.mark.sphinx(
++    'html',
++    testroot='basic',
++    # alabaster changed default sidebars in 1.0.0
++    confoverrides={'html_sidebars': {'**': [
++        'about.html',
++        'navigation.html',
++        'relations.html',
++        'searchbox.html',
++        'donate.html',
++    ]}},
++)
+ def test_html_sidebar(app, status, warning):
+     ctx = {}
+ 
+--- sphinx-7.4.7/tests/test_intl/test_intl.py.orig
++++ sphinx-7.4.7/tests/test_intl/test_intl.py
+@@ -1684,7 +1684,11 @@
+     assert 'FEATURES' not in content
+ 
+ 
+-@pytest.mark.sphinx('html', testroot='basic', confoverrides={'language': 'de'})
++@pytest.mark.sphinx(
++    'html',
++    testroot='basic',
++    confoverrides={'language': 'de', 'html_sidebars': {'**': ['searchbox.html']}},
++)
+ def test_customize_system_message(make_app, app_params):
+     try:
+         # clear translators cache

--- a/components/python/sphinx/patches/06-pygments-2.17.patch
+++ b/components/python/sphinx/patches/06-pygments-2.17.patch
@@ -1,0 +1,44 @@
+https://github.com/sphinx-doc/sphinx/commit/865b513cf2c88d3e30450718914aa896d90fd14e
+
+--- sphinx-7.4.7/sphinx/highlighting.py.orig
++++ sphinx-7.4.7/sphinx/highlighting.py
+@@ -6,6 +6,7 @@
+ from importlib import import_module
+ from typing import TYPE_CHECKING, Any
+ 
++import pygments
+ from pygments import highlight
+ from pygments.filters import ErrorToken
+ from pygments.formatters import HtmlFormatter, LatexFormatter
+@@ -30,6 +31,11 @@
+     from pygments.lexer import Lexer
+     from pygments.style import Style
+ 
++if tuple(map(int, pygments.__version__.split('.')))[:2] < (2, 18):
++    from pygments.formatter import Formatter
++
++    Formatter.__class_getitem__ = lambda cls, name: cls
++
+ logger = logging.getLogger(__name__)
+ 
+ lexers: dict[str, Lexer] = {}
+--- sphinx-7.4.7/tests/test_highlighting.py.orig
++++ sphinx-7.4.7/tests/test_highlighting.py
+@@ -2,12 +2,17 @@
+ 
+ from unittest import mock
+ 
++import pygments
+ from pygments.formatters.html import HtmlFormatter
+ from pygments.lexer import RegexLexer
+ from pygments.token import Name, Text
+ 
+ from sphinx.highlighting import PygmentsBridge
+ 
++if tuple(map(int, pygments.__version__.split('.')))[:2] < (2, 18):
++    from pygments.formatter import Formatter
++    Formatter.__class_getitem__ = lambda cls, name: cls
++
+ 
+ class MyLexer(RegexLexer):
+     name = 'testlexer'

--- a/components/python/sphinx/patches/07-pygments-2.19.patch
+++ b/components/python/sphinx/patches/07-pygments-2.19.patch
@@ -1,0 +1,196 @@
+https://github.com/sphinx-doc/sphinx/commit/5ff3740063c1ac57f17ecd697bcd06cc1de4e75c
+
+--- sphinx-7.4.7/tests/test_builders/test_build_html_code.py.orig
++++ sphinx-7.4.7/tests/test_builders/test_build_html_code.py
+@@ -1,3 +1,4 @@
++import pygments
+ import pytest
+ 
+ 
+@@ -24,11 +25,16 @@
+ 
+ @pytest.mark.sphinx('html', testroot='reST-code-role')
+ def test_html_code_role(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build()
+     content = (app.outdir / 'index.html').read_text(encoding='utf8')
+ 
+     common_content = (
+-        '<span class="k">def</span> <span class="nf">foo</span>'
++        f'<span class="k">def</span>{sp}<span class="nf">foo</span>'
+         '<span class="p">(</span>'
+         '<span class="mi">1</span> '
+         '<span class="o">+</span> '
+--- sphinx-7.4.7/tests/test_builders/test_build_latex.py.orig
++++ sphinx-7.4.7/tests/test_builders/test_build_latex.py
+@@ -8,6 +8,7 @@
+ from shutil import copyfile
+ from subprocess import CalledProcessError
+ 
++import pygments
+ import pytest
+ 
+ from sphinx.builders.latex import default_latex_documents
+@@ -1677,12 +1678,16 @@
+ 
+ @pytest.mark.sphinx('latex', testroot='reST-code-role')
+ def test_latex_code_role(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = r'\PYG{+w}{ }'
++    else:
++        sp = ' '
++
+     app.build()
+     content = (app.outdir / 'projectnamenotset.tex').read_text(encoding='utf8')
+ 
+     common_content = (
+-        r'\PYG{k}{def} '
+-        r'\PYG{n+nf}{foo}'
++        r'\PYG{k}{def}' + sp + r'\PYG{n+nf}{foo}'
+         r'\PYG{p}{(}'
+         r'\PYG{l+m+mi}{1} '
+         r'\PYG{o}{+} '
+--- sphinx-7.4.7/tests/test_directives/test_directive_code.py.orig
++++ sphinx-7.4.7/tests/test_directives/test_directive_code.py
+@@ -2,6 +2,7 @@
+ 
+ import os.path
+ 
++import pygments
+ import pytest
+ from docutils import nodes
+ 
+@@ -405,6 +406,11 @@
+ 
+ @pytest.mark.sphinx('html', testroot='directive-code')
+ def test_literal_include_linenos(app, status, warning):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build(filenames=[app.srcdir / 'linenos.rst'])
+     html = (app.outdir / 'linenos.html').read_text(encoding='utf8')
+ 
+@@ -417,7 +423,7 @@
+             '# Literally included file using Python highlighting</span>' in html)
+ 
+     # :lines: 5-9
+-    assert ('<span class="linenos">5</span><span class="k">class</span> '
++    assert (f'<span class="linenos">5</span><span class="k">class</span>{sp}'
+             '<span class="nc">Foo</span><span class="p">:</span>' in html)
+ 
+ 
+@@ -549,11 +555,16 @@
+ 
+ @pytest.mark.sphinx('html', testroot='directive-code')
+ def test_linenothreshold(app, status, warning):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build(filenames=[app.srcdir / 'linenothreshold.rst'])
+     html = (app.outdir / 'linenothreshold.html').read_text(encoding='utf8')
+ 
+     # code-block using linenothreshold
+-    assert ('<span class="linenos">1</span><span class="k">class</span> '
++    assert (f'<span class="linenos">1</span><span class="k">class</span>{sp}'
+             '<span class="nc">Foo</span><span class="p">:</span>' in html)
+ 
+     # code-block not using linenothreshold (no line numbers)
+--- sphinx-7.4.7/tests/test_extensions/test_ext_viewcode.py.orig
++++ sphinx-7.4.7/tests/test_extensions/test_ext_viewcode.py
+@@ -3,10 +3,16 @@
+ import re
+ import shutil
+ 
++import pygments
+ import pytest
+ 
+ 
+ def check_viewcode_output(app, warning):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span> </span>'
++    else:
++        sp = ' '
++
+     warnings = re.sub(r'\\+', '/', warning.getvalue())
+     assert re.findall(
+         r"index.rst:\d+: WARNING: Object named 'func1' not found in include " +
+@@ -32,7 +38,7 @@
+     assert ('<div class="viewcode-block" id="Class1">\n'
+             '<a class="viewcode-back" href="../../index.html#spam.Class1">[docs]</a>\n') in result
+     assert '<span>@decorator</span>\n' in result
+-    assert '<span>class</span> <span>Class1</span><span>:</span>\n' in result
++    assert f'<span>class</span>{sp}<span>Class1</span><span>:</span>\n' in result
+     assert '<span>    </span><span>&quot;&quot;&quot;</span>\n' in result
+     assert '<span>    this is Class1</span>\n' in result
+     assert '<span>    &quot;&quot;&quot;</span>\n' in result
+--- sphinx-7.4.7/tests/test_highlighting.py.orig
++++ sphinx-7.4.7/tests/test_highlighting.py
+@@ -9,7 +9,7 @@
+ 
+ from sphinx.highlighting import PygmentsBridge
+ 
+-if tuple(map(int, pygments.__version__.split('.')))[:2] < (2, 18):
++if tuple(map(int, pygments.__version__.split('.')[:2])) < (2, 18):
+     from pygments.formatter import Formatter
+     Formatter.__class_getitem__ = lambda cls, name: cls
+ 
+--- sphinx-7.4.7/tests/test_intl/test_intl.py.orig
++++ sphinx-7.4.7/tests/test_intl/test_intl.py
+@@ -9,6 +9,7 @@
+ import shutil
+ import time
+ 
++import pygments
+ import pytest
+ from babel.messages import mofile, pofile
+ from babel.messages.catalog import Catalog
+@@ -1337,6 +1338,11 @@
+ @pytest.mark.sphinx('html')
+ @pytest.mark.test_params(shared_result='test_intl_basic')
+ def test_additional_targets_should_not_be_translated(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build()
+     # [literalblock.txt]
+     result = (app.outdir / 'literalblock.html').read_text(encoding='utf8')
+@@ -1371,7 +1377,7 @@
+     # doctest block should not be translated but be highlighted
+     expected_expr = (
+         """<span class="gp">&gt;&gt;&gt; </span>"""
+-        """<span class="kn">import</span> <span class="nn">sys</span>  """
++        f"""<span class="kn">import</span>{sp}<span class="nn">sys</span>  """
+         """<span class="c1"># sys importing</span>""")
+     assert_count(expected_expr, result, 1)
+ 
+@@ -1413,6 +1419,11 @@
+     },
+ )
+ def test_additional_targets_should_be_translated(app):
++    if tuple(map(int, pygments.__version__.split('.')[:2])) >= (2, 19):
++        sp = '<span class="w"> </span>'
++    else:
++        sp = ' '
++
+     app.build()
+     # [literalblock.txt]
+     result = (app.outdir / 'literalblock.html').read_text(encoding='utf8')
+@@ -1456,7 +1467,7 @@
+     # doctest block should not be translated but be highlighted
+     expected_expr = (
+         """<span class="gp">&gt;&gt;&gt; </span>"""
+-        """<span class="kn">import</span> <span class="nn">sys</span>  """
++        f"""<span class="kn">import</span>{sp}<span class="nn">sys</span>  """
+         """<span class="c1"># SYS IMPORTING</span>""")
+     assert_count(expected_expr, result, 1)
+ 

--- a/components/python/sphinx/patches/08-docutils.patch
+++ b/components/python/sphinx/patches/08-docutils.patch
@@ -1,0 +1,46 @@
+https://github.com/sphinx-doc/sphinx/commit/71b1a06024268e39f59e3772e2420555cb9bf174
+
+--- sphinx-7.4.7/tests/test_builders/test_build_html_image.py.orig
++++ sphinx-7.4.7/tests/test_builders/test_build_html_image.py
+@@ -52,17 +52,32 @@
+     assert re.search('\n<img alt="_images/img.png" src="_images/img.png" />', context)
+ 
+     # scaled_image_link
+-    # Docutils 0.21 adds a newline before the closing </a> tag
+-    closing_space = "\n" if docutils.__version_info__[:2] >= (0, 21) else ""
+-    assert re.search('\n<a class="reference internal image-reference" href="_images/img.png">'
+-                     '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />'
+-                     f'{closing_space}</a>',
+-                     context)
++    if docutils.__version_info__[:2] >= (0, 22):
++        assert re.search(
++            '\n<a class="reference internal image-reference" href="_images/img.png">'
++            '<img alt="_images/img.png" height="[^"]+" src="_images/img.png" width="[^"]+" />'
++            '\n</a>',
++            context,
++        )
++    else:
++        # Docutils 0.21 adds a newline before the closing </a> tag
++        closing_space = "\n" if docutils.__version_info__[:2] >= (0, 21) else ""
++        assert re.search('\n<a class="reference internal image-reference" href="_images/img.png">'
++                         '<img alt="_images/img.png" src="_images/img.png" style="[^"]+" />'
++                         f'{closing_space}</a>',
++                         context)
+ 
+     # no-scaled-link class disables the feature
+-    assert re.search('\n<img alt="_images/img.png" class="no-scaled-link"'
+-                     ' src="_images/img.png" style="[^"]+" />',
+-                     context)
++    if docutils.__version_info__[:2] >= (0, 22):
++        assert re.search(
++            '\n<img alt="_images/img.png" class="no-scaled-link"'
++            ' height="[^"]+" src="_images/img.png" width="[^"]+" />',
++            context,
++        )
++    else:
++        assert re.search('\n<img alt="_images/img.png" class="no-scaled-link"'
++                         ' src="_images/img.png" style="[^"]+" />',
++                         context)
+ 
+ 
+ @pytest.mark.sphinx('html', testroot='images')

--- a/components/python/sphinx/patches/09-docutils-latex.patch
+++ b/components/python/sphinx/patches/09-docutils-latex.patch
@@ -1,0 +1,38 @@
+https://github.com/sphinx-doc/sphinx/commit/68d56109ff50dd81dd31d4a01e3dccbd006c50ee
+
+--- sphinx-7.4.7/tests/test_builders/test_build_latex.py.orig
++++ sphinx-7.4.7/tests/test_builders/test_build_latex.py
+@@ -8,6 +8,7 @@
+ from shutil import copyfile
+ from subprocess import CalledProcessError
+ 
++import docutils
+ import pygments
+ import pytest
+ 
+@@ -1545,9 +1546,15 @@
+ 
+     result = (app.outdir / 'projectnamenotset.tex').read_text(encoding='utf8')
+ 
++    # ref: docutils r10151
++    if docutils.__version_info__[:2] < (0, 22):
++        figure_id, table_id = 'id1', 'id2'
++    else:
++        figure_id, table_id = 'id2', 'id3'
++
+     # figures
+     assert (r'\caption{labeled figure}'
+-            r'\label{\detokenize{index:id1}}'
++            r'\label{\detokenize{index:' + figure_id + '}}'
+             r'\label{\detokenize{index:figure2}}'
+             r'\label{\detokenize{index:figure1}}'
+             r'\end{figure}' in result)
+@@ -1566,7 +1573,7 @@
+ 
+     # tables
+     assert (r'\sphinxcaption{table caption}'
+-            r'\label{\detokenize{index:id2}}'
++            r'\label{\detokenize{index:' + table_id + '}}'
+             r'\label{\detokenize{index:table2}}'
+             r'\label{\detokenize{index:table1}}' in result)
+     assert (r'\sphinxcaption{table caption}'

--- a/components/python/sphinx/patches/10-docutils-manpage.patch
+++ b/components/python/sphinx/patches/10-docutils-manpage.patch
@@ -1,0 +1,22 @@
+https://github.com/sphinx-doc/sphinx/commit/586c0cd178f1d36692717dff0707078bb8f899ae
+
+--- sphinx-7.4.7/tests/test_builders/test_build_manpage.py.orig
++++ sphinx-7.4.7/tests/test_builders/test_build_manpage.py
+@@ -7,8 +7,6 @@
+ from sphinx.config import Config
+ 
+ 
+-@pytest.mark.xfail(docutils.__version_info__[:2] > (0, 21),
+-                   reason='Docutils has removed the reference key in master')
+ @pytest.mark.sphinx('man')
+ def test_all(app, status, warning):
+     app.build(force_all=True)
+@@ -49,8 +47,6 @@
+     assert (app.outdir / 'man1' / 'projectnamenotset.1').exists()
+ 
+ 
+-@pytest.mark.xfail(docutils.__version_info__[:2] > (0, 21),
+-                   reason='Docutils has removed the reference key in master')
+ @pytest.mark.sphinx('man', testroot='directive-code')
+ def test_captioned_code_block(app, status, warning):
+     app.build(force_all=True)

--- a/components/python/sphinx/pkg5
+++ b/components/python/sphinx/pkg5
@@ -10,6 +10,7 @@
         "library/python/packaging-39",
         "library/python/pygments-39",
         "library/python/requests-39",
+        "library/python/roman-numerals-39",
         "library/python/snowballstemmer-39",
         "library/python/sphinxcontrib-applehelp-39",
         "library/python/sphinxcontrib-devhelp-39",

--- a/components/python/sphinx/python-integrate-project.conf
+++ b/components/python/sphinx/python-integrate-project.conf
@@ -13,8 +13,16 @@
 # Copyright 2023 Marcel Telka
 #
 
+%patch% 01-roman-numerals-py.patch
 %patch% 02-pytest-no-color.patch
 %patch% 03-test-gmsgfmt.patch
+%patch% 04-roman-numerals.patch
+%patch% 05-alabaster.patch
+%patch% 06-pygments-2.17.patch
+%patch% 07-pygments-2.19.patch
+%patch% 08-docutils.patch
+%patch% 09-docutils-latex.patch
+%patch% 10-docutils-manpage.patch
 
 %hook-no-license%
 # see LICENSE file

--- a/components/python/sphinx/sphinx-PYVER.p5m
+++ b/components/python/sphinx/sphinx-PYVER.p5m
@@ -27,10 +27,10 @@ file path=usr/bin/sphinx-apidoc-$(PYVER)
 file path=usr/bin/sphinx-autogen-$(PYVER)
 file path=usr/bin/sphinx-build-$(PYVER)
 file path=usr/bin/sphinx-quickstart-$(PYVER)
-file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/LICENSE.rst
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/METADATA
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/WHEEL
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/entry_points.txt
+file path=usr/lib/python$(PYVER)/vendor-packages/sphinx-$(HUMAN_VERSION).dist-info/licenses/LICENSE.rst
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx/__init__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx/__main__.py
 file path=usr/lib/python$(PYVER)/vendor-packages/sphinx/_cli/__init__.py
@@ -632,6 +632,7 @@ depend type=require fmri=pkg:/library/python/jinja2-$(PYV)
 depend type=require fmri=pkg:/library/python/packaging-$(PYV)
 depend type=require fmri=pkg:/library/python/pygments-$(PYV)
 depend type=require fmri=pkg:/library/python/requests-$(PYV)
+depend type=require fmri=pkg:/library/python/roman-numerals-$(PYV)
 depend type=require fmri=pkg:/library/python/snowballstemmer-$(PYV)
 depend type=require fmri=pkg:/library/python/sphinxcontrib-applehelp-$(PYV)
 depend type=require fmri=pkg:/library/python/sphinxcontrib-devhelp-$(PYV)

--- a/components/python/sphinx/test/results-all.master
+++ b/components/python/sphinx/test/results-all.master
@@ -3,7 +3,7 @@ py$(PYV): commands[0]> python -X dev -X warn_default_encoding -m pytest --durati
 ============================= test session starts ==============================
 platform sunos5 -- Python $(PYTHON_VERSION).X -- $(@D)/.tox/py$(PYV)/bin/python
 cachedir: .tox/py$(PYV)/.pytest_cache
-libraries: Sphinx-7.4.7, docutils-0.21.2
+libraries: Sphinx-7.4.7, docutils-0.22
 rootdir: $(@D)
 configfile: pyproject.toml
 testpaths: tests
@@ -690,7 +690,8 @@ tests/test_builders/test_build_linkcheck.py::test_check_link_response_only PASSE
 tests/test_builders/test_build_linkcheck.py::test_too_many_retries PASSED
 tests/test_builders/test_build_linkcheck.py::test_raw_node PASSED
 tests/test_builders/test_build_linkcheck.py::test_anchors_ignored PASSED
-tests/test_builders/test_build_linkcheck.py::test_anchors_ignored_for_url PASSED
+tests/test_builders/test_build_linkcheck.py::test_anchors_ignored_for_url ----------------------------------------
+PASSED
 tests/test_builders/test_build_linkcheck.py::test_raises_for_invalid_status PASSED
 tests/test_builders/test_build_linkcheck.py::test_incomplete_html_anchor PASSED
 tests/test_builders/test_build_linkcheck.py::test_decoding_error_anchor_ignored PASSED
@@ -2199,18 +2200,135 @@ tests/test_writers/test_docutilsconf.py::test_html_with_default_docutilsconf PAS
 tests/test_writers/test_docutilsconf.py::test_html_with_docutilsconf PASSED
 tests/test_writers/test_writer_latex.py::test_rstdim_to_latexdim PASSED
 
-================================== XFAILURES ===================================
-$(@D)/tests/test_util/test_util_typing.py:390: ImportError: cannot import name 'ParamSpec' from 'typing' ($(PYTHON_DIR)/typing.py)
-$(@D)/tests/test_util/test_util_typing.py:743: ImportError: cannot import name 'ParamSpec' from 'typing' ($(PYTHON_DIR)/typing.py)
 =============================== warnings summary ===============================
+tests/test_application.py: 7 warnings
+tests/test_builders/test_build.py: 3 warnings
+tests/test_builders/test_build_dirhtml.py: 1 warning
+tests/test_builders/test_build_epub.py: 11 warnings
+tests/test_builders/test_build_html.py: 61 warnings
+tests/test_builders/test_build_html_5_output.py: 167 warnings
+tests/test_builders/test_build_html_assets.py: 4 warnings
+tests/test_builders/test_build_html_code.py: 3 warnings
+tests/test_builders/test_build_html_download.py: 2 warnings
+tests/test_builders/test_build_html_highlight.py: 6 warnings
+tests/test_builders/test_build_html_image.py: 6 warnings
+tests/test_builders/test_build_html_maths.py: 7 warnings
+tests/test_builders/test_build_html_numfig.py: 227 warnings
+tests/test_builders/test_build_html_tocdepth.py: 57 warnings
+tests/test_builders/test_build_linkcheck.py: 6 warnings
+tests/test_builders/test_build_warnings.py: 2 warnings
+tests/test_config/test_config.py: 16 warnings
+tests/test_config/test_correct_year.py: 3 warnings
+tests/test_directives/test_directive_code.py: 7 warnings
+tests/test_directives/test_directive_object_description.py: 1 warning
+tests/test_directives/test_directive_option.py: 3 warnings
+tests/test_directives/test_directive_other.py: 10 warnings
+tests/test_directives/test_directive_patch.py: 3 warnings
+tests/test_directives/test_directives_no_typesetting.py: 49 warnings
+tests/test_domains/test_domain_c.py: 20 warnings
+tests/test_domains/test_domain_cpp.py: 25 warnings
+tests/test_domains/test_domain_js.py: 14 warnings
+tests/test_domains/test_domain_py.py: 42 warnings
+tests/test_domains/test_domain_py_canonical.py: 5 warnings
+tests/test_domains/test_domain_py_fields.py: 7 warnings
+tests/test_domains/test_domain_py_pyfunction.py: 14 warnings
+tests/test_domains/test_domain_py_pyobject.py: 17 warnings
+tests/test_domains/test_domain_rst.py: 7 warnings
+tests/test_domains/test_domain_std.py: 19 warnings
+tests/test_environment/test_environment.py: 1 warning
+tests/test_environment/test_environment_record_dependencies.py: 1 warning
+tests/test_environment/test_environment_toctree.py: 1 warning
+tests/test_extensions/test_ext_autodoc.py: 82 warnings
+tests/test_extensions/test_ext_autodoc_autoattribute.py: 12 warnings
+tests/test_extensions/test_ext_autodoc_autoclass.py: 24 warnings
+tests/test_extensions/test_ext_autodoc_autodata.py: 6 warnings
+tests/test_extensions/test_ext_autodoc_autofunction.py: 14 warnings
+tests/test_extensions/test_ext_autodoc_automodule.py: 6 warnings
+tests/test_extensions/test_ext_autodoc_autoproperty.py: 6 warnings
+tests/test_extensions/test_ext_autodoc_configs.py: 22 warnings
+tests/test_extensions/test_ext_autodoc_events.py: 6 warnings
+tests/test_extensions/test_ext_autodoc_preserve_defaults.py: 2 warnings
+tests/test_extensions/test_ext_autodoc_private_members.py: 5 warnings
+tests/test_extensions/test_ext_autosectionlabel.py: 3 warnings
+tests/test_extensions/test_ext_autosummary.py: 8 warnings
+tests/test_extensions/test_ext_extlinks.py: 3 warnings
+tests/test_extensions/test_ext_githubpages.py: 3 warnings
+tests/test_extensions/test_ext_graphviz.py: 3 warnings
+tests/test_extensions/test_ext_ifconfig.py: 1 warning
+tests/test_extensions/test_ext_inheritance_diagram.py: 4 warnings
+tests/test_extensions/test_ext_intersphinx.py: 12 warnings
+tests/test_extensions/test_ext_math.py: 20 warnings
+tests/test_extensions/test_ext_napoleon_docstring.py: 2 warnings
+tests/test_extensions/test_ext_todo.py: 2 warnings
+tests/test_extensions/test_ext_viewcode.py: 6 warnings
+tests/test_extensions/test_extension.py: 1 warning
+tests/test_highlighting.py: 1 warning
+tests/test_intl/test_catalogs.py: 3 warnings
+tests/test_intl/test_intl.py: 19 warnings
+tests/test_intl/test_locale.py: 1 warning
+tests/test_markup/test_markup.py: 31 warnings
+tests/test_markup/test_parser.py: 1 warning
+tests/test_markup/test_smartquotes.py: 6 warnings
+tests/test_project.py: 1 warning
+tests/test_quickstart.py: 1 warning
+tests/test_search.py: 15 warnings
+tests/test_theming/test_html_theme.py: 3 warnings
+tests/test_theming/test_templating.py: 3 warnings
+tests/test_theming/test_theming.py: 20 warnings
+tests/test_toctree.py: 3 warnings
+tests/test_transforms/test_transforms_post_transforms.py: 4 warnings
+tests/test_transforms/test_transforms_post_transforms_code.py: 2 warnings
+tests/test_transforms/test_transforms_reorder_nodes.py: 3 warnings
+tests/test_util/test_util_display.py: 1 warning
+tests/test_util/test_util_docutils.py: 1 warning
+tests/test_util/test_util_fileutil.py: 1 warning
+tests/test_util/test_util_i18n.py: 1 warning
+tests/test_util/test_util_inventory.py: 3 warnings
+tests/test_util/test_util_logging.py: 17 warnings
+tests/test_util/test_util_nodes.py: 14 warnings
+tests/test_util/test_util_rst.py: 7 warnings
+tests/test_versioning.py: 1 warning
+tests/test_writers/test_api_translator.py: 5 warnings
+  $(@D)/sphinx/builders/html/__init__.py:204: PendingDeprecationWarning: Argument "parser_name" will be removed in Docutils 2.0.
+    Specify parser name in the "parser" argument.
+    reader: Reader[DocTreeInput] = docutils.readers.doctree.Reader(
+
+tests/test_builders/test_build.py: 5 warnings
+tests/test_builders/test_build_epub.py: 1 warning
+tests/test_builders/test_build_gettext.py: 13 warnings
+tests/test_builders/test_build_html.py: 10 warnings
+tests/test_builders/test_build_html_5_output.py: 14 warnings
+tests/test_builders/test_build_latex.py: 3 warnings
+tests/test_builders/test_builder.py: 5 warnings
+tests/test_directives/test_directive_option.py: 10 warnings
+tests/test_domains/test_domain_std.py: 1 warning
+tests/test_extensions/test_ext_autosummary.py: 46 warnings
+tests/test_extensions/test_ext_autosummary_imports.py: 1 warning
+tests/test_intl/test_intl.py: 14 warnings
+tests/test_theming/test_templating.py: 2 warnings
+  $(@D)/sphinx/directives/patches.py:194: PendingDeprecationWarning: The auxiliary function roles.set_classes() is obsoleted by roles.normalize_options() and will be removed in Docutils 2.0
+    set_classes(self.options)
+
 tests/test_builders/test_build.py: 1 warning
 tests/test_builders/test_build_linkcheck.py: 33 warnings
   $(@D)/sphinx/builders/linkcheck.py:86: RemovedInSphinx80Warning: The default value for 'linkcheck_report_timeouts_as_broken' will change to False in Sphinx 8, meaning that request timeouts will be reported with a new 'timeout' status, instead of as 'broken'. This is intended to provide more detail as to the failure mode. See https://github.com/sphinx-doc/sphinx/issues/11868 for details.
     warnings.warn(deprecation_msg, RemovedInSphinx80Warning, stacklevel=1)
 
+tests/test_builders/test_build_html_code.py: 1 warning
+tests/test_domains/test_domain_cpp.py: 5 warnings
+tests/test_markup/test_smartquotes.py: 20 warnings
+  $(@D)/sphinx/roles.py:422: PendingDeprecationWarning: The auxiliary function roles.set_classes() is obsoleted by roles.normalize_options() and will be removed in Docutils 2.0
+    docutils.parsers.rst.roles.set_classes(options)
+
+tests/test_builders/test_build_manpage.py: 1 warning
+tests/test_directives/test_directive_patch.py: 4 warnings
+tests/test_directives/test_directives_no_typesetting.py: 7 warnings
+  $(@D)/sphinx/directives/patches.py:96: PendingDeprecationWarning: The auxiliary function roles.set_classes() is obsoleted by roles.normalize_options() and will be removed in Docutils 2.0
+    set_classes(self.options)
+
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
 ============================= slowest 25 durations =============================
 =========================== short test summary info ============================
-======== 2166 passed, 21 skipped, 2 xfailed, 34 warnings ========
+======== 2166 passed, 21 skipped, 2 xfailed, 1453 warnings ========
   py$(PYV): OK
   congratulations :)


### PR DESCRIPTION
... to work properly with `docutils 0.22`.

This also backports some test fixes for new `alabaster`, `docutils`, and `pygments`.