### PR TITLE
erlang: don't substitue i386 header files.

### DIFF
--- a/components/runtime/erlang/Makefile
+++ b/components/runtime/erlang/Makefile
@@ -31,6 +31,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= erlang
 COMPONENT_VERSION= 28.1.1
+COMPONENT_REVISION= 1
 COMPONENT_VERSION_SHORT= $(shell echo $(COMPONENT_VERSION) | cut -d'.' -f1-2)
 COMPONENT_SUMMARY= Erlang programming language and OTP libraries
 COMPONENT_PROJECT_URL= https://erlang.org/

--- a/components/runtime/erlang/erlang.p5m
+++ b/components/runtime/erlang/erlang.p5m
@@ -115,12 +115,14 @@ file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/erl_fixed_size_int_types.
 file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/erl_int_sizes_config.h
 file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/erl_nif.h
 file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/erl_nif_api_funcs.h
-file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/$(MACH)/atomic.h
-file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/$(MACH)/ethr_dw_atomic.h
-file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/$(MACH)/ethr_membar.h
-file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/$(MACH)/ethread.h
-file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/$(MACH)/rwlock.h
-file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/$(MACH)/spinlock.h
+# the next 6 header files are needed as is, not substituted with MACH.
+# Otherwise they don't get delivered on none i386 architectures.
+file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/i386/atomic.h
+file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/i386/ethr_dw_atomic.h
+file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/i386/ethr_membar.h
+file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/i386/ethread.h
+file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/i386/rwlock.h
+file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/i386/spinlock.h
 file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/README
 file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/erl_errno.h
 file path=usr/lib/$(MACH64)/erlang/erts-16.1.1/include/internal/erl_misc_utils.h


### PR DESCRIPTION
Otherwise they don't get delivered on SPARC builds.