### PR TITLE
illumos-gate: align NIGHTLY_OPTIONS for DEBUG=yes build with non-DEBUG build

### DIFF
--- a/components/openindiana/illumos-gate/Makefile
+++ b/components/openindiana/illumos-gate/Makefile
@@ -28,7 +28,7 @@ FETCH=$(WS_TOOLS)/userland-fetch
 DEBUG=no
 
 ifeq ($(DEBUG),yes)
-NIGHTLY_OPTIONS=-nCDmp
+NIGHTLY_OPTIONS=-nDmpL
 else
 NIGHTLY_OPTIONS=-nmpL
 endif


### PR DESCRIPTION
This makes sure that both `DEBUG=yes` and the non-DEBUG build uses the same set of `NIGHTLY_OPTIONS`.  This is needed to make sure we get similar build result for both cases.

It turned out that we do the `DEBUG=yes` build in `illumos-gate` regularly as I learned recently in #24013.  Unfortunately, I was not aware about this when I did #24012.