### PR TITLE
wsdd: update SMF manifest

### DIFF
--- a/components/network/wsdd/Makefile
+++ b/components/network/wsdd/Makefile
@@ -18,7 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		wsdd
 COMPONENT_VERSION=	0.9
-COMPONENT_REVISION=	0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Web Service Discovery host daemon
 COMPONENT_DESCRIPTION=	This enables SMB server to be found by Web Service Discovery Clients like Windows.
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)

--- a/components/network/wsdd/files/wsdd.xml
+++ b/components/network/wsdd/files/wsdd.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
 <service_bundle type='manifest' name='export'>
   <service name='site/wsdd' type='service' version='0'>
-    <create_default_instance enabled='true'/>
+    <create_default_instance enabled='false'/>
     <single_instance/>
     <dependency name='smb_server' grouping='require_all' restart_on='error' type='service'>
       <service_fmri value='svc:/network/smb/server:default'/>
@@ -18,7 +18,7 @@
     <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'/>
     <property_group name='config' type='application'>
       <propval name='domain' type='astring' value='example.lan'/>
-      <propval name='interface' type='astring' value='vnic_smb1'/>
+      <propval name='interface' type='astring' value='igb0'/>
       <propval name='debug' type='astring' value='-v'/>
     </property_group>
     <property_group name='application' type='application'/>


### PR DESCRIPTION
Do not start the service during install, because it has to be configured first.