### PR TITLE
seaweedfs: add seaweedfs

### DIFF
--- a/components/network/seaweedfs/Makefile
+++ b/components/network/seaweedfs/Makefile
@@ -1,0 +1,58 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+BUILD_STYLE= justmake
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= seaweedfs
+COMPONENT_VERSION= 3.97
+COMPONENT_SUMMARY= SeaweedFS is a fast distributed storage system for blobs, objects, files
+COMPONENT_PROJECT_URL= https://github.com/seaweedfs/seaweedfs
+COMPONENT_SRC= $(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL= $(COMPONENT_PROJECT_URL)/archive/refs/tags/$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:9760263fffe2c3b25a0467cfb51ec5dbdf2b2ac015a07282e1e9e6f22c276430
+COMPONENT_FMRI= network/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION= Web Services/Application and Web Servers
+
+include $(WS_MAKE_RULES)/common.mk
+
+CLONEY_MODE=copy
+
+PATH= $(PATH.gnu)
+PATH.prepend = /usr/bin
+
+COMPONENT_LICENSE= Apache-2.0
+COMPONENT_LICENSE_FILE= LICENSE
+
+COMPONENT_BUILD_ENV += GOOS="illumos"
+COMPONENT_BUILD_ENV += GOPATH="$(BUILD_DIR)/$(MACH64)/gopath"
+COMPONENT_BUILD_ENV += PATH="$(BUILD_DIR)/$(MACH64)/gopath/bin:$(PATH)"
+COMPONENT_BUILD_ENV += PREFIX=/usr
+COMPONENT_BUILD_ENV += HOME=/tmp
+
+COMPONENT_INSTALL_ENV += GOOS="illumos"
+COMPONENT_INSTALL_ENV += GOPATH="$(BUILD_DIR)/$(MACH64)/gopath"
+COMPONENT_INSTALL_ENV += PATH="$(BUILD_DIR)/$(MACH64)/gopath/bin:$(PATH)"
+COMPONENT_INSTALL_ENV += PREFIX=/usr
+COMPONENT_INSTALL_ENV += HOME=/tmp
+
+COMPONENT_POST_INSTALL_ACTION = $(INSTALL) -D $(BUILD_DIR)/$(MACH64)/gopath/bin/weed $(PROTOUSRBINDIR)/weed
+
+# Build dependencies
+REQUIRED_PACKAGES+=developer/golang
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/network/seaweedfs/manifests/sample-manifest.p5m
+++ b/components/network/seaweedfs/manifests/sample-manifest.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/weed

--- a/components/network/seaweedfs/pkg5
+++ b/components/network/seaweedfs/pkg5
@@ -1,0 +1,10 @@
+{
+    "dependencies": [
+        "developer/golang",
+        "system/library"
+    ],
+    "fmris": [
+        "network/seaweedfs"
+    ],
+    "name": "seaweedfs"
+}

--- a/components/network/seaweedfs/seaweedfs.p5m
+++ b/components/network/seaweedfs/seaweedfs.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/weed


### PR DESCRIPTION
Another S3 compatible storage.
It seems that Tribblix has been providing packages for years.