### PR TITLE
Add xf86-video-illumosfb: Xorg driver for UEFI framebuffer on illumos

### DIFF
--- a/components/x11/xf86-video-illumosfb/Makefile
+++ b/components/x11/xf86-video-illumosfb/Makefile
@@ -1,0 +1,29 @@
+X11_CATEGORY=DRIVER
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=xf86-video-illumosfb
+COMPONENT_VERSION=0.5
+COMPONENT_SUMMARY=Xorg driver for illumos UEFI frame buffer
+COMPONENT_PROJECT_URL=  https://github.com/LuminousMonkey/xf86-video-illumosfb/
+COMPONENT_FMRI=         x11/server/xorg/driver/xorg-video-illumosfb
+COMPONENT_SRC=          xf86-video-illumosfb
+COMPONENT_CLASSIFICATION=       Drivers/Display
+COMPONENT_LICENSE=      ISC
+COMPONENT_LICENSE_FILE= LICENSE
+COMPONENT_PREP_ACTION= cd $(@D) && PATH="$(PATH)" NOCONFIGURE=1 /usr/bin/bash ./autogen.sh
+
+GIT_BRANCH=main
+GIT_REPO=https://github.com/LuminousMonkey/xf86-video-illumosfb.git
+GIT_COMMIT_ID=8ad57812ca2e99be6281f5142101811482026c55
+GIT_HASH=sha256:315963e992a849eb0a84373d9889a5e604eb8f7e4764518abfedbd7ba7c98888
+
+TEST_TARGET= $(NO_TESTS)
+
+include $(WS_MAKE_RULES)/common.mk
+
+REQUIRED_PACKAGES += x11/server/xorg
+REQUIRED_PACKAGES += library/graphics/pixman
+REQUIRED_PACKAGES += developer/build/autoconf/xorg-macros
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library

--- a/components/x11/xf86-video-illumosfb/manifests/sample-manifest.p5m
+++ b/components/x11/xf86-video-illumosfb/manifests/sample-manifest.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/$(MACH64)/xorg/modules/drivers/illumosfb_drv.so
+file path=usr/share/man/man4/illumosfb.4

--- a/components/x11/xf86-video-illumosfb/pkg5
+++ b/components/x11/xf86-video-illumosfb/pkg5
@@ -1,0 +1,12 @@
+{
+    "dependencies": [
+        "developer/build/autoconf/xorg-macros",
+        "library/graphics/pixman",
+        "system/library",
+        "x11/server/xorg"
+    ],
+    "fmris": [
+        "x11/server/xorg/driver/xorg-video-illumosfb"
+    ],
+    "name": "xf86-video-illumosfb"
+}

--- a/components/x11/xf86-video-illumosfb/xf86-video-illumosfb.p5m
+++ b/components/x11/xf86-video-illumosfb/xf86-video-illumosfb.p5m
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Bill Sommerfeld
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/lib/$(MACH64)/xorg/modules/drivers/illumosfb_drv.so
+file path=usr/share/man/man4/illumosfb.4


### PR DESCRIPTION
Driver by Mike Aldred, based on work by Matthieu Herrb for *BSD.