### PR TITLE
dtlsqueak: squeak 4.6 from dtlewis290 github

### DIFF
--- a/components/runtime/smalltalk/dtlsqueak/Makefile
+++ b/components/runtime/smalltalk/dtlsqueak/Makefile
@@ -1,0 +1,235 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2024, 2025, 2026 David Stes
+#
+
+
+#
+# dtlsqueak is an alternative to the subversion squeak package
+# With download from David T. Lewis (dtl) github repository
+# Package Makefile for the "Classic VM" Squeak Smalltalk system
+# See http://squeak.org and http://squeakvm.org
+#
+# squeak uses cmake and a custom configure script (not GNU autoconf)
+# in order to build this package, "cmake" and "pkg-config" must be installed
+#
+# squeak was built both in 32-bit and 64-bit mode
+# but since 2023 version 4.20.6 now only in 64 bit per OpenIndiana request
+# OpenIndiana is dropping 32bit libraries so we can't build 32bit any longer
+#
+# the squeak driver script was/is checking the Smalltalk image (using ckformat),
+# and depending on whether the image is 32bit or 64bit,
+# it launches the squeak virtual machine 32bit or 64bit for the image
+#
+# we now (since 4.20.6) try to use the 64bit executable to launch 32bit images
+# and for 64bit images simply fail (with an error message)
+#
+# for 32-bit : ckformat reports 6505
+# 6505: a 32-bit V3 image with closure support and float words stored 
+# in native platform order
+#
+# for 64-bit : ckformat reports 68000
+# 68000: a 64-bit V3 image with no closure support and 
+# no native platform float word order requirement
+#
+# note that since 4.20.6 the 64bit images (68000) are no longer working
+# but this is not much of a problem due to the fact that all images are 6502
+# or 6504 (32bit)
+#
+# squeak places its 64-bit shared object files in
+# usr/lib/squeak/<version>-<svnversion>_64bit/  with a _64bit suffix
+# which is unfortunately not conforming to the usr/lib/amd64 usage
+# and it generates a hard error by pkglint "64-bit object in 32-bit path"
+# so we deliver a patch and rename files
+# in order to put the 64-bit objects in their usual usr/lib/amd64 location
+
+USE_COMMON_TEST_MASTER=no
+
+# there is support for OpenSSL 1.1 and 3.x in the squeak SSL module
+# but the SUnit squeak images tests seem to be written for old ssl versions
+# this can be set before including shared-macros.mk
+USE_OPENSSL10=yes
+
+# the goal is to use libjpeg8-turbo (or any other libjpeg implementation)
+# special care for included header files as the struct sizes vary
+# we 'fix' the Squeak source code that has an old libjpeg included in source
+# this should be fixed upstream in the Squeak sources
+# the default OpenIndiana JPEG_IMPLEM at time of writing is libjpeg8-turbo
+JPEG_IMPLEM=libjpeg8-turbo
+
+include ../../../../make-rules/shared-macros.mk
+
+# the version is the same as the VMMaker Smalltalk sources
+# it cannot be changed here randomly, it must match the VMMaker version
+
+COMPONENT_NAME=		dtlsqueak
+COMPONENT_VERSION=	4.21.3
+# this could be a git tag, a branch name, or a git commit
+GIT_TAG=		1d750d97072664809df73fb541e14d98538eeb56
+COMPONENT_SUMMARY=	The Squeak Virtual Machine
+COMPONENT_PROJECT_URL=	http://www.squeak.org
+COMPONENT_FMRI=		runtime/smalltalk/dtlsqueak
+COMPONENT_CLASSIFICATION=	Development/Smalltalk
+
+COMPONENT_SRC=		squeakvm.org-$(GIT_TAG)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_HASH= sha256:57269551ce1c46b9f91e5d0f089d68df064d134464477f2da2b1ff83e6f8f351
+COMPONENT_ARCHIVE_URL=  https://codeload.github.com/dtlewis290/squeakvm.org/tar.gz/$(GIT_TAG)
+
+# also update squeak.ips when changing SQREV
+SQREV=                  dtl
+
+# See http://wiki.squeak.org/squeak/933
+# See http://wiki.squeak.org/squeak/159
+# there's 2 license lines in the manifest, the MIT squeak.license and this one
+COMPONENT_LICENSE=      Squeak4
+COMPONENT_LICENSE_FILE= dtlsqueak4.license
+
+# Squeak has an extensive test framework called SUnit
+# it requires a X11 connection (graphical user interface)
+# if connection to $DISPLAY fails from "gmake test" the tests will fail
+# the tests are ran only on 32bit image for Squeak classical VM
+# because inisqueak downloads a 32 bit image (provided by squeak.org)
+# for OpenSmalltalk (see cog-spur and stack-spur) 32bit + 64bit
+# since version 2023 4.20.6 we use a 64bit executable to run the 32image
+# because OpenIndiana stopped shipping 32bit libraries for 32bit executables
+COMPONENT_TEST_CMD=	$(COMPONENT_TEST_RESULTS_DIR)/testrunner.sh $(BITS) $(COMPONENT_DIR) $(BUILD_DIR_64)
+
+include $(WS_MAKE_RULES)/common.mk
+
+PKG_OPTIONS += -DBRANCHID="$(BRANCHID)"
+PKG_OPTIONS += -DSVN_REV="$(SQREV)"
+
+PATH=$(PATH.gnu)
+
+# override gcc_OPT (defaults to -O3) for the moment
+# squeak compiles with -O2 or -O3 but
+# KernelTests-Chronology with gcc 7.5 version 4.16.7 or 4.19.*
+# gcc -O : 438 pass tests
+# gcc -O2 : 20 failures 1 errors  #testAsDelay error
+# the system compiled with -O3 / -O2 is usable but has Chronology failures
+
+# the example squeak Makefile specifies _FILE_OFFSET_BITS=64
+# goal is large file support (as in man lfcompile)
+# lfcompile - large file compilation environment for 32-bit applications
+
+gcc_OPT=	-O
+
+# for gcc 14.2 add -Wno-error options
+gcc_OPT+=		-Wno-error=implicit-function-declaration
+gcc_OPT+=		-Wno-error=incompatible-pointer-types
+gcc_OPT+=		-Wno-error=return-mismatch
+gcc_OPT+=		-Wno-error=int-to-pointer-cast
+gcc_OPT+=		-Wno-error=int-conversion
+
+# add -D_FILE_OFFSET_BITS=64 to CPPFLAGS but unlike OpenSmalltalk,
+# must also add this to CFLAGS because Squeak configure is not using CPPFLAGS
+# (see CFLAGS += CPPFLAGS below)
+# since 2023 4.20.6 compile 64bit without largefiles flags to open 32bit images
+# CPPFLAGS +=     $(CPP_LARGEFILES)
+
+# use libjpeg8 turbo (see Illumos feature request #7391 for libjpeg8-turbo)
+# use --link-shared-lib to avoid the Squeak copy of libjpeg
+CPPFLAGS +=     $(JPEG_CPPFLAGS)
+LDFLAGS  +=     $(JPEG_LDFLAGS)
+
+# include "jpeglib.h" uses incorrect /usr/include/jpeglib.h unless CFLAGS set
+# CPPFLAGS seems not respected by Squeak configure while CFLAGS is
+CFLAGS   +=     $(CPPFLAGS)
+
+# cleanup the plugin directory
+SOURCE_JPEG = $(SOURCE_DIR)/platforms/Cross/plugins/JPEGReadWriter2Plugin
+
+# squeak configure looks for .svn or svnversion file, but
+# dtlsqueak also checks for .git files and issues a "git" command
+# we use an unversioned copy of the sources (no svnversion or .git files)
+COMPONENT_PRE_CONFIGURE_ACTION = \
+( echo $(SQREV) > $(SOURCE_DIR)/platforms/unix/svnversion; \
+  find $(SOURCE_JPEG) -type f \
+     \! -name JPEGReadWriter2Plugin.h \
+     \! -name sqJPEGReadWriter2Plugin.c \
+     \! -name Error.c \
+     \! -name jinclude.h \
+     \! -name jmemdatasrc.c \
+     \! -name jmemdatadst.c \
+  -exec rm {} \;)
+
+# do not build vm-sound-Sun as we only package vm-sound-pulse (bug #17109)
+# do not build Mpeg3Plugin and RePlugin as it uses old copies of those libraries
+# do not build GStreamerPlugin, it uses the GStreamer 0.10 and not GStreamer 1.0 (bug #17111)
+ 
+CONFIGURE_SCRIPT= $(SOURCE_DIR)/platforms/unix/cmake/configure
+CONFIGURE_OPTIONS +=    --link-shared-lib
+CONFIGURE_OPTIONS +=    --without-vm-sound-Sun
+CONFIGURE_OPTIONS +=    --without-RePlugin
+CONFIGURE_OPTIONS +=    --without-Mpeg3Plugin
+CONFIGURE_OPTIONS +=    --without-GStreamerPlugin
+CONFIGURE_OPTIONS +=    --without-ScratchPlugin
+# cmake 4.x requires this -D because the CMakeLists.txt indicates cmake 2.x MINVERSION
+CONFIGURE_OPTIONS +=    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+# in the 64bit case the vm is called squeakvm64 (not squeakvm)
+# the plugin directory under usr/lib/squeak has a _64bit suffix
+# CONFIGURE_OPTIONS.64+=	--image64
+# CONFIGURE_OPTIONS.64+=	--vm-only
+# since 2023 4.20.6 we try to avoid CMakeLists.txt SET (SQ_VI_BYTES_PER_WORD 8)
+CONFIGURE_OPTIONS.64+=	-Dversionsuffix=_64bit
+CONFIGURE_OPTIONS.64+=	-Dscriptsuffix=64
+
+# Makefile install/strip doesn't work
+# the squeakvm is called either squeakvm or squeakvm64 in different directories
+COMPONENT_POST_INSTALL_ACTION = \
+( find $(PROTOUSRLIBDIR)/squeak -name 'squeakvm*' -exec strip {} \; )
+
+#
+# target to update the manifests from sample-manifest
+#
+
+rebuild-manifests::
+	cp manifests/dtlsqueak.p5m dtlsqueak.p5m
+	cp manifests/dtlsqueak-vep.p5m dtlsqueak-vep.p5m
+	cp manifests/dtlsqueak-ssl.p5m dtlsqueak-ssl.p5m
+	cp manifests/dtlsqueak-display-X11.p5m dtlsqueak-display-X11.p5m
+	cp manifests/dtlsqueak-nodisplay.p5m dtlsqueak-nodisplay.p5m
+	cp manifests/sample-manifest.p5m sample-manifest.p5m
+	tools/subversion.sh $(SQREV) <sample-manifest.p5m >sample.p5m
+	tools/classify.pl <sample.p5m
+	tools/amd64-p5m.sh
+	rm -f sample-manifest.p5m sample.p5m
+
+# disable pkglint until we find solution for 64bit object in 32-bit path error
+PKGLINT= /bin/true
+
+# OpenGL support for mesa and nvidia
+# to force using the nvidia libGL.so.1 use
+# svccfg -s svc:/application/opengl/ogl-select
+# setprop options/vendor = astring: nvidia
+# ogl-select has a dependency on x11/library/mesa
+REQUIRED_PACKAGES += x11/library/mesa
+REQUIRED_PACKAGES += system/library/dbus
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(JPEG_IMPLEM_PKG)
+REQUIRED_PACKAGES += $(OPENSSL_PKG)
+REQUIRED_PACKAGES += library/audio/pulseaudio
+REQUIRED_PACKAGES += library/desktop/cairo
+REQUIRED_PACKAGES += library/desktop/pango
+REQUIRED_PACKAGES += library/glib2
+REQUIRED_PACKAGES += library/libffi
+REQUIRED_PACKAGES += shell/ksh93
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/freetype-2
+REQUIRED_PACKAGES += system/library/libdbus
+REQUIRED_PACKAGES += system/library/math
+REQUIRED_PACKAGES += x11/library/libx11
+REQUIRED_PACKAGES += x11/library/libxext
+REQUIRED_PACKAGES += x11/library/libxrender

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak-display-X11.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak-display-X11.p5m
@@ -1,0 +1,44 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+# 32-bit objects in 64-bit multiarch build are rejected by lint
+<transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
+
+# the minimal installation consists of the squeak-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.B3DAcceleratorPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.B3DAcceleratorPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.ClipboardExtendedPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.ClipboardExtendedPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.HostWindowPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.HostWindowPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.ImmX11Plugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.ImmX11Plugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.Squeak3D path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.Squeak3D
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.XDisplayControlPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.XDisplayControlPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.vm-display-X11 path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.vm-display-X11

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak-nodisplay.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak-nodisplay.p5m
@@ -1,0 +1,55 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# 32-bit objects in 64-bit multiarch build are rejected by lint
+# since 2023 version 4.20.6 we only deliver 64bit binaries
+<transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
+
+# since 2023 version 4.20.6 32bit do not provide 32bit binaries
+file inidtlsqueak4 path=usr/bin/inidtlsqueak4
+file dtlsqueak.ips path=usr/bin/dtlsqueak4
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/ckformat path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/ckformat mode=0555
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/squeakvm64 path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/squeakvm64 mode=0555
+
+file usr/share/man/man1/squeak.1 path=usr/share/man/man1/dtlsqueak4.1
+
+# the squeak script uses test -L (test for symbolic link) - use hardlink
+
+hardlink path=usr/bin/squeak target=dtlsqueak4 mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+hardlink path=usr/bin/inisqueak target=inidtlsqueak4 mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+hardlink path=usr/bin/ckformat target=/usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/ckformat mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+hardlink path=usr/share/man/man1/squeak.1 target=dtlsqueak4.1 mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.AioPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.AioPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.FileCopyPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.FileCopyPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.UnixOSProcessPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.UnixOSProcessPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.vm-display-null path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.vm-display-null
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.vm-sound-null path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.vm-sound-null

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak-ssl.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak-ssl.p5m
@@ -1,0 +1,30 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.SqueakSSL path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.SqueakSSL

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak-vep.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak-vep.p5m
@@ -1,0 +1,29 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.VectorEnginePlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.VectorEnginePlugin

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak.ips
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak.ips
@@ -1,0 +1,183 @@
+#!/bin/sh
+# 
+# Launch squeakvm from the command line or a menu script, with a good
+# plugin path, text encodings and pulseaudio kludge
+# 
+# Last edited: 2013-11-13 19:51:35 by piumarta on emilia
+
+PATH=/usr/bin:/bin
+
+realpath () {
+    path="$1"
+    while test -L "${path}"; do
+	dir=`dirname "${path}"`
+	dir=`cd "${dir}" && pwd -P`
+	path=`basename "${path}"`
+	path=`ls -l "${dir}/${path}" | sed 's,.* -> ,,'`
+	if test `expr "${path}" : "/"` -eq 0; then
+	    path="${dir}/${path}"
+	fi
+    done
+    if test -d "${path}"; then
+	(cd "${path}" && pwd -P)
+    else
+	dir=`dirname "${path}"`
+	base=`basename "${path}"`
+	(cd "${dir}" && echo "`pwd -P`/${base}")
+    fi
+}
+
+bindir=`realpath "${0}"`
+bindir=`dirname  "${bindir}"`
+prefix=`dirname  "${bindir}"`
+libdir="${prefix}/lib/squeak"
+plgdir="${libdir}/4.21.3-dtl"
+useoss="false"
+ck="ckformat"
+squeakvm="squeakvm"
+squeakvm64="squeakvm64"
+plgd64="${prefix}/lib/amd64/squeak/4.21.3-dtl"
+cogvm="cogvm"
+cogvm64="cogvm64"
+vm=""
+plugins=""
+wrapper=""
+image=""
+format=""
+info=""
+jit=""
+
+# look for VM options affecting this script's behaviour
+
+options () {
+    while test "$#" -gt "0"; do
+	case $1 in
+	    -vm-sound*)     useoss="false";;
+	    -vm)            shift; case "$1" in sound*) useoss="false"; esac;;
+            -image-info)    info="true";;
+	    --)		    break;;
+	    *)		    if test ! "$image" -a \( -f "$1.image" -o -f "$1" \); then image="$1"; fi;;
+	esac
+	shift
+    done
+}
+
+case "$1" in
+    -jit)	jit=$1; shift; squeakvm=""; squeakvm64="";;
+    -nojit)	jit=$1; shift; cogvm=""; cogvm64="";;
+esac
+
+options "$@"
+
+# try to find the image file format
+
+if   test -x "${plgd64}/${ck}"; then ck="${plgd64}/${ck}"
+elif test -x "${plgdir}/${ck}"; then ck="${plgdir}/${ck}"
+elif test -x "${libdir}/${ck}"; then ck="${libdir}/${ck}"
+elif test -x "${bindir}/${ck}"; then ck="${bindir}/${ck}"
+elif test -x "`which ${ck}`";	then ck="`which ${ck}`"
+fi
+
+if test   -z "${image}";	then image="${SQUEAK_IMAGE}"; fi
+if test   -z "${image}";	then image="squeak";	      fi
+if test   -f "${image}.image";	then image="${image}.image";  fi
+
+if test "${info}"; then
+    if test ! -x "${ck}"; then
+	echo "cannot find executable file: ${ck}" >&2
+	exit 1
+    fi
+    if test ! -f "${image}"; then
+	echo "cannot find image file: ${image}" >&2
+	exit 1
+    fi
+    exec "${ck}" "${image}"
+fi
+
+# OpenIndiana 2023 version 4.20.6
+# because it is not possible any longer to build 32bit
+# use a 64bit executable to run 32bit images and print error for
+# 64bit images (that are very rare anyway for Squeak 4.6)
+if test -x "${ck}" -a -f "${image}"; then
+    format=`"${ck}" "${image}"`
+    case "${format}" in
+	6502|6504|6505)	vms="${squeakvm64}";plgdir="${plgd64}";;
+	68000|68002|68003)	echo "unsupported image"; exit 1;;
+	*)	vms="${squeakvm64}";;
+    esac
+else
+    vms="${squeakvm}" # no image found, run default VM with args
+fi
+
+# find the vm and set the plugin path
+
+if test -z "${vms}"; then
+    echo "cannot find VM to run image '${image}' with option '${jit}'" >&2
+    exit 1
+fi
+
+for avm in ${vms}; do
+    #echo CHECKING ${avm}
+    if test -x "${plgdir}/${avm}"; then	# bin/squeak -> lib/squeak/x.y-z/squeakvm
+	vm="${plgdir}/${avm}"
+	plugins="${plgdir}"
+	break;
+    elif test -x "${bindir}/${avm}"; then	# bld/squeak -> bld/squeakvm
+	vm="${bindir}/${avm}"
+	plugins="${bindir}/%n"
+	break;
+    elif test -x "`which ${avm}`"; then
+	vm="`which ${avm}`"
+	plugins=""
+	break;
+    fi
+done
+
+if test -z "${vm}"; then
+    echo "cannot find executable file: ${vms}" >&2
+    exit 1
+fi
+
+# command-line overrides environment, so communicate anything we decide here via the environment
+
+if test -z "${SQUEAK_PATHENC}";  then SQUEAK_PATHENC="UTF-8";  export SQUEAK_PATHENC;  fi
+if test -z "${SQUEAK_ENCODING}"; then SQUEAK_ENCODING="UTF-8"; export SQUEAK_ENCODING; fi
+
+if test -z "${SQUEAK_PLUGINS}"; then
+    if test -n "${plugins}"; then
+	SQUEAK_PLUGINS="${plugins}"
+	export SQUEAK_PLUGINS
+    fi
+fi
+
+# deal with pulseaudio if it is running
+
+if test -z "${SQUEAK_VM}"; then
+    if ${useoss}; then
+	if pulseaudio --check 2>/dev/null; then
+	    if padsp true 2>/dev/null; then
+		wrapper="padsp"
+		SQUEAK_VM="sound-OSS"
+		export SQUEAK_VM
+	    fi
+	fi
+    fi
+fi
+
+# fix broken locales
+
+if test -z "$LC_ALL"; then
+    LC_ALL="$LANG"
+    export LC_ALL
+fi
+
+# debug output
+
+if test "0$SQUEAK_DEBUG" -gt "0"; then
+    set | fgrep SQUEAK_
+    set -x
+fi
+
+# run the vm
+
+exec ${wrapper} "${vm}" "$@"

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak.license
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak.license
@@ -1,0 +1,24 @@
+
+MIT License
+
+Copyright (c) 1996-2020 The individual, corporate, and institutional contributors who have collectively contributed elements to this software ("The Squeak Community"). All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Portions of Squeak are covered by the Apache License:
+Apache License, Version 2.0
+
+Copyright (c) 1981-1982 Xerox Corp. All rights reserved.
+Copyright (c) 1985-1996 Apple Computer, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak.p5m
@@ -1,0 +1,49 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# 64-bit objects in 32-bit multiarch build are rejected by lint
+<transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
+
+# the minimal installation consists of the squeak-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+# the minimal installation does not install the MATE/GNOME icon/desktop files
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.CameraPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.CameraPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.DBusPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.DBusPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.FT2Plugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.FT2Plugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.KedamaPlugin2 path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.KedamaPlugin2
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.PseudoTTYPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.PseudoTTYPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.RomePlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.RomePlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.SqueakFFIPrims path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.UUIDPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.UUIDPlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.UnicodePlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.UnicodePlugin
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.vm-display-custom path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.vm-display-custom
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.vm-sound-custom path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.vm-sound-custom
+file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.vm-sound-pulse path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.vm-sound-pulse

--- a/components/runtime/smalltalk/dtlsqueak/dtlsqueak4.license
+++ b/components/runtime/smalltalk/dtlsqueak/dtlsqueak4.license
@@ -1,0 +1,53 @@
+Source files below 'platforms/Cross' in this distribution that do not
+contain individual copyright and license notices, and
+
+Source files below 'platforms/unix/src' in this distribution that do
+not contain individual copyright and license notices are:
+
+  Copyright (C) 1996-2006 by Viewpoints Research Institute and other
+                             authors/contributors as listed.
+
+  All rights reserved.
+
+All other source files below platforms/unix in this distribution that do not
+contain individual copyright and license notices are:
+
+  Copyright (C) 1996-2006 by Ian Piumarta and other authors/contributors
+                             listed in individual source files.
+
+  All rights reserved.
+
+For all of the above files:
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+--
+
+See http://wiki.squeak.org/squeak/933
+See http://wiki.squeak.org/squeak/159
+
+FAQ: Licenses
+Last updated at 4:51 am UTC on 18 February 2017
+License since Squeak 4.0 is MIT
+
+From the Squeak 4.0 release notes:
+
+Welcome to Squeak - a free, open Smalltalk system.
+Squeak 4.0 is the pinnacle of several years of relicensing work. Though this version is functionally equivalent to Squeak 3.10.2, it is the first version of Squeak to be licensed fully under FOSS terms. Squeak 4.0 is licensed under MIT, with some original Apple parts remaining under the Apache 2.0 license.
+

--- a/components/runtime/smalltalk/dtlsqueak/inidtlsqueak4
+++ b/components/runtime/smalltalk/dtlsqueak/inidtlsqueak4
@@ -1,0 +1,249 @@
+#!/bin/sh
+# $Id: inisqueak4,v 1.2 2020/12/01 09:44:53 stes Exp $
+# 
+# inisqueak -- setup a directory for use with Squeak
+# 
+#   Copyright (C) 1996-2004 by Ian Piumarta and other authors/contributors
+#                              listed elsewhere in this file.
+#   All rights reserved.
+#
+#   Copyright (C) 2020 by David Stes
+#   All rights reserved.
+#   
+#   This file is part of Unix Squeak.
+# 
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+# 
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+# 
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#   SOFTWARE.
+# 
+# Author: Ian.Piumarta@INRIA.Fr
+# Last edited: 2006-10-18 10:14:20 by piumarta on emilia.local
+#
+# Author: David Stes
+# -r option to use wget and download image from files.squeak.org
+# $Id: inisqueak4,v 1.2 2020/12/01 09:44:53 stes Exp $
+# 
+
+# subtle difference between SqueakV46.sources not SqueakV4.6.sources
+MAJOR=4.6
+MAJORV=46
+VERSION=4.6-15118
+
+REMOTEDIR="http://files.squeak.org/${MAJOR}/"
+REMOTESOURCES=SqueakV${MAJORV}.sources.zip
+REMOTEIMAGEZIP=Squeak${VERSION}.zip
+
+prefix=/usr
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+imgdir=${prefix}/lib/squeak
+
+if test ! -w .; then
+  echo "You don't have write permission in this directory." >&2
+  exit 1
+fi
+
+# Sun's /bin/sh does not understand "test -e", but [/usr]/bin/test does
+test="`which test`"
+
+list=false
+startup=true
+batch=false
+interactive=true
+remote=true
+
+while true; do
+  case "$1" in
+    -l) list=true; shift;;
+    -n) startup=false; shift;;
+    -r) remote=true; shift;;
+    -R) remote=false; shift;;
+    -b) batch=true; interactive=false; shift;;
+    -h|-help|--help)
+        echo "`basename $0` [-option...] [rootdir]"
+        echo '    -b      batch (avoid interaction, exit status reflects success)'
+        echo '    -h      you already know about'
+        echo '    -r      download Squeak from remote server (default)'
+        echo '    -R      do not download Squeak from remote server'
+        echo '    -help   same as -h'
+        echo '    -l      always present a list of alternative images (overrides -b)'
+        echo '    -n      do not run Squeak after installing the files'
+        echo '    --help  same as -help'
+        exit 0;;
+    *)  break;;
+  esac
+done
+
+if test "$1" != ""; then
+  bindir=${1}/${bindir}
+  imgdir=${1}/${imgdir}
+fi
+
+SQUEAK=${bindir}/squeak
+SOURCES=SqueakV${MAJORV}.sources
+IMAGE=squeak.image.gz
+CHANGES=squeak.changes.gz
+
+# local install function
+
+missing()
+{
+  echo "The file ${1} is missing." >&2
+  echo "Please check your Squeak installation." >&2
+  exit 1
+}
+
+if ${remote}; then
+  echo "Downloading $REMOTESOURCES from $REMOTEDIR"
+  wget -O $REMOTESOURCES $REMOTEDIR/$REMOTESOURCES
+  case $? in
+   0) ;;
+   *) echo "Unable to download $REMOTESOURCES from $REMOTEDIR"; exit 1;
+  esac
+  unzip $REMOTESOURCES
+  case $? in
+   0) ;;
+   *) echo "Unable to unzip $REMOTESOURCES"; exit 1;
+  esac
+  echo "Downloading $REMOTEIMAGEZIP from $REMOTEDIR"
+  wget -O $REMOTEIMAGEZIP $REMOTEDIR/$REMOTEIMAGEZIP
+  case $? in
+   0) ;;
+   *) echo "Unable to download $REMOTEIMAGEZIP from $REMOTEDIR"; exit 1;
+  esac
+  unzip $REMOTEIMAGEZIP
+  case $? in
+   0) ;;
+   *) echo "Unable to unzip $REMOTEIMAGEZIP"; exit 1;
+  esac
+  echo "Copying to default image name .."
+  cp Squeak${VERSION}.image squeak.image
+  cp Squeak${VERSION}.changes squeak.changes
+fi
+
+if ${test} \( -f squeak.image \) -a \( -f squeak.changes \) -a \( -e ${SOURCES} \)
+then
+  if ${startup}; then
+    if test ! -x ${SQUEAK}; then
+      missing "${SQUEAK}"
+    fi
+    if ${interactive}; then
+      echo "Running ${SQUEAK}";
+    fi
+    exec ${SQUEAK}
+  else
+    if ${interactive}; then
+      echo "Squeak is already installed in this directory" >&2
+    fi
+    exit 1
+  fi
+fi
+
+install()
+{
+  cpy="${1}"
+  src="${2}"
+  red="${3}"
+  dst="${4}"
+  if ${test} ! -e ${dst}; then
+    if ${test} -e ${src}; then
+      if ${interactive}; then
+	echo "+ ${cpy} ${src} ${red} ${dst}";
+      fi
+      eval      ${cpy} ${src} ${red} ${dst}
+    else
+      missing "${src}"
+    fi
+  else
+    echo "${dst} is already present -- leaving it alone"
+#   startup=false
+  fi
+}
+
+# choose an image to install
+
+if ${list}; then :; else
+  if ${test} \( ! -e ${imgdir}/${IMAGE} \) \
+          -o \( ! -e ${imgdir}/${CHANGES} \) ; then
+    if ${batch}; then
+      echo "Could not find default image to install -- giving up." >&2
+      exit 1;
+    fi
+    list=true
+    echo "No default image, looking for alternatives..."
+    echo
+  fi
+fi
+
+if ${list}; then
+  images=`ls -1 ${imgdir}/*.image.gz 2>/dev/null | \
+          sed "s.${imgdir}/..;s/.image.gz//"`
+  if test "$images" = ""; then
+    echo "I could not find an image to install." >&2
+    echo "Please check your Squeak installation." >&2
+    exit 1
+  fi
+  nimg=`echo ${images} | tr ' ' '\012' | wc -l`
+  nimg=`echo ${nimg}`
+  more=true
+  while ${more}; do
+    echo "I found the following images:"
+    echo ${images} | tr ' ' '\012' | cat -n
+    if echo ${images} | fgrep "Squeak${VERSION}" >/dev/null; then
+      echo "(of which I might recommend Squeak${VERSION}, unless you know better)."
+    fi
+    echo -n "Which one should I install [1-${nimg}]? "
+    read reply
+    case ${reply} in
+      [1-9]) ;;
+      [1-9][0-9]) ;;
+      *) echo
+         echo "Let's try that again, with a NUMBER between 1 and ${nimg}."
+         echo
+         continue;;
+    esac
+    if test \( ${reply} -ge 1 \) -a \( ${reply} -le ${nimg} \); then
+      more=false
+    fi
+    if ${more}; then
+      echo
+      echo "Ha ha, very clever.  Now give me a number between 1 and ${nimg}"
+      echo "(or hit your interrupt key [^C or whatever] if you don't like"
+      echo "the look of any of them)."
+      echo
+    fi
+  done
+  IMAGE=`echo ${images} | tr ' ' '\012' | tail +${reply} | head -1`
+  CHANGES=${IMAGE}.changes.gz
+  IMAGE=${IMAGE}.image.gz
+fi
+
+if ${interactive}; then echo "Installing ${IMAGE} in `pwd`"; fi
+
+install "ln -s"      "${imgdir}/${SOURCES}" " " "${SOURCES}"
+install "gunzip -dc" "${imgdir}/${IMAGE}"   ">" "squeak.image"
+install "gunzip -dc" "${imgdir}/${CHANGES}" ">" "squeak.changes"
+
+if ${startup}; then
+  if test ! -x ${SQUEAK}; then
+    missing "${SQUEAK}"
+  fi
+  if ${interactive}; then
+    echo "Running ${SQUEAK}";
+  fi
+  exec ${SQUEAK}
+fi

--- a/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-display-X11.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-display-X11.p5m
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-display-X11@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+<transform file -> add pkg.depend.bypass-generate libGL\.so\.1>
+# 32-bit objects in 64-bit multiarch build are rejected by lint
+<transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
+
+# the minimal installation consists of the squeak-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+

--- a/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-nodisplay.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-nodisplay.p5m
@@ -1,0 +1,50 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# 32-bit objects in 64-bit multiarch build are rejected by lint
+# since 2023 version 4.20.6 we only deliver 64bit binaries
+<transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
+
+# since 2023 version 4.20.6 32bit do not provide 32bit binaries
+file inidtlsqueak4 path=usr/bin/inidtlsqueak4
+file dtlsqueak.ips path=usr/bin/dtlsqueak4
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/ckformat path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/ckformat mode=0555
+file usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/squeakvm64 path=usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/squeakvm64 mode=0555
+
+file usr/share/man/man1/squeak.1 path=usr/share/man/man1/dtlsqueak4.1
+
+# the squeak script uses test -L (test for symbolic link) - use hardlink
+
+hardlink path=usr/bin/squeak target=dtlsqueak4 mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+hardlink path=usr/bin/inisqueak target=inidtlsqueak4 mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+hardlink path=usr/bin/ckformat target=/usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/ckformat mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+hardlink path=usr/share/man/man1/squeak.1 target=dtlsqueak4.1 mediator=squeak \
+    mediator-version=4 mediator-implementation=dtl
+

--- a/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-ssl.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-ssl.p5m
@@ -1,0 +1,29 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-ssl@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) SSLPlugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+
+

--- a/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-vep.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak-vep.p5m
@@ -1,0 +1,28 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/runtime/smalltalk/dtlsqueak-vep@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY) VectorEnginePlugin"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-nodisplay@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+

--- a/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/manifests/dtlsqueak.p5m
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2020, 2021, 2022, 2023, 2026 David Stes
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+
+license dtlsqueak.license license='MIT'
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+# 64-bit objects in 32-bit multiarch build are rejected by lint
+<transform file path=usr/lib/squeak/$(COMPONENT_VERSION)-$(SVN_REV)_64bit/* -> set pkg.linted.userland.action001.2 true>
+
+# the minimal installation consists of the squeak-nodisplay package
+# which can run "headless" squeak -nodisplay images
+# with only minimal installation requirements (only ksh, libc, math)
+# the minimal installation does not install the MATE/GNOME icon/desktop files
+
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-ssl@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+depend type=require fmri=pkg:/runtime/smalltalk/dtlsqueak-display-X11@$(IPS_COMPONENT_VERSION)-$(BRANCHID)
+

--- a/components/runtime/smalltalk/dtlsqueak/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/dtlsqueak/manifests/sample-manifest.p5m
@@ -1,0 +1,56 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/squeak
+file path=usr/bin/squeak.sh
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/ckformat
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.AioPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.B3DAcceleratorPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.CameraPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.ClipboardExtendedPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.DBusPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.FT2Plugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.FileCopyPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.HostWindowPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.ImmX11Plugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.KedamaPlugin2
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.PseudoTTYPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.RomePlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.Squeak3D
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.SqueakFFIPrims
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.SqueakSSL
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.UUIDPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.UnicodePlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.UnixOSProcessPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.VectorEnginePlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.XDisplayControlPlugin
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.vm-display-X11
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.vm-display-custom
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.vm-display-null
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.vm-sound-custom
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.vm-sound-null
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/so.vm-sound-pulse
+file path=usr/lib/squeak/$(HUMAN_VERSION)-dtl_64bit/squeakvm64
+file path=usr/share/man/man1/squeak.1

--- a/components/runtime/smalltalk/dtlsqueak/patches/02-openssl-cmake.patch
+++ b/components/runtime/smalltalk/dtlsqueak/patches/02-openssl-cmake.patch
@@ -1,0 +1,18 @@
+--- platforms/unix/plugins/SqueakSSL/config.cmake	Mon Jun 16 08:44:32 2025
++++ p0/platforms/unix/plugins/SqueakSSL/config.cmake	Tue Jun 17 11:44:51 2025
+@@ -10,13 +10,13 @@
+ 
+ # Traditional dynamic linking.
+ #
+-# PLUGIN_DEFINITIONS("-DSQSSL_OPENSSL_LINKED")
++PLUGIN_DEFINITIONS("-DSQSSL_OPENSSL_LINKED")
+ 
+ # Runtime symbol and function lookup.
+ # Portable across platforms because only required symbols are looked up.
+ # Requires a Gnu extension for implementation of symbol lookup.
+ #
+-PLUGIN_DEFINITIONS("-D_GNU_SOURCE")
++# PLUGIN_DEFINITIONS("-D_GNU_SOURCE")
+ 
+ ################################################################################
+ #            Explanation from commit notice on opensmalltalk-vm:               #

--- a/components/runtime/smalltalk/dtlsqueak/patches/03-cameraconfig.patch
+++ b/components/runtime/smalltalk/dtlsqueak/patches/03-cameraconfig.patch
@@ -1,0 +1,7 @@
+--- platforms/unix/plugins/CameraPlugin/config.cmake	Mon Jun 16 08:44:29 2025
++++ p0/platforms/unix/plugins/CameraPlugin/config.cmake	Tue Jun 17 11:44:51 2025
+@@ -1,3 +1,3 @@
+-PLUGIN_REQUIRE_INCLUDE(V4L2 linux/videodev2.h /usr/include)
++PLUGIN_REQUIRE_INCLUDE(V4L2 sys/videodev2.h /usr/include)
+ 
+ 

--- a/components/runtime/smalltalk/dtlsqueak/patches/04-sqCamera.patch
+++ b/components/runtime/smalltalk/dtlsqueak/patches/04-sqCamera.patch
@@ -1,0 +1,19 @@
+--- platforms/unix/plugins/CameraPlugin/sqCamera-linux.c	Mon Jun 16 08:44:31 2025
++++ p0/platforms/unix/plugins/CameraPlugin/sqCamera-linux.c	Tue Jun 17 11:44:51 2025
+@@ -49,11 +49,12 @@
+ #include <sys/ioctl.h>
+ #include <dlfcn.h>
+ 
+-#include <asm/types.h>	  /* for videodev2.h */
++#include <sys/videodev2.h>
++#ifndef V4L2_PIX_FMT_RGB444
++/* illumos sys/videodev2.h currently does not define RGB444 */
++#define V4L2_PIX_FMT_RGB444 v4l2_fourcc('R','4','4','4')
++#endif
+ 
+-#include <linux/videodev2.h>
+-
+-
+ #define true 1
+ #define false 0
+ 

--- a/components/runtime/smalltalk/dtlsqueak/patches/05-jmemdatasrc.patch
+++ b/components/runtime/smalltalk/dtlsqueak/patches/05-jmemdatasrc.patch
@@ -1,0 +1,29 @@
+--- platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatasrc.c	Mon Jun 16 08:44:09 2025
++++ p0/platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatasrc.c	Tue Jun 17 11:44:51 2025
+@@ -151,13 +151,12 @@
+   /* no work necessary here */
+ }
+ 
+-#if !defined(USE_LIBRARY_SHARED)
+ /*
+  * Prepare for input from a stdio stream.
+  * The caller must have already opened the stream, and is responsible
+  * for closing it after finishing decompression.
+  */
+-GLOBAL(void) jpeg_mem_src (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize) {
++GLOBAL(void) sqJpeg_mem_src (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize) {
+   my_src_ptr src;
+ 
+   /* The source object and input buffer are made permanent so that a series
+@@ -189,10 +188,9 @@
+   src->pub.bytes_in_buffer = 0; /* forces fill_input_buffer on first read */
+   src->pub.next_input_byte = NULL; /* until buffer loaded */
+ }
+-#endif
+ 
+ /* This function allows data to be moved if necessary */
+-GLOBAL(int) jpeg_mem_src_newLocationOfData (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize) {
++GLOBAL(int) sqJpeg_mem_src_newLocationOfData (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize) {
+   my_src_ptr src;
+   unsigned offset;
+ 

--- a/components/runtime/smalltalk/dtlsqueak/patches/06-jmemdatadst.patch
+++ b/components/runtime/smalltalk/dtlsqueak/patches/06-jmemdatadst.patch
@@ -1,0 +1,23 @@
+--- platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatadst.c	Mon Jun 16 08:44:10 2025
++++ p0/platforms/Cross/plugins/JPEGReadWriter2Plugin/jmemdatadst.c	Tue Jun 17 11:44:51 2025
+@@ -115,13 +115,12 @@
+   }
+ }
+ 
+-#if !defined(USE_LIBRARY_SHARED)
+ /*
+  * Prepare for output to a stdio stream.
+  * The caller must have already opened the stream, and is responsible
+  * for closing it after finishing compression.
+  */
+-GLOBAL(void) jpeg_mem_dest (j_compress_ptr cinfo, char * pDestination, unsigned *pDestinationSize) {
++GLOBAL(void) sqJpeg_mem_dest (j_compress_ptr cinfo, char * pDestination, unsigned *pDestinationSize) {
+   my_dest_ptr dest;
+ 
+   /* The destination object is made permanent so that multiple JPEG images
+@@ -145,5 +144,4 @@
+   dest->pSpaceUsed = pDestinationSize;
+   *(dest->pSpaceUsed) = 0;
+ }
+-#endif
+ 

--- a/components/runtime/smalltalk/dtlsqueak/patches/07-sqJPEGReadWriter2Plugin.patch
+++ b/components/runtime/smalltalk/dtlsqueak/patches/07-sqJPEGReadWriter2Plugin.patch
@@ -1,0 +1,29 @@
+--- platforms/Cross/plugins/JPEGReadWriter2Plugin/sqJPEGReadWriter2Plugin.c	Mon Jun 16 08:44:10 2025
++++ p0/platforms/Cross/plugins/JPEGReadWriter2Plugin/sqJPEGReadWriter2Plugin.c	Tue Jun 17 11:44:51 2025
+@@ -63,7 +63,7 @@
+ 
+ 	if (*destinationSizePtr) {
+ 		jpeg_create_compress(pcinfo);
+-		jpeg_mem_dest(pcinfo, destination, destinationSizePtr);
++		sqJpeg_mem_dest(pcinfo, destination, destinationSizePtr);
+ 
+ 		pcinfo->image_width = width;
+ 		pcinfo->image_height = height;
+@@ -159,7 +159,7 @@
+ 	}
+ 
+ 	if (ok)
+-		ok = jpeg_mem_src_newLocationOfData(pcinfo, source, sourceSize);
++		ok = sqJpeg_mem_src_newLocationOfData(pcinfo, source, sourceSize);
+ 
+ 	if (ok) {
+ 		jpeg_start_decompress(pcinfo);
+@@ -301,7 +301,7 @@
+ 
+ 	if (sourceSize) {
+ 		jpeg_create_decompress(pcinfo);
+-		jpeg_mem_src(pcinfo, source, sourceSize);
++		sqJpeg_mem_src(pcinfo, source, sourceSize);
+ 		jpeg_read_header(pcinfo, TRUE);
+ 	}
+ }

--- a/components/runtime/smalltalk/dtlsqueak/patches/08-JPEGReadWriter2Plugin.patch
+++ b/components/runtime/smalltalk/dtlsqueak/patches/08-JPEGReadWriter2Plugin.patch
@@ -1,0 +1,15 @@
+--- platforms/Cross/plugins/JPEGReadWriter2Plugin/JPEGReadWriter2Plugin.h	Mon Jun 16 08:44:09 2025
++++ p0/platforms/Cross/plugins/JPEGReadWriter2Plugin/JPEGReadWriter2Plugin.h	Tue Jun 17 11:44:51 2025
+@@ -12,9 +12,9 @@
+ typedef struct error_mgr2* error_ptr2;
+ 
+ void error_exit (j_common_ptr cinfo);
+-GLOBAL(void) jpeg_mem_src (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize);
+-GLOBAL(int) jpeg_mem_src_newLocationOfData (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize);
+-GLOBAL(void) jpeg_mem_dest (j_compress_ptr cinfo, char * pDestination, unsigned *pDestinationSize);
++GLOBAL(void) sqJpeg_mem_src (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize);
++GLOBAL(int) sqJpeg_mem_src_newLocationOfData (j_decompress_ptr cinfo, char * pSourceData, unsigned sourceDataSize);
++GLOBAL(void) sqJpeg_mem_dest (j_compress_ptr cinfo, char * pDestination, unsigned *pDestinationSize);
+ void primJPEGWriteImageonByteArrayformqualityprogressiveJPEGerrorMgrWriteScanlines(
+     unsigned int, 
+     unsigned int, 

--- a/components/runtime/smalltalk/dtlsqueak/pkg5
+++ b/components/runtime/smalltalk/dtlsqueak/pkg5
@@ -1,0 +1,29 @@
+{
+    "dependencies": [
+        "image/library/libjpeg8-turbo",
+        "library/audio/pulseaudio",
+        "library/desktop/cairo",
+        "library/desktop/pango",
+        "library/glib2",
+        "library/libffi",
+        "library/security/openssl",
+        "shell/ksh93",
+        "system/library",
+        "system/library/dbus",
+        "system/library/freetype-2",
+        "system/library/libdbus",
+        "system/library/math",
+        "x11/library/libx11",
+        "x11/library/libxext",
+        "x11/library/libxrender",
+        "x11/library/mesa"
+    ],
+    "fmris": [
+        "runtime/smalltalk/dtlsqueak",
+        "runtime/smalltalk/dtlsqueak-display-X11",
+        "runtime/smalltalk/dtlsqueak-nodisplay",
+        "runtime/smalltalk/dtlsqueak-ssl",
+        "runtime/smalltalk/dtlsqueak-vep"
+    ],
+    "name": "dtlsqueak"
+}

--- a/components/runtime/smalltalk/dtlsqueak/test/results-32.master
+++ b/components/runtime/smalltalk/dtlsqueak/test/results-32.master
@@ -1,0 +1,1 @@
+Squeak only tested in 32bit.  See OpenSmalltalk for 64bit.

--- a/components/runtime/smalltalk/dtlsqueak/test/results-64.master
+++ b/components/runtime/smalltalk/dtlsqueak/test/results-64.master
@@ -1,0 +1,22 @@
+SUnit Results
+Squeak4.6
+solaris2.11
+Squeak4.6 of 21 July 2021 [latest update: #15118]
+Failed Tests
+'BrowserTest>>#testSelectClassNamedPreservesPlace'
+'ClosureCompilerTest>>#testSourceRangeAccessForBlueBookInjectInto'
+'DecompilerTests>>#testDecompilerInClassesPNtoPZ'
+'ExceptionTests>>#testHandlerFromAction'
+'FontTest>>#testParagraph'
+'FontTest>>#testParagraphFallback'
+'PackageDependencyTest>>#testMonticello'
+'PackageDependencyTest>>#testNetwork'
+'PackageDependencyTest>>#testPreferenceBrowser'
+'SocketTest>>#testSocketReuse'
+'SocketTest>>#testUDP'
+'TestVMStatistics>>#testVmStatisticsReportString'
+'TestValueWithinFix>>#testValueWithinTimingRepeat'
+Errors
+Total Number of Passed Tests: 3750
+Total Number of Failures: 13
+Total Number of Errors: 0

--- a/components/runtime/smalltalk/dtlsqueak/test/testrunner.sh
+++ b/components/runtime/smalltalk/dtlsqueak/test/testrunner.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+BITS=$1
+COMPONENT_DIR=$2
+BUILD_DIR=$3
+
+LOGFILE=testrunner-log.$BITS
+
+echo "BITS set to $BITS" >> $LOGFILE
+echo "COMPONENT_DIR set to $COMPONENT_DIR" >> $LOGFILE
+echo "BUILD_DIR set to $BUILD_DIR" >> $LOGFILE
+
+# the tests could be ran after pkg install as:
+#       inisqueak -n;squeak squeak.image testrunner.st
+# or interactively simply by opening a Squeak image and going to TestRunner
+
+# however here we want to do this on the newly built 32bit VM
+# so we start squeak from the BUILD_DIR directory
+# we only test the 32bit VM because inisqueak downloads a 32bit image
+
+case $BITS in
+ 32) echo "Squeak only tested in 64bit.  See OpenSmalltalk for 64bit.";exit 0;;
+ 64) ;;
+  *) echo "Unknown BITS $BITS";exit 1;;
+esac
+
+# unlike OpenSmalltalk libtool/configure plugins are not found in build dir
+# make sure that the newly built VM loads plugins fro the build dir
+
+for plugin in vm-display-X11 vm-display-null vm-sound-pulse vm-sound-null UUIDPlugin SqueakSSL
+do
+  SQUEAK_PLUGINS=$SQUEAK_PLUGINS:$BUILD_DIR/$plugin
+# LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BUILD_DIR/$plugin
+done
+#echo "Setting LD_LIBRARY_PATH to $LD_LIBRARY_PATH" >> $LOGFILE
+#export LD_LIBRARY_PATH
+echo "Setting SQUEAK_PLUGINS to $SQUEAK_PLUGINS" >> $LOGFILE
+export SQUEAK_PLUGINS
+
+# download squeak.image to current directory
+echo "Running $COMPONENT_DIR/inidtlsqueak4 -n" >> $LOGFILE
+$COMPONENT_DIR/inidtlsqueak4 -n >> $LOGFILE 2>&1
+
+# start squeak binary from the build dir
+cd $BUILD_DIR
+
+# check DISPLAY is set
+if [ -z "$DISPLAY" ]
+then
+  echo "Setting DISPLAY to :0" >> $LOGFILE
+  DISPLAY=":0"
+  export DISPLAY
+fi
+
+echo "Running $BUILD_DIR/squeakvm64 -display $DISPLAY squeak.image $COMPONENT_DIR/test/testrunner.st" >> $LOGFILE
+$BUILD_DIR/squeakvm64 -display $DISPLAY squeak.image $COMPONENT_DIR/test/testrunner.st >> $LOGFILE 2>&1
+
+# testrunner.st saves output in a file , dump that file as output
+cat results-32.vm
+

--- a/components/runtime/smalltalk/dtlsqueak/test/testrunner.st
+++ b/components/runtime/smalltalk/dtlsqueak/test/testrunner.st
@@ -1,0 +1,27 @@
+| file result testRunner |
+Utilities setAuthorInitials:'hipster'.
+testRunner _ TestRunner new runAll.
+result _ testRunner result.
+file _ StandardFileStream fileNamed:'results-32.vm'.
+file nextPutAll: 'SUnit Results'; lf.
+file nextPutAll: Smalltalk version; lf.
+file nextPutAll: Smalltalk osVersion; lf.
+file nextPutAll: Smalltalk vmVersion; lf.
+file nextPutAll: 'Failed Tests'; lf.
+testRunner failedList do:
+		[ : each | each printOn:file.  file lf ].
+file nextPutAll: 'Errors'; lf.
+testRunner errorList do:
+		[ : each | each printOn:file.  file lf ].
+file nextPutAll: 'Total Number of Passed Tests: '.
+result passedCount printOn:file.
+file lf.
+file nextPutAll: 'Total Number of Failures: '.
+result failureCount printOn:file.
+file lf.
+file nextPutAll: 'Total Number of Errors: '.
+result errorCount printOn:file.
+file lf.
+file close.
+Smalltalk quitPrimitive.
+

--- a/components/runtime/smalltalk/dtlsqueak/tools/amd64-p5m.sh
+++ b/components/runtime/smalltalk/dtlsqueak/tools/amd64-p5m.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+for f in dtlsqueak.p5m dtlsqueak-display-X11.p5m dtlsqueak-nodisplay.p5m dtlsqueak-ssl.p5m dtlsqueak-vep.p5m
+do
+  tools/amd64.pl < $f > $f.out
+  mv $f.out $f
+done
+

--- a/components/runtime/smalltalk/dtlsqueak/tools/amd64.pl
+++ b/components/runtime/smalltalk/dtlsqueak/tools/amd64.pl
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+
+#
+# currently (and perhaps forever) the Makefile of squeak places binaries
+# in subversion-revision_suffix where suffix can be 64bit
+#
+# the pkglint check for 64binaries in 32bit path will complain on this;
+# the usage enforced by pkglint is 
+# /usr/lib/amd64/squeak/xyz/plugin  instead of /usr/lib/squeak/xyz_64bit/plugin
+# ./amd64.pl < in > out
+# example:  ./amd64.pl < ../manifests/sample-manifest.p5m > sample-manifest.p5m
+#
+
+while (<>) {
+	if (/ckformat/) {
+	   # don't process cause _64bit is already processed
+	   print $_;
+	} elsif (/squeakvm/) {
+	   # don't process cause _64bit is already processed
+	   print $_;
+	} elsif (/transform/) {
+	   # don't process cause _64bit is already processed
+	   print $_;
+	} elsif (/_64bit/) {
+		s/file path=//;
+		chomp;
+		$file = $_;
+		$path = $_;
+		$path =~ s/usr\/lib/usr\/lib\/amd64/;
+		$path =~ s/_64bit//;
+		print "file ",$file," path=",$path,"\n";
+	} else {
+		print $_;
+	}
+}
+

--- a/components/runtime/smalltalk/dtlsqueak/tools/classify.pl
+++ b/components/runtime/smalltalk/dtlsqueak/tools/classify.pl
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+
+#
+# because Squeak has many plugins,
+# there are also many dependencies 
+# in order to have a small "kernel" package
+# this script is used
+#
+# the script "classifies" plugins into currently 3 categories:
+#  - squeak-nodisplay (only libc,libm math,libpthread, ksh)
+#  - squeak-display-X11 (only x11,xext,xrender)
+#  - squeak (ssl,ffi,pulseaudio freetype2,gnome, everything else)
+#
+# Usage: check the samplemanifest,
+# ./subversion.pl < ../manifests/sample-manifest.p5m > sample2.p5m
+# then classify the files as follows:
+# ./classify.pl < sample2.p5m
+# then alias the amd64 files (install in component directory)
+# ./amd64.pl < squeak.p5m > ../squeak.p5m
+# or run ./amd64-p5m.sh
+#
+
+open(NODISPLAY,">>","dtlsqueak-nodisplay.p5m") || die "Can't open dtlsqueak-nodisplay.p5m";
+
+open(X11,">>","dtlsqueak-display-X11.p5m") || die "Can't open dtlsqueak-display-X11.p5m";
+
+open(VEP,">>","dtlsqueak-vep.p5m") || die "Can't open dtlsqueak-vep.p5m";
+
+open(SSL,">>","dtlsqueak-ssl.p5m") || die "Can't open dtlsqueak-ssl.p5m";
+
+open(REST,">>","dtlsqueak.p5m") || die "Can't open dtlsqueak.p5m";
+
+while (<>) {
+	if (/^#/) {
+		# ignore lines that start with comment
+	} elsif (/^$/) {
+		# ignore empty lines
+	} elsif (/license /) {
+		# ignore license lines
+	} elsif (/set name=/) {
+		# ignore those lines
+	} elsif (/dir  path=/) {
+		# ignore those lines
+	} elsif (/file path=/) {
+		if (/Sun/) {
+			# ignore the Sun sound plugin - we use pulseaudio
+		} elsif (/usr\/bin/) {
+			# don't deal with driver scripts here
+		} elsif (/man1/) {
+			# don't deal with the manpages here
+		} elsif (/squeakvm/) {
+			# don't deal with the actual binary here
+		} elsif (/ckformat/) {
+			# don't deal with the ckformat binary here
+		} elsif (/AioPlugin/) {
+			print NODISPLAY $_;
+		} elsif (/ClipboardExtendedPlugin/) {
+			print X11 $_;
+		} elsif (/FileCopyPlugin/) {
+			print NODISPLAY $_;
+		} elsif (/HostWindowPlugin/) {
+			print X11 $_;
+		} elsif (/ImmX11Plugin/) {
+			print X11 $_;
+		} elsif (/Squeak3D/) {
+			print X11 $_;
+		} elsif (/SqueakSSL/) {
+			print SSL $_;
+		} elsif (/B3DAcceleratorPlugin/) {
+			print X11 $_;
+		} elsif (/UnixOSProcessPlugin/) {
+			print NODISPLAY $_;
+		} elsif (/VectorEnginePlugin/) {
+			print VEP $_;
+		} elsif (/XDisplayControlPlugin/) {
+			print X11 $_;
+		} elsif (/vm-sound-null/) {
+			print NODISPLAY $_;
+		} elsif (/vm-display-null/) {
+			print NODISPLAY $_;
+		} elsif (/vm-display-X11/) {
+			print X11 $_;
+		} elsif (/vm-display-X11/) {
+			print X11 $_;
+		} elsif (/usr\/lib\/squeak/) {
+			print REST $_;
+		} else {
+			# unclassified files
+			print $_;
+		}
+	} elsif (/hardlink path=/) {
+		# unclassified files
+		print $_;
+	} elsif (/link path=/) {
+		# unclassified files
+		print $_;
+	} else {
+		# unclassified files
+		print $_;
+	}
+}
+

--- a/components/runtime/smalltalk/dtlsqueak/tools/subversion.sh
+++ b/components/runtime/smalltalk/dtlsqueak/tools/subversion.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+#
+# script to replace the subversion version by the string $(SVN_REV)
+#
+
+svn_rev=$1
+perl -p -e "s/$svn_rev/\\$\(SVN_REV\)/;"
+


### PR DESCRIPTION

Same package as squeak:  provides a VM for running Squeak 4.6 and older images (perhaps Squeak 1.x or Squeak 2.x)

tested "SUnit Tests" and same results as with the "squeak" package

the IPS mediator can be set :

pkg set-mediator -V 4 -I dtl squeak

