### PR TITLE
ogl-select: drop 32 bit support

### DIFF
--- a/components/x11/ogl-select/Makefile
+++ b/components/x11/ogl-select/Makefile
@@ -13,11 +13,13 @@
 # Copyright 2019 Michal Nowak
 #
 
+BUILD_STYLE = pkg
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ogl-select
 COMPONENT_VERSION=	0.5.11
-COMPONENT_REVISION=	6
+COMPONENT_REVISION=	7
 COMPONENT_SUMMARY=	ogl-select - boot time selection of OpenGL vendor files
 COMPONENT_PROJECT_URL = https://www.openindiana.org/
 COMPONENT_FMRI=		service/opengl/ogl-select
@@ -25,20 +27,7 @@ COMPONENT_LICENSE=	MIT
 COMPONENT_LICENSE_FILE=	ogl-select.license
 COMPONENT_CLASSIFICATION= System/X11
 
-
-include $(WS_MAKE_RULES)/ips.mk
-
-download:
-
-prep:
-
-build:
-
-install:
-	[ -d $(PROTO_DIR) ] || mkdir -p $(PROTO_DIR)
-
-clean:
-	$(RM) -r $(BUILD_DIR) $(PROTO_DIR)
+include $(WS_MAKE_RULES)/common.mk
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += SUNWcs

--- a/components/x11/ogl-select/files/mesa_vendor_select
+++ b/components/x11/ogl-select/files/mesa_vendor_select
@@ -85,17 +85,13 @@ if [[ -d /usr/lib/mesa/modules/extensions/${DIR64} ]] ; then
 fi
 
 # User libraries
-make_link ../../../../usr/lib/mesa/libGL.so.1 ${LINKDIR}/lib/libGL.so.1
 make_link ../../../../../usr/lib/mesa/${DIR64}/libGL.so.1 \
 	${LINKDIR}/lib/${DIR64}/libGL.so.1
 
-make_link ../../../../usr/lib/mesa/libEGL.so.1 ${LINKDIR}/lib/libEGL.so.1
 make_link ../../../../../usr/lib/mesa/${DIR64}/libEGL.so.1 \
 	${LINKDIR}/lib/${DIR64}/libEGL.so.1
 
 # Server modules
-make_link ../../../../usr/lib/mesa/modules/extensions/libglx.so \
-	${LINKDIR}/server/libglx.so
 if [[ -d /usr/lib/mesa/modules/extensions/${DIR64} ]] ; then
     make_link \
 	../../../../../usr/lib/mesa/modules/extensions/${DIR64}/libglx.so \

--- a/components/x11/ogl-select/files/nvidia_vendor_select
+++ b/components/x11/ogl-select/files/nvidia_vendor_select
@@ -78,14 +78,11 @@ function make_link {
 dir_init
 
 # User libraries
-make_link /usr/X11/lib/NVIDIA/libGL.so.1 $LINKDIR/lib/libGL.so.1
 make_link /usr/X11/lib/NVIDIA/amd64/libGL.so.1 $LINKDIR/lib/amd64/libGL.so.1
-make_link /usr/X11/lib/NVIDIA/libEGL.so.1 $LINKDIR/lib/libEGL.so.1
 make_link /usr/X11/lib/NVIDIA/amd64/libEGL.so.1 $LINKDIR/lib/amd64/libEGL.so.1
 make_link amd64 $LINKDIR/lib/64
 
 # Server libraries
-make_link /usr/X11/lib/modules/extensions/NVIDIA/libglx.so $LINKDIR/server/libglx.so
 make_link /usr/X11/lib/modules/extensions/NVIDIA/amd64/libglx.so $LINKDIR/server/amd64/libglx.so
 
 # Includes

--- a/components/x11/ogl-select/manifests/sample-manifest.p5m
+++ b/components/x11/ogl-select/manifests/sample-manifest.p5m
@@ -10,10 +10,11 @@
 #
 
 #
-# Copyright 2018 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)

--- a/components/x11/ogl-select/ogl-select.p5m
+++ b/components/x11/ogl-select/ogl-select.p5m
@@ -14,6 +14,7 @@
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
 set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
@@ -39,8 +40,6 @@ link path=usr/X11/lib/$(MACH64)/libGL.so target=libGL.so.1
 link path=usr/X11/lib/$(MACH64)/libGL.so.1 target=../GL/$(MACH64)/libGL.so.1
 link path=usr/X11/lib/64 target=$(MACH64)
 link path=usr/X11/lib/GL target=../../lib/GL
-link path=usr/X11/lib/libGL.so target=libGL.so.1
-link path=usr/X11/lib/libGL.so.1 target=GL/libGL.so.1
 link path=usr/include/GL/gl.h target=../../../var/run/opengl/include/gl.h
 link path=usr/include/GL/glext.h target=../../../var/run/opengl/include/glext.h
 link path=usr/include/GL/glx.h target=../../../var/run/opengl/include/glx.h
@@ -54,13 +53,4 @@ link path=usr/lib/GL/$(MACH64)/libEGL.so.1 target=../../../../var/run/opengl/lib
 link path=usr/lib/GL/$(MACH64)/libGL.so target=libGL.so.1
 link path=usr/lib/GL/$(MACH64)/libGL.so.1 target=../../../../var/run/opengl/lib/$(MACH64)/libGL.so.1
 link path=usr/lib/GL/64 target=$(MACH64)
-link path=usr/lib/GL/libEGL.so target=libEGL.so.1
-link path=usr/lib/GL/libEGL.so.1 target=../../../var/run/opengl/lib/libEGL.so.1
-link path=usr/lib/GL/libGL.so target=libGL.so.1
-link path=usr/lib/GL/libGL.so.1 target=../../../var/run/opengl/lib/libGL.so.1
-link path=usr/lib/libEGL.so target=libEGL.so.1
-link path=usr/lib/libEGL.so.1 target=GL/libEGL.so.1
-link path=usr/lib/libGL.so target=libGL.so.1
-link path=usr/lib/libGL.so.1 target=GL/libGL.so.1
 link path=usr/lib/xorg/modules/extensions/$(MACH64)/libglx.so target=../../../../../../var/run/opengl/server/$(MACH64)/libglx.so
-link path=usr/lib/xorg/modules/extensions/libglx.so target=../../../../../var/run/opengl/server/libglx.so


### PR DESCRIPTION
This removes symlinks to 32 bit libraries that are mostly dead links anyway these days.
For example, mesa dropped 32 bit support in June 2024.