### PR TITLE
Add Crypt-SysRandom-XS Perl distribution

### DIFF
--- a/components/perl/Crypt-SysRandom-XS/.gitignore
+++ b/components/perl/Crypt-SysRandom-XS/.gitignore
@@ -1,0 +1,1 @@
+/Crypt-SysRandom-XS-0.011/

--- a/components/perl/Crypt-SysRandom-XS/Crypt-SysRandom-XS-PERLVER.p5m
+++ b/components/perl/Crypt-SysRandom-XS/Crypt-SysRandom-XS-PERLVER.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using perl-integrate-module
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Crypt::SysRandom::XS.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/Crypt/SysRandom/XS.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/auto/Crypt/SysRandom/XS/XS.so
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/perl/Crypt-SysRandom-XS/Makefile
+++ b/components/perl/Crypt-SysRandom-XS/Makefile
@@ -1,0 +1,36 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# This file was automatically generated using the following command:
+#   $WS_TOOLS/perl-integrate-module Crypt-SysRandom-XS
+#
+
+BUILD_STYLE = modulebuild
+
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME =		Crypt-SysRandom-XS
+HUMAN_VERSION =			0.011
+COMPONENT_SUMMARY =		Perl interface to system randomness, XS version
+COMPONENT_CPAN_AUTHOR =		LEONT
+COMPONENT_ARCHIVE_HASH =	\
+	sha256:80e566e3e45aeba2ad05086b3dac18a52f35dde0dc9cfc8da1827e1d17ee2297
+COMPONENT_LICENSE =		Artistic-1.0-Perl OR GPL-1.0-or-later
+COMPONENT_LICENSE_FILE =	LICENSE
+
+include $(WS_MAKE_RULES)/common.mk
+
+# Auto-generated dependencies
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES.perl += library/perl-5/dist-build
+REQUIRED_PACKAGES.perl += runtime/perl
+TEST_REQUIRED_PACKAGES.perl += library/perl-5/test-simple

--- a/components/perl/Crypt-SysRandom-XS/manifests/sample-manifest.p5m
+++ b/components/perl/Crypt-SysRandom-XS/manifests/sample-manifest.p5m
@@ -1,0 +1,34 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)-$(PLV)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/perl5/$(PERLVER)/man/man3perl/Crypt::SysRandom::XS.3perl
+file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/Crypt/SysRandom/XS.pm
+file path=usr/perl5/vendor_perl/$(PERLVER)/$(PERL_ARCH)/auto/Crypt/SysRandom/XS/XS.so
+
+# perl modules are unusable without perl runtime binary
+depend type=require fmri=__TBD pkg.debug.depend.file=perl \
+    pkg.debug.depend.path=usr/perl5/$(PERLVER)/bin
+
+# Automatically generated dependencies based on distribution metadata

--- a/components/perl/Crypt-SysRandom-XS/pkg5
+++ b/components/perl/Crypt-SysRandom-XS/pkg5
@@ -1,0 +1,18 @@
+{
+    "dependencies": [
+        "library/perl-5/dist-build-538",
+        "library/perl-5/dist-build-540",
+        "library/perl-5/dist-build-542",
+        "runtime/perl-538",
+        "runtime/perl-540",
+        "runtime/perl-542",
+        "system/library"
+    ],
+    "fmris": [
+        "library/perl-5/crypt-sysrandom-xs",
+        "library/perl-5/crypt-sysrandom-xs-538",
+        "library/perl-5/crypt-sysrandom-xs-540",
+        "library/perl-5/crypt-sysrandom-xs-542"
+    ],
+    "name": "Crypt-SysRandom-XS"
+}

--- a/components/perl/Crypt-SysRandom-XS/test/results-all.master
+++ b/components/perl/Crypt-SysRandom-XS/test/results-all.master
@@ -1,0 +1,6 @@
+prove
+t/00-compile.t .. ok
+t/basic.t ....... ok
+All tests successful.
+Files=2, Tests=4
+Result: PASS


### PR DESCRIPTION
This is transitionally needed for new `Crypt-DSA`:

- the new `Crypt-DSA` needs `Crypt-SysRandom` (not packaged yet),
- `Crypt-SysRandom` needs `Crypt-SysRandom-XS`.