### PR TITLE
install-types: add NFS file system SVC to server profile.

### DIFF
--- a/components/meta-packages/install-types/Makefile
+++ b/components/meta-packages/install-types/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		install-types
-COMPONENT_VERSION =	21
+COMPONENT_VERSION =	22
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/meta-packages/install-types/includes/server_software
+++ b/components/meta-packages/install-types/includes/server_software
@@ -1,8 +1,10 @@
 # Server-specific software
 
 depend type=require fmri=diagnostic/ddu/text
+depend type=require fmri=service/file-system/nfs
 depend type=require fmri=service/network/dns/bind
 depend type=require fmri=service/resource-cap
+depend type=require fmri=system/boot/network
 depend type=require fmri=system/network/udapl
 depend type=require fmri=system/network/udapl/udapl-tavor
 depend type=require fmri=web/server/apache-24


### PR DESCRIPTION
Without this service it's impossible to configure NFS4 domain name using sharectl.