### PR TITLE
opensmalltalk cog-spur: add PseudoTTYPlugin from VMMaker.3719

### DIFF
--- a/components/runtime/smalltalk/cog-spur/Makefile
+++ b/components/runtime/smalltalk/cog-spur/Makefile
@@ -9,7 +9,7 @@
 #
 
 #
-# Copyright 2020, 2021, 2022, 2023, 2024, 2025 David Stes
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025, 2026 David Stes
 #
 
 
@@ -43,9 +43,9 @@ include ../../../../make-rules/shared-macros.mk
 # sometimes the Stack VM is generated from a different VMMaker as the Cog VM
 
 COMPONENT_NAME=		cog-spur
-COMPONENT_VERSION=	5.0.3705
-GIT_TAG=		sun-v5.0.80
-PLUGIN_REV=		7.0-202512121941-cog
+COMPONENT_VERSION=	5.0.3719
+GIT_TAG=		sun-v5.0.81
+PLUGIN_REV=		7.0-202601110734-cog
 COMPONENT_SUMMARY=	The OpenSmalltalk Cog Spur Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_FMRI=		runtime/smalltalk/cog-spur
@@ -59,7 +59,7 @@ COMPONENT_LICENSE_FILE=	squeak5.license
 
 COMPONENT_SRC=		opensmalltalk-vm-$(GIT_TAG)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:6acac2f8165a3de5954759ed4bff704625582629a3022260e32dda199a076369
+COMPONENT_ARCHIVE_HASH=	sha256:8d2b006f10a137164e49cdc0ded80b391c735c165d4b8b91b4a9ea7a8ef6d6a0
 COMPONENT_ARCHIVE_URL=	https://codeload.github.com/cstes/opensmalltalk-vm/tar.gz/$(GIT_TAG)
 
 # run SUnit tests in the build directories on 32bit and 64bit Squeak images
@@ -158,6 +158,7 @@ COMPONENT_POST_INSTALL_ACTION = \
 rebuild-manifests::
 	cp manifests/cog-spur.p5m cog-spur.p5m
 	cp manifests/cog-spur-vep.p5m cog-spur-vep.p5m
+	cp manifests/cog-spur-pty.p5m cog-spur-pty.p5m
 	cp manifests/cog-spur-ssl.p5m cog-spur-ssl.p5m
 	cp manifests/cog-spur-display-X11.p5m cog-spur-display-X11.p5m
 	cp manifests/cog-spur-nodisplay.p5m cog-spur-nodisplay.p5m

--- a/components/runtime/smalltalk/cog-spur/cog-spur-pty.p5m
+++ b/components/runtime/smalltalk/cog-spur/cog-spur-pty.p5m
@@ -1,0 +1,29 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-pty@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) PseudoTTYPlugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+file path=usr/lib/$(MACH64)/squeak/$(PLUGIN_REV)-64bit/PseudoTTYPlugin.so

--- a/components/runtime/smalltalk/cog-spur/manifests/cog-spur-pty.p5m
+++ b/components/runtime/smalltalk/cog-spur/manifests/cog-spur-pty.p5m
@@ -1,0 +1,28 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/cog-spur-pty@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) PseudoTTYPlugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license squeak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/runtime/smalltalk/cog-spur-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+

--- a/components/runtime/smalltalk/cog-spur/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/cog-spur/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2025 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -31,27 +31,28 @@ file path=usr/doc/squeak/LICENSE
 file path=usr/doc/squeak/README.Contributing
 file path=usr/doc/squeak/README.Keyboard
 file path=usr/doc/squeak/README.Sound
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/B3DAcceleratorPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/ClipboardExtendedPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/DESPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/FileAttributesPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/ImmX11Plugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/LocalePlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/MD5Plugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/SHA2Plugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/Squeak3D.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/SqueakFFIPrims.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/SqueakSSL.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/UUIDPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/UnicodePlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/UnixOSProcessPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/VectorEnginePlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/XDisplayControlPlugin.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/squeak
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/vm-display-X11.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/vm-display-null.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/vm-sound-null.so
-file path=usr/lib/$(MACH64)/squeak/7.0-202512121941-cog-64bit/vm-sound-pulse.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/B3DAcceleratorPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/ClipboardExtendedPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/DESPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/FileAttributesPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/ImmX11Plugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/LocalePlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/MD5Plugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/PseudoTTYPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/SHA2Plugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/Squeak3D.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/SqueakFFIPrims.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/SqueakSSL.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/UUIDPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/UnicodePlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/UnixOSProcessPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/VectorEnginePlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/XDisplayControlPlugin.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/squeak
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/vm-display-X11.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/vm-display-null.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/vm-sound-null.so
+file path=usr/lib/$(MACH64)/squeak/7.0-202601110734-cog-64bit/vm-sound-pulse.so
 hardlink path=usr/share/man/man1/inisqueak.1 target=squeak.1
 file path=usr/share/man/man1/squeak.1
 file path=usr/squeak

--- a/components/runtime/smalltalk/cog-spur/patches/02-sqSCCSVersion.patch
+++ b/components/runtime/smalltalk/cog-spur/patches/02-sqSCCSVersion.patch
@@ -1,15 +1,15 @@
---- opensmalltalk-vm-sun-v5.0.80/platforms/Cross/vm/sqSCCSVersion.h	Fri Dec 12 20:41:17 2025
-+++ p0/opensmalltalk-vm-sun-v5.0.80/platforms/Cross/vm/sqSCCSVersion.h	Sat Dec 13 14:32:22 2025
+--- opensmalltalk-vm-sun-v5.0.81/platforms/Cross/vm/sqSCCSVersion.h	Sun Jan 11 08:34:24 2026
++++ p0/opensmalltalk-vm-sun-v5.0.81/platforms/Cross/vm/sqSCCSVersion.h	Fri Jan 16 18:44:18 2026
 @@ -30,13 +30,13 @@
  
  #if SUBVERSION
  # define PREFIX "r"
 -static char SvnRawRevisionString[] = "$Rev$";
-+static char SvnRawRevisionString[] = "$Rev: 202512121941-cog $";
++static char SvnRawRevisionString[] = "$Rev: 202601110734-cog $";
  # define REV_START (SvnRawRevisionString + 6)
  
 -static char SvnRawRevisionDate[] = "$Date$";
-+static char SvnRawRevisionDate[] = "$Date: Fri Dec 12 20:41:17 2025 +0100 $";
++static char SvnRawRevisionDate[] = "$Date: Sun Jan 11 08:34:24 2026 +0100 $";
  # define DATE_START (SvnRawRevisionDate + 7)
  
 -static char SvnRawRepositoryURL[] = "$URL$";
@@ -22,12 +22,12 @@
  #elif GIT
  # define PREFIX ""
 -static char GitRawRevisionString[] = "$Rev$";
-+static char GitRawRevisionString[] = "$Rev: 202512121941-cog $";
++static char GitRawRevisionString[] = "$Rev: 202601110734-cog $";
  # define REV_START (GitRawRevisionString + 6)
  # define REV_TIME_START (GitRawRevisionString + 14)
  
 -static char GitRawRevisionDate[] = "$Date$";
-+static char GitRawRevisionDate[] = "$Date: Fri Dec 12 20:41:17 2025 +0100 $";
++static char GitRawRevisionDate[] = "$Date: Sun Jan 11 08:34:24 2026 +0100 $";
  # define DATE_START (GitRawRevisionDate + 7)
  
 -static char GitRawRepositoryURL[] = "$URL$";
@@ -35,7 +35,7 @@
  # define URL_START (GitRawRepositoryURL + 6)
  
 -static char GitRawRevisionShortHash[] = "$CommitHash$";
-+static char GitRawRevisionShortHash[] = "$CommitHash: 8c74b1e05 $";
++static char GitRawRevisionShortHash[] = "$CommitHash: 85f911a13 $";
  # define SHORTHASH_START (GitRawRevisionShortHash + 13)
  
  static char *

--- a/components/runtime/smalltalk/cog-spur/patches/03-sqPluginsSCCSVersion.patch
+++ b/components/runtime/smalltalk/cog-spur/patches/03-sqPluginsSCCSVersion.patch
@@ -1,11 +1,11 @@
---- opensmalltalk-vm-sun-v5.0.80/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri Dec 12 20:41:17 2025
-+++ p0/opensmalltalk-vm-sun-v5.0.80/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sat Dec 13 14:32:22 2025
+--- opensmalltalk-vm-sun-v5.0.81/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Sun Jan 11 08:34:24 2026
++++ p0/opensmalltalk-vm-sun-v5.0.81/platforms/Cross/plugins/sqPluginsSCCSVersion.h	Fri Jan 16 18:44:18 2026
 @@ -9,10 +9,10 @@
   */
  
  #if SUBVERSION
 -static char SvnRawPluginsRevisionString[] = "$Rev$";
-+static char SvnRawPluginsRevisionString[] = "$Rev: 202512121941-cog $";
++static char SvnRawPluginsRevisionString[] = "$Rev: 202601110734-cog $";
  # define PLUGINS_REV_START (SvnRawPluginsRevisionString + 6)
  
 -static char SvnRawPluginsRepositoryURL[] = "$URL$";
@@ -18,7 +18,7 @@
  # undef URL_START
  #elif GIT
 -static char GitRawPluginsRevisionString[] = "$Rev$";
-+static char GitRawPluginsRevisionString[] = "$Rev: 202512121941-cog $";
++static char GitRawPluginsRevisionString[] = "$Rev: 202601110734-cog $";
  # define PLUGINS_REV_START (GitRawPluginsRevisionString + 6)
  
 -static char GitRawPluginsRepositoryURL[] = "$URL$";

--- a/components/runtime/smalltalk/cog-spur/pkg5
+++ b/components/runtime/smalltalk/cog-spur/pkg5
@@ -21,6 +21,7 @@
         "runtime/smalltalk/cog-spur",
         "runtime/smalltalk/cog-spur-display-X11",
         "runtime/smalltalk/cog-spur-nodisplay",
+        "runtime/smalltalk/cog-spur-pty",
         "runtime/smalltalk/cog-spur-ssl",
         "runtime/smalltalk/cog-spur-vep"
     ],

--- a/components/runtime/smalltalk/cog-spur/plugins.ext
+++ b/components/runtime/smalltalk/cog-spur/plugins.ext
@@ -3,13 +3,11 @@ EXTERNAL_PLUGINS = \
 MIDIPlugin \
 B3DAcceleratorPlugin \
 ClipboardExtendedPlugin \
-BochsIA32Plugin \
-BochsX64Plugin \
-GdbARMPlugin \
 FileAttributesPlugin \
 Squeak3D \
 SqueakFFIPrims \
 SqueakSSL \
+PseudoTTYPlugin \
 LocalePlugin \
 UnicodePlugin \
 UnixOSProcessPlugin \

--- a/components/runtime/smalltalk/cog-spur/squeak.ips
+++ b/components/runtime/smalltalk/cog-spur/squeak.ips
@@ -6,7 +6,7 @@
 # Last edited: 2013-11-13 19:51:35 by piumarta on emilia
 
 PATH=/usr/bin:/bin
-PLUGIN_REV=7.0-202512121941-cog
+PLUGIN_REV=7.0-202601110734-cog
 
 realpath () {
     path="$1"

--- a/components/runtime/smalltalk/cog-spur/tools/classify.pl
+++ b/components/runtime/smalltalk/cog-spur/tools/classify.pl
@@ -20,6 +20,7 @@ open(X11,">>","cog-spur-display-X11.p5m") || die "Can't open cog-spur-display-X1
 
 open(SSL,">>","cog-spur-ssl.p5m") || die "Can't open cog-spur-ssl.p5m";
 open(VEP,">>","cog-spur-vep.p5m") || die "Can't open cog-spur-vep.p5m";
+open(PTY,">>","cog-spur-pty.p5m") || die "Can't open cog-spur-pty.p5m";
 
 open(REST,">>","cog-spur.p5m") || die "Can't open cog-spur.p5m";
 
@@ -69,6 +70,8 @@ while (<>) {
 			print X11 $_;
 		} elsif (/UnixOSProcessPlugin/) {
 			print NODISPLAY $_;
+		} elsif (/PseudoTTYPlugin/) {
+			print PTY $_;
 		} elsif (/MD5Plugin/) {
 			print NODISPLAY $_;
 		} elsif (/SHA2Plugin/) {


### PR DESCRIPTION

update to 3719
add an optional plugin for PTY (pseudotty) support 
permits to run a unix shell in a smalltalk image