### PR TITLE
squeak: remove KedamaPlugin2 from build

### DIFF
--- a/components/runtime/smalltalk/squeak/Makefile
+++ b/components/runtime/smalltalk/squeak/Makefile
@@ -71,7 +71,7 @@ include ../../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		squeak
 COMPONENT_VERSION=	4.21.3
-COMPONENT_REVISION=	3
+COMPONENT_REVISION=	4
 COMPONENT_SUMMARY=	The Squeak Virtual Machine
 COMPONENT_PROJECT_URL=	http://www.squeak.org
 COMPONENT_ARCHIVE_URL=  http://squeakvm.org
@@ -189,6 +189,7 @@ CLEAN_PATHS+= .patched-08-JPEGReadWriter2Plugin.patch
 # do not build vm-sound-Sun as we only package vm-sound-pulse (bug #17109)
 # do not build Mpeg3Plugin and RePlugin as it uses old copies of those libraries
 # do not build GStreamerPlugin, it uses the GStreamer 0.10 and not GStreamer 1.0 (bug #17111)
+# do not build KedamaPlugin2
  
 CONFIGURE_SCRIPT= $(SOURCE_DIR_2)/cmake/configure
 CONFIGURE_OPTIONS +=	--src=$(SOURCE_DIR_0)
@@ -198,6 +199,7 @@ CONFIGURE_OPTIONS +=    --without-RePlugin
 CONFIGURE_OPTIONS +=    --without-Mpeg3Plugin
 CONFIGURE_OPTIONS +=    --without-GStreamerPlugin
 CONFIGURE_OPTIONS +=    --without-ScratchPlugin
+CONFIGURE_OPTIONS +=    --without-KedamaPlugin2
 # cmake 4.x requires this -D because the CMakeLists.txt indicates cmake 2.x MINVERSION
 CONFIGURE_OPTIONS +=    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 

--- a/components/runtime/smalltalk/squeak/manifests/sample-manifest.p5m
+++ b/components/runtime/smalltalk/squeak/manifests/sample-manifest.p5m
@@ -35,7 +35,6 @@ file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.FT2Plugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.FileCopyPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.HostWindowPlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.ImmX11Plugin
-file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.KedamaPlugin2
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.RomePlugin
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.Squeak3D
 file path=usr/lib/squeak/$(HUMAN_VERSION)-3840_64bit/so.SqueakFFIPrims

--- a/components/runtime/smalltalk/squeak/squeak.p5m
+++ b/components/runtime/smalltalk/squeak/squeak.p5m
@@ -41,7 +41,6 @@ depend type=require fmri=pkg:/$(COMPONENT_FMRI)-display-X11@$(IPS_COMPONENT_VERS
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.CameraPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.CameraPlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.DBusPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.DBusPlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.FT2Plugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.FT2Plugin
-file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.KedamaPlugin2 path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.KedamaPlugin2
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.RomePlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.RomePlugin
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.SqueakFFIPrims path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.SqueakFFIPrims
 file usr/lib/squeak/$(HUMAN_VERSION)-$(SVN_REV)_64bit/so.UUIDPlugin path=usr/lib/amd64/squeak/$(HUMAN_VERSION)-$(SVN_REV)/so.UUIDPlugin

--- a/components/runtime/smalltalk/squeak/tools/amd64-p5m.sh
+++ b/components/runtime/smalltalk/squeak/tools/amd64-p5m.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-for f in squeak.p5m squeak-display-X11.p5m squeak-nodisplay.p5m squeak-ssl.p5m squeak-vep.p5m
+# name can be changed to cog-spur or stack-spur for opensmalltalk packages
+name=squeak
+
+for f in ${name}.p5m ${name}-display-X11.p5m ${name}-nodisplay.p5m ${name}-ssl.p5m ${name}-vep.p5m
 do
   tools/amd64.pl < $f > $f.out
   mv $f.out $f

--- a/components/runtime/smalltalk/squeak/tools/classify.pl
+++ b/components/runtime/smalltalk/squeak/tools/classify.pl
@@ -20,15 +20,21 @@
 # or run ./amd64-p5m.sh
 #
 
-open(NODISPLAY,">>","squeak-nodisplay.p5m") || die "Can't open squeak-nodisplay.p5m";
+# name can be changed to cog-spur or stack-spur for squeak opensmalltalk packages
+$name="squeak";
 
-open(X11,">>","squeak-display-X11.p5m") || die "Can't open squeak-display-X11.p5m";
+open(NODISPLAY,">>","${name}-nodisplay.p5m") || die "Can't open ${name}-nodisplay.p5m";
 
-open(VEP,">>","squeak-vep.p5m") || die "Can't open squeak-vep.p5m";
+open(X11,">>","${name}-display-X11.p5m") || die "Can't open ${name}-display-X11.p5m";
 
-open(SSL,">>","squeak-ssl.p5m") || die "Can't open squeak-ssl.p5m";
+open(VEP,">>","${name}-vep.p5m") || die "Can't open ${name}-vep.p5m";
 
-open(REST,">>","squeak.p5m") || die "Can't open squeak.p5m";
+open(SSL,">>","${name}-ssl.p5m") || die "Can't open ${name}-ssl.p5m";
+
+open(REST,">>","${name}.p5m") || die "Can't open ${name}.p5m";
+
+# TODO: PTY support in squeak 4.21.5
+# open(PTY,">>","${name}-pty.p5m") || die "Can't open ${name}-pty.p5m";
 
 while (<>) {
 	if (/^#/) {
@@ -41,16 +47,24 @@ while (<>) {
 		# ignore those lines
 	} elsif (/dir  path=/) {
 		# ignore those lines
+	} elsif (/file path=usr\/squeak/) {
+		# ignore those lines
 	} elsif (/file path=/) {
 		if (/Sun/) {
 			# ignore the Sun sound plugin - we use pulseaudio
+		} elsif (/vm-sound-OSS/) {
+			# ignore the OSS sound plugin - we use pulseaudio
 		} elsif (/usr\/bin/) {
 			# don't deal with driver scripts here
+		} elsif (/usr\/doc/) {
+			# don't deal with docs here
 		} elsif (/man1/) {
 			# don't deal with the manpages here
+		} elsif (/squeak$/) {
+			# don't deal with the actual binary here
 		} elsif (/squeakvm/) {
 			# don't deal with the actual binary here
-		} elsif (/ckformat/) {
+		} elsif (/ckformat$/) {
 			# don't deal with the ckformat binary here
 		} elsif (/AioPlugin/) {
 			print NODISPLAY $_;
@@ -70,10 +84,19 @@ while (<>) {
 			print X11 $_;
 		} elsif (/UnixOSProcessPlugin/) {
 			print NODISPLAY $_;
-		} elsif (/VectorEnginePlugin/) {
-			print VEP $_;
+		} elsif (/PseudoTTYPlugin/) {
+# TODO: PTY support in squeak 4.21.5
+#			print PTY $_;
+		} elsif (/MD5Plugin/) {
+			print NODISPLAY $_;
+		} elsif (/SHA2Plugin/) {
+			print NODISPLAY $_;
+		} elsif (/DESPlugin/) {
+			print NODISPLAY $_;
 		} elsif (/XDisplayControlPlugin/) {
 			print X11 $_;
+		} elsif (/VectorEnginePlugin/) {
+			print VEP $_;
 		} elsif (/vm-sound-null/) {
 			print NODISPLAY $_;
 		} elsif (/vm-display-null/) {
@@ -84,10 +107,14 @@ while (<>) {
 			print X11 $_;
 		} elsif (/usr\/lib\/squeak/) {
 			print REST $_;
+		} elsif (/usr\/lib\/\$\(MACH64\)\/squeak/) {
+			print REST $_;
 		} else {
 			# unclassified files
 			print $_;
 		}
+	} elsif (/inisqueak.1/) {
+		# ignore manpage hardlink
 	} elsif (/hardlink path=/) {
 		# unclassified files
 		print $_;


### PR DESCRIPTION

Kedama is an application using eToys

eToys runs on squeak, unsure whether Kedama still runs, but the plugin was enabled by default - disable it until tested

OpenSmalltalk cog-spur and stack-spur do not provide the KedamaPlugin2 by default (it may work on OpenSmalltalk)