### PR TITLE
w3m: update to 0.5.6

### DIFF
--- a/components/web/w3m/Makefile
+++ b/components/web/w3m/Makefile
@@ -17,16 +17,16 @@
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= w3m
-COMPONENT_VERSION=  0.5.5
+COMPONENT_VERSION=  0.5.6
 COMPONENT_SUMMARY= A text-based web browser
-COMPONENT_SRC= $(COMPONENT_NAME)-v0.5.5
+COMPONENT_SRC= $(COMPONENT_NAME)-v$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_SRC).tar.gz
 COMPONENT_ARCHIVE_HASH= \
-  sha256:b271c86b13be2207700230cb3f9061271ea37fd1ace199f48b72ea542a529a0f
+  sha256:8dd652cd3f31817d68c7263c34eeffb50118c80be19e1159bf8cbf763037095e
 COMPONENT_ARCHIVE_URL= \
   https://git.sr.ht/~rkta/w3m/archive/v$(COMPONENT_VERSION).tar.gz
 COMPONENT_PROJECT_URL= https://sr.ht/~rkta/w3m/
-COMPONENT_FMRI= web/browser/w3m
+COMPONENT_FMRI= web/browser/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION= Applications/Internet
 COMPONENT_LICENSE= MIT
 
@@ -36,8 +36,6 @@ include $(WS_MAKE_RULES)/common.mk
 
 COMPONENT_PRE_CONFIGURE_ACTION =        ($(CLONEY) $(SOURCE_DIR) $(@D))
 
-CONFIGURE_OPTIONS+= --sysconfdir=/etc
-CONFIGURE_OPTIONS+= --libexecdir=/usr/lib
 CONFIGURE_OPTIONS+= --with-browser=/usr/bin/firefox
 CONFIGURE_OPTIONS+= --with-imagelib=imlib2
 

--- a/components/web/w3m/manifests/sample-manifest.p5m
+++ b/components/web/w3m/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2025 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -25,17 +25,17 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/w3m
 file path=usr/bin/w3mman
-file path=usr/lib/w3m/cgi-bin/dirlist.cgi
-file path=usr/lib/w3m/cgi-bin/multipart.cgi
-file path=usr/lib/w3m/cgi-bin/w3mbookmark
-file path=usr/lib/w3m/cgi-bin/w3mdict.cgi
-file path=usr/lib/w3m/cgi-bin/w3mhelp.cgi
-file path=usr/lib/w3m/cgi-bin/w3mhelperpanel
-file path=usr/lib/w3m/cgi-bin/w3mmail.cgi
-file path=usr/lib/w3m/cgi-bin/w3mman2html.cgi
-file path=usr/lib/w3m/inflate
-file path=usr/lib/w3m/w3mimgdisplay
-file path=usr/lib/w3m/xface2xpm
+file path=usr/libexec/w3m/cgi-bin/dirlist.cgi
+file path=usr/libexec/w3m/cgi-bin/multipart.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mbookmark
+file path=usr/libexec/w3m/cgi-bin/w3mdict.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mhelp.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mhelperpanel
+file path=usr/libexec/w3m/cgi-bin/w3mmail.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mman2html.cgi
+file path=usr/libexec/w3m/inflate
+file path=usr/libexec/w3m/w3mimgdisplay
+file path=usr/libexec/w3m/xface2xpm
 file path=usr/share/locale/de/LC_MESSAGES/w3m.mo
 file path=usr/share/locale/it/LC_MESSAGES/w3m.mo
 file path=usr/share/locale/ja/LC_MESSAGES/w3m.mo

--- a/components/web/w3m/patches/01-use-MKDIR_P.patch
+++ b/components/web/w3m/patches/01-use-MKDIR_P.patch
@@ -1,0 +1,13 @@
+/bin/sh[5]: @mkdir_p@: not found [No such file or directory]
+
+--- w3m-v0.5.6/po/Makefile.in.in.old	2026-02-07 11:33:48.968833499 -0500
++++ w3m-v0.5.6/po/Makefile.in.in	2026-02-07 11:34:36.909343192 -0500
+@@ -42,7 +42,7 @@
+ mkinstalldirs = $(SHELL) @install_sh@ -d
+ install_sh = $(SHELL) @install_sh@
+ MKDIR_P = @MKDIR_P@
+-mkdir_p = @mkdir_p@
++mkdir_p = @MKDIR_P@
+ 
+ # When building gettext-tools, we prefer to use the built programs
+ # rather than installed programs.  However, we can't do that when we

--- a/components/web/w3m/w3m.p5m
+++ b/components/web/w3m/w3m.p5m
@@ -26,17 +26,17 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
 file path=usr/bin/w3m
 file path=usr/bin/w3mman
-file path=usr/lib/w3m/cgi-bin/dirlist.cgi mode=0555
-file path=usr/lib/w3m/cgi-bin/multipart.cgi mode=0555
-file path=usr/lib/w3m/cgi-bin/w3mbookmark mode=0555
-file path=usr/lib/w3m/cgi-bin/w3mdict.cgi mode=0555
-file path=usr/lib/w3m/cgi-bin/w3mhelp.cgi mode=0555
-file path=usr/lib/w3m/cgi-bin/w3mhelperpanel mode=0555
-file path=usr/lib/w3m/cgi-bin/w3mmail.cgi mode=0555
-file path=usr/lib/w3m/cgi-bin/w3mman2html.cgi mode=0555
-file path=usr/lib/w3m/inflate mode=0555
-file path=usr/lib/w3m/w3mimgdisplay mode=0555
-file path=usr/lib/w3m/xface2xpm mode=0555
+file path=usr/libexec/w3m/cgi-bin/dirlist.cgi
+file path=usr/libexec/w3m/cgi-bin/multipart.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mbookmark
+file path=usr/libexec/w3m/cgi-bin/w3mdict.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mhelp.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mhelperpanel
+file path=usr/libexec/w3m/cgi-bin/w3mmail.cgi
+file path=usr/libexec/w3m/cgi-bin/w3mman2html.cgi
+file path=usr/libexec/w3m/inflate
+file path=usr/libexec/w3m/w3mimgdisplay
+file path=usr/libexec/w3m/xface2xpm
 file path=usr/share/locale/de/LC_MESSAGES/w3m.mo
 file path=usr/share/locale/it/LC_MESSAGES/w3m.mo
 file path=usr/share/locale/ja/LC_MESSAGES/w3m.mo


### PR DESCRIPTION
You gave some advice during the w3m 0.5.5 of changes to consider which I said at the time I will do during the following release.  I no longer have the notes given at the time.  Please advise if an other changes are needed.

I only recall this to remove from Makefile:
CONFIGURE_OPTIONS+= --sysconfdir=/etc
CONFIGURE_OPTIONS+= --libexecdir=/usr/lib