### PR TITLE
valgrind: update to 3.27.0

### DIFF
--- a/components/developer/valgrind/Makefile
+++ b/components/developer/valgrind/Makefile
@@ -24,22 +24,22 @@
 # Copyright (c) 2019 Michal Nowak
 # Copyright (c) 2021 David Stes
 # Copyright (c) 2022,2023 Friedrich Kink
-# Copyright (c) 2025 Paul Floyd
+# Copyright (c) 2025,2026 Paul Floyd
 #
 
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		valgrind
-COMPONENT_VERSION=	3.26.0
+COMPONENT_VERSION=	3.27.0
 COMPONENT_FMRI=		developer/debug/valgrind
 COMPONENT_CLASSIFICATION=Development/System
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.bz2
-COMPONENT_ARCHIVE_HASH=	sha256:8d54c717029106f1644aadaf802ab9692e53d93dd015cbd19e74190eba616bd7
+COMPONENT_ARCHIVE_HASH=	sha256:5b5937de8257ee8f51698ea71b9711adce98061aa07daa4a685efc3af9215bef
 COMPONENT_ARCHIVE_URL=	https://sourceware.org/pub/valgrind/$(COMPONENT_ARCHIVE)
 COMPONENT_PROJECT_URL =	https://valgrind.org
 COMPONENT_SUMMARY=	Valgrind: instrumentation framework and tools to detect memory and threading problems
-COMPONENT_LICENSE=	GPLv2
+COMPONENT_LICENSE=	GPLv3
 COMPONENT_LICENSE_FILE=	COPYING
 
 include $(WS_MAKE_RULES)/common.mk
@@ -71,8 +71,8 @@ COMPONENT_POST_CONFIGURE_ACTION += ( cp $(@D)/config.h $(SOURCE_DIR) )
 COMPONENT_POST_BUILD_ACTION += ( cd $(@D)/docs && $(ENV) $(GMAKE) man-pages )
 
 #
-# currently 3.25.0
-# == 894 tests, 6 stderr failures, 0 stdout failures, 16 stderrB failures, 3 stdoutB failures, 1 post failure ==
+# currently 3.27.0
+# == 918 tests, 5 stderr failures, 0 stdout failures, 8 stderrB failures, 3 stdoutB failures, 1 post failure ==
 #
 COMPONENT_TEST_TARGETS = regtest
 # check just overal test results

--- a/components/developer/valgrind/test/results-all.master
+++ b/components/developer/valgrind/test/results-all.master
@@ -1,1 +1,1 @@
-== 925 tests, 6 stderr failures, 0 stdout failures, 8 stderrB failures, 3 stdoutB failures, 1 post failure ==
+== 918 tests, 5 stderr failures, 0 stdout failures, 8 stderrB failures, 3 stdoutB failures, 1 post failure ==


### PR DESCRIPTION
Main thing for illumos (and Solaris) is

516289  illumos lsframe2 regtest fails

A really nasty bug that is much more serious than I originally thought.

When I run make regest in the oi-userland git repo I get a few more failures than when I run the Valgrind nightly tests. I don't see any obvious cause. Some of the gdbserver tests fail because this sed filter doesn't remove the gdb noise about the index:

/\.\/gdb: warning: Couldn't determine a path for the index cache directory\./d

Also the none/tests/rc_option_with_spaces fails due to missing blank lines in the output.