### PR TITLE
Add ExtUtils-Builder Perl distribution

### DIFF
--- a/components/perl/ExtUtils-Builder/.gitignore
+++ b/components/perl/ExtUtils-Builder/.gitignore
@@ -1,0 +1,1 @@
+/ExtUtils-Builder-0.020/

--- a/components/perl/ExtUtils-Builder/ExtUtils-Builder-PERLVER.p5m
+++ b/components/perl/ExtUtils-Builder/ExtUtils-Builder-PERLVER.p5m
@@ -1,0 +1,74 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Code.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Command.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Composite.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Function.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Perl.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Primitive.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::CPAN::Tool.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::MakeMaker.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Node.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Plan.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Planner.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Planner::Extension.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Serializer.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Util.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Code.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Command.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Composite.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Function.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Perl.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Primitive.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/CPAN/Tool.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet/Filter.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet/Free.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet/Subst.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/MakeMaker.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Node.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Plan.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Planner.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Planner/Extension.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Serializer.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Util.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/cpan-meta-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/extutils-config-$(PLV)@0.9
+depend type=require fmri=pkg:/library/perl-5/extutils-helpers-$(PLV)@0.27
+depend type=require fmri=pkg:/library/perl-5/extutils-makemaker-$(PLV)@6.68
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/perl-ostype-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/scalar-list-utils-$(PLV)@1.45

--- a/components/perl/ExtUtils-Builder/Makefile
+++ b/components/perl/ExtUtils-Builder/Makefile
@@ -1,0 +1,41 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module ExtUtils-Builder
+#
+
+BUILD_STYLE = makemaker
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		ExtUtils-Builder
+HUMAN_VERSION =			0.020
+COMPONENT_SUMMARY =		An abstract representation of build processes
+COMPONENT_CPAN_AUTHOR =		LEONT
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:52d651e3aa0327250e47987d45ff48e9cc90b5b7bd2fb0ff3f78783e532affcc
+COMPONENT_LICENSE =		Artistic-1.0-Perl OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES.perl += library/perl-5/cpan-meta
+REQUIRED_PACKAGES.perl += library/perl-5/extutils-config
+REQUIRED_PACKAGES.perl += library/perl-5/extutils-helpers
+REQUIRED_PACKAGES.perl += library/perl-5/extutils-makemaker
+REQUIRED_PACKAGES.perl += library/perl-5/parent
+REQUIRED_PACKAGES.perl += library/perl-5/perl-ostype
+REQUIRED_PACKAGES.perl += library/perl-5/scalar-list-utils
+REQUIRED_PACKAGES.perl += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/ExtUtils-Builder/manifests/sample-manifest.p5m
+++ b/components/perl/ExtUtils-Builder/manifests/sample-manifest.p5m
@@ -1,0 +1,74 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Code.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Command.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Composite.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Function.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Perl.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Action::Primitive.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::CPAN::Tool.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::MakeMaker.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Node.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Plan.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Planner.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Planner::Extension.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Serializer.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Util.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Code.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Command.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Composite.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Function.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Perl.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Action/Primitive.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/CPAN/Tool.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet/Filter.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet/Free.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/FileSet/Subst.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/MakeMaker.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Node.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Plan.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Planner.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Planner/Extension.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Serializer.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Util.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/cpan-meta-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/extutils-config-$(PLV)@0.9
+depend type=require fmri=pkg:/library/perl-5/extutils-helpers-$(PLV)@0.27
+depend type=require fmri=pkg:/library/perl-5/extutils-makemaker-$(PLV)@6.68
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/perl-ostype-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/scalar-list-utils-$(PLV)@1.45

--- a/components/perl/ExtUtils-Builder/pkg5
+++ b/components/perl/ExtUtils-Builder/pkg5
@@ -1,0 +1,35 @@
+{
+    "dependencies": [
+        "library/perl-5/cpan-meta-538",
+        "library/perl-5/cpan-meta-540",
+        "library/perl-5/cpan-meta-542",
+        "library/perl-5/extutils-config-538",
+        "library/perl-5/extutils-config-540",
+        "library/perl-5/extutils-config-542",
+        "library/perl-5/extutils-helpers-538",
+        "library/perl-5/extutils-helpers-540",
+        "library/perl-5/extutils-helpers-542",
+        "library/perl-5/extutils-makemaker-538",
+        "library/perl-5/extutils-makemaker-540",
+        "library/perl-5/extutils-makemaker-542",
+        "library/perl-5/parent-538",
+        "library/perl-5/parent-540",
+        "library/perl-5/parent-542",
+        "library/perl-5/perl-ostype-538",
+        "library/perl-5/perl-ostype-540",
+        "library/perl-5/perl-ostype-542",
+        "library/perl-5/scalar-list-utils-538",
+        "library/perl-5/scalar-list-utils-540",
+        "library/perl-5/scalar-list-utils-542",
+        "runtime/perl-538",
+        "runtime/perl-540",
+        "runtime/perl-542"
+    ],
+    "fmris": [
+        "library/perl-5/extutils-builder",
+        "library/perl-5/extutils-builder-538",
+        "library/perl-5/extutils-builder-540",
+        "library/perl-5/extutils-builder-542"
+    ],
+    "name": "ExtUtils-Builder"
+}

--- a/components/perl/ExtUtils-Builder/test/results-all.master
+++ b/components/perl/ExtUtils-Builder/test/results-all.master
@@ -1,0 +1,14 @@
+t/00-compile.t .......... ok
+t/10-action-code.t ...... ok
+t/10-action-command.t ... ok
+t/10-action-function.t .. ok
+t/20-node.t ............. ok
+t/30-plan.t ............. ok
+t/35-planner.t .......... ok
+t/35-serializer.t ....... ok
+t/36-dsl.t .............. ok
+t/37-fileset.t .......... ok
+t/40-eumm-plan.t ........ ok
+All tests successful.
+Files=11, Tests=92
+Result: PASS


### PR DESCRIPTION
This is transitionally needed for new `Crypt-DSA`:

- the new `Crypt-DSA` needs `Crypt-SysRandom` (not packaged yet),
- `Crypt-SysRandom` needs `Crypt-SysRandom-XS` (not packaged yet),
- `Crypt-SysRandom-XS` needs `Dist-Build` (not packaged yet),
- `Dist-Build` needs `ExtUtils-Builder`.