### PR TITLE
illumos-gate: do not run pkglint; do not check for cstyle/hdrchk errors

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -28,9 +28,9 @@ FETCH=$(WS_TOOLS)/userland-fetch
 DEBUG=no
 
 ifeq ($(DEBUG),yes)
-NIGHTLY_OPTIONS=-nCDmpt
+NIGHTLY_OPTIONS=-nCDmp
 else
-NIGHTLY_OPTIONS=-nCmpt
+NIGHTLY_OPTIONS=-nmpL
 endif
 ONNV_BUILDNUM=$(BRANCHID)
 


### PR DESCRIPTION
Both pkglint (`-L`) and cstyle/hdrchk errors (`-C`) checks are primarily targeted for developers and have little added value for release builds like we do by default here in `oi-userland`.  We should silently expect that the `illumos-gate` is of high quality and these checks were executed before any new change was merged to the gate.  Please note that I left these checks untouched for debug build so we will still have the opportunity to easily try the more strict build if needed.

While here I also removed the `-t` flag which is default.