### PR TITLE
rsync - fix IPv6

### DIFF
--- a/components/network/rsync/Makefile
+++ b/components/network/rsync/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		rsync
 COMPONENT_VERSION=	3.4.1
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Utility that provides fast incremental file transfer and copy
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=	https://rsync.samba.org/

--- a/components/network/rsync/patches/10-ipv6.patch
+++ b/components/network/rsync/patches/10-ipv6.patch
@@ -1,0 +1,78 @@
+diff --git a/configure.ac b/configure.ac
+index d2bcb471..9758d125 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -376,36 +376,6 @@ if test x"$rsync_cv_HAVE_BROKEN_LARGEFILE" != x"yes"; then
+    AC_SYS_LARGEFILE
+ fi
+ 
+-AC_MSG_CHECKING([whether to enable ipv6])
+-AC_ARG_ENABLE(ipv6,
+-AS_HELP_STRING([--disable-ipv6],[disable to omit ipv6 support]),
+-[ case "$enableval" in
+-  no)
+-	AC_MSG_RESULT(no)
+-	;;
+-  *)	AC_MSG_RESULT(yes)
+-	AC_DEFINE(INET6, 1, [true if you have IPv6])
+-	;;
+-  esac ],
+-
+-  AC_RUN_IFELSE([AC_LANG_SOURCE([[ /* AF_INET6 availability check */
+-#include <stdlib.h>
+-#include <sys/types.h>
+-#include <sys/socket.h>
+-int main()
+-{
+-   if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
+-     exit(1);
+-   else
+-     exit(0);
+-}
+-]])],
+-  [AC_MSG_RESULT(yes)
+-  AC_DEFINE(INET6, 1, true if you have IPv6)],
+-  [AC_MSG_RESULT(no)],
+-  [AC_MSG_RESULT(no)]
+-))
+-
+ dnl Do you want to disable use of locale functions
+ AC_ARG_ENABLE([locale],
+ 	AS_HELP_STRING([--disable-locale],[disable to omit locale features]))
+@@ -716,6 +686,36 @@ if test x"$ac_cv_func_connect" = x"no"; then
+     fi
+ fi
+ 
++AC_MSG_CHECKING([whether to enable ipv6])
++AC_ARG_ENABLE(ipv6,
++AS_HELP_STRING([--disable-ipv6],[disable to omit ipv6 support]),
++[ case "$enableval" in
++  no)
++	AC_MSG_RESULT(no)
++	;;
++  *)	AC_MSG_RESULT(yes)
++	AC_DEFINE(INET6, 1, [true if you have IPv6])
++	;;
++  esac ],
++
++  AC_RUN_IFELSE([AC_LANG_SOURCE([[ /* AF_INET6 availability check */
++#include <stdlib.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++int main()
++{
++   if (socket(AF_INET6, SOCK_STREAM, 0) < 0)
++     exit(1);
++   else
++     exit(0);
++}
++]])],
++  [AC_MSG_RESULT(yes)
++  AC_DEFINE(INET6, 1, true if you have IPv6)],
++  [AC_MSG_RESULT(no)],
++  [AC_MSG_RESULT(no)]
++))
++
+ AC_SEARCH_LIBS(inet_ntop, resolv)
+ 
+ # For OS X, Solaris, HP-UX, etc.: figure out if -liconv is needed.  We'll


### PR DESCRIPTION
The test program, which checks for AF_INET6 fails to build because socket() requires -lsocket. We need to do this test after checking whether we need -lsocket.

I've already sent this patch to the samba project. This commit can be reverted as soon as it is merged upstream.