### PR TITLE
tools/python-integrate-project: disable all pytest plugins for test style discovery

### DIFF
--- a/tools/python-integrate-project
+++ b/tools/python-integrate-project
@@ -383,13 +383,11 @@ while true ; do
 	TOX_RET=$?
 	((TOX_RET == 0)) && ! printf "%s" "$TOX_OUT" | grep -q 'assuming empty tox\.ini' && TEST_STYLE="tox" && break
 
-	# Disable some pytest plugins that almost always collects tests to run
-	# even there are no pytest tests available otherwise.
-	#
-	# The system-statistics plugin is disabled because it often causes the
-	# pytest to fail.
-	# See also https://github.com/saltstack/pytest-system-statistics/issues/4
-	pytest -p no:black -p no:checkdocs -p no:cov -p no:mypy -p no:relaxed -p no:system-statistics --setup-plan
+	# Disable autoload of all pytest plugins because some of them almost
+	# always collects tests to run even there are no pytest tests available
+	# otherwise.  Some other plugins could do the opposite: prevent tests
+	# collection even there are pytest tests available.
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --setup-plan
 	(($? != 5)) && TEST_STYLE="pytest" && break
 
 	[[ -f setup.py ]] && python setup.py test --help && TEST_STYLE="setup.py" && break


### PR DESCRIPTION
The [recent](https://github.com/OpenIndiana/oi-userland/pull/23951) `pytest-run-parallel` update caused that the test style detection stopped to work properly.  Let's disable all pytest plugins during the test style discovery.