### PR TITLE
librsvg: readd gdk-pixbufloader, minor update 2.61.4

### DIFF
--- a/components/library/librsvg/Makefile
+++ b/components/library/librsvg/Makefile
@@ -20,14 +20,13 @@ BUILD_STYLE= meson
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		librsvg
-COMPONENT_VERSION=	2.61.3
-COMPONENT_REVISION=	1
+COMPONENT_VERSION=	2.61.4
 COMPONENT_MAJOR_VERSION=$(basename $(COMPONENT_VERSION))
 COMPONENT_SUMMARY=	Library for SVG support for GNOME
 COMPONENT_PROJECT_URL= https://wiki.gnome.org/Projects/LibRsvg
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
-COMPONENT_ARCHIVE_HASH= sha256:a56d2c80d744ad2f2718f85df466fe71d24ff1f9bc3e5ef588bde4d7e87815f2
+COMPONENT_ARCHIVE_HASH= sha256:fca0ea28d1f28f95c8407d2579f4702dac085e7c758644daca8b40d1e072ca0c
 COMPONENT_ARCHIVE_URL= https://download.gnome.org/sources/$(COMPONENT_NAME)/$(COMPONENT_MAJOR_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		image/library/librsvg
 COMPONENT_CLASSIFICATION=System/Multimedia Libraries
@@ -43,6 +42,7 @@ LD_OPTIONS=-M /usr/lib/ld/map.noexstk -M /usr/lib/ld/map.noexdata -M /usr/lib/ld
 
 # Disable avif since it is encumbered
 CONFIGURE_OPTIONS += -Davif=disabled
+CONFIGURE_OPTIONS += -Dpixbuf-loader=enabled
 
 COMPONENT_PRE_CONFIGURE_ACTION = $(GSED) -i -e 's/= .*version-script.*$$/= []/' $(SOURCE_DIR)/rsvg/meson.build
 

--- a/components/library/librsvg/librsvg.p5m
+++ b/components/library/librsvg/librsvg.p5m
@@ -31,6 +31,7 @@ file path=usr/include/librsvg-2.0/librsvg/rsvg-features.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg-pixbuf.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg-version.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg.h
+file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader_svg.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Rsvg-2.0.typelib
 link path=usr/lib/$(MACH64)/librsvg-2.so target=librsvg-2.so.2
 file path=usr/lib/$(MACH64)/librsvg-2.so.$(HUMAN_VERSION)
@@ -165,5 +166,6 @@ file path=usr/share/doc/Rsvg-2.0/type_func.Error.quark.html
 file path=usr/share/doc/Rsvg-2.0/urlmap.js
 file path=usr/share/gir-1.0/Rsvg-2.0.gir
 file path=usr/share/man/man1/rsvg-convert.1
+file path=usr/share/thumbnailers/librsvg.thumbnailer
 file path=usr/share/vala/vapi/librsvg-2.0.deps
 file path=usr/share/vala/vapi/librsvg-2.0.vapi

--- a/components/library/librsvg/manifests/sample-manifest.p5m
+++ b/components/library/librsvg/manifests/sample-manifest.p5m
@@ -29,6 +29,7 @@ file path=usr/include/librsvg-2.0/librsvg/rsvg-features.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg-pixbuf.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg-version.h
 file path=usr/include/librsvg-2.0/librsvg/rsvg.h
+file path=usr/lib/$(MACH64)/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader_svg.so
 file path=usr/lib/$(MACH64)/girepository-1.0/Rsvg-2.0.typelib
 link path=usr/lib/$(MACH64)/librsvg-2.so target=librsvg-2.so.2
 file path=usr/lib/$(MACH64)/librsvg-2.so.$(HUMAN_VERSION)
@@ -163,5 +164,6 @@ file path=usr/share/doc/Rsvg-2.0/type_func.Error.quark.html
 file path=usr/share/doc/Rsvg-2.0/urlmap.js
 file path=usr/share/gir-1.0/Rsvg-2.0.gir
 file path=usr/share/man/man1/rsvg-convert.1
+file path=usr/share/thumbnailers/librsvg.thumbnailer
 file path=usr/share/vala/vapi/librsvg-2.0.deps
 file path=usr/share/vala/vapi/librsvg-2.0.vapi


### PR DESCRIPTION
glycin loader do not work for svg, readd legacy pixbufloader. There are missing icons in Gimp and Inkscape seen.
For get them back, recreate caches:
sudo gdk-pixbuf-query-loaders --update-cache
sudo gtk-update-icon-cache /usr/share/icons/*
sudo update-mime-database /usr/share/mime
