### PR TITLE
pari: set mediator pari to gmp

### DIFF
--- a/components/scientific/pari/Makefile
+++ b/components/scientific/pari/Makefile
@@ -9,19 +9,26 @@
 #
 
 #
-# Copyright (c) 2021,2022 David Stes
-# Copyright (c) 2023 Andreas Wacknitz
+# Copyright (c) 2025 David Stes
+# Copyright (c) 2025 Andreas Wacknitz
 # Copyright (c) 2024 David Stes
+# Copyright (c) 2023 Andreas Wacknitz
+# Copyright (c) 2021,2022 David Stes
 
 #
-# The manifest pari.p5m holds no license and copyright info per explicit request from 
-# Bill Allombert from the PARI team
+# IPS mediator "pari" mediator-implementation set to "gmp".
+# An alternative is the pari-native package (which can be optionally installed) for mediator-implementation "native".
+# The native or classical PARI kernel does not use GNU gmp.
+#
+# NOTE: the PARI manifest files are NOT covered by the CDDL.
+# The manifest files hold no license and copyright info per explicit request from Bill Allombert from the PARI team.
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pari
 COMPONENT_VERSION=	2.17.2
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	The PARI Computer Algebra System
 COMPONENT_PROJECT_URL=	https://pari.math.u-bordeaux.fr
 COMPONENT_SRC=		pari-$(COMPONENT_VERSION)
@@ -79,3 +86,4 @@ REQUIRED_PACKAGES += runtime/perl
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libx11
+

--- a/components/scientific/pari/pari.p5m
+++ b/components/scientific/pari/pari.p5m
@@ -9,8 +9,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-link path=usr/bin/gp target=gp-2.17
-file path=usr/bin/gp-2.17
+link path=usr/bin/gp target=gp-gmp-2.17 \
+    mediator=pari mediator-implementation=gmp
+file usr/bin/gp-2.17 path=usr/bin/gp-gmp-2.17
 file path=usr/bin/gphelp
 file path=usr/bin/tex2mail
 link path=usr/include/pari/genpari.h target=pari.h
@@ -34,7 +35,8 @@ file path=usr/include/pari/paritune.h
 file path=usr/lib/$(MACH64)/libpari-gmp-tls.so.$(HUMAN_VERSION)
 link path=usr/lib/$(MACH64)/libpari-gmp-tls.so.9 \
     target=libpari-gmp-tls.so.$(HUMAN_VERSION)
-link path=usr/lib/$(MACH64)/libpari.so target=libpari-gmp-tls.so.$(HUMAN_VERSION)
+link path=usr/lib/$(MACH64)/libpari.so target=libpari-gmp-tls.so.$(HUMAN_VERSION) \
+    mediator=pari mediator-implementation=gmp
 file path=usr/lib/pari/pari.cfg
 file path=usr/share/man/man1/gp-2.17.1
 link path=usr/share/man/man1/gp.1 target=gp-2.17.1


### PR DESCRIPTION

pkg set-mediator -I gmp pari

is the default but can be used to set the implementation mediator to GMP (GNU multiprecision arithmetic)
