### PR TITLE
garage: add garage

### DIFF
--- a/components/network/garage/Makefile
+++ b/components/network/garage/Makefile
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+BUILD_STYLE= justmake
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME= garage
+COMPONENT_VERSION= 2.1.0
+COMPONENT_SUMMARY= An open-source distributed object storage service tailored for self-hosting
+COMPONENT_PROJECT_URL= https://garagehq.deuxfleurs.fr
+COMPONENT_SRC= $(COMPONENT_NAME)
+COMPONENT_ARCHIVE= $(COMPONENT_SRC)-v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_URL= https://git.deuxfleurs.fr/Deuxfleurs/garage/archive/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:63b2a0a513464136728bb50a91b40a5911fc25603f3c3e54fe030c01ea5a6084
+COMPONENT_FMRI= network/$(COMPONENT_NAME)
+COMPONENT_CLASSIFICATION= Web Services/Application and Web Servers
+
+include $(WS_MAKE_RULES)/common.mk
+
+CLONEY_MODE=copy
+
+PATH= $(PATH.gnu)
+
+COMPONENT_LICENSE= AGPL v3
+COMPONENT_LICENSE_FILE= LICENSE
+
+# https://www.illumos.org/issues/15767
+LD_Z_IGNORE=
+
+COMPONENT_BUILD_CMD = cargo build --release --target-dir $(BUILD_DIR)/$(MACH64)/target
+COMPONENT_BUILD_ENV += SODIUM_USE_PKG_CONFIG=1
+COMPONENT_BUILD_ENV += CARGO_PROFILE_RELEASE_LTO=false
+COMPONENT_BUILD_ENV += GIT_VERSION=cargo:$(COMPONENT_VERSION)
+
+
+COMPONENT_INSTALL_ACTION = $(INSTALL) -D $(BUILD_DIR)/$(MACH64)/target/release/garage $(PROTOUSRBINDIR)/garage
+
+# Build dependencies
+REQUIRED_PACKAGES+= developer/lang/rustc
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += library/security/libsodium
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/network/garage/garage.p5m
+++ b/components/network/garage/garage.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Jiwon Na
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/garage

--- a/components/network/garage/manifests/sample-manifest.p5m
+++ b/components/network/garage/manifests/sample-manifest.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/garage

--- a/components/network/garage/pkg5
+++ b/components/network/garage/pkg5
@@ -1,0 +1,13 @@
+{
+    "dependencies": [
+        "developer/lang/rustc",
+        "library/security/libsodium",
+        "system/library",
+        "system/library/gcc-14-runtime",
+        "system/library/math"
+    ],
+    "fmris": [
+        "network/garage"
+    ],
+    "name": "garage"
+}


### PR DESCRIPTION
Another s3 compatible storage.

garage.toml should be provided as well, but since additional setup steps is required for the configuration, only binary file has been included.

https://garagehq.deuxfleurs.fr/documentation/quick-start/