### PR TITLE
Rebuild NSS after sqlite3 upgrade to resolve dependency problems

### DIFF
--- a/components/library/mozilla-nss/Makefile
+++ b/components/library/mozilla-nss/Makefile
@@ -20,7 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		nss
 COMPONENT_VERSION=	3.98
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_PROJECT_URL=	https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz


### PR DESCRIPTION
When building my Rust IPS implementation I noticed that system/library depends on a old uninstallable version of sqlite3 through mozilla-nss Rebuilding NSS resolves this issue in the dependency graph. (Yes I know we have incorporations but that just tapers over the issue.)