### PR TITLE
quilt: fix license meta data

### DIFF
--- a/components/developer/quilt/Makefile
+++ b/components/developer/quilt/Makefile
@@ -28,7 +28,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=         quilt
 COMPONENT_VERSION=      0.69
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=      Quilt - tool to manage series of patches
 COMPONENT_SRC=          $(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_PROJECT_URL=  https://savannah.nongnu.org/projects/quilt/
@@ -37,8 +37,8 @@ COMPONENT_ARCHIVE_HASH=	sha256:555ddffde22da3c86d1caf5a9c1fb8a152ac2b84730437bd3
 COMPONENT_ARCHIVE_URL= 	https://download.savannah.gnu.org/releases/quilt/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=         developer/quilt
 COMPONENT_CLASSIFICATION= Development/Source Code Management
-COMPONENT_LICENSE=      GPLv2 
-COMPONENT_LICENSE_FILE= COPYING 
+COMPONENT_LICENSE=      GPLv2
+COMPONENT_LICENSE_FILE= COPYING
 
 include $(WS_MAKE_RULES)/common.mk
 

--- a/components/developer/quilt/manifests/sample-manifest.p5m
+++ b/components/developer/quilt/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2025 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
@@ -51,7 +51,7 @@ link path=usr/share/quilt/compat/find target=/usr/gnu/bin/find
 link path=usr/share/quilt/compat/getopt target=/usr/gnu/bin/getopt
 link path=usr/share/quilt/compat/grep target=/usr/gnu/bin/grep
 link path=usr/share/quilt/compat/patch target=/usr/gnu/bin/patch
-link path=usr/share/quilt/compat/perl target=/usr/perl5/5.40/bin/perl
+link path=usr/share/quilt/compat/perl target=/usr/perl5/5.42/bin/perl
 link path=usr/share/quilt/compat/sed target=/usr/gnu/bin/sed
 link path=usr/share/quilt/compat/sendmail target=/usr/sbin/sendmail
 link path=usr/share/quilt/compat/tail target=/usr/gnu/bin/tail


### PR DESCRIPTION
I discovered today that I am unable to pkg install a new package with the quilt revision 1 package installed--problem fixed when I uninstalled quilt.  pkg said that 'GPLv2' != 'GPLv2 ' for quilt.
Removed last space from two LICENSE strings in Makefile.  Also included new sample-manifest since it was not included in revision 1.