### PR TITLE
illumos-closed: need more drivers for SPARC debug builds

### DIFF
--- a/components/openindiana/illumos-closed/Makefile
+++ b/components/openindiana/illumos-closed/Makefile
@@ -10,14 +10,14 @@
 
 #
 # Copyright 2016 Adam Stevko 
-# Copyright 2024 Klaus Ziegler
+# Copyright 2026 Klaus Ziegler
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		illumos-closed
 COMPONENT_VERSION=	5.11
-COMPONENT_REVISION=	6
+COMPONENT_REVISION=	7
 COMPONENT_SUMMARY=	illumos-closed - illumos closed binaries
 COMPONENT_PROJECT_URL=	https://www.openindiana.org/
 COMPONENT_FMRI=		developer/illumos-closed
@@ -84,3 +84,4 @@ build:		$(BUILD_32)
 install:	$(INSTALL_32)
 
 test:		$(TEST_32)
+# Auto-generated dependencies

--- a/components/openindiana/illumos-closed/illumos-closed.p5m
+++ b/components/openindiana/illumos-closed/illumos-closed.p5m
@@ -3892,14 +3892,18 @@ file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/afb 
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/ctsmc mode=0755 variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/ffb mode=0755 variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/gfb mode=0755 variant.arch=sparc
+file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/gfxp mode=0755 variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/ifb mode=0755 variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/jfb mode=0755 variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/m1535ppm mode=0755 variant.arch=sparc
+file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/m64 mode=0755 variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/mi2cv mode=0755 variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/smbus_ara mode=0755 variant.arch=sparc
+file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/drv/$(MACH64)/zulu mode=0755 variant.arch=sparc
 dir  path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/misc variant.arch=sparc
 dir  path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/misc/$(MACH64) variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/misc/$(MACH64)/forthdebug mode=0755 variant.arch=sparc
+file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/misc/$(MACH64)/zuluvm mode=0755 variant.arch=sparc
 dir  path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/tod variant.arch=sparc
 dir  path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/tod/$(MACH64) variant.arch=sparc
 file path=opt/onbld/closed/root_$(MACH)/platform/sun4u/kernel/tod/$(MACH64)/todm5823 mode=0755 variant.arch=sparc

--- a/components/openindiana/illumos-closed/manifests/sample-manifest.p5m
+++ b/components/openindiana/illumos-closed/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2023 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -94,7 +94,7 @@ file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/marvell88sx \
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/mpt mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcn mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/pcser mode=0755
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/sdpib group=sys mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/sdpib mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/$(MACH64)/usbser_edge \
     mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/acpi_toshiba mode=0755
@@ -121,7 +121,7 @@ file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/mpt.conf mode=0644
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcn mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/pcser mode=0755
-file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib group=sys mode=0755
+file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/sdpib.conf mode=0644
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge mode=0755
 file path=opt/onbld/closed/root_i386-nd/kernel/drv/usbser_edge.conf mode=0644
@@ -160,7 +160,7 @@ file \
 dir  path=opt/onbld/closed/root_i386-nd/kernel/strmod
 dir  path=opt/onbld/closed/root_i386-nd/kernel/strmod/$(MACH64)
 hardlink path=opt/onbld/closed/root_i386-nd/kernel/strmod/$(MACH64)/sdpib \
-    target=../../../kernel/drv/$(MACH64)/sdpib
+    target=../../drv/$(MACH64)/sdpib
 hardlink path=opt/onbld/closed/root_i386-nd/kernel/strmod/sdpib \
     target=../drv/sdpib
 dir  path=opt/onbld/closed/root_i386-nd/lib


### PR DESCRIPTION
I didn't changed the i386 contents to not break anything, however added a new sample-manifest, because of standard procedure.