### PR TITLE
glib: update to 2.86.2

### DIFF
--- a/components/library/glib/Makefile
+++ b/components/library/glib/Makefile
@@ -23,9 +23,9 @@ USE_COMMON_TEST_MASTER = no
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		glib
-HUMAN_VERSION=		2.82.5
+HUMAN_VERSION=		2.86.2
 COMPONENT_SUMMARY=	GNOME core libraries
-COMPONENT_ARCHIVE_HASH=	sha256:05c2031f9bdf6b5aba7a06ca84f0b4aced28b19bf1b50c6ab25cc675277cbc3f
+COMPONENT_ARCHIVE_HASH=	sha256:8a724e970855357ea8101e27727202392a0ffd5410a98336aed54ec59113e611
 COMPONENT_FMRI=		library/glib2
 COMPONENT_CLASSIFICATION= Desktop (GNOME)/Libraries
 COMPONENT_LICENSE=	LGPL-2.1-only
@@ -81,6 +81,20 @@ COMPONENT_BUILD_ENV += DFLAGS=$(DFLAGS.$(BITS))
 # typelib compilation to fail
 COMPONENT_BUILD_ENV += LD_LIBRARY_PATH=gio:glib:gobject
 
+# fix python scripts
+COMPONENT_POST_INSTALL_ACTION.32 += \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/i86/gtester-report && \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/i86/gdbus-codegen && \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/i86/glib-genmarshal && \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/i86/glib-mkenums
+
+
+COMPONENT_POST_INSTALL_ACTION.64 += \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/gtester-report && \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/gdbus-codegen && \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/glib-genmarshal && \
+        $(GSED) -i "s|/usr/bin/env python3|$(PYTHON)|" $(PROTO_DIR)/usr/bin/glib-mkenums
+
 # dbus-daemon is in /usr/lib
 COMPONENT_TEST_ENV.32 = LD_LIBRARY_PATH=$(PROTO_DIR)/usr/lib PATH=$(PATH):/usr/lib
 COMPONENT_TEST_ENV.64 = LD_LIBRARY_PATH=$(PROTO_DIR)/usr/lib/$(MACH64) PATH=$(PATH):/usr/lib/$(MACH64)
@@ -108,9 +122,6 @@ TEST_REQUIRED_PACKAGES += system/library/dbus
 TEST_REQUIRED_PACKAGES += library/desktop/desktop-file-utils
 
 # Auto-generated dependencies
-PYTHON_REQUIRED_PACKAGES += library/python/python-subunit
-PYTHON_REQUIRED_PACKAGES += library/python/testtools
-PYTHON_REQUIRED_PACKAGES += runtime/python
 REQUIRED_PACKAGES += library/file-monitor/gamin
 REQUIRED_PACKAGES += library/libffi
 REQUIRED_PACKAGES += library/pcre2
@@ -118,3 +129,6 @@ REQUIRED_PACKAGES += library/zlib
 REQUIRED_PACKAGES += shell/ksh93
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES.python += library/python/python-subunit
+REQUIRED_PACKAGES.python += library/python/testtools
+REQUIRED_PACKAGES.python += runtime/python

--- a/components/library/glib/patches/04-xopen-version.patch
+++ b/components/library/glib/patches/04-xopen-version.patch
@@ -1,16 +1,29 @@
-Remove Unix standard settings for Solaris 11.4, so we don't exclude all
-features added between XPG2 & XPG7, now that these are exposed by default.
-
-To send upstream, need to adjust to right version for each OS level
-
---- glib-2.82.0/meson.build.orig
-+++ glib-2.82.0/meson.build
-@@ -2477,8 +2477,6 @@
+--- glib-2.86.0/meson.build.~1~	2025-09-05 08:42:14.000000000 -0400
++++ glib-2.86.0/meson.build	2025-09-14 19:26:07.323353559 -0400
+@@ -2549,26 +2549,6 @@
+ # Some installed tests require a custom environment
+ env_program = find_program('env', required: installed_tests_enabled)
  
- # FIXME: How to detect Solaris? https://github.com/mesonbuild/meson/issues/1578
- if host_system == 'sunos'
--  glib_conf.set('_XOPEN_SOURCE_EXTENDED', 1)
--  glib_conf.set('_XOPEN_SOURCE', 2)
-   glib_conf.set('__EXTENSIONS__',1)
- endif
- 
+-# illumos & Solaris may need extra definitions to expose some SUS/POSIX
+-# interfaces in headers that conflict with previous Solaris headers.
+-# But if we define them to request an older version of the standards,
+-# we may hide things introduced in newer versions.  We only check the
+-# versions that are supported on systems new enough that meson runs on them.
+-if host_system == 'sunos'
+-  xopen_test_code = '''#include <unistd.h>
+-  #if _XOPEN_VERSION != _XOPEN_SOURCE
+-  #error "XOPEN_SOURCE of _XOPEN_SOURCE not supported"
+-  #endif'''
+-  foreach std : ['800', '700', '600']
+-    if cc.compiles(xopen_test_code, args: '-D_XOPEN_SOURCE=' + std, name: 'building with _XOPEN_SOURCE=' + std)
+-      xopen_version = std
+-      break
+-    endif
+-  endforeach
+-  glib_conf.set('_XOPEN_SOURCE', xopen_version)
+-  glib_conf.set('__EXTENSIONS__',1)
+-endif
+-
+ # Sadly Meson does not expose this value:
+ # https://github.com/mesonbuild/meson/pull/3460
+ if host_system == 'windows'

--- a/components/library/glib/patches/05-missing-sysinfo-member.patch
+++ b/components/library/glib/patches/05-missing-sysinfo-member.patch
@@ -1,0 +1,12 @@
+--- glib-2.85.4/gio/gmemorymonitorbase.c.old	2025-09-03 13:52:12.377161622 -0400
++++ glib-2.85.4/gio/gmemorymonitorbase.c	2025-09-03 13:53:17.725158450 -0400
+@@ -29,6 +29,9 @@
+ #include "gmemorymonitor.h"
+ #include "gmemorymonitorbase.h"
+ 
++/* error: 'struct sysinfo' has no member named 'totalram' */
++#undef HAVE_SYSINFO
++
+ #ifdef HAVE_SYSINFO
+ #include <sys/sysinfo.h>
+ #endif

--- a/components/library/glib/patches/06-libsocket.patch
+++ b/components/library/glib/patches/06-libsocket.patch
@@ -1,0 +1,80 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/gio/tests/meson.build a/gio/tests/meson.build
+--- a~/gio/tests/meson.build	1970-01-01 00:00:00
++++ a/gio/tests/meson.build	1970-01-01 00:00:00
+@@ -106,7 +106,11 @@ gio_tests = {
+   'memory-output-stream' : {},
+   'memory-settings-backend' : {},
+   'mount-operation' : {},
+-  'network-address' : {'extra_sources': ['mock-resolver.c']},
++  'network-address' : {
++    'extra_sources': ['mock-resolver.c'],
++    'c_args' : network_args,
++    'dependencies' : network_libs,
++  },
+   'network-monitor' : {},
+   'network-monitor-race' : {},
+   'null-settings-backend' : {},
+@@ -126,6 +130,8 @@ gio_tests = {
+     # FIXME: https://gitlab.gnome.org/GNOME/glib/-/issues/1392
+     # FIXME: https://gitlab.gnome.org/GNOME/glib/-/issues/3148
+     'can_fail' : host_system in ['darwin', 'gnu'],
++    'c_args' : network_args,
++    'dependencies' : network_libs
+   },
+   'socket-listener' : {},
+   'socket-service' : {},
+@@ -144,7 +150,10 @@ gio_tests = {
+   'tls-interaction' : {'extra_sources' : ['gtesttlsbackend.c']},
+   'tls-database' : {'extra_sources' : ['gtesttlsbackend.c']},
+   'tls-bindings' : {'extra_sources' : ['gtesttlsbackend.c']},
+-  'unix-fd' : {},
++  'unix-fd' : {
++    'c_args' : network_args,
++    'dependencies' : network_libs
++  },
+   'gdbus-address-get-session' : {
+     'extra_programs': host_system != 'windows' ? ['dbus-launch'] : [],
+     # FIXME: https://gitlab.gnome.org/GNOME/glib/-/issues/1392
+@@ -260,7 +269,10 @@ if host_machine.system() != 'windows'
+       # FIXME: https://gitlab.gnome.org/GNOME/glib/-/issues/3148
+       'can_fail' : host_system == 'gnu',
+     },
+-    'gdbus-peer-object-manager' : {},
++    'gdbus-peer-object-manager' : {
++      'c_args' : network_args,
++      'dependencies' : network_libs
++    },
+     'gdbus-sasl' : {},
+     'live-g-file' : {},
+     'portal-support-flatpak-none' : {
+@@ -307,6 +319,8 @@ if host_machine.system() != 'windows'
+     'stream-rw_all' : {
+       # FIXME: https://gitlab.gnome.org/GNOME/glib/-/issues/3148
+       'can_fail' : host_system == 'gnu',
++      'c_args' : network_args,
++      'dependencies' : network_libs
+     },
+     'unix-mounts' : {},
+     'unix-streams' : {},
+@@ -606,8 +620,8 @@ if host_machine.system() != 'windows'
+ 
+   # This test is currently unreliable
+   executable('gdbus-overflow', 'gdbus-overflow.c',
+-      c_args : test_c_args,
+-      dependencies : common_gio_tests_deps,
++      c_args : [test_c_args, network_args],
++      dependencies : [common_gio_tests_deps, network_libs],
+       install_dir : installed_tests_execdir,
+       install_tag : 'tests',
+       install : installed_tests_enabled)
+diff -wpruN --no-dereference '--exclude=*.orig' a~/glib/tests/meson.build a/glib/tests/meson.build
+--- a~/glib/tests/meson.build	1970-01-01 00:00:00
++++ a/glib/tests/meson.build	1970-01-01 00:00:00
+@@ -140,6 +140,7 @@ glib_tests = {
+   },
+   'spawn-singlethread' : {
+     'dependencies' : [winsock2],
++    'link_args' : '-lsocket',
+     'extra_programs' : ['test-spawn-echo'],
+     # FIXME: https://gitlab.gnome.org/GNOME/glib/-/issues/3148
+     'can_fail' : host_system == 'gnu',

--- a/components/library/glib/patches/07-mntent.patch
+++ b/components/library/glib/patches/07-mntent.patch
@@ -1,0 +1,34 @@
+
+The field that stores mount options in 'struct mnttab' is mnt_mntopts on
+OmniOS and mnt_opts on Linux; adjust.
+
+diff -wpruN --no-dereference '--exclude=*.orig' a~/gio/gunixmounts.c a/gio/gunixmounts.c
+--- a~/gio/gunixmounts.c	1970-01-01 00:00:00
++++ a/gio/gunixmounts.c	1970-01-01 00:00:00
+@@ -712,7 +712,7 @@ _g_unix_mounts_get_from_file (const char
+                                              mntent->mnt_dir,
+                                              NULL,
+                                              mntent->mnt_type,
+-                                             mntent->mnt_opts,
++                                             mntent->mnt_mntopts,
+                                              is_read_only);
+ 
+       g_hash_table_insert (mounts_hash,
+@@ -843,7 +843,7 @@ _g_unix_mounts_get_from_file (const char
+                                              mntent.mnt_mountp,
+                                              NULL,
+                                              mntent.mnt_fstype,
+-                                             mntent.mnt_opts,
++                                             mntent.mnt_mntopts,
+                                              is_read_only);
+ 
+       g_ptr_array_add (return_array, g_steal_pointer (&mount_entry));
+@@ -1363,7 +1363,7 @@ _g_unix_mount_points_get_from_file (cons
+       mount_point = create_unix_mount_point (device_path,
+                                              mntent->mnt_dir,
+                                              mntent->mnt_type,
+-                                             mntent->mnt_opts,
++                                             mntent->mnt_mntopts,
+                                              is_read_only,
+                                              is_user_mountable,
+                                              is_loopback);

--- a/components/library/glib/patches/08-gio-trash-only-home.patch
+++ b/components/library/glib/patches/08-gio-trash-only-home.patch
@@ -1,6 +1,6 @@
---- glib-2.82.0/gio/glocalfile.c.orig
-+++ glib-2.82.0/gio/glocalfile.c
-@@ -2000,6 +2000,7 @@
+--- glib-2.85.4/gio/glocalfile.c.~1~	2025-08-22 08:29:34.000000000 -0400
++++ glib-2.85.4/gio/glocalfile.c	2025-09-03 13:37:38.047224783 -0400
+@@ -2095,6 +2095,7 @@
    char *dirname, *globaldir;
    GVfsClass *class;
    GVfs *vfs;
@@ -8,170 +8,16 @@
    int errsv;
    size_t basename_len;
    GError *my_error = NULL;
-@@ -2057,146 +2058,25 @@
+@@ -2156,7 +2157,7 @@
        g_free (path);
      }
  
--  if (file_stat.st_dev == home_stat.st_dev)
-+  /* Always move to .Trash in the user's home directory  */
-+  is_homedir_trash = TRUE;
-+  errno = 0;
-+  trashdir = g_build_filename (g_get_user_data_dir (), "Trash", NULL);
-+  if (g_mkdir_with_parents (trashdir, 0700) < 0)
+-  if (checked_st_dev == home_stat.st_dev)
++  if (1)
      {
--      is_homedir_trash = TRUE;
--      errno = 0;
--      trashdir = g_build_filename (g_get_user_data_dir (), "Trash", NULL);
--      if (g_mkdir_with_parents (trashdir, 0700) < 0)
--	{
--          char *display_name;
--          errsv = errno;
--
--          display_name = g_filename_display_name (trashdir);
--          g_set_error (error, G_IO_ERROR,
--                       g_io_error_from_errno (errsv),
--                       _("Unable to create trash directory %s: %s"),
--                       display_name, g_strerror (errsv));
--          g_free (display_name);
--          g_free (trashdir);
--          return FALSE;
--	}
--      topdir = g_strdup (g_get_user_data_dir ());
--    }
--  else
--    {
--      uid_t uid;
--      char uid_str[32];
--      gboolean success = FALSE;
--
--      uid = geteuid ();
--      g_snprintf (uid_str, sizeof (uid_str), "%lu", (unsigned long)uid);
--
--      topdir = _g_local_file_find_topdir_for (local->filename);
--      if (topdir == NULL)
--	{
--          g_set_io_error (error,
--                          _("Unable to find toplevel directory to trash %s"),
--                          file, ENOTSUP);
--	  return FALSE;
--	}
--
--      if (ignore_trash_path (topdir))
--        {
--          g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
--                       _("Trashing on system internal mounts is not supported"));
--          g_free (topdir);
--
--          return FALSE;
--        }
--
--      /* Try looking for global trash dir $topdir/.Trash/$uid */
--      globaldir = g_build_filename (topdir, ".Trash", NULL);
--      if (g_lstat (globaldir, &global_stat) == 0 &&
--	  S_ISDIR (global_stat.st_mode) &&
--	  (global_stat.st_mode & S_ISVTX) != 0)
--	{
--	  trashdir = g_build_filename (globaldir, uid_str, NULL);
--	  success = TRUE;
--
--	  if (g_lstat (trashdir, &trash_stat) == 0)
--	    {
--	      if (!S_ISDIR (trash_stat.st_mode) ||
--		  trash_stat.st_uid != uid)
--		{
--		  /* Not a directory or not owned by user, ignore */
--		  g_free (trashdir);
--		  trashdir = NULL;
--		  success = FALSE;
--		}
--	    }
--	  else if (g_mkdir (trashdir, 0700) == -1)
--	    {
--	      g_free (trashdir);
--	      trashdir = NULL;
--	      success = FALSE;
--	    }
--	}
--      g_free (globaldir);
--
--      if (trashdir == NULL)
--	{
--	  gboolean tried_create;
--	  
--	  /* No global trash dir, or it failed the tests, fall back to $topdir/.Trash-$uid */
--	  dirname = g_strdup_printf (".Trash-%s", uid_str);
--	  trashdir = g_build_filename (topdir, dirname, NULL);
--          success = TRUE;
--	  g_free (dirname);
--
--	  tried_create = FALSE;
--
--	retry:
--	  if (g_lstat (trashdir, &trash_stat) == 0)
--	    {
--	      if (!S_ISDIR (trash_stat.st_mode) ||
--		  trash_stat.st_uid != uid)
--		{
--		  /* Remove the failed directory */
--		  if (tried_create)
--		    g_remove (trashdir);
--		  
--		  /* Not a directory or not owned by user, ignore */
--		  success = FALSE;
--		}
--	    }
--	  else
--	    {
--	      if (!tried_create &&
--		  g_mkdir (trashdir, 0700) != -1)
--		{
--		  /* Ensure that the created dir has the right uid etc.
--		     This might fail on e.g. a FAT dir */
--		  tried_create = TRUE;
--		  goto retry;
--		}
--	      else
--		{
--		  success = FALSE;
--		}
--	    }
--	}
--
--      if (!success)
--	{
--          gchar *trashdir_display_name = NULL, *file_display_name = NULL;
--
--          trashdir_display_name = g_filename_display_name (trashdir);
--          file_display_name = g_filename_display_name (local->filename);
--          g_set_error (error, G_IO_ERROR,
--                       G_IO_ERROR_NOT_SUPPORTED,
--                       _("Unable to find or create trash directory %s to trash %s"),
--                       trashdir_display_name, file_display_name);
--
--          g_free (trashdir_display_name);
--          g_free (file_display_name);
--
--          g_free (topdir);
--          g_free (trashdir);
-+      char *display_name;
-+      errsv = errno;
- 
--	  return FALSE;
--	}
-+      display_name = g_filename_display_name (trashdir);
-+      g_set_error (error, G_IO_ERROR,
-+          g_io_error_from_errno (errsv),
-+          _("Unable to create trash directory %s: %s"),
-+          display_name, g_strerror (errsv));
-+      g_free (display_name);
-+      g_free (trashdir);
-+      return FALSE;
-     }
-+  topdir = g_strdup (g_get_user_data_dir ());
- 
-   /* Trashdir points to the trash dir with the "info" and "files" subdirectories */
- 
-@@ -2366,8 +2246,8 @@
+       is_homedir_trash = TRUE;
+       errno = 0;
+@@ -2478,8 +2479,8 @@
    trashfile = g_build_filename (filesdir, trashname, NULL);
  
    g_free (filesdir);
@@ -182,7 +28,7 @@
      {
        errsv = errno;
  
-@@ -2376,6 +2256,7 @@
+@@ -2488,6 +2489,7 @@
        g_free (trashname);
        g_free (infofile);
        g_free (trashfile);
@@ -190,7 +36,7 @@
  
        if (errsv == EXDEV)
  	/* The trash dir was actually on another fs anyway!?
-@@ -2398,6 +2279,7 @@
+@@ -2510,6 +2512,7 @@
      class->local_file_moved (vfs, local->filename, trashfile);
  
    g_free (trashfile);

--- a/components/library/glib/patches/09-IPV6-check.patch
+++ b/components/library/glib/patches/09-IPV6-check.patch
@@ -1,0 +1,11 @@
+--- glib-2.86.0/gio/ginetaddress.c.old	2025-09-14 21:01:27.619784403 -0400
++++ glib-2.86.0/gio/ginetaddress.c	2025-09-14 21:03:19.137493200 -0400
+@@ -464,7 +464,7 @@
+       GInetAddress *address = NULL;
+       
+       status = getaddrinfo (string, NULL, &hints, &res);
+-      if (status == 0)
++      if ((status == 0) && (res->ai_family == AF_INET6))
+         {
+           g_assert (res->ai_addrlen == sizeof (struct sockaddr_in6));
+           struct sockaddr_in6 *sockaddr6 = (struct sockaddr_in6 *)res->ai_addr;

--- a/components/library/glib/patches/18-pid-format.patch
+++ b/components/library/glib/patches/18-pid-format.patch
@@ -1,11 +1,11 @@
---- glib-2.82.0/glib/tests/mapping.c.orig
-+++ glib-2.82.0/glib/tests/mapping.c
-@@ -228,7 +228,7 @@
+--- glib-2.85.4/glib/tests/mapping.c.~1~	2025-08-22 08:29:34.000000000 -0400
++++ glib-2.85.4/glib/tests/mapping.c	2025-09-03 13:40:32.045301689 -0400
+@@ -234,7 +234,7 @@
    spawn_flags |= G_SPAWN_DO_NOT_REAP_CHILD;
  #endif
  
--  g_snprintf (pid, sizeof(pid), "%d", getpid ());
-+  g_snprintf (pid, sizeof(pid), "%ld", (long) getpid ());
+-  g_snprintf (pid, sizeof (pid), "%d", (int) getpid ());
++  g_snprintf (pid, sizeof (pid), "%ld", (long) getpid ());
    child_argv[0] = local_argv[0];
    child_argv[1] = "mapchild";
    child_argv[2] = pid;

--- a/components/library/glib/test/results-32.master
+++ b/components/library/glib/test/results-32.master
@@ -1,8 +1,12 @@
 glib:fuzzing / fuzz_bookmark                                           OK
 glib:fuzzing / fuzz_canonicalize_filename                              OK
+glib:fuzzing / fuzz_data_input_stream_read_line                        OK
+glib:fuzzing / fuzz_data_input_stream_read_line_utf8                   OK
+glib:fuzzing / fuzz_data_input_stream_read_upto                        OK
 glib:fuzzing / fuzz_date_parse                                         OK
 glib:fuzzing / fuzz_date_time_new_from_iso8601                         OK
 glib:fuzzing / fuzz_dbus_message                                       OK
+glib:fuzzing / fuzz_get_locale_variants                                OK
 glib:fuzzing / fuzz_inet_address_mask_new_from_string                  OK
 glib:fuzzing / fuzz_inet_address_new_from_string                       OK
 glib:fuzzing / fuzz_inet_socket_address_new_from_string                OK
@@ -11,6 +15,8 @@ glib:fuzzing / fuzz_network_address_parse                              OK
 glib:fuzzing / fuzz_network_address_parse_uri                          OK
 glib:fuzzing / fuzz_paths                                              OK
 glib:fuzzing / fuzz_resolver                                           OK
+glib:fuzzing / fuzz_special_dirs                                       OK
+glib:fuzzing / fuzz_string                                             OK
 glib:fuzzing / fuzz_uri_escape                                         OK
 glib:fuzzing / fuzz_uri_parse                                          OK
 glib:fuzzing / fuzz_uri_parse_params                                   OK
@@ -20,7 +26,7 @@ glib:fuzzing / fuzz_uuid_string_is_valid                               OK
 glib:fuzzing / fuzz_variant_binary                                     OK
 glib:fuzzing / fuzz_variant_binary_byteswap                            OK
 glib:fuzzing / fuzz_variant_text                                       OK
-glib:gio / appinfo                                                     OK   11 subtests passed
+glib:gio / appinfo                                                     OK   14 subtests passed
 glib:gio / application-command-line                                    OK   1 subtests passed
 glib:gio / appmonitor                                                  ERROR   killed by signal 6 SIGABRT
 glib:gio / async-close-output-stream                                   OK   3 subtests passed
@@ -28,41 +34,65 @@ glib:gio / async-splice-output-stream                                  OK   5 su
 glib:gio / autoptr-gio                                                 OK   1 subtests passed
 glib:gio / buffered-input-stream                                       OK   10 subtests passed
 glib:gio / buffered-output-stream                                      OK   5 subtests passed
-glib:gio / cancellable                                                 OK   9 subtests passed
+glib:gio / cancellable                                                 OK   17 subtests passed
 glib:gio / contenttype                                                 OK   12 subtests passed
 glib:gio / contexts                                                    OK   5 subtests passed
-glib:gio / converter                                                   OK   1 subtests passed
+glib:gio / converter                                                   OK   3 subtests passed
 glib:gio / converter-stream                                            ERROR   killed by signal 6 SIGABRT
 glib:gio / credentials                                                 OK   1 subtests passed
 glib:gio / data-input-stream                                           OK   10 subtests passed
 glib:gio / data-output-stream                                          OK   7 subtests passed
-glib:gio / desktop-app-info                                            OK   56 subtests passed
+glib:gio / dbus-appinfo                                                ERROR   killed by signal 6 SIGABRT
+glib:gio / debugcontroller                                             OK   3 subtests passed
+glib:gio / defaultvalue                                                OK   51 subtests passed
+glib:gio / desktop-app-info                                            OK   58 subtests passed
 glib:gio / error                                                       OK   2 subtests passed
+glib:gio / fdo-notification-backend                                    OK   2 subtests passed
 glib:gio / file                                                        OK   45 subtests passed
+glib:gio / file-enumerator                                             OK   1 subtests passed
 glib:gio / file-thumbnail                                              OK   7 subtests passed
 glib:gio / fileattributematcher                                        OK   3 subtests passed
+glib:gio / filenamecompleter                                           OK   1 subtests passed
 glib:gio / filter-streams                                              OK   4 subtests passed
 glib:gio / g-file                                                      OK   8 subtests passed
 glib:gio / g-file-info                                                 OK   4 subtests passed
 glib:gio / g-file-info-filesystem-readonly                             SKIP   0 subtests passed
 glib:gio / g-icon                                                      OK   6 subtests passed
+glib:gio / gapplication                                                OK   25 subtests passed
 glib:gio / gdbus-address-get-session                                   OK   2 subtests passed
 glib:gio / gdbus-addresses                                             OK   9 subtests passed
+glib:gio / gdbus-auth                                                  OK   5 subtests passed
+glib:gio / gdbus-bz627724                                              OK   1 subtests passed
+glib:gio / gdbus-close-pending                                         OK   2 subtests passed
+glib:gio / gdbus-connection                                            OK   9 subtests passed
 glib:gio / gdbus-connection-flush                                      OK   2 subtests passed
+glib:gio / gdbus-connection-loss                                       OK   1 subtests passed
+glib:gio / gdbus-connection-slow                                       OK   2 subtests passed
+glib:gio / gdbus-error                                                 OK   4 subtests passed
+glib:gio / gdbus-exit-on-close                                         OK   4 subtests passed
+glib:gio / gdbus-introspection                                         OK   4 subtests passed
 glib:gio / gdbus-message                                               OK   3 subtests passed
+glib:gio / gdbus-method-invocation                                     OK   1 subtests passed
+glib:gio / gdbus-names                                                 OK   10 subtests passed
 glib:gio / gdbus-non-socket                                            OK   1 subtests passed
 glib:gio / gdbus-peer                                                  ERROR   killed by signal 5 SIGTRAP
 glib:gio / gdbus-peer-object-manager                                   OK   2 subtests passed
+glib:gio / gdbus-proxy                                                 OK   5 subtests passed
+glib:gio / gdbus-proxy-threads                                         OK   1 subtests passed
+glib:gio / gdbus-proxy-unique-name                                     OK   1 subtests passed
+glib:gio / gdbus-proxy-well-known-name                                 OK   1 subtests passed
 glib:gio / gdbus-sasl                                                  OK   1 subtests passed
 glib:gio / gdbus-serialization                                         OK   18 subtests passed
 glib:gio / gdbus-server-auth                                           OK   9 subtests passed
+glib:gio / gdbus-subscribe                                             OK   24 subtests passed
 glib:gio / giomodule                                                   OK   3 subtests passed
 glib:gio / glistmodel                                                  OK   18 subtests passed
+glib:gio / gnotification                                               OK   2 subtests passed
 glib:gio / gschema-compile                                             OK   82 subtests passed
 glib:gio / gsettings                                                   ERROR   killed by signal 5 SIGTRAP
 glib:gio / gsocketclient-slow                                          OK   4 subtests passed
-glib:gio / gsubprocess                                                 OK   82 subtests passed
-glib:gio / inet-address                                                OK   11 subtests passed
+glib:gio / gsubprocess                                                 OK   83 subtests passed
+glib:gio / inet-address                                                ERROR   killed by signal 6 SIGABRT
 glib:gio / io-stream                                                   OK   3 subtests passed
 glib:gio / live-g-file                                                 OK   12 subtests passed
 glib:gio / max-version                                                 OK   1 subtests passed
@@ -70,26 +100,26 @@ glib:gio / memory-input-stream                                         OK   6 su
 glib:gio / memory-monitor                                              OK   1 subtests passed
 glib:gio / memory-output-stream                                        OK   10 subtests passed
 glib:gio / memory-settings-backend                                     OK   1 subtests passed
-glib:gio / mimeapps                                                    OK   7 subtests passed
+glib:gio / mimeapps                                                    OK   13 subtests passed
 glib:gio / mount-operation                                             OK   2 subtests passed
 glib:gio / network-address                                             OK   72 subtests passed
 glib:gio / network-monitor                                             OK   4 subtests passed
 glib:gio / network-monitor-race                                        OK   1 subtests passed
 glib:gio / null-settings-backend                                       OK   1 subtests passed
 glib:gio / permission                                                  OK   1 subtests passed
-glib:gio / pollable                                                    OK   4 subtests passed
+glib:gio / pollable                                                    ERROR   killed by signal 6 SIGABRT
 glib:gio / power-profile-monitor                                       OK   1 subtests passed
 glib:gio / proxy-test                                                  OK   11 subtests passed
 glib:gio / readwrite                                                   OK   3 subtests passed
 glib:gio / resolver-parsing                                            OK   21 subtests passed
-glib:gio / resources                                                   OK   16 subtests passed
+glib:gio / resources                                                   OK   18 subtests passed
 glib:gio / sandbox                                                     OK   4 subtests passed
 glib:gio / simple-async-result                                         OK   2 subtests passed
 glib:gio / simple-proxy                                                OK   3 subtests passed
 glib:gio / sleepy-stream                                               OK   2 subtests passed
-glib:gio / socket                                                      OK   27 subtests passed
+glib:gio / socket                                                      OK   29 subtests passed
 glib:gio / socket-address                                              OK   2 subtests passed
-glib:gio / socket-listener                                             OK   1 subtests passed
+glib:gio / socket-listener                                             ERROR   killed by signal 6 SIGABRT
 glib:gio / socket-service                                              OK   4 subtests passed
 glib:gio / srvtarget                                                   OK   1 subtests passed
 glib:gio / stream-rw_all                                               OK   3 subtests passed
@@ -114,7 +144,10 @@ glib:gio+cpp / cxx-17                                                  OK
 glib:gio+cpp / cxx-20                                                  OK
 glib:gio+cpp / cxx-2b                                                  OK
 glib:gio+cpp / cxx-98                                                  OK
-glib:gio+no-valgrind / gio-tool.py                                     OK   3 subtests passed
+glib:gio+gdbus-codegen / gdbus-test-codegen                            OK   8 subtests passed
+glib:gio+gdbus-codegen / gdbus-test-codegen-min-required-2-64          OK   8 subtests passed
+glib:gio+gdbus-codegen / gdbus-test-codegen-old                        OK   8 subtests passed
+glib:gio+no-valgrind / gio-tool.py                                     OK   9 subtests passed
 glib:gio+no-valgrind+gdbus-codegen+slow / codegen.py                   OK   39 subtests passed
 glib:gio+no-valgrind+pkg-config / gio-2.0-pkg-config                   FAIL   exit status 1
 glib:gio+no-valgrind+pkg-config / gio-unix-2.0-pkg-config              OK
@@ -126,25 +159,35 @@ glib:gio+portal-support / portal-support-flatpak-none                  OK   1 su
 glib:gio+portal-support / portal-support-none                          OK   1 subtests passed
 glib:gio+portal-support / portal-support-snap                          OK   7 subtests passed
 glib:gio+portal-support / portal-support-snap-classic                  OK   3 subtests passed
+glib:gio+slow / actions                                                OK   13 subtests passed
+glib:gio+slow / gdbus-export                                           OK   5 subtests passed
+glib:gio+slow / gdbus-threading                                        OK   3 subtests passed
+glib:gio+slow / gmenumodel                                             OK   15 subtests passed
+glib:gio+slow / testfilemonitor                                        ERROR   killed by signal 6 SIGABRT
 glib:girepository+core / autoptr-girepository                          OK   24 subtests passed
+glib:girepository+core / callable-info                                 OK   5 subtests passed
 glib:girepository+core / cmph-bdz                                      OK   2 subtests passed
 glib:girepository+core / dump                                          OK   4 subtests passed
+glib:girepository+core / field-info                                    OK   4 subtests passed
 glib:girepository+core / function-info                                 OK   1 subtests passed
 glib:girepository+core / gthash                                        OK   1 subtests passed
+glib:girepository+core / ir-parser                                     OK   1 subtests passed
 glib:girepository+core / object-info                                   OK   2 subtests passed
 glib:girepository+core / registered-type-info                          OK   1 subtests passed
-glib:girepository+core / repository                                    OK   23 subtests passed
+glib:girepository+core / repository                                    OK   24 subtests passed
 glib:girepository+core / repository-search-paths                       OK   4 subtests passed
 glib:girepository+core / struct-info                                   OK   4 subtests passed
 glib:girepository+core / throws                                        OK   3 subtests passed
 glib:girepository+core / union-info                                    OK   2 subtests passed
+glib:girepository+no-valgrind+compiler / gi-compile-repository.py      OK   7 subtests passed
+glib:girepository+no-valgrind+inspector / gi-inspect-typelib.py        OK   12 subtests passed
 glib:glib+core / 1bit-mutex                                            OK   2 subtests passed
-glib:glib+core / array-test                                            OK   109 subtests passed
+glib:glib+core / array-test                                            OK   116 subtests passed
 glib:glib+core / asyncqueue                                            OK   7 subtests passed
 glib:glib+core / atomic                                                OK   2 subtests passed
 glib:glib+core / autoptr                                               OK   57 subtests passed
 glib:glib+core / base64                                                OK   28 subtests passed
-glib:glib+core / bitlock                                               OK   1 subtests passed
+glib:glib+core / bitlock                                               OK   2 subtests passed
 glib:glib+core / bookmarkfile                                          OK   96 subtests passed
 glib:glib+core / bytes                                                 OK   20 subtests passed
 glib:glib+core / cache                                                 OK   1 subtests passed
@@ -155,8 +198,8 @@ glib:glib+core / completion                                            OK   1 su
 glib:glib+core / cond                                                  OK   3 subtests passed
 glib:glib+core / constructor                                           OK   2 subtests passed
 glib:glib+core / convert                                               OK   14 subtests passed
-glib:glib+core / dataset                                               OK   14 subtests passed
-glib:glib+core / date                                                  OK   118 subtests passed
+glib:glib+core / dataset                                               OK   15 subtests passed
+glib:glib+core / date                                                  OK   119 subtests passed
 glib:glib+core / dir                                                   OK   3 subtests passed
 glib:glib+core / environment                                           OK   6 subtests passed
 glib:glib+core / error                                                 OK   10 subtests passed
@@ -169,15 +212,15 @@ glib:glib+core / gwakeup-fallback                                      OK   2 su
 glib:glib+core / hash                                                  OK   34 subtests passed
 glib:glib+core / hmac                                                  OK   37 subtests passed
 glib:glib+core / hook                                                  OK   2 subtests passed
-glib:glib+core / hostutils                                             OK   3 subtests passed
+glib:glib+core / hostutils                                             OK   4 subtests passed
 glib:glib+core / include                                               OK   1 subtests passed
 glib:glib+core / io-channel                                            OK   2 subtests passed
 glib:glib+core / io-channel-basic                                      OK   1 subtests passed
 glib:glib+core / keyfile                                               OK   36 subtests passed
 glib:glib+core / list                                                  OK   20 subtests passed
-glib:glib+core / logging                                               OK   17 subtests passed
+glib:glib+core / logging                                               OK   20 subtests passed
 glib:glib+core / macros                                                OK   3 subtests passed
-glib:glib+core / mainloop                                              OK   44 subtests passed
+glib:glib+core / mainloop                                              OK   46 subtests passed
 glib:glib+core / mappedfile                                            OK   7 subtests passed
 glib:glib+core / mapping                                               OK   3 subtests passed
 glib:glib+core / markup                                                OK   1 subtests passed
@@ -193,11 +236,12 @@ glib:glib+core / node                                                  OK   6 su
 glib:glib+core / once                                                  OK   5 subtests passed
 glib:glib+core / onceinit                                              OK   1 subtests passed
 glib:glib+core / option-argv0                                          SKIP   0 subtests passed
-glib:glib+core / option-context                                        OK   57 subtests passed
+glib:glib+core / option-context                                        OK   61 subtests passed
 glib:glib+core / overflow                                              OK   6 subtests passed
 glib:glib+core / overflow-fallback                                     OK   6 subtests passed
 glib:glib+core / pathbuf                                               OK   3 subtests passed
 glib:glib+core / pattern                                               OK   90 subtests passed
+glib:glib+core / print                                                 SKIP   0 subtests passed
 glib:glib+core / private                                               OK   8 subtests passed
 glib:glib+core / protocol                                              OK   9 subtests passed
 glib:glib+core / queue                                                 OK   12 subtests passed
@@ -206,13 +250,13 @@ glib:glib+core / rcbox                                                 OK   8 su
 glib:glib+core / rec-mutex                                             OK   29 subtests passed
 glib:glib+core / refcount                                              OK   4 subtests passed
 glib:glib+core / refcount-macro                                        OK   4 subtests passed
-glib:glib+core / refstring                                             OK   6 subtests passed
-glib:glib+core / regex                                                 OK   848 subtests passed
+glib:glib+core / refstring                                             OK   8 subtests passed
+glib:glib+core / regex                                                 OK   849 subtests passed
 glib:glib+core / relation                                              OK   1 subtests passed
 glib:glib+core / rwlock                                                OK   8 subtests passed
-glib:glib+core / scannerapi                                            OK   4 subtests passed
+glib:glib+core / scannerapi                                            OK   8 subtests passed
 glib:glib+core / search-utils                                          OK   6 subtests passed
-glib:glib+core / shell                                                 OK   51 subtests passed
+glib:glib+core / shell                                                 OK   52 subtests passed
 glib:glib+core / slice                                                 OK   3 subtests passed
 glib:glib+core / slist                                                 OK   14 subtests passed
 glib:glib+core / sort                                                  OK   5 subtests passed
@@ -220,11 +264,12 @@ glib:glib+core / spawn-multithreaded                                   OK   4 su
 glib:glib+core / spawn-path-search                                     OK   7 subtests passed
 glib:glib+core / spawn-singlethread                                    OK   9 subtests passed
 glib:glib+core / spawn-test                                            OK   2 subtests passed
-glib:glib+core / strfuncs                                              OK   50 subtests passed
-glib:glib+core / string                                                OK   23 subtests passed
+glib:glib+core / strfuncs                                              OK   51 subtests passed
+glib:glib+core / string                                                OK   25 subtests passed
 glib:glib+core / strvbuilder                                           OK   7 subtests passed
-glib:glib+core / test-printf                                           OK   21 subtests passed
-glib:glib+core / testing                                               OK   43 subtests passed
+glib:glib+core / test-printf                                           OK   23 subtests passed
+glib:glib+core / testing                                               OK   44 subtests passed
+glib:glib+core / testing-nonfatal                                      OK
 glib:glib+core / thread                                                OK   6 subtests passed
 glib:glib+core / thread-deprecated                                     OK   6 subtests passed
 glib:glib+core / thread-pool                                           OK   5 subtests passed
@@ -240,9 +285,11 @@ glib:glib+core / uri                                                   OK   24 s
 glib:glib+core / utf8-misc                                             OK   7 subtests passed
 glib:glib+core / utf8-performance                                      OK   36 subtests passed
 glib:glib+core / utf8-pointer                                          OK   3 subtests passed
-glib:glib+core / utf8-validate                                         OK   216 subtests passed
-glib:glib+core / utils                                                 OK   39 subtests passed
+glib:glib+core / utf8-private                                          OK   2 subtests passed
+glib:glib+core / utf8-validate                                         OK   238 subtests passed
+glib:glib+core / utils                                                 OK   40 subtests passed
 glib:glib+core / utils-isolated                                        OK   11 subtests passed
+glib:glib+core / utils-unisolated                                      OK   1 subtests passed
 glib:glib+core+cc / atomic-c-11                                        OK   2 subtests passed
 glib:glib+core+cc / atomic-c-17                                        OK   2 subtests passed
 glib:glib+core+cc / atomic-c-89                                        OK   2 subtests passed
@@ -251,17 +298,17 @@ glib:glib+core+cc / macros-c-11                                        OK   4 su
 glib:glib+core+cc / macros-c-17                                        ERROR   killed by signal 6 SIGABRT
 glib:glib+core+cc / macros-c-89                                        OK   4 subtests passed
 glib:glib+core+cc / macros-c-99                                        OK   4 subtests passed
-glib:glib+core+cc / utils-c-11                                         OK   39 subtests passed
-glib:glib+core+cc / utils-c-17                                         OK   39 subtests passed
-glib:glib+core+cc / utils-c-89                                         OK   39 subtests passed
-glib:glib+core+cc / utils-c-99                                         OK   39 subtests passed
-glib:glib+core+cpp / cxx                                               OK   21 subtests passed
+glib:glib+core+cc / utils-c-11                                         OK   40 subtests passed
+glib:glib+core+cc / utils-c-17                                         OK   40 subtests passed
+glib:glib+core+cc / utils-c-89                                         OK   40 subtests passed
+glib:glib+core+cc / utils-c-99                                         OK   40 subtests passed
+glib:glib+core+cpp / cxx                                               OK   22 subtests passed
 glib:glib+core+cpp / cxx-03                                            OK   22 subtests passed
 glib:glib+core+cpp / cxx-11                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-14                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-17                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-20                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-2b                                            OK   21 subtests passed
+glib:glib+core+cpp / cxx-14                                            OK   23 subtests passed
+glib:glib+core+cpp / cxx-17                                            OK   23 subtests passed
+glib:glib+core+cpp / cxx-20                                            OK   23 subtests passed
+glib:glib+core+cpp / cxx-2b                                            OK   22 subtests passed
 glib:glib+core+cpp / cxx-98                                            OK   22 subtests passed
 glib:glib+core+no-valgrind / assert-msg-test.py                        OK   2 subtests passed
 glib:glib+core+no-valgrind / messages-low-memory.py                    OK   1 subtests passed
@@ -270,7 +317,7 @@ glib:glib+core+slow / 1bit-emufutex                                    OK   2 su
 glib:glib+core+slow / 642026                                           OK   1 subtests passed
 glib:glib+core+slow / 642026-ec                                        OK   1 subtests passed
 glib:glib+core+slow / gdatetime                                        OK   58 subtests passed
-glib:glib+core+slow / gvariant                                         OK   64 subtests passed
+glib:glib+core+slow / gvariant                                         OK   69 subtests passed
 glib:glib+core+slow / sequence                                         OK   16 subtests passed
 glib:glib+core+slow / thread-pool-slow                                 OK   7 subtests passed
 glib:gmodule / max-version                                             OK   1 subtests passed
@@ -312,13 +359,13 @@ glib:gobject / object                                                  OK   1 su
 glib:gobject / objects-refcount1                                       OK   1 subtests passed
 glib:gobject / override                                                OK   1 subtests passed
 glib:gobject / param                                                   OK   31 subtests passed
-glib:gobject / properties                                              OK   13 subtests passed
+glib:gobject / properties                                              OK   14 subtests passed
 glib:gobject / properties-introspection                                OK   2 subtests passed
 glib:gobject / properties-refcount1                                    OK   1 subtests passed
 glib:gobject / properties-refcount4                                    OK   1 subtests passed
 glib:gobject / qdata                                                   OK   2 subtests passed
 glib:gobject / reference                                               OK   29 subtests passed
-glib:gobject / references                                              OK   1 subtests passed
+glib:gobject / references                                              OK   4 subtests passed
 glib:gobject / signal-handler                                          OK   7 subtests passed
 glib:gobject / signalgroup                                             OK   9 subtests passed
 glib:gobject / signals                                                 OK   31 subtests passed
@@ -357,10 +404,10 @@ glib:lint+no-valgrind / flake8.sh                                      SKIP
 glib:lint+no-valgrind / reuse.sh                                       SKIP
 glib:lint+no-valgrind / shellcheck.sh                                  SKIP
 
-Ok:                 342 
+Ok:                 383 
 Expected Fail:      0   
-Fail:               9   
+Fail:               14  
 Unexpected Pass:    0   
-Skipped:            7   
+Skipped:            8   
 Timeout:            0   
 

--- a/components/library/glib/test/results-64.master
+++ b/components/library/glib/test/results-64.master
@@ -1,8 +1,12 @@
 glib:fuzzing / fuzz_bookmark                                           OK
 glib:fuzzing / fuzz_canonicalize_filename                              OK
+glib:fuzzing / fuzz_data_input_stream_read_line                        OK
+glib:fuzzing / fuzz_data_input_stream_read_line_utf8                   OK
+glib:fuzzing / fuzz_data_input_stream_read_upto                        OK
 glib:fuzzing / fuzz_date_parse                                         OK
 glib:fuzzing / fuzz_date_time_new_from_iso8601                         OK
 glib:fuzzing / fuzz_dbus_message                                       OK
+glib:fuzzing / fuzz_get_locale_variants                                OK
 glib:fuzzing / fuzz_inet_address_mask_new_from_string                  OK
 glib:fuzzing / fuzz_inet_address_new_from_string                       OK
 glib:fuzzing / fuzz_inet_socket_address_new_from_string                OK
@@ -11,6 +15,8 @@ glib:fuzzing / fuzz_network_address_parse                              OK
 glib:fuzzing / fuzz_network_address_parse_uri                          OK
 glib:fuzzing / fuzz_paths                                              OK
 glib:fuzzing / fuzz_resolver                                           OK
+glib:fuzzing / fuzz_special_dirs                                       OK
+glib:fuzzing / fuzz_string                                             OK
 glib:fuzzing / fuzz_uri_escape                                         OK
 glib:fuzzing / fuzz_uri_parse                                          OK
 glib:fuzzing / fuzz_uri_parse_params                                   OK
@@ -20,7 +26,7 @@ glib:fuzzing / fuzz_uuid_string_is_valid                               OK
 glib:fuzzing / fuzz_variant_binary                                     OK
 glib:fuzzing / fuzz_variant_binary_byteswap                            OK
 glib:fuzzing / fuzz_variant_text                                       OK
-glib:gio / appinfo                                                     OK   11 subtests passed
+glib:gio / appinfo                                                     OK   14 subtests passed
 glib:gio / application-command-line                                    OK   1 subtests passed
 glib:gio / appmonitor                                                  ERROR   killed by signal 6 SIGABRT
 glib:gio / async-close-output-stream                                   OK   3 subtests passed
@@ -28,41 +34,65 @@ glib:gio / async-splice-output-stream                                  OK   5 su
 glib:gio / autoptr-gio                                                 OK   1 subtests passed
 glib:gio / buffered-input-stream                                       OK   10 subtests passed
 glib:gio / buffered-output-stream                                      OK   5 subtests passed
-glib:gio / cancellable                                                 OK   9 subtests passed
+glib:gio / cancellable                                                 OK   17 subtests passed
 glib:gio / contenttype                                                 OK   12 subtests passed
 glib:gio / contexts                                                    OK   5 subtests passed
-glib:gio / converter                                                   OK   1 subtests passed
+glib:gio / converter                                                   OK   3 subtests passed
 glib:gio / converter-stream                                            ERROR   killed by signal 6 SIGABRT
 glib:gio / credentials                                                 OK   1 subtests passed
 glib:gio / data-input-stream                                           OK   10 subtests passed
 glib:gio / data-output-stream                                          OK   7 subtests passed
-glib:gio / desktop-app-info                                            OK   56 subtests passed
+glib:gio / dbus-appinfo                                                ERROR   killed by signal 6 SIGABRT
+glib:gio / debugcontroller                                             OK   3 subtests passed
+glib:gio / defaultvalue                                                OK   51 subtests passed
+glib:gio / desktop-app-info                                            OK   58 subtests passed
 glib:gio / error                                                       OK   2 subtests passed
+glib:gio / fdo-notification-backend                                    OK   2 subtests passed
 glib:gio / file                                                        OK   45 subtests passed
+glib:gio / file-enumerator                                             OK   1 subtests passed
 glib:gio / file-thumbnail                                              OK   7 subtests passed
 glib:gio / fileattributematcher                                        OK   3 subtests passed
+glib:gio / filenamecompleter                                           OK   1 subtests passed
 glib:gio / filter-streams                                              OK   4 subtests passed
 glib:gio / g-file                                                      OK   8 subtests passed
 glib:gio / g-file-info                                                 OK   4 subtests passed
 glib:gio / g-file-info-filesystem-readonly                             SKIP   0 subtests passed
 glib:gio / g-icon                                                      OK   6 subtests passed
+glib:gio / gapplication                                                OK   25 subtests passed
 glib:gio / gdbus-address-get-session                                   OK   2 subtests passed
 glib:gio / gdbus-addresses                                             OK   9 subtests passed
+glib:gio / gdbus-auth                                                  OK   5 subtests passed
+glib:gio / gdbus-bz627724                                              OK   1 subtests passed
+glib:gio / gdbus-close-pending                                         OK   2 subtests passed
+glib:gio / gdbus-connection                                            OK   9 subtests passed
 glib:gio / gdbus-connection-flush                                      OK   2 subtests passed
+glib:gio / gdbus-connection-loss                                       OK   1 subtests passed
+glib:gio / gdbus-connection-slow                                       OK   2 subtests passed
+glib:gio / gdbus-error                                                 OK   4 subtests passed
+glib:gio / gdbus-exit-on-close                                         OK   4 subtests passed
+glib:gio / gdbus-introspection                                         OK   4 subtests passed
 glib:gio / gdbus-message                                               OK   3 subtests passed
+glib:gio / gdbus-method-invocation                                     OK   1 subtests passed
+glib:gio / gdbus-names                                                 OK   10 subtests passed
 glib:gio / gdbus-non-socket                                            OK   1 subtests passed
 glib:gio / gdbus-peer                                                  ERROR   killed by signal 5 SIGTRAP
 glib:gio / gdbus-peer-object-manager                                   OK   2 subtests passed
+glib:gio / gdbus-proxy                                                 OK   5 subtests passed
+glib:gio / gdbus-proxy-threads                                         OK   1 subtests passed
+glib:gio / gdbus-proxy-unique-name                                     OK   1 subtests passed
+glib:gio / gdbus-proxy-well-known-name                                 OK   1 subtests passed
 glib:gio / gdbus-sasl                                                  OK   1 subtests passed
 glib:gio / gdbus-serialization                                         OK   18 subtests passed
 glib:gio / gdbus-server-auth                                           OK   9 subtests passed
+glib:gio / gdbus-subscribe                                             OK   24 subtests passed
 glib:gio / giomodule                                                   OK   3 subtests passed
 glib:gio / glistmodel                                                  OK   18 subtests passed
+glib:gio / gnotification                                               OK   2 subtests passed
 glib:gio / gschema-compile                                             OK   82 subtests passed
 glib:gio / gsettings                                                   ERROR   killed by signal 5 SIGTRAP
 glib:gio / gsocketclient-slow                                          OK   4 subtests passed
-glib:gio / gsubprocess                                                 OK   82 subtests passed
-glib:gio / inet-address                                                OK   11 subtests passed
+glib:gio / gsubprocess                                                 OK   83 subtests passed
+glib:gio / inet-address                                                ERROR   killed by signal 6 SIGABRT
 glib:gio / io-stream                                                   OK   3 subtests passed
 glib:gio / live-g-file                                                 OK   12 subtests passed
 glib:gio / max-version                                                 OK   1 subtests passed
@@ -70,26 +100,26 @@ glib:gio / memory-input-stream                                         OK   6 su
 glib:gio / memory-monitor                                              OK   1 subtests passed
 glib:gio / memory-output-stream                                        OK   10 subtests passed
 glib:gio / memory-settings-backend                                     OK   1 subtests passed
-glib:gio / mimeapps                                                    OK   7 subtests passed
+glib:gio / mimeapps                                                    OK   13 subtests passed
 glib:gio / mount-operation                                             OK   2 subtests passed
 glib:gio / network-address                                             OK   72 subtests passed
 glib:gio / network-monitor                                             OK   4 subtests passed
 glib:gio / network-monitor-race                                        OK   1 subtests passed
 glib:gio / null-settings-backend                                       OK   1 subtests passed
 glib:gio / permission                                                  OK   1 subtests passed
-glib:gio / pollable                                                    OK   4 subtests passed
+glib:gio / pollable                                                    ERROR   killed by signal 6 SIGABRT
 glib:gio / power-profile-monitor                                       OK   1 subtests passed
 glib:gio / proxy-test                                                  OK   11 subtests passed
 glib:gio / readwrite                                                   OK   3 subtests passed
 glib:gio / resolver-parsing                                            OK   21 subtests passed
-glib:gio / resources                                                   OK   16 subtests passed
+glib:gio / resources                                                   OK   18 subtests passed
 glib:gio / sandbox                                                     OK   4 subtests passed
 glib:gio / simple-async-result                                         OK   2 subtests passed
 glib:gio / simple-proxy                                                OK   3 subtests passed
 glib:gio / sleepy-stream                                               OK   2 subtests passed
-glib:gio / socket                                                      OK   27 subtests passed
+glib:gio / socket                                                      OK   29 subtests passed
 glib:gio / socket-address                                              OK   2 subtests passed
-glib:gio / socket-listener                                             OK   1 subtests passed
+glib:gio / socket-listener                                             ERROR   killed by signal 6 SIGABRT
 glib:gio / socket-service                                              OK   4 subtests passed
 glib:gio / srvtarget                                                   OK   1 subtests passed
 glib:gio / stream-rw_all                                               OK   3 subtests passed
@@ -114,7 +144,10 @@ glib:gio+cpp / cxx-17                                                  OK
 glib:gio+cpp / cxx-20                                                  OK
 glib:gio+cpp / cxx-2b                                                  OK
 glib:gio+cpp / cxx-98                                                  OK
-glib:gio+no-valgrind / gio-tool.py                                     OK   3 subtests passed
+glib:gio+gdbus-codegen / gdbus-test-codegen                            OK   8 subtests passed
+glib:gio+gdbus-codegen / gdbus-test-codegen-min-required-2-64          OK   8 subtests passed
+glib:gio+gdbus-codegen / gdbus-test-codegen-old                        OK   8 subtests passed
+glib:gio+no-valgrind / gio-tool.py                                     OK   9 subtests passed
 glib:gio+no-valgrind+gdbus-codegen+slow / codegen.py                   OK   39 subtests passed
 glib:gio+no-valgrind+pkg-config / gio-2.0-pkg-config                   FAIL   exit status 1
 glib:gio+no-valgrind+pkg-config / gio-unix-2.0-pkg-config              OK
@@ -126,25 +159,35 @@ glib:gio+portal-support / portal-support-flatpak-none                  OK   1 su
 glib:gio+portal-support / portal-support-none                          OK   1 subtests passed
 glib:gio+portal-support / portal-support-snap                          OK   7 subtests passed
 glib:gio+portal-support / portal-support-snap-classic                  OK   3 subtests passed
+glib:gio+slow / actions                                                OK   13 subtests passed
+glib:gio+slow / gdbus-export                                           ERROR   killed by signal 6 SIGABRT
+glib:gio+slow / gdbus-threading                                        OK   3 subtests passed
+glib:gio+slow / gmenumodel                                             OK   15 subtests passed
+glib:gio+slow / testfilemonitor                                        ERROR   killed by signal 6 SIGABRT
 glib:girepository+core / autoptr-girepository                          OK   24 subtests passed
+glib:girepository+core / callable-info                                 OK   5 subtests passed
 glib:girepository+core / cmph-bdz                                      OK   2 subtests passed
 glib:girepository+core / dump                                          OK   4 subtests passed
+glib:girepository+core / field-info                                    OK   4 subtests passed
 glib:girepository+core / function-info                                 OK   1 subtests passed
 glib:girepository+core / gthash                                        OK   1 subtests passed
+glib:girepository+core / ir-parser                                     OK   1 subtests passed
 glib:girepository+core / object-info                                   OK   2 subtests passed
 glib:girepository+core / registered-type-info                          OK   1 subtests passed
-glib:girepository+core / repository                                    OK   23 subtests passed
+glib:girepository+core / repository                                    OK   24 subtests passed
 glib:girepository+core / repository-search-paths                       OK   4 subtests passed
 glib:girepository+core / struct-info                                   OK   4 subtests passed
 glib:girepository+core / throws                                        OK   3 subtests passed
 glib:girepository+core / union-info                                    OK   2 subtests passed
+glib:girepository+no-valgrind+compiler / gi-compile-repository.py      OK   7 subtests passed
+glib:girepository+no-valgrind+inspector / gi-inspect-typelib.py        OK   12 subtests passed
 glib:glib+core / 1bit-mutex                                            OK   2 subtests passed
-glib:glib+core / array-test                                            OK   109 subtests passed
+glib:glib+core / array-test                                            OK   116 subtests passed
 glib:glib+core / asyncqueue                                            OK   7 subtests passed
 glib:glib+core / atomic                                                OK   2 subtests passed
 glib:glib+core / autoptr                                               OK   57 subtests passed
 glib:glib+core / base64                                                OK   28 subtests passed
-glib:glib+core / bitlock                                               OK   1 subtests passed
+glib:glib+core / bitlock                                               OK   2 subtests passed
 glib:glib+core / bookmarkfile                                          OK   96 subtests passed
 glib:glib+core / bytes                                                 OK   21 subtests passed
 glib:glib+core / cache                                                 OK   1 subtests passed
@@ -155,8 +198,8 @@ glib:glib+core / completion                                            OK   1 su
 glib:glib+core / cond                                                  OK   3 subtests passed
 glib:glib+core / constructor                                           OK   2 subtests passed
 glib:glib+core / convert                                               OK   14 subtests passed
-glib:glib+core / dataset                                               OK   14 subtests passed
-glib:glib+core / date                                                  OK   118 subtests passed
+glib:glib+core / dataset                                               OK   15 subtests passed
+glib:glib+core / date                                                  OK   119 subtests passed
 glib:glib+core / dir                                                   OK   3 subtests passed
 glib:glib+core / environment                                           OK   6 subtests passed
 glib:glib+core / error                                                 OK   10 subtests passed
@@ -169,15 +212,15 @@ glib:glib+core / gwakeup-fallback                                      OK   2 su
 glib:glib+core / hash                                                  OK   34 subtests passed
 glib:glib+core / hmac                                                  OK   37 subtests passed
 glib:glib+core / hook                                                  OK   2 subtests passed
-glib:glib+core / hostutils                                             OK   3 subtests passed
+glib:glib+core / hostutils                                             OK   4 subtests passed
 glib:glib+core / include                                               OK   1 subtests passed
 glib:glib+core / io-channel                                            OK   2 subtests passed
 glib:glib+core / io-channel-basic                                      OK   1 subtests passed
 glib:glib+core / keyfile                                               OK   36 subtests passed
 glib:glib+core / list                                                  OK   20 subtests passed
-glib:glib+core / logging                                               OK   17 subtests passed
+glib:glib+core / logging                                               OK   20 subtests passed
 glib:glib+core / macros                                                OK   3 subtests passed
-glib:glib+core / mainloop                                              OK   44 subtests passed
+glib:glib+core / mainloop                                              OK   46 subtests passed
 glib:glib+core / mappedfile                                            OK   7 subtests passed
 glib:glib+core / mapping                                               OK   3 subtests passed
 glib:glib+core / markup                                                OK   1 subtests passed
@@ -193,11 +236,12 @@ glib:glib+core / node                                                  OK   6 su
 glib:glib+core / once                                                  OK   5 subtests passed
 glib:glib+core / onceinit                                              OK   1 subtests passed
 glib:glib+core / option-argv0                                          SKIP   0 subtests passed
-glib:glib+core / option-context                                        OK   57 subtests passed
+glib:glib+core / option-context                                        OK   61 subtests passed
 glib:glib+core / overflow                                              OK   6 subtests passed
 glib:glib+core / overflow-fallback                                     OK   6 subtests passed
 glib:glib+core / pathbuf                                               OK   3 subtests passed
 glib:glib+core / pattern                                               OK   90 subtests passed
+glib:glib+core / print                                                 SKIP   0 subtests passed
 glib:glib+core / private                                               OK   8 subtests passed
 glib:glib+core / protocol                                              OK   9 subtests passed
 glib:glib+core / queue                                                 OK   12 subtests passed
@@ -206,13 +250,13 @@ glib:glib+core / rcbox                                                 OK   8 su
 glib:glib+core / rec-mutex                                             OK   29 subtests passed
 glib:glib+core / refcount                                              OK   4 subtests passed
 glib:glib+core / refcount-macro                                        OK   4 subtests passed
-glib:glib+core / refstring                                             OK   6 subtests passed
-glib:glib+core / regex                                                 OK   848 subtests passed
+glib:glib+core / refstring                                             OK   8 subtests passed
+glib:glib+core / regex                                                 OK   849 subtests passed
 glib:glib+core / relation                                              OK   1 subtests passed
 glib:glib+core / rwlock                                                OK   8 subtests passed
-glib:glib+core / scannerapi                                            OK   4 subtests passed
+glib:glib+core / scannerapi                                            OK   8 subtests passed
 glib:glib+core / search-utils                                          OK   6 subtests passed
-glib:glib+core / shell                                                 OK   51 subtests passed
+glib:glib+core / shell                                                 OK   52 subtests passed
 glib:glib+core / slice                                                 OK   3 subtests passed
 glib:glib+core / slist                                                 OK   14 subtests passed
 glib:glib+core / sort                                                  OK   5 subtests passed
@@ -220,11 +264,12 @@ glib:glib+core / spawn-multithreaded                                   OK   4 su
 glib:glib+core / spawn-path-search                                     OK   7 subtests passed
 glib:glib+core / spawn-singlethread                                    OK   9 subtests passed
 glib:glib+core / spawn-test                                            OK   2 subtests passed
-glib:glib+core / strfuncs                                              OK   50 subtests passed
-glib:glib+core / string                                                OK   23 subtests passed
+glib:glib+core / strfuncs                                              OK   51 subtests passed
+glib:glib+core / string                                                OK   25 subtests passed
 glib:glib+core / strvbuilder                                           OK   7 subtests passed
-glib:glib+core / test-printf                                           OK   21 subtests passed
-glib:glib+core / testing                                               OK   43 subtests passed
+glib:glib+core / test-printf                                           OK   23 subtests passed
+glib:glib+core / testing                                               OK   44 subtests passed
+glib:glib+core / testing-nonfatal                                      OK
 glib:glib+core / thread                                                OK   6 subtests passed
 glib:glib+core / thread-deprecated                                     OK   6 subtests passed
 glib:glib+core / thread-pool                                           OK   5 subtests passed
@@ -240,9 +285,11 @@ glib:glib+core / uri                                                   OK   24 s
 glib:glib+core / utf8-misc                                             OK   7 subtests passed
 glib:glib+core / utf8-performance                                      OK   36 subtests passed
 glib:glib+core / utf8-pointer                                          OK   3 subtests passed
-glib:glib+core / utf8-validate                                         OK   216 subtests passed
-glib:glib+core / utils                                                 OK   39 subtests passed
+glib:glib+core / utf8-private                                          OK   2 subtests passed
+glib:glib+core / utf8-validate                                         OK   238 subtests passed
+glib:glib+core / utils                                                 OK   40 subtests passed
 glib:glib+core / utils-isolated                                        OK   11 subtests passed
+glib:glib+core / utils-unisolated                                      OK   1 subtests passed
 glib:glib+core+cc / atomic-c-11                                        OK   2 subtests passed
 glib:glib+core+cc / atomic-c-17                                        OK   2 subtests passed
 glib:glib+core+cc / atomic-c-89                                        OK   2 subtests passed
@@ -251,17 +298,17 @@ glib:glib+core+cc / macros-c-11                                        OK   4 su
 glib:glib+core+cc / macros-c-17                                        ERROR   killed by signal 6 SIGABRT
 glib:glib+core+cc / macros-c-89                                        OK   4 subtests passed
 glib:glib+core+cc / macros-c-99                                        OK   4 subtests passed
-glib:glib+core+cc / utils-c-11                                         OK   39 subtests passed
-glib:glib+core+cc / utils-c-17                                         OK   39 subtests passed
-glib:glib+core+cc / utils-c-89                                         OK   39 subtests passed
-glib:glib+core+cc / utils-c-99                                         OK   39 subtests passed
-glib:glib+core+cpp / cxx                                               OK   21 subtests passed
+glib:glib+core+cc / utils-c-11                                         OK   40 subtests passed
+glib:glib+core+cc / utils-c-17                                         OK   40 subtests passed
+glib:glib+core+cc / utils-c-89                                         OK   40 subtests passed
+glib:glib+core+cc / utils-c-99                                         OK   40 subtests passed
+glib:glib+core+cpp / cxx                                               OK   22 subtests passed
 glib:glib+core+cpp / cxx-03                                            OK   22 subtests passed
 glib:glib+core+cpp / cxx-11                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-14                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-17                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-20                                            OK   22 subtests passed
-glib:glib+core+cpp / cxx-2b                                            OK   21 subtests passed
+glib:glib+core+cpp / cxx-14                                            OK   23 subtests passed
+glib:glib+core+cpp / cxx-17                                            OK   23 subtests passed
+glib:glib+core+cpp / cxx-20                                            OK   23 subtests passed
+glib:glib+core+cpp / cxx-2b                                            OK   22 subtests passed
 glib:glib+core+cpp / cxx-98                                            OK   22 subtests passed
 glib:glib+core+no-valgrind / assert-msg-test.py                        OK   2 subtests passed
 glib:glib+core+no-valgrind / messages-low-memory.py                    OK   1 subtests passed
@@ -270,7 +317,7 @@ glib:glib+core+slow / 1bit-emufutex                                    OK   2 su
 glib:glib+core+slow / 642026                                           OK   1 subtests passed
 glib:glib+core+slow / 642026-ec                                        OK   1 subtests passed
 glib:glib+core+slow / gdatetime                                        OK   58 subtests passed
-glib:glib+core+slow / gvariant                                         OK   64 subtests passed
+glib:glib+core+slow / gvariant                                         OK   69 subtests passed
 glib:glib+core+slow / sequence                                         OK   16 subtests passed
 glib:glib+core+slow / thread-pool-slow                                 OK   7 subtests passed
 glib:gmodule / max-version                                             OK   1 subtests passed
@@ -312,13 +359,13 @@ glib:gobject / object                                                  OK   1 su
 glib:gobject / objects-refcount1                                       OK   1 subtests passed
 glib:gobject / override                                                OK   1 subtests passed
 glib:gobject / param                                                   OK   31 subtests passed
-glib:gobject / properties                                              OK   13 subtests passed
+glib:gobject / properties                                              OK   14 subtests passed
 glib:gobject / properties-introspection                                OK   2 subtests passed
 glib:gobject / properties-refcount1                                    OK   1 subtests passed
 glib:gobject / properties-refcount4                                    OK   1 subtests passed
 glib:gobject / qdata                                                   OK   2 subtests passed
 glib:gobject / reference                                               OK   29 subtests passed
-glib:gobject / references                                              OK   1 subtests passed
+glib:gobject / references                                              OK   4 subtests passed
 glib:gobject / signal-handler                                          OK   7 subtests passed
 glib:gobject / signalgroup                                             OK   9 subtests passed
 glib:gobject / signals                                                 OK   31 subtests passed
@@ -357,10 +404,10 @@ glib:lint+no-valgrind / flake8.sh                                      SKIP
 glib:lint+no-valgrind / reuse.sh                                       SKIP
 glib:lint+no-valgrind / shellcheck.sh                                  SKIP
 
-Ok:                 342 
+Ok:                 382 
 Expected Fail:      0   
-Fail:               9   
+Fail:               15  
 Unexpected Pass:    0   
-Skipped:            7   
+Skipped:            8   
 Timeout:            0   
 


### PR DESCRIPTION
64-bit tests do not run.  Only included 32-bit test results.