### PR TITLE
hdf5: fix pkg-config files

### DIFF
--- a/components/scientific/hdf5/Makefile
+++ b/components/scientific/hdf5/Makefile
@@ -15,12 +15,13 @@
 
 BUILD_STYLE= cmake
 USE_DEFAULT_TEST_TRANSFORMS= yes
+USE_PARALLEL_BUILD = yes
+
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=           hdf5
-COMPONENT_MJR_VERSION=    2.1
-COMPONENT_BLD_VERSION=    $(COMPONENT_MJR_VERSION).1
-COMPONENT_VERSION=        $(COMPONENT_BLD_VERSION)
+COMPONENT_VERSION=		2.1.1
+COMPONENT_REVISION=		1
 COMPONENT_SUMMARY=        HDF5 - Data model, library, and file format for storing and managing data
 COMPONENT_PROJECT_URL=    https://www.hdfgroup.org
 COMPONENT_SRC=            $(COMPONENT_NAME)-$(HUMAN_VERSION)
@@ -40,17 +41,8 @@ CMAKE_OPTIONS += -DHDF5_BUILD_HL_LIB=ON
 CMAKE_OPTIONS += -DHDF5_BUILD_FORTRAN=ON
 CMAKE_OPTIONS += -DHDF5_ENABLE_ZLIB_SUPPORT=ON
 CMAKE_OPTIONS += -DHDF5_INSTALL_CMAKE_DIR=lib/cmake/hdf5
-CMAKE_OPTIONS += -DHDF5_INSTALL_LIB_DIR=/usr/lib/$(MACH64)
-CMAKE_OPTIONS += -DHDF5_INSTALL_INCLUDE_DIR=/usr/include/hdf5
-
-COMPONENT_TEST_TRANSFORMS += \
-	' -e "/Testing/p" ' \
-	' -e "/passed/p" ' \
-	' -e "/skipped/p" ' \
-	' -e "/=====/p" ' \
-	' -e "/finished/p" ' \
-	' -e "/Test log/p" ' \
-	' -e "/Test sizes/p" '
+CMAKE_OPTIONS += -DHDF5_INSTALL_LIB_DIR=lib/$(MACH64)
+CMAKE_OPTIONS += -DHDF5_INSTALL_INCLUDE_DIR=include/hdf5
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)

--- a/components/scientific/hdf5/patches/01-no-rpath.patch
+++ b/components/scientific/hdf5/patches/01-no-rpath.patch
@@ -1,7 +1,7 @@
 /usr/lib/amd64 getting added as RUNPATH/RPATH to binaries and libraries, causing gmake publish to fail.   Do not append the system 64-bit library path to RPATH.
 
---- hdf5-2.1.1/config/HDFMacros.cmake.old	2026-04-27 08:17:19.292870024 -0400
-+++ hdf5-2.1.1/config/HDFMacros.cmake	2026-04-27 08:17:50.259338151 -0400
+--- hdf5-2.1.1/config/HDFMacros.cmake.orig
++++ hdf5-2.1.1/config/HDFMacros.cmake
 @@ -505,8 +505,6 @@
          "@loader_path/../${${package_prefix}_INSTALL_LIB_DIR}"
          "@loader_path/"

--- a/components/scientific/hdf5/test/results-all.master
+++ b/components/scientific/hdf5/test/results-all.master
@@ -3199,7 +3199,6 @@ Test H5_cpp_ex-clear-objects ...................................................
 Test H5_cpp_ex-clean-objects ....................................................   Passed
 
 100% tests passed, 0 tests failed out of 3180
-100% tests passed, 0 tests failed out of 3180
 
 
 The following tests did not run:


### PR DESCRIPTION
Example of the change/fix:
```
$ diff -u /usr/lib/amd64/pkgconfig/hdf5.pc build/prototype/i386/usr/lib/amd64/pkgconfig/hdf5.pc 
--- /usr/lib/amd64/pkgconfig/hdf5.pc    Tue Apr 28 01:52:46 2026
+++ build/prototype/i386/usr/lib/amd64/pkgconfig/hdf5.pc        Tue May  5 07:21:13 2026
@@ -1,7 +1,7 @@
 prefix=/usr
 exec_prefix=${prefix}
-libdir=${exec_prefix}//usr/lib/amd64
-includedir=${prefix}//usr/include/hdf5
+libdir=${exec_prefix}/lib/amd64
+includedir=${prefix}/include/hdf5
 
 Name: hdf5
 Description: HDF5 (Hierarchical Data Format 5) Software Library
$
```