### PR TITLE
Obsolete SUNWlibevent

### DIFF
--- a/components/meta-packages/history/history
+++ b/components/meta-packages/history/history
@@ -102,6 +102,7 @@ SUNWlang-zhCN-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-zhHK-extra@0.5.11,5.11-2015.0.2.0
 SUNWlang-zhTW-extra@0.5.11,5.11-2015.0.2.0
 SUNWlibcompizconfig@0.5.11,5.11-2015.0.2.0
+SUNWlibevent@1.3.5,5.11-0.133.1
 SUNWlibm@0.5.11,5.11-2015.0.3.0
 SUNWlibms@0.5.11,5.11-2015.0.3.0
 SUNWlibvirt@0.5.11,5.11-2015.0.2.0


### PR DESCRIPTION
This is currently a renamed package (in the IPS repo) that depends on `library/libevent`.  Since `library/libevent` has been obsoleted 5 months ago we should obsolete `SUNWlibevent` too.