### PR TITLE
opensmalltalk stack-spur: add PseudoTTYPlugin from VMMaker.3719

### DIFF
--- a/components/runtime/smalltalk/stack-spur/Makefile
+++ b/components/runtime/smalltalk/stack-spur/Makefile
@@ -9,7 +9,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2022, 2023, 2024, 2025 David Stes
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025, 2026 David Stes
 #
 
 
@@ -49,9 +49,9 @@ include ../../../../make-rules/shared-macros.mk
 # sometimes the Stack VM is generated from a different VMMaker as the Cog VM
 
 COMPONENT_NAME=		stack-spur
-COMPONENT_VERSION=	5.0.3704
-GIT_TAG=		sun-v5.0.80
-PLUGIN_REV=		7.0-202512121941
+COMPONENT_VERSION=	5.0.3719
+GIT_TAG=		sun-v5.0.81
+PLUGIN_REV=		7.0-202601110734
 COMPONENT_SUMMARY=	The OpenSmalltalk Stack Spur Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_FMRI=		runtime/smalltalk/stack-spur
@@ -65,7 +65,7 @@ COMPONENT_LICENSE_FILE=	squeak5.license
 
 COMPONENT_SRC=		opensmalltalk-vm-$(GIT_TAG)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:6acac2f8165a3de5954759ed4bff704625582629a3022260e32dda199a076369
+COMPONENT_ARCHIVE_HASH=	sha256:8d2b006f10a137164e49cdc0ded80b391c735c165d4b8b91b4a9ea7a8ef6d6a0
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 # run SUnit tests in the build directories on 32bit and 64bit Squeak images
@@ -166,6 +166,7 @@ rebuild-manifests::
 	cp manifests/stack-spur.p5m stack-spur.p5m
 	cp manifests/stack-spur-ssl.p5m stack-spur-ssl.p5m
 	cp manifests/stack-spur-vep.p5m stack-spur-vep.p5m
+	cp manifests/stack-spur-pty.p5m stack-spur-pty.p5m
 	cp manifests/stack-spur-display-X11.p5m stack-spur-display-X11.p5m
 	cp manifests/stack-spur-nodisplay.p5m stack-spur-nodisplay.p5m
 	cp manifests/sample-manifest.p5m sample-manifest.p5m

--- a/components/runtime/smalltalk/stack-spur/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2025 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -31,27 +31,28 @@ file path=usr/doc/squeak/LICENSE
 file path=usr/doc/squeak/README.Contributing
 file path=usr/doc/squeak/README.Keyboard
 file path=usr/doc/squeak/README.Sound
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/B3DAcceleratorPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/ClipboardExtendedPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/DESPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/ImmX11Plugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/MD5Plugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/SHA2Plugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/UnixOSProcessPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/VectorEnginePlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/XDisplayControlPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/squeak
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/vm-display-X11.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/vm-display-null.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/vm-sound-null.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-64bit/vm-sound-pulse.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/ClipboardExtendedPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/PseudoTTYPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/VectorEnginePlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/squeak
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-64bit/vm-sound-pulse.so
 hardlink path=usr/share/man/man1/inisqueak.1 target=squeak.1
 file path=usr/share/man/man1/squeak.1
 file path=usr/squeak

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur-display-X11.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur-display-X11.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur-nodisplay.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur-nodisplay.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur-pty.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur-pty.p5m
@@ -10,12 +10,12 @@
 #
 
 #
-# Copyright 2020, 2021, 2023, 2026 David Stes
+# Copyright 2026 David Stes
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-pty@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) PseudoTTYPlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -26,4 +26,3 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/SqueakSSL.so

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur-ssl.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur-ssl.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur-vep.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur-vep.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/manifests/stack-spur.p5m
+++ b/components/runtime/smalltalk/stack-spur/manifests/stack-spur.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023, 2024 David Stes
+# Copyright 2020, 2021, 2023, 2024, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/patches/02-sqSCCSVersion.patch
+++ b/components/runtime/smalltalk/stack-spur/patches/02-sqSCCSVersion.patch
@@ -1,15 +1,15 @@
---- opensmalltalk-vm-sun-v5.0.80/platforms/Cross/vm/sqSCCSVersion.h	Fri Dec 12 20:41:17 2025
-+++ p0/opensmalltalk-vm-sun-v5.0.80/platforms/Cross/vm/sqSCCSVersion.h	Sat Dec 13 13:58:22 2025
+--- opensmalltalk-vm-sun-v5.0.81/platforms/Cross/vm/sqSCCSVersion.h	Sun Jan 11 08:34:24 2026
++++ p0/opensmalltalk-vm-sun-v5.0.81/platforms/Cross/vm/sqSCCSVersion.h	Sun Jan 11 15:38:06 2026
 @@ -30,13 +30,13 @@
  
  #if SUBVERSION
  # define PREFIX "r"
 -static char SvnRawRevisionString[] = "$Rev$";
-+static char SvnRawRevisionString[] = "$Rev: 202512121941 $";
++static char SvnRawRevisionString[] = "$Rev: 202601110734 $";
  # define REV_START (SvnRawRevisionString + 6)
  
 -static char SvnRawRevisionDate[] = "$Date$";
-+static char SvnRawRevisionDate[] = "$Date: Fri Dec 12 20:41:17 2025 +0100 $";
++static char SvnRawRevisionDate[] = "$Date: Sun Jan 11 08:34:24 2026 +0100 $";
  # define DATE_START (SvnRawRevisionDate + 7)
  
 -static char SvnRawRepositoryURL[] = "$URL$";
@@ -22,12 +22,12 @@
  #elif GIT
  # define PREFIX ""
 -static char GitRawRevisionString[] = "$Rev$";
-+static char GitRawRevisionString[] = "$Rev: 202512121941 $";
++static char GitRawRevisionString[] = "$Rev: 202601110734 $";
  # define REV_START (GitRawRevisionString + 6)
  # define REV_TIME_START (GitRawRevisionString + 14)
  
 -static char GitRawRevisionDate[] = "$Date$";
-+static char GitRawRevisionDate[] = "$Date: Fri Dec 12 20:41:17 2025 +0100 $";
++static char GitRawRevisionDate[] = "$Date: Sun Jan 11 08:34:24 2026 +0100 $";
  # define DATE_START (GitRawRevisionDate + 7)
  
 -static char GitRawRepositoryURL[] = "$URL$";
@@ -35,7 +35,7 @@
  # define URL_START (GitRawRepositoryURL + 6)
  
 -static char GitRawRevisionShortHash[] = "$CommitHash$";
-+static char GitRawRevisionShortHash[] = "$CommitHash: 8c74b1e05 $";
++static char GitRawRevisionShortHash[] = "$CommitHash: 85f911a13 $";
  # define SHORTHASH_START (GitRawRevisionShortHash + 13)
  
  static char *

--- a/components/runtime/smalltalk/stack-spur/patches/03-sqPluginsSCCSVersion.patch
+++ b/components/runtime/smalltalk/stack-spur/patches/03-sqPluginsSCCSVersion.patch
@@ -1,11 +1,11 @@
---- opensmalltalk-vm-sun-v5.0.80/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri Dec 12 20:41:17 2025
-+++ p0/opensmalltalk-vm-sun-v5.0.80/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sat Dec 13 13:58:22 2025
+--- opensmalltalk-vm-sun-v5.0.81/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sun Jan 11 08:34:24 2026
++++ p0/opensmalltalk-vm-sun-v5.0.81/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sun Jan 11 15:38:06 2026
 @@ -9,10 +9,10 @@
   */
  
  #if SUBVERSION
 -static char SvnRawPluginsRevisionString[] = "$Rev$";
-+static char SvnRawPluginsRevisionString[] = "$Rev: 202512121941 $";
++static char SvnRawPluginsRevisionString[] = "$Rev: 202601110734 $";
  # define PLUGINS_REV_START (SvnRawPluginsRevisionString + 6)
  
 -static char SvnRawPluginsRepositoryURL[] = "$URL$";
@@ -18,7 +18,7 @@
  # undef URL_START
  #elif GIT
 -static char GitRawPluginsRevisionString[] = "$Rev$";
-+static char GitRawPluginsRevisionString[] = "$Rev: 202512121941 $";
++static char GitRawPluginsRevisionString[] = "$Rev: 202601110734 $";
  # define PLUGINS_REV_START (GitRawPluginsRevisionString + 6)
  
 -static char GitRawPluginsRepositoryURL[] = "$URL$";

--- a/components/runtime/smalltalk/stack-spur/pkg5
+++ b/components/runtime/smalltalk/stack-spur/pkg5
@@ -21,6 +21,7 @@
         "runtime/smalltalk/stack-spur",
         "runtime/smalltalk/stack-spur-display-X11",
         "runtime/smalltalk/stack-spur-nodisplay",
+        "runtime/smalltalk/stack-spur-pty",
         "runtime/smalltalk/stack-spur-ssl",
         "runtime/smalltalk/stack-spur-vep"
     ],

--- a/components/runtime/smalltalk/stack-spur/plugins.ext
+++ b/components/runtime/smalltalk/stack-spur/plugins.ext
@@ -15,6 +15,7 @@ ImmX11Plugin \
 XDisplayControlPlugin \
 # Cuis plugin
 VectorEnginePlugin \
+PseudoTTYPlugin \
 DESPlugin \
 MD5Plugin \
 SHA2Plugin \

--- a/components/runtime/smalltalk/stack-spur/squeak.ips
+++ b/components/runtime/smalltalk/stack-spur/squeak.ips
@@ -6,7 +6,7 @@
 # Last edited: 2013-11-13 19:51:35 by piumarta on emilia
 
 PATH=/usr/bin:/bin
-PLUGIN_REV=7.0-202512121941
+PLUGIN_REV=7.0-202601110734
 
 realpath () {
     path="$1"

--- a/components/runtime/smalltalk/stack-spur/stack-spur-display-X11.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur-display-X11.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/stack-spur-nodisplay.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur-nodisplay.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/stack-spur-pty.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur-pty.p5m
@@ -10,12 +10,12 @@
 #
 
 #
-# Copyright 2020, 2021, 2023, 2026 David Stes
+# Copyright 2026 David Stes
 #
 
 
-set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
-set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=pkg.fmri value=pkg:/runtime/smalltalk/stack-spur-pty@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) PseudoTTYPlugin"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
 set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
@@ -26,4 +26,4 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 depend type=require fmri=pkg:/runtime/smalltalk/stack-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
 
-file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/PseudoTTYPlugin.so

--- a/components/runtime/smalltalk/stack-spur/stack-spur-vep.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur-vep.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023 David Stes
+# Copyright 2020, 2021, 2023, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/stack-spur.p5m
+++ b/components/runtime/smalltalk/stack-spur/stack-spur.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2023, 2024 David Stes
+# Copyright 2020, 2021, 2023, 2024, 2026 David Stes
 #
 
 

--- a/components/runtime/smalltalk/stack-spur/test/results-64.master
+++ b/components/runtime/smalltalk/stack-spur/test/results-64.master
@@ -1,7 +1,7 @@
 SUnit Results
 Squeak5.3
 solaris2.11
-Open Smalltalk Stack VM [StackInterpreterPrimitives VMMaker.oscog-eem.3704]
+Open Smalltalk Stack VM [StackInterpreterPrimitives VMMaker.oscog-eem.3719]
 Failed Tests
 'BorderedMorphTests>>#test01OldInstVarRefs'
 'OrderedDictionaryTest>>#testGrow'

--- a/components/runtime/smalltalk/stack-spur/tools/classify.pl
+++ b/components/runtime/smalltalk/stack-spur/tools/classify.pl
@@ -20,6 +20,7 @@ open(X11,">>","stack-spur-display-X11.p5m") || die "Can't open stack-spur-displa
 
 open(SSL,">>","stack-spur-ssl.p5m") || die "Can't open stack-spur-ssl.p5m";
 open(VEP,">>","stack-spur-vep.p5m") || die "Can't open stack-spur-vep.p5m";
+open(PTY,">>","stack-spur-pty.p5m") || die "Can't open stack-spur-pty.p5m";
 
 open(REST,">>","stack-spur.p5m") || die "Can't open stack-spur.p5m";
 
@@ -69,6 +70,8 @@ while (<>) {
 			print X11 $_;
 		} elsif (/UnixOSProcessPlugin/) {
 			print NODISPLAY $_;
+		} elsif (/PseudoTTYPlugin/) {
+			print PTY $_;
 		} elsif (/MD5Plugin/) {
 			print NODISPLAY $_;
 		} elsif (/SHA2Plugin/) {


### PR DESCRIPTION

update to 3719
add an optional plugin for PTY (pseudotty) support 
permits to run a unix shell in a smalltalk image