### PR TITLE
Add ExtUtils-Builder-Compiler Perl distribution

### DIFF
--- a/components/perl/ExtUtils-Builder-Compiler/.gitignore
+++ b/components/perl/ExtUtils-Builder-Compiler/.gitignore
@@ -1,0 +1,1 @@
+/ExtUtils-Builder-Compiler-0.036/

--- a/components/perl/ExtUtils-Builder-Compiler/ExtUtils-Builder-Compiler-PERLVER.p5m
+++ b/components/perl/ExtUtils-Builder-Compiler/ExtUtils-Builder-Compiler-PERLVER.p5m
@@ -1,0 +1,70 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::ArgumentCollector.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::AutoDetect::C.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Binary.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::BuildTools::Base.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::BuildTools::FromPerl.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler::MSVC.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler::Unixy.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler::VMS.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Conf.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Linker.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::ParseXS.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Profile::Perl.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/ArgumentCollector.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/AutoDetect/C.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Binary.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/BuildTools/Base.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/BuildTools/FromPerl.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler/MSVC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler/Unixy.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler/VMS.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Conf.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/Ar.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/COFF.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/ELF/Any.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/ELF/GCC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/Mach/GCC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/PE/GCC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/PE/MSVC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/Unixy.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/XCOFF.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/ParseXS.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Profile/Perl.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/extutils-builder-$(PLV)@0.18
+depend type=require fmri=pkg:/library/perl-5/extutils-config-$(PLV)@0.7
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/perl-ostype-$(PLV)

--- a/components/perl/ExtUtils-Builder-Compiler/Makefile
+++ b/components/perl/ExtUtils-Builder-Compiler/Makefile
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module ExtUtils-Builder-Compiler
+#
+
+BUILD_STYLE = makemaker
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		ExtUtils-Builder-Compiler
+HUMAN_VERSION =			0.036
+COMPONENT_SUMMARY =		An interface around different compilers.
+COMPONENT_CPAN_AUTHOR =		LEONT
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:1582f7d6ae787852afe8f0dd063bc6f68a819df00f1f478e35629c9549cdf112
+COMPONENT_LICENSE =		Artistic-1.0-Perl OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES.perl += library/perl-5/extutils-builder
+REQUIRED_PACKAGES.perl += library/perl-5/extutils-config
+REQUIRED_PACKAGES.perl += library/perl-5/extutils-makemaker
+REQUIRED_PACKAGES.perl += library/perl-5/parent
+REQUIRED_PACKAGES.perl += library/perl-5/perl-ostype
+REQUIRED_PACKAGES.perl += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-differences
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/ExtUtils-Builder-Compiler/manifests/sample-manifest.p5m
+++ b/components/perl/ExtUtils-Builder-Compiler/manifests/sample-manifest.p5m
@@ -1,0 +1,70 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::ArgumentCollector.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::AutoDetect::C.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Binary.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::BuildTools::Base.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::BuildTools::FromPerl.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler::MSVC.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler::Unixy.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Compiler::VMS.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Conf.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Linker.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::ParseXS.3perl
+file path=usr/perl5/$(PERLVER)/man/man3perl/ExtUtils::Builder::Profile::Perl.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/ArgumentCollector.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/AutoDetect/C.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Binary.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/BuildTools/Base.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/BuildTools/FromPerl.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler/MSVC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler/Unixy.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Compiler/VMS.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Conf.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/Ar.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/COFF.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/ELF/Any.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/ELF/GCC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/Mach/GCC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/PE/GCC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/PE/MSVC.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/Unixy.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Linker/XCOFF.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/ParseXS.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/ExtUtils/Builder/Profile/Perl.pm
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata
+depend type=require fmri=pkg:/library/perl-5/extutils-builder-$(PLV)@0.18
+depend type=require fmri=pkg:/library/perl-5/extutils-config-$(PLV)@0.7
+depend type=require fmri=pkg:/library/perl-5/parent-$(PLV)
+depend type=require fmri=pkg:/library/perl-5/perl-ostype-$(PLV)

--- a/components/perl/ExtUtils-Builder-Compiler/pkg5
+++ b/components/perl/ExtUtils-Builder-Compiler/pkg5
@@ -1,0 +1,29 @@
+{
+    "dependencies": [
+        "library/perl-5/extutils-builder-538",
+        "library/perl-5/extutils-builder-540",
+        "library/perl-5/extutils-builder-542",
+        "library/perl-5/extutils-config-538",
+        "library/perl-5/extutils-config-540",
+        "library/perl-5/extutils-config-542",
+        "library/perl-5/extutils-makemaker-538",
+        "library/perl-5/extutils-makemaker-540",
+        "library/perl-5/extutils-makemaker-542",
+        "library/perl-5/parent-538",
+        "library/perl-5/parent-540",
+        "library/perl-5/parent-542",
+        "library/perl-5/perl-ostype-538",
+        "library/perl-5/perl-ostype-540",
+        "library/perl-5/perl-ostype-542",
+        "runtime/perl-538",
+        "runtime/perl-540",
+        "runtime/perl-542"
+    ],
+    "fmris": [
+        "library/perl-5/extutils-builder-compiler",
+        "library/perl-5/extutils-builder-compiler-538",
+        "library/perl-5/extutils-builder-compiler-540",
+        "library/perl-5/extutils-builder-compiler-542"
+    ],
+    "name": "ExtUtils-Builder-Compiler"
+}

--- a/components/perl/ExtUtils-Builder-Compiler/test/results-all.master
+++ b/components/perl/ExtUtils-Builder-Compiler/test/results-all.master
@@ -1,0 +1,7 @@
+t/30-compiler-unixy.t ............ ok
+t/30-linker-elf-gcc.t ............ ok
+t/40-fromperl-executable.t ....... ok
+t/40-fromperl-loadable-object.t .. ok
+All tests successful.
+Files=4, Tests=26
+Result: PASS


### PR DESCRIPTION
This is transitionally needed for new `Crypt-DSA`:

- the new `Crypt-DSA` needs `Crypt-SysRandom` (not packaged yet),
- `Crypt-SysRandom` needs `Crypt-SysRandom-XS` (not packaged yet),
- `Crypt-SysRandom-XS` needs `Dist-Build` (not packaged yet),
- `Dist-Build` needs `ExtUtils-Builder-Compiler`.