### PR TITLE
prep-patch.mk: remove duplicate target

### DIFF
--- a/make-rules/prep-patch.mk
+++ b/make-rules/prep-patch.mk
@@ -80,10 +80,6 @@ $$(SOURCE_DIR$(1))/.patched-%:	$(PATCH_DIR)/% $(MAKEFILE_PREREQ)
 	$(GPATCH) -d $$(@D) $$(GPATCH_FLAGS) < $$<
 	$(TOUCH) $$(@)
 
-$$(SOURCE_DIR$(1))/.patched-%:	$(MAKEFILE_PREREQ)
-	$(GPATCH) -d $$(@D) $$(GPATCH_FLAGS) < $$<
-	$(TOUCH) $$(@)
-
 $$(SOURCE_DIR$(1))/.patched:	$$(PATCH_STAMPS$(1))
 	$(TOUCH) $$(@)
 


### PR DESCRIPTION
This got forgotten during the parfait cleanup in #9308.  It went unnoticed for more than 3 years because it is effectively no-op.