### PR TITLE
giflib: update to 5.2.2 - drop 32bit libs/binaries.

### DIFF
--- a/components/library/giflib/Makefile
+++ b/components/library/giflib/Makefile
@@ -20,64 +20,42 @@
 #
 # Copyright (c) 2013, Aurelien Larcher. All rights reserved.
 # Copyright (c) 2016 Jim Klimov
+# Copyright (c) 2025 Klaus Ziegler
 #
 
-BUILD_BITS= 32_and_64
+BUILD_STYLE= justmake
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         giflib
-COMPONENT_VERSION=      5.1.4
-COMPONENT_REVISION=     2
+COMPONENT_VERSION=      5.2.2
 COMPONENT_SUMMARY=      GIFLIB - A library and utilities for processing GIFs
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  https://giflib.sourceforge.net/
-COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.bz2
-COMPONENT_ARCHIVE_HASH= sha256:df27ec3ff24671f80b29e6ab1c4971059c14ac3db95406884fc26574631ba8d5
+COMPONENT_ARCHIVE=      $(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb
 COMPONENT_ARCHIVE_URL=  https://sourceforge.net/projects/giflib/files/$(COMPONENT_ARCHIVE)/download
 COMPONENT_FMRI=         library/giflib
 COMPONENT_CLASSIFICATION=System/Libraries
 COMPONENT_LICENSE=      MIT
 COMPONENT_LICENSE_FILE= COPYING
 
-# For backwards compatibility, deliver shared lib of previous version SO number
-COMPONENT_VERSION_1=	5.0.6
-COMPONENT_SRC_1=	$(COMPONENT_NAME)-$(COMPONENT_VERSION_1)
-COMPONENT_ARCHIVE_1=	$(COMPONENT_SRC_1).tar.bz2
-COMPONENT_ARCHIVE_HASH_1= sha256:8909839ccbdfca75cfbe6a4db907b55978e11fb268a8f3cde24bd923a0f669ea
-COMPONENT_ARCHIVE_URL_1= https://sourceforge.net/projects/giflib/files/$(COMPONENT_ARCHIVE_1)/download
-CLEAN_PATHS +=	$(COMPONENT_SRC_1)
-SOURCE_DIR_1 =	$(COMPONENT_DIR)/$(COMPONENT_SRC_1)
-
-TEST_TARGET=$(NO_TESTS)
 include $(WS_MAKE_RULES)/common.mk
 
-PATH=$(PATH.gnu)
+PATH= $(PATH.gnu)
 
-CONFIGURE_OPTIONS+=	--enable-shared
-CONFIGURE_OPTIONS+=	--disable-static
+COMPONENT_POST_CONFIGURE_ACTION += ( \
+	cd $(COMPONENT_SRC); \
+	$(GSED) -i -e 's/MACH64/$(MACH64)/' -e 's/gcc_OPT/$(gcc_OPT)/' Makefile );
 
-# Macros to configure, build, and install the old version for the time being.
-# Snatched from libreadline recipe
-BUILD_OLD_DIR_32 = $(COMPONENT_DIR)/build/$(COMPONENT_VERSION_1)-$(MACH32)
-BUILD_OLD_DIR_64 = $(COMPONENT_DIR)/build/$(COMPONENT_VERSION_1)-$(MACH64)
+COMPONENT_POST_INSTALL_ACTION += ( \
+	$(MV) $(PROTOUSRSHAREMAN3DIR)/giflib.7 $(PROTOUSRSHAREMAN3DIR)/giflib.3; \
+	$(GSED) -i -e 's@"7"@"3"@g' $(PROTOUSRSHAREMAN3DIR)/giflib.3 );
 
-$(BUILD_OLD_DIR_32)/.configured: CONFIGURE_SCRIPT = $(SOURCE_DIR_1)/configure
-$(BUILD_OLD_DIR_64)/.configured: CONFIGURE_SCRIPT = $(SOURCE_DIR_1)/configure
-$(BUILD_OLD_DIR_32)/.configured:        BITS=32
-$(BUILD_OLD_DIR_64)/.configured:        BITS=64
-
-BUILD_32 += $(BUILD_OLD_DIR_32)/.built
-BUILD_64 += $(BUILD_OLD_DIR_64)/.built
-
-INSTALL_32 += $(BUILD_OLD_DIR_32)/.installed
-INSTALL_64 += $(BUILD_OLD_DIR_64)/.installed
-
-# install the old version first
-$(BUILD_DIR_32)/.installed:     $(BUILD_OLD_DIR_32)/.installed
-$(BUILD_DIR_64)/.installed:     $(BUILD_OLD_DIR_64)/.installed
-
-# Build dependencies
-REQUIRED_PACKAGES += text/xmlto
+OMPONENT_TEST_TRANSFORMS= "-n"
+COMPONENT_TEST_TRANSFORMS += "-e '/Testing/p'"
+COMPONENT_TEST_TRANSFORMS += "-e '/Checking/p'"
+COMPONENT_TEST_TRANSFORMS += "-e '/basic sanity check/p'"
+COMPONENT_TEST_TRANSFORMS += "-e '/No output is good news/p'"
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += system/library

--- a/components/library/giflib/giflib.p5m
+++ b/components/library/giflib/giflib.p5m
@@ -11,6 +11,7 @@
 #
 # Copyright 2013 Aurelien Larcher. All rights reserved.
 # Copyright (c) 2016 Jim Klimov
+# Copyright (c) 2025 Klaus Ziegler
 #
 
 <transform file path=usr.*/man/.+ -> default mangler.man.stability uncommitted>
@@ -24,17 +25,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/gif2raw
-file path=usr/bin/$(MACH64)/gif2rgb
-file path=usr/bin/$(MACH64)/gifbuild
-file path=usr/bin/$(MACH64)/gifclrmp
-file path=usr/bin/$(MACH64)/gifecho
-file path=usr/bin/$(MACH64)/giffix
-file path=usr/bin/$(MACH64)/gifinto
-file path=usr/bin/$(MACH64)/giftext
-file path=usr/bin/$(MACH64)/giftool
-
-file path=usr/bin/gif2raw
 file path=usr/bin/gif2rgb
 file path=usr/bin/gifbuild
 file path=usr/bin/gifclrmp
@@ -50,23 +40,19 @@ file path=usr/share/man/man1/gifclrmp.1
 file path=usr/share/man/man1/gifecho.1
 file path=usr/share/man/man1/giffix.1
 file path=usr/share/man/man1/gifinto.1
-file path=usr/share/man/man1/giflib.1
 file path=usr/share/man/man1/giftext.1
 file path=usr/share/man/man1/giftool.1
+file path=usr/share/man/man3/giflib.3
 
 file path=usr/include/gif_lib.h
 
-file path=usr/lib/$(MACH64)/libgif.so.7.0.0
-link path=usr/lib/$(MACH64)/libgif.so target=libgif.so.7.0.0
-link path=usr/lib/$(MACH64)/libgif.so.7 target=libgif.so.7.0.0
-
-file path=usr/lib/libgif.so.7.0.0
-link path=usr/lib/libgif.so target=libgif.so.7.0.0
-link path=usr/lib/libgif.so.7 target=libgif.so.7.0.0
+file path=usr/lib/$(MACH64)/libgif.so.7.2.0
+link path=usr/lib/$(MACH64)/libgif.so target=libgif.so.7.2.0
+link path=usr/lib/$(MACH64)/libgif.so.7 target=libgif.so.7.2.0
 
 # Old version - deliver only libs (and gif2raw seems to be with it too)
-file path=usr/lib/$(MACH64)/libgif.so.6.0.1
-link path=usr/lib/$(MACH64)/libgif.so.6 target=libgif.so.6.0.1
+#file path=usr/lib/$(MACH64)/libgif.so.6.0.1
+#link path=usr/lib/$(MACH64)/libgif.so.6 target=libgif.so.6.0.1
 
-file path=usr/lib/libgif.so.6.0.1
-link path=usr/lib/libgif.so.6 target=libgif.so.6.0.1
+#file path=usr/lib/libgif.so.6.0.1
+#link path=usr/lib/libgif.so.6 target=libgif.so.6.0.1

--- a/components/library/giflib/manifests/sample-manifest.p5m
+++ b/components/library/giflib/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2025 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -23,16 +23,6 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
-file path=usr/bin/$(MACH64)/gif2raw
-file path=usr/bin/$(MACH64)/gif2rgb
-file path=usr/bin/$(MACH64)/gifbuild
-file path=usr/bin/$(MACH64)/gifclrmp
-file path=usr/bin/$(MACH64)/gifecho
-file path=usr/bin/$(MACH64)/giffix
-file path=usr/bin/$(MACH64)/gifinto
-file path=usr/bin/$(MACH64)/giftext
-file path=usr/bin/$(MACH64)/giftool
-file path=usr/bin/gif2raw
 file path=usr/bin/gif2rgb
 file path=usr/bin/gifbuild
 file path=usr/bin/gifclrmp
@@ -42,23 +32,16 @@ file path=usr/bin/gifinto
 file path=usr/bin/giftext
 file path=usr/bin/giftool
 file path=usr/include/gif_lib.h
-link path=usr/lib/$(MACH64)/libgif.so target=libgif.so.7.0.0
-link path=usr/lib/$(MACH64)/libgif.so.6 target=libgif.so.6.0.1
-file path=usr/lib/$(MACH64)/libgif.so.6.0.1
-link path=usr/lib/$(MACH64)/libgif.so.7 target=libgif.so.7.0.0
-file path=usr/lib/$(MACH64)/libgif.so.7.0.0
-link path=usr/lib/libgif.so target=libgif.so.7.0.0
-link path=usr/lib/libgif.so.6 target=libgif.so.6.0.1
-file path=usr/lib/libgif.so.6.0.1
-link path=usr/lib/libgif.so.7 target=libgif.so.7.0.0
-file path=usr/lib/libgif.so.7.0.0
-file path=usr/share/man/man1/gif2raw.1
+file path=usr/lib/$(MACH64)/libgif.a
+link path=usr/lib/$(MACH64)/libgif.so target=libgif.so.7
+link path=usr/lib/$(MACH64)/libgif.so.7 target=libgif.so.7.2.0
+file path=usr/lib/$(MACH64)/libgif.so.7.2.0
 file path=usr/share/man/man1/gif2rgb.1
 file path=usr/share/man/man1/gifbuild.1
 file path=usr/share/man/man1/gifclrmp.1
 file path=usr/share/man/man1/gifecho.1
 file path=usr/share/man/man1/giffix.1
 file path=usr/share/man/man1/gifinto.1
-file path=usr/share/man/man1/giflib.1
 file path=usr/share/man/man1/giftext.1
 file path=usr/share/man/man1/giftool.1
+file path=usr/share/man/man3/giflib.3

--- a/components/library/giflib/patches/01-makefile.patch
+++ b/components/library/giflib/patches/01-makefile.patch
@@ -1,0 +1,107 @@
+--- giflib-5.2.2/Makefile.~1~	2024-02-19 03:01:50.000000000 +0200
++++ giflib-5.2.2/Makefile	2025-11-13 21:38:55.835395949 +0200
+@@ -6,18 +6,17 @@
+ # of code space in the shared library.
+ 
+ #
+-OFLAGS = -O0 -g
+-OFLAGS  = -O2
+-CFLAGS  = -std=gnu99 -fPIC -Wall -Wno-format-truncation $(OFLAGS)
++
++CFLAGS  =  -fPIC -Wall gcc_OPT
+ 
+ SHELL = /bin/sh
+ TAR = tar
+ INSTALL = install
+ 
+-PREFIX = /usr/local
++PREFIX = /usr
+ BINDIR = $(PREFIX)/bin
+ INCDIR = $(PREFIX)/include
+-LIBDIR = $(PREFIX)/lib
++LIBDIR = $(PREFIX)/lib/MACH64
+ MANDIR = $(PREFIX)/share/man
+ 
+ # No user-serviceable parts below this line
+@@ -43,7 +42,9 @@
+ INSTALLABLE = \
+ 	gif2rgb \
+ 	gifbuild \
++	gifecho \
+ 	giffix \
++	gifinto \
+ 	giftext \
+ 	giftool \
+ 	gifclrmp
+@@ -54,23 +55,25 @@
+ UTILS = $(INSTALLABLE) \
+ 	gifbg \
+ 	gifcolor \
+-	gifecho \
+ 	giffilter \
+ 	gifhisto \
+-	gifinto \
+ 	gifsponge \
+ 	gifwedge
+ 
+ LDLIBS=libgif.a -lm
+ 
+ MANUAL_PAGES = \
+-	doc/gif2rgb.xml \
+-	doc/gifbuild.xml \
+-	doc/gifclrmp.xml \
+-	doc/giffix.xml \
+-	doc/giflib.xml \
+-	doc/giftext.xml \
+-	doc/giftool.xml
++	doc/gif2rgb.1 \
++	doc/gifbuild.1 \
++	doc/gifclrmp.1 \
++	doc/gifecho.1 \
++	doc/giffix.1 \
++	doc/gifinto.1 \
++	doc/giftext.1 \
++	doc/giftool.1
++
++MAN3_PAGES = \
++	doc/giflib.3
+ 
+ SOEXTENSION	= so
+ LIBGIFSO	= libgif.$(SOEXTENSION)
+@@ -99,7 +102,7 @@
+ ifeq ($(UNAME), Darwin)
+ 	$(CC) $(CFLAGS) -dynamiclib -current_version $(LIBVER) $(OBJECTS) -o $(LIBGIFSO)
+ else
+-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBGIFSOMAJOR) -o $(LIBGIFSO) $(OBJECTS)
++	$(CC) $(CFLAGS) -fPIC -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBGIFSOMAJOR) -o $(LIBGIFSO) $(OBJECTS)
+ endif
+ 
+ libgif.a: $(OBJECTS) $(HEADERS)
+@@ -109,7 +112,7 @@
+ ifeq ($(UNAME), Darwin)
+ 	$(CC) $(CFLAGS) -dynamiclib -current_version $(LIBVER) $(OBJECTS) -o $(LIBUTILSO)
+ else
+-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBUTILMAJOR) -o $(LIBUTILSO) $(UOBJECTS)
++	$(CC) $(CFLAGS) -fPIC -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBUTILMAJOR) -o $(LIBUTILSO) $(UOBJECTS)
+ endif
+ 
+ libutil.a: $(UOBJECTS) $(UHEADERS)
+@@ -149,7 +152,9 @@
+ 	ln -sf $(LIBGIFSOMAJOR) "$(DESTDIR)$(LIBDIR)/$(LIBGIFSO)"
+ install-man:
+ 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man1"
++	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man3"
+ 	$(INSTALL) -m 644 $(MANUAL_PAGES) "$(DESTDIR)$(MANDIR)/man1"
++	$(INSTALL) -m 644 doc/giflib.7 "$(DESTDIR)$(MANDIR)/man3"
+ uninstall: uninstall-man uninstall-include uninstall-lib uninstall-bin
+ uninstall-bin:
+ 	cd "$(DESTDIR)$(BINDIR)" && rm -f $(INSTALLABLE)
+@@ -160,7 +165,7 @@
+ 		rm -f libgif.a $(LIBGIFSO) $(LIBGIFSOMAJOR) $(LIBGIFSOVER)
+ uninstall-man:
+ 	cd "$(DESTDIR)$(MANDIR)/man1" && rm -f $(shell cd doc >/dev/null && echo *.1)
+-	cd "$(DESTDIR)$(MANDIR)/man7" && rm -f $(shell cd doc >/dev/null && echo *.7)
++	cd "$(DESTDIR)$(MANDIR)/man3" && rm -f $(shell cd doc >/dev/null && echo *.7)
+ 
+ # Make distribution tarball
+ #

--- a/components/library/giflib/patches/02-doc-makefile.patch
+++ b/components/library/giflib/patches/02-doc-makefile.patch
@@ -1,0 +1,11 @@
+--- giflib-5.2.2/doc/Makefile.orig	2024-02-18 20:15:05.000000000 +0200
++++ giflib-5.2.2/doc/Makefile	2025-06-17 18:46:18.724644866 +0300
+@@ -43,7 +43,7 @@
+ 
+ # Logo image file for HTML docs
+ giflib-logo.gif: ../pic/gifgrid.gif
+-	convert $^ -resize 50x50 $@
++	magick $^ -resize 50x50 $@
+ 
+ # Philosophical choice: the website gets the internal manual pages
+ allhtml: $(XMLALL:.xml=.html) giflib-logo.gif

--- a/components/library/giflib/pkg5
+++ b/components/library/giflib/pkg5
@@ -1,10 +1,7 @@
 {
     "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
         "system/library",
-        "system/library/math",
-        "text/xmlto"
+        "system/library/math"
     ],
     "fmris": [
         "library/giflib"

--- a/components/library/giflib/test/results-all.master
+++ b/components/library/giflib/test/results-all.master
@@ -1,0 +1,107 @@
+/usr/gnu/bin/make -C doc
+make[1]: Entering directory '$(@D)/doc'
+make[1]: Nothing to be done for 'all'.
+make[1]: Leaving directory '$(@D)/doc'
+/usr/gnu/bin/make -C tests
+make[1]: Entering directory '$(@D)/tests'
+Testing RGB rendering of ../pic/fire.gif
+Testing RGB rendering of ../pic/fire.gif
+Testing RGB rendering of ../pic/gifgrid.gif
+Testing RGB rendering of ../pic/gifgrid.gif
+Testing RGB rendering of ../pic/porsche.gif
+Testing RGB rendering of ../pic/porsche.gif
+Testing RGB rendering of ../pic/solid2.gif
+Testing RGB rendering of ../pic/solid2.gif
+Testing RGB rendering of ../pic/treescap-interlaced.gif
+Testing RGB rendering of ../pic/treescap-interlaced.gif
+Testing RGB rendering of ../pic/treescap.gif
+Testing RGB rendering of ../pic/treescap.gif
+Testing RGB rendering of ../pic/welcome2.gif
+Testing RGB rendering of ../pic/welcome2.gif
+Testing RGB rendering of ../pic/x-trans.gif
+Testing RGB rendering of ../pic/x-trans.gif
+gifbuild: basic sanity check
+gifbuild: basic sanity check
+gifbuild: Checking idempotency on an icon file.
+gifbuild: Checking idempotency on an icon file.
+gifbuild: Checking idempotency on an animation.
+gifbuild: Checking idempotency on an animation.
+gifclrmap: Checking colormap of ../pic/fire.gif
+gifclrmap: Checking colormap of ../pic/fire.gif
+gifclrmap: Checking colormap of ../pic/gifgrid.gif
+gifclrmap: Checking colormap of ../pic/gifgrid.gif
+gifclrmap: Checking colormap of ../pic/porsche.gif
+gifclrmap: Checking colormap of ../pic/porsche.gif
+gifclrmap: Checking colormap of ../pic/solid2.gif
+gifclrmap: Checking colormap of ../pic/solid2.gif
+gifclrmap: Checking colormap of ../pic/treescap-interlaced.gif
+gifclrmap: Checking colormap of ../pic/treescap-interlaced.gif
+gifclrmap: Checking colormap of ../pic/treescap.gif
+gifclrmap: Checking colormap of ../pic/treescap.gif
+gifclrmap: Checking colormap of ../pic/welcome2.gif
+gifclrmap: Checking colormap of ../pic/welcome2.gif
+gifclrmap: Checking colormap of ../pic/x-trans.gif
+gifclrmap: Checking colormap of ../pic/x-trans.gif
+gifecho: Testing gifecho behavior
+gifecho: Testing gifecho behavior
+giffiltr: Testing copy of ../pic/fire.gif
+giffiltr: Testing copy of ../pic/fire.gif
+giffiltr: Testing copy of ../pic/gifgrid.gif
+giffiltr: Testing copy of ../pic/gifgrid.gif
+giffiltr: Testing copy of ../pic/porsche.gif
+giffiltr: Testing copy of ../pic/porsche.gif
+giffiltr: Testing copy of ../pic/solid2.gif
+giffiltr: Testing copy of ../pic/solid2.gif
+giffiltr: Testing copy of ../pic/treescap-interlaced.gif
+giffiltr: Testing copy of ../pic/treescap-interlaced.gif
+giffiltr: Testing copy of ../pic/treescap.gif
+giffiltr: Testing copy of ../pic/treescap.gif
+giffiltr: Testing copy of ../pic/welcome2.gif
+giffiltr: Testing copy of ../pic/welcome2.gif
+giffiltr: Testing copy of ../pic/x-trans.gif
+giffiltr: Testing copy of ../pic/x-trans.gif
+giffix: Testing giffix behavior
+giffix: Testing giffix behavior
+gifsponge: Testing copy of ../pic/fire.gif
+gifsponge: Testing copy of ../pic/fire.gif
+gifsponge: Testing copy of ../pic/gifgrid.gif
+gifsponge: Testing copy of ../pic/gifgrid.gif
+gifsponge: Testing copy of ../pic/porsche.gif
+gifsponge: Testing copy of ../pic/porsche.gif
+gifsponge: Testing copy of ../pic/solid2.gif
+gifsponge: Testing copy of ../pic/solid2.gif
+gifsponge: Testing copy of ../pic/treescap-interlaced.gif
+gifsponge: Testing copy of ../pic/treescap-interlaced.gif
+gifsponge: Testing copy of ../pic/treescap.gif
+gifsponge: Testing copy of ../pic/treescap.gif
+gifsponge: Testing copy of ../pic/welcome2.gif
+gifsponge: Testing copy of ../pic/welcome2.gif
+gifsponge: Testing copy of ../pic/x-trans.gif
+gifsponge: Testing copy of ../pic/x-trans.gif
+giftext: Checking text dump of ../pic/fire.gif
+giftext: Checking text dump of ../pic/fire.gif
+giftext: Checking text dump of ../pic/gifgrid.gif
+giftext: Checking text dump of ../pic/gifgrid.gif
+giftext: Checking text dump of ../pic/porsche.gif
+giftext: Checking text dump of ../pic/porsche.gif
+giftext: Checking text dump of ../pic/solid2.gif
+giftext: Checking text dump of ../pic/solid2.gif
+giftext: Checking text dump of ../pic/treescap-interlaced.gif
+giftext: Checking text dump of ../pic/treescap-interlaced.gif
+giftext: Checking text dump of ../pic/treescap.gif
+giftext: Checking text dump of ../pic/treescap.gif
+giftext: Checking text dump of ../pic/welcome2.gif
+giftext: Checking text dump of ../pic/welcome2.gif
+giftext: Checking text dump of ../pic/x-trans.gif
+giftext: Checking text dump of ../pic/x-trans.gif
+giftool: Checking that expensive copy via giftool is faithful.
+giftool: Checking that expensive copy via giftool is faithful.
+giftool: Checking that it de-interlaces correctly.
+giftool: Checking that it de-interlaces correctly.
+giftool: Checking that it interlaces correctly.
+giftool: Checking that it interlaces correctly.
+gifwedge: Checking wedge generation.
+gifwedge: Checking wedge generation.
+No output is good news
+No output is good news
+make[1]: Leaving directory '$(@D)/tests'


### PR DESCRIPTION
I checked all dependent packages - they are all already on 64bit so there should be no harm to them.