### PR TITLE
dash: update to 0.5.13.1

### DIFF
--- a/components/shell/dash/Makefile
+++ b/components/shell/dash/Makefile
@@ -17,13 +17,13 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		dash
-COMPONENT_VERSION=	0.5.12
+COMPONENT_VERSION=	0.5.13.1
 COMPONENT_SUMMARY=	DASH is a POSIX-compliant implementation of /bin/sh that aims to be as small as possible.
 COMPONENT_PROJECT_URL=  http://gondor.apana.org.au/~herbert/dash
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_URL=	https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/$(COMPONENT_ARCHIVE)
-COMPONENT_ARCHIVE_HASH=	sha256:0d632f6b945058d84809cac7805326775bd60cb4a316907d0bd4228ff7107154
+COMPONENT_ARCHIVE_URL=	http://gondor.apana.org.au/~herbert/dash/files/$(COMPONENT_ARCHIVE)
+COMPONENT_ARCHIVE_HASH=	sha256:d9271bce09c127d9866e25c011582ddc75ab988958a04bc4d8553a3b8f30e370
 COMPONENT_FMRI=		shell/dash
 COMPONENT_CLASSIFICATION=System/Shells
 COMPONENT_LICENSE=	BSD
@@ -33,8 +33,11 @@ include $(WS_MAKE_RULES)/common.mk
 
 PATH= $(PATH.gnu)
 
+CONFIGURE_OPTIONS += --with-libedit
+
 COMPONENT_PRE_CONFIGURE_ACTION= \
 	(cd $(SOURCE_DIR) && autoreconf -fi)
 
 # Auto-generated dependencies
+REQUIRED_PACKAGES += library/libedit
 REQUIRED_PACKAGES += system/library

--- a/components/shell/dash/manifests/sample-manifest.p5m
+++ b/components/shell/dash/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2022 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/shell/dash/patches/02-no-d_type.patch
+++ b/components/shell/dash/patches/02-no-d_type.patch
@@ -1,0 +1,19 @@
+--- dash-0.5.13/src/expand.c.old
++++ dash-0.5.13/src/expand.c
+@@ -1727,9 +1727,16 @@
+ 
+ 		if (*dname == '.' && !matchdot)
+ 			goto check_int;
++#ifdef __sun
++		struct stat s;
++		stat(dp->d_name, &s);
++		if (c && !(s.st_mode & S_IFDIR) && !(s.st_mode & S_IFLNK) )
++			goto check_int;
++#else
+ 		if (c && dp->d_type != DT_DIR && dp->d_type != DT_LNK &&
+ 		    dp->d_type != DT_UNKNOWN)
+ 			goto check_int;
++#endif
+ 		len = strlen(dname) + 1;
+ 		p = dname;
+ 		if (!FNMATCH_IS_ENABLED) {

--- a/components/shell/dash/patches/03-no-optreset.patch
+++ b/components/shell/dash/patches/03-no-optreset.patch
@@ -1,0 +1,16 @@
+$NetBSD: patch-src_histedit.c,v 1.1 2025/06/28 02:40:08 schmonz Exp $
+
+Avoid "'optreset' undeclared" on Illumos.
+
+--- a/src/histedit.c.orig	2025-06-28 02:26:40.738340552 +0000
++++ a/src/histedit.c
+@@ -217,6 +217,8 @@ histcmd(int argc, char **argv)
+ 
+ #ifdef __GLIBC__
+ 	optind = 0;
++#elif defined(__sun)
++	optind = 1;
+ #else
+ 	optreset = 1; optind = 1; /* initialize getopt */
+ #endif
+

--- a/components/shell/dash/pkg5
+++ b/components/shell/dash/pkg5
@@ -1,7 +1,6 @@
 {
     "dependencies": [
-        "SUNWcs",
-        "shell/ksh93",
+        "library/libedit",
         "system/library"
     ],
     "fmris": [


### PR DESCRIPTION
03-no-optreset.patch came from pkgsrc
Changed archive source to match source that pkgsrc also uses.