### PR TITLE
prep-patch.mk: ADDITIONAL_PATCHES does not need a guard

### DIFF
--- a/make-rules/prep-patch.mk
+++ b/make-rules/prep-patch.mk
@@ -61,9 +61,7 @@ PATCH_PATTERN$(1) ?=	%.patch$(1)
 PATCHES$(1) = $(filter %.patch$(1),$(PATCHES))
 endif
 
-ifneq ($(strip $(ADDITIONAL_PATCHES$(1))),)
 PATCHES$(1) += $(ADDITIONAL_PATCHES$(1))
-endif
 
 ifneq ($$(PATCHES$(1)),)
 PATCH_STAMPS$(1) += $$(PATCHES$(1):$(PATCH_DIR)/%=$$(SOURCE_DIR$(1))/.patched-%)


### PR DESCRIPTION
The guard removed here prevents to add empty `ADDITIONAL_PATCHES` to `PATCHES`.  With the guard removed we will simply add empty `ADDITIONAL_PATCHES` to `PATCHES`, but that's a no-op anyway :-).