### PR TITLE
w3m: update to 0.5.5

### DIFF
--- a/components/web/w3m/Makefile
+++ b/components/web/w3m/Makefile
@@ -14,21 +14,18 @@
 # Copyright 2023 Niklas Poslovski
 #
 
-OPENSSL_VERSION= 3.1
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= w3m
-COMPONENT_VERSION=  0.5.3.20230121
-HUMAN_VERSION= 0.5.3+git20230121
-COMPONENT_REVISION= 1
+COMPONENT_VERSION=  0.5.5
 COMPONENT_SUMMARY= A text-based web browser
-COMPONENT_SRC= $(COMPONENT_NAME)-0.5.3-git20230121
+COMPONENT_SRC= $(COMPONENT_NAME)-v0.5.5
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:fdc7d55d3c0104db26aa9759db34f37e5eee03f44c868796e3bbfb8935c96e39
+  sha256:b271c86b13be2207700230cb3f9061271ea37fd1ace199f48b72ea542a529a0f
 COMPONENT_ARCHIVE_URL= \
-  https://github.com/tats/w3m/archive/refs/tags/v$(HUMAN_VERSION).tar.gz
-COMPONENT_PROJECT_URL= https://w3m.sourceforge.net/
+  https://git.sr.ht/~rkta/w3m/archive/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_PROJECT_URL= https://sr.ht/~rkta/w3m/
 COMPONENT_FMRI= web/browser/w3m
 COMPONENT_CLASSIFICATION= Applications/Internet
 COMPONENT_LICENSE= MIT
@@ -42,12 +39,19 @@ COMPONENT_PRE_CONFIGURE_ACTION =        ($(CLONEY) $(SOURCE_DIR) $(@D))
 CONFIGURE_OPTIONS+= --sysconfdir=/etc
 CONFIGURE_OPTIONS+= --libexecdir=/usr/lib
 CONFIGURE_OPTIONS+= --with-browser=/usr/bin/firefox
+CONFIGURE_OPTIONS+= --with-imagelib=imlib2
+
+# Use better openssl
+CFLAGS  += -I$(OPENSSL_INCDIR)
+LDFLAGS += -L$(OPENSSL_LIBDIR) -R$(OPENSSL_LIBDIR)
+
+# make gcc 14 happy
+CFLAGS += -Wno-implicit-function-declaration
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(OPENSSL_PKG)
-REQUIRED_PACKAGES += library/desktop/gdk-pixbuf
 REQUIRED_PACKAGES += library/gc
-REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/imlib2
 REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += runtime/perl
 REQUIRED_PACKAGES += shell/ksh93

--- a/components/web/w3m/manifests/sample-manifest.p5m
+++ b/components/web/w3m/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2024 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/web/w3m/pkg5
+++ b/components/web/w3m/pkg5
@@ -1,9 +1,8 @@
 {
     "dependencies": [
-        "library/desktop/gdk-pixbuf",
         "library/gc",
-        "library/glib2",
-        "library/security/openssl-31",
+        "library/imlib2",
+        "library/security/openssl-3",
         "library/zlib",
         "runtime/perl",
         "shell/ksh93",


### PR DESCRIPTION
imlib2 needs to be published before this package can be built.

Switch to imlib2 to display images due to gtk2 deprecation.
Switch to latest openssl.
Update Project URL.