### PR TITLE
build-essential: do not depend on readline

### DIFF
--- a/components/meta-packages/build-essential/Makefile
+++ b/components/meta-packages/build-essential/Makefile
@@ -18,7 +18,7 @@ BUILD_STYLE = pkg
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		build-essential
-COMPONENT_VERSION =	21
+COMPONENT_VERSION =	22
 COMPONENT_SUMMARY=	A meta-package that installs common development tools such as gcc
 COMPONENT_CLASSIFICATION=	Meta Packages/Group Packages
 COMPONENT_FMRI=	metapackages/build-essential

--- a/components/meta-packages/build-essential/build-essential.p5m
+++ b/components/meta-packages/build-essential/build-essential.p5m
@@ -86,8 +86,6 @@ depend fmri=developer/icu type=require
 # Useful Libraries
 depend fmri=library/pcre type=require
 depend fmri=library/popt type=require
-#depend fmri=library/boost type=require
-depend fmri=library/readline type=require
 depend fmri=library/zlib type=require
 depend fmri=library/neon type=require
 depend fmri=library/libxslt type=require


### PR DESCRIPTION
... because there is no need to depend on it:
- the `libreadline` is not a common development tool (see the `COMPONENT_SUMMARY` here),
- when an individual component depends on `libreadline` then it lists it in its `REQUIRED_PACKAGES` anyway, so we do not need this implicit dependency.