### PR TITLE
bind: update to 9.20.23

### DIFF
--- a/components/network/bind/Makefile
+++ b/components/network/bind/Makefile
@@ -29,7 +29,7 @@ USE_DEFAULT_TEST_TRANSFORMS= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		bind
-COMPONENT_VERSION=	9.20.22
+COMPONENT_VERSION=	9.20.23
 COMPONENT_SUMMARY=	BIND DNS name server and configuration tools.
 COMPONENT_DESCRIPTION=	BIND is open source software that implements the Domain Name System \
                         (DNS) protocols for the Internet.  This package contains the DNS \
@@ -37,7 +37,7 @@ COMPONENT_DESCRIPTION=	BIND is open source software that implements the Domain N
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.xz
 COMPONENT_PROJECT_URL=	https://www.isc.org/software/bind/
-COMPONENT_ARCHIVE_HASH=	sha256:cba92ff631b949655f475fe4b54290f6860fd0070d399f2279f6437c0d383ec6
+COMPONENT_ARCHIVE_HASH=	sha256:5d4475aed3f9e500ef554b2b14d972bdb83d33de214a9b3be92918ea46908371
 COMPONENT_ARCHIVE_URL=	https://ftp.isc.org/isc/bind9/$(COMPONENT_VERSION)/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		network/dns/$(COMPONENT_NAME)
 COMPONENT_CLASSIFICATION=	Applications/Internet

--- a/components/network/bind/Solaris/server.xml
+++ b/components/network/bind/Solaris/server.xml
@@ -35,36 +35,36 @@ Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
   type='service'
   version='1'>
 
-    <dependency
-      name='filesystem_minimal'
-      grouping='require_all'
-      restart_on='none'
-      type='service'>
-      <service_fmri value='svc:/system/filesystem/local' />
-    </dependency>
-
-    <dependency
-      name='loopback'
-      grouping='require_any'
-      restart_on='error'
-      type='service'>
-      <service_fmri value='svc:/network/loopback' />
-    </dependency>
-
-    <dependency
-      name='network'
-      grouping='optional_all'
-      restart_on='error'
-      type='service'>
-      <service_fmri value='svc:/milestone/network' />
-    </dependency>
-
     <!--
       	In order to run multiple named(1M) processes with their own
       	configuration file or properties each must have a unique
       	instance.
     -->
     <instance name='default' enabled='false' >
+
+      <dependency
+	name='filesystem_minimal'
+	grouping='require_all'
+	restart_on='none'
+	type='service'>
+	<service_fmri value='svc:/system/filesystem/local' />
+      </dependency>
+
+      <dependency
+	name='loopback'
+	grouping='require_any'
+	restart_on='error'
+	type='service'>
+	<service_fmri value='svc:/network/loopback' />
+      </dependency>
+
+      <dependency
+	name='network'
+	grouping='optional_all'
+	restart_on='error'
+	type='service'>
+	<service_fmri value='svc:/milestone/network' />
+      </dependency>
 
       <exec_method
 	type='method'


### PR DESCRIPTION
Fix SMF manifest to move dependencies to the service instance; avoids clash with unbound manifest which installs to a different instance of the same SMF service.

On my development machine, tests proxystream_test, tcp_test, and tls_test are all flaky -- they sometimes pass and sometimes fail.