### PR TITLE
tools/license-detector: use https in MPL-2.0 header

### DIFF
--- a/tools/licenses/header.MPL-2.0
+++ b/tools/licenses/header.MPL-2.0
@@ -1,3 +1,3 @@
 This Source Code Form is subject to the terms of the Mozilla Public License,
 v. 2.0. If a copy of the MPL was not distributed with this file, You can
-obtain one at http://mozilla.org/MPL/2.0/.
+obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Reference: https://github.com/spdx/license-list-XML/commit/2ea3821e2ac8b880632b57eb6cebd15ca0d6b43d