### PR TITLE
sysutils/cmatrix: Add cmatrix version 2.0

### DIFF
--- a/components/sysutils/cmatrix/Makefile
+++ b/components/sysutils/cmatrix/Makefile
@@ -1,0 +1,45 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have been accompanied
+# with this source.  A copy of the CDDL is also available via the
+# Internet at http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Akad Arpad Padak <akadarpadpadak@hotmail.com>
+#
+
+BUILD_BITS=		64
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=		cmatrix
+COMPONENT_VERSION=	2.0
+COMPONENT_SUMMARY=	Terminal based Matrix screensaver
+COMPONENT_PROJECT_URL=	https://github.com/abishekvashok/cmatrix
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=	https://github.com/abishekvashok/cmatrix/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_FMRI=		sysutils/cmatrix
+COMPONENT_CLASSIFICATION=	Applications/Accessories
+COMPONENT_LICENSE=	GPLv3
+COMPONENT_LICENSE_FILE=	COPYING
+
+include ../../../make-rules/prep.mk
+include ../../../make-rules/configure.mk
+include ../../../make-rules/ips.mk
+
+CONFIGURE_OPTIONS += --with-ncurses
+CFLAGS            += -I/usr/include/ncurses
+
+COMPONENT_BUILD_ARGS =
+COMPONENT_INSTALL_ARGS = DESTDIR=$(PROTODIR) install
+
+build:		$(BUILD_64)
+
+install:	$(INSTALL_64)
+
+test:		$(TEST_64)

--- a/components/sysutils/cmatrix/cmatrix.p5m
+++ b/components/sysutils/cmatrix/cmatrix.p5m
@@ -1,0 +1,33 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have been accompanied
+# with this source.  A copy of the CDDL is also available via the
+# Internet at http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Akad Arpad Padak <akadarpadpadak@hotmail.com>
+#
+
+set name=pkg.fmri value=pkg:/sysutils/cmatrix@2.0,5.11-1
+set name=pkg.summary value="Terminal based Matrix screensaver"
+set name=pkg.description value="A stylish terminal based Matrix screensaver clone using ncurses."
+set name=pkg.human-version value=2.0
+set name=info.classification value=org.opensolaris.category.2008:Applications/Accessories
+
+dir  path=usr owner=root group=sys mode=0755
+dir  path=usr/bin owner=root group=bin mode=0755
+file path=usr/bin/cmatrix owner=root group=bin mode=0755
+dir  path=usr/share owner=root group=sys mode=0755
+dir  path=usr/share/doc owner=root group=other mode=0755
+dir  path=usr/share/doc/cmatrix owner=root group=bin mode=0755
+file path=usr/share/doc/cmatrix/COPYING owner=root group=bin mode=0644
+dir  path=usr/share/man owner=root group=bin mode=0755
+dir  path=usr/share/man/man1 owner=root group=bin mode=0755
+file path=usr/share/man/man1/cmatrix.1 owner=root group=bin mode=0644
+
+license COPYING license=GPLv3


### PR DESCRIPTION
Hi, 

This PR adds the `cmatrix` (https://github.com/abishekvashok/cmatrix)  terminal screensaver clone to OpenIndiana. 
The component has been created under `sysutils/cmatrix` with its respective CDDL headers, Makefile rules, and clean IPS manifest attributes. 

Verified and tested to be working on illumos amd64. Please review and merge. 

Thanks!