### PR TITLE
openssh: fix libwrap patch to correctly set log levels

### DIFF
--- a/components/network/openssh/Makefile
+++ b/components/network/openssh/Makefile
@@ -30,6 +30,7 @@ COMPONENT_NAME=		openssh
 #   OpenSSH <x>.<y>p<n>     => IPS <x>.<y>.0.<n>
 #   OpenSSH <x>.<y>.<z>p<n> => IPS <x>.<y>.<z>.<n>
 COMPONENT_VERSION=	10.3.0.1
+COMPONENT_REVISION=	1
 HUMAN_VERSION=		10.3p1
 COMPONENT_SUMMARY=	OpenSSH client and associated utilities
 # OpenSSH made a mistake when releasing openssh 10.0p1 which identifies itself as 10.0p2.

--- a/components/network/openssh/patches/0031-Restore-tcpwrappers-libwrap-support.patch
+++ b/components/network/openssh/patches/0031-Restore-tcpwrappers-libwrap-support.patch
@@ -90,8 +90,8 @@
  #endif
  
 +#ifdef LIBWRAP
-+	int allow_severity = options.log_facility|LOG_INFO;
-+	int deny_severity = options.log_facility|LOG_WARNING;
++	allow_severity = options.log_facility|LOG_INFO;
++	deny_severity = options.log_facility|LOG_WARNING;
 +	/* Check whether logins are denied from this host. */
 +	if (ssh_packet_connection_is_on_socket(ssh)) {
 +		struct request_info req;


### PR DESCRIPTION
{allow,deny}_severity are declared extern in tcpd.h as part of the interface to libwrap; they should not be redeclared locally.