### PR TITLE
illumos-gate: do not do non-DEBUG build for DEBUG=yes

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -28,7 +28,7 @@ FETCH=$(WS_TOOLS)/userland-fetch
 DEBUG=no
 
 ifeq ($(DEBUG),yes)
-NIGHTLY_OPTIONS=-nCDmp
+NIGHTLY_OPTIONS=-FnCDAmpr
 else
 NIGHTLY_OPTIONS=-nmpL
 endif


### PR DESCRIPTION
This also adds `-A` (checks for new interfaces in libraries) and `-r` (checks for changes in ELF runpaths) to `NIGHTLY_OPTIONS`.  These options are useful for developers who usually do debug builds.  The default `NIGHTLY_OPTIONS` in `illumos-gate/usr/src/tools/env/illumos.sh` is basically the same.