### PR TITLE
squeak: fix ckformat mediator link

### DIFF
--- a/components/runtime/smalltalk/squeak/Makefile
+++ b/components/runtime/smalltalk/squeak/Makefile
@@ -71,7 +71,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.21.3
-COMPONENT_REVISION=	1
+COMPONENT_REVISION=	2
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org

--- a/components/runtime/smalltalk/squeak/manifests/squeak-nodisplay.p5m
+++ b/components/runtime/smalltalk/squeak/manifests/squeak-nodisplay.p5m
@@ -43,6 +43,8 @@ hardlink path=usr/bin/squeak target=squeak4 mediator=squeak \
     mediator-version=4
 hardlink path=usr/bin/inisqueak target=inisqueak4 mediator=squeak \
     mediator-version=4
+hardlink path=usr/bin/ckformat target=/usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/ckformat mediator=squeak \
+    mediator-version=4
 hardlink path=usr/share/man/man1/squeak.1 target=squeak4.1 mediator=squeak \
     mediator-version=4
 

--- a/components/runtime/smalltalk/squeak/squeak-nodisplay.p5m
+++ b/components/runtime/smalltalk/squeak/squeak-nodisplay.p5m
@@ -43,6 +43,8 @@ hardlink path=usr/bin/squeak target=squeak4 mediator=squeak \
     mediator-version=4
 hardlink path=usr/bin/inisqueak target=inisqueak4 mediator=squeak \
     mediator-version=4
+hardlink path=usr/bin/ckformat target=/usr/lib/amd64/squeak/$(COMPONENT_VERSION)-$(SVN_REV)/ckformat mediator=squeak \
+    mediator-version=4
 hardlink path=usr/share/man/man1/squeak.1 target=squeak4.1 mediator=squeak \
     mediator-version=4
 


### PR DESCRIPTION
fix the mediator link for ckformat
(the link was set in the opensmalltalk cog-spur and stack-spur packages but not in the classical squeak package)

ckformat is a utility from dtlewis290 and is in the source code distribution of both classical squeak and opensmalltalk 

in fact the utility is provided here as a C program but is maintained by dtlewis290 in the ImageFormat Smalltalk package (the C source code is generated from Smalltalk)

more info at http://wiki.squeak.org/squeak/676 and http://wiki.squeak.org/squeak/6290
