### PR TITLE
netbeans: refacter p5m arch support; re-add missing x86_64 binaries

### DIFF
--- a/components/editor/netbeans/Makefile
+++ b/components/editor/netbeans/Makefile
@@ -19,7 +19,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME= netbeans
 COMPONENT_VERSION= 29
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY= Apache Netbeans IDE
 COMPONENT_FMRI= editor/netbeans
 COMPONENT_CLASSIFICATION=System/Text Tools
@@ -45,20 +45,20 @@ COMPONENT_BUILD_ARGS=
 PYTHON_SHEBANG="\#\!\/usr\/bin\/python$(PYTHON_VERSION)"
 
 ifeq ($(MACH), i386)
-NARCH=x86_64
+BINARCH_64=x86_64
 endif
 
 ifeq ($(MACH), sparc)
-NARCH=sparc_64
+BINARCH_64=sparc_64
 endif
 
 # these macros are used in the package manifest
-PKG_MACROS += NARCH=$(NARCH) JAVA_DEFAULT=$(JAVA_DEFAULT)
+PKG_MACROS += JAVA_DEFAULT=$(JAVA_DEFAULT) BINARCH_64=$(BINARCH_64)
 
 $(BUILD_DIR_64)/.installed: $(BUILD_DIR_64)/.built
 	mkdir -p $(PROTO_DIR)/usr/netbeans/;
 	[ -d $(PROTO_DIR)/usr/netbeans/$(COMPONENT_VERSION) ] || cp -R $(BUILD_DIR_64)/nbbuild/netbeans $(PROTO_DIR)/usr/netbeans/$(COMPONENT_VERSION);
-	for FILE in $(PROTO_DIR)/usr/netbeans/$(COMPONENT_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/{pty,pty_open,process_start,killall}; do \
+	for FILE in $(PROTO_DIR)/usr/netbeans/$(COMPONENT_VERSION)/ide/bin/nativeexecution/SunOS-$(BINARCH_64)/{pty,pty_open,process_start,killall}; do \
 		/usr/bin/elfedit -e 'dyn:delete RUNPATH' $$FILE; \
 		/usr/bin/elfedit -e 'dyn:delete RPATH' $$FILE; \
 	done;

--- a/components/editor/netbeans/netbeans.p5m
+++ b/components/editor/netbeans/netbeans.p5m
@@ -27,7 +27,7 @@ license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 depend type=require fmri=runtime/java/openjdk$(JAVA_DEFAULT)
 depend type=require fmri=runtime/python
 
-<transform file path=usr/netbeans/$(COMPONENT_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/unbuffer.so -> default pkg.linted.userland.action001.2 true >
+<transform file path=usr/netbeans/$(COMPONENT_VERSION)/ide/bin/nativeexecution/SunOS-$(BINARCH_64)/unbuffer.so -> default pkg.linted.userland.action001.2 true >
 
 <transform file path=.*\.built$ -> drop>
 <transform file path=.*\.lastModified$ -> drop>
@@ -36,8 +36,9 @@ depend type=require fmri=runtime/python
 <transform file path=.*\.bat$ -> drop>
 <transform file path=.*\.cmd$ -> drop>
 
-<transform path=.*/nativeexecution/SunOS-(x86|sparc.*)/.*$ -> drop>
-<transform path=.*/.*sparc.*/.*$ -> drop>
+<transform path=.*/.*SunOS-sparc.*/.*$ -> set variant.arch sparc>
+<transform path=.*/.*solaris-sparcv9.*/.*$ -> set variant.arch sparc>
+<transform path=.*/.*SunOS-x86.*/.*$ -> set variant.arch i386>
 <transform path=.*/nativeexecution/Linux.*$ -> drop>
 <transform path=.*/linux.*$ -> drop>
 <transform path=.*/freebsd.*$ -> drop>
@@ -46,6 +47,8 @@ depend type=require fmri=runtime/python
 <transform path=.*/bin/[^/]+$ -> default mode 0555>
 
 <transform file path=.*/runant.py -> add pkg.depend.bypass-generate .*>
+
+<transform file path=.*/x86_64 -> set variant.arch i386>
 
 link path=usr/bin/netbeans target=../netbeans/$(COMPONENT_VERSION)/bin/netbeans mode=0555
 
@@ -1135,14 +1138,14 @@ file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/MacOSX-x86_64/pt
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/MacOSX-x86_64/pty_open
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/MacOSX-x86_64/stat
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/MacOSX-x86_64/unbuffer.dylib
-file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/killall
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/killall
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/privp
-file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/process_start
-file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/pty
-file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/pty_open
-file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/sigqueue
-file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/stat
-file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-$(NARCH)/unbuffer.so
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/process_start
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/pty
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/pty_open
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/sigqueue
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/stat
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-sparc_64/unbuffer.so
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86/killall
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86/privp
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86/process_start
@@ -1151,6 +1154,13 @@ file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86/pty_op
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86/sigqueue
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86/stat
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86/unbuffer.so
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86_64/killall
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86_64/process_start
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86_64/pty
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86_64/pty_open
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86_64/sigqueue
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86_64/stat
+file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/SunOS-x86_64/unbuffer.so
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/Windows-x86/killall
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/Windows-x86/process_start
 file path=usr/netbeans/$(HUMAN_VERSION)/ide/bin/nativeexecution/Windows-x86/pty


### PR DESCRIPTION
Hopefully, this provides better variant.arch detection for both SPARC and x86.  This has only been tested on x86.  It is optimal to have variant.arch placed in transforms to allow for complete replacement of "file" lines in p5m file (and not need to check for modifiers such as variant.arch).

Changed NARCH to BINARCH_64 to better identify the type of files.

Restored 64-bit binary x86 files.