### PR TITLE
claws-mail: rebuild for new libetpan

### DIFF
--- a/components/mail/claws-mail/Makefile
+++ b/components/mail/claws-mail/Makefile
@@ -20,6 +20,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		claws-mail
 COMPONENT_VERSION=	4.4.0
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	The user-friendly, lightweight, and fast email client
 COMPONENT_PROJECT_URL=	https://www.claws-mail.org
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)


### PR DESCRIPTION
This needs to be built after the new libetpan is published