### PR TITLE
Bump Emacs revision number.  There are no actual changes in this patc…

### DIFF
--- a/components/editor/emacs/Makefile
+++ b/components/editor/emacs/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         emacs
 COMPONENT_VERSION=      30.2
+COMPONENT_REVISION=     1
 COMPONENT_PROJECT_URL=  https://www.gnu.org/software/emacs/
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.xz


### PR DESCRIPTION
…h, and the only goal is to get Jenkins to do a build in order to view logs (the logs from the last build have been removed already), in order to debug why the Emacs build on Jenkins isn't picking up libxml2.