### PR TITLE
tools/python-integrate-project: drop support for setup.py test style

### DIFF
--- a/tools/python-integrate-project
+++ b/tools/python-integrate-project
@@ -406,8 +406,6 @@ while true ; do
 
 	python${PYTHON_VERSIONS%% *} -m unittest discover 2>&1 | grep '^Ran' | grep -q -v '^Ran 0 ' && TEST_STYLE='unittest' && break
 
-	[[ -f setup.py ]] && python${PYTHON_VERSIONS%% *} setup.py test --help > /dev/null 2>&1 && TEST_STYLE='setup.py' && break
-
 	TEST_STYLE="none"
 	break
 done


### PR DESCRIPTION
Support for `setup.py test` subcommand has been removed from `setuptools` more than a year ago (in version 72) and so the `setup.py` test style detection cannot succeed anyway.