### PR TITLE
librsvg: add librsvg-2.0.pc

### DIFF
--- a/components/library/librsvg/Makefile
+++ b/components/library/librsvg/Makefile
@@ -21,6 +21,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		librsvg
 COMPONENT_VERSION=	2.61.3
+COMPONENT_REVISION=	1
 COMPONENT_MAJOR_VERSION=$(basename $(COMPONENT_VERSION))
 COMPONENT_SUMMARY=	Library for SVG support for GNOME
 COMPONENT_PROJECT_URL= https://wiki.gnome.org/Projects/LibRsvg
@@ -39,6 +40,9 @@ RUST_ARCH=              x86_64-unknown-illumos
 CARGO_HOME=             $(@D)/.cargo
 # if -z ignore is added to LD_OPTIONS the build will fail
 LD_OPTIONS=-M /usr/lib/ld/map.noexstk -M /usr/lib/ld/map.noexdata -M /usr/lib/ld/map.pagealign -Bdirect
+
+# Disable avif since it is encumbered
+CONFIGURE_OPTIONS += -Davif=disabled
 
 COMPONENT_PRE_CONFIGURE_ACTION = $(GSED) -i -e 's/= .*version-script.*$$/= []/' $(SOURCE_DIR)/rsvg/meson.build
 

--- a/components/library/librsvg/librsvg.p5m
+++ b/components/library/librsvg/librsvg.p5m
@@ -35,6 +35,7 @@ file path=usr/lib/$(MACH64)/girepository-1.0/Rsvg-2.0.typelib
 link path=usr/lib/$(MACH64)/librsvg-2.so target=librsvg-2.so.2
 file path=usr/lib/$(MACH64)/librsvg-2.so.$(HUMAN_VERSION)
 link path=usr/lib/$(MACH64)/librsvg-2.so.2 target=librsvg-2.so.$(HUMAN_VERSION)
+file path=usr/lib/$(MACH64)/pkgconfig/librsvg-2.0.pc
 file path=usr/share/doc/Rsvg-2.0/RedHatDisplay-Black.woff
 file path=usr/share/doc/Rsvg-2.0/RedHatDisplay-Black.woff2
 file path=usr/share/doc/Rsvg-2.0/RedHatDisplay-BlackItalic.woff

--- a/components/library/librsvg/manifests/sample-manifest.p5m
+++ b/components/library/librsvg/manifests/sample-manifest.p5m
@@ -33,6 +33,7 @@ file path=usr/lib/$(MACH64)/girepository-1.0/Rsvg-2.0.typelib
 link path=usr/lib/$(MACH64)/librsvg-2.so target=librsvg-2.so.2
 file path=usr/lib/$(MACH64)/librsvg-2.so.$(HUMAN_VERSION)
 link path=usr/lib/$(MACH64)/librsvg-2.so.2 target=librsvg-2.so.$(HUMAN_VERSION)
+file path=usr/lib/$(MACH64)/pkgconfig/librsvg-2.0.pc
 file path=usr/share/doc/Rsvg-2.0/RedHatDisplay-Black.woff
 file path=usr/share/doc/Rsvg-2.0/RedHatDisplay-Black.woff2
 file path=usr/share/doc/Rsvg-2.0/RedHatDisplay-BlackItalic.woff

--- a/components/library/librsvg/patches/01-fix-pkgconfig-generate.patch
+++ b/components/library/librsvg/patches/01-fix-pkgconfig-generate.patch
@@ -1,0 +1,14 @@
+Fix problem:
+librsvg-2.61.3/rsvg/meson.build:299:21: ERROR: requires argument not a string, library with pkgconfig-generated file or pkgconfig-dependency object, got <ExternalLibrary socket: True>
+
+--- librsvg-2.61.3/meson.build.old
++++ librsvg-2.61.3/meson.build
+@@ -377,7 +377,7 @@
+ endif
+ 
+ private_libraries += [m_dep]
+-private_dependencies += network_deps
++# private_dependencies += network_deps
+ # appleframeworks cannot be exposed to pkg-config
+ library_dependencies += foundation_dep
+ library_dependencies += other_library_dependencies


### PR DESCRIPTION
After adding the patch so the librsvg-2.0.pc gets generated, then avif support got enabled by default. This was disabled in the Makefile since the codec is encumbered. librsvg is used in unencumbered software.