### PR TITLE
openssh: remove unnecessary dependency ssh-askpass for OI server syst…

### DIFF
--- a/components/network/openssh/Makefile
+++ b/components/network/openssh/Makefile
@@ -31,6 +31,7 @@ COMPONENT_NAME=		openssh
 #   OpenSSH <x>.<y>.<z>p<n> => IPS <x>.<y>.<z>.<n>
 COMPONENT_VERSION=	10.2.0.1
 HUMAN_VERSION=		10.2p1
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	OpenSSH client and associated utilities
 # OpenSSH made a mistake when releasing openssh 10.0p1 which identifies itself as 10.0p2.
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
@@ -98,7 +99,6 @@ REQUIRED_PACKAGES += $(OPENSSL_PKG)
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += library/libedit
 REQUIRED_PACKAGES += library/zlib
-REQUIRED_PACKAGES += network/ssh-askpass
 REQUIRED_PACKAGES += service/security/kerberos-5
 REQUIRED_PACKAGES += shell/bash
 REQUIRED_PACKAGES += shell/ksh93

--- a/components/network/openssh/pkg5
+++ b/components/network/openssh/pkg5
@@ -4,7 +4,6 @@
         "library/libedit",
         "library/security/openssl-3",
         "library/zlib",
-        "network/ssh-askpass",
         "service/security/kerberos-5",
         "shell/bash",
         "shell/ksh93",

--- a/components/network/openssh/ssh.p5m
+++ b/components/network/openssh/ssh.p5m
@@ -12,6 +12,7 @@
 #
 # Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2018 Till Wegmüller
+# Copyright 2025 Klaus Ziegler
 #
 
 # A full copy of the text of the CDDL should have accompanied this
@@ -34,8 +35,11 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 depend type=conditional fmri=pkg:/x11/session/xauth \
     predicate=pkg:/x11/library/libxau
 
-depend type=conditional fmri=pkg:/network/ssh-askpass \
-    predicate=pkg:/x11/server/xserver-common
+# Note:
+# this pulls in gnome/zenity package, which makes it impossible
+# to install a server system without all the needed X-windows stuff.
+# depend type=conditional fmri=pkg:/network/ssh-askpass \
+#    predicate=pkg:/x11/server/xserver-common
 
 # We have to preserve original_name as file was once moved to
 # ssh-common and back again


### PR DESCRIPTION
…ems.
The network/ssh-askpass dependency will be placed into the desktop_common profile in metapackage: install-types in a later commit.