### PR TITLE
gcc-13, gcc-14: fix COMPONENT_TEST_TRANSFORMS typo

### DIFF
--- a/components/developer/gcc-13/Makefile
+++ b/components/developer/gcc-13/Makefile
@@ -16,7 +16,7 @@ USE_PARALLEL_BUILD = yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_VERSION= 13.4.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SRC= gcc-releases-gcc-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_URL= https://github.com/gcc-mirror/gcc/archive/releases/$(COMPONENT_ARCHIVE)
@@ -82,7 +82,7 @@ CONFIGURE_OPTIONS += --with-diagnostics-urls=auto-if-env
 CONFIGURE_OPTIONS += enable_frame_pointer=yes
 
 COMPONENT_TEST_ENV += LC_ALL=C.UTF-8
-COMPONEMT_TEST_TRANSFORMS= -n \
+COMPONENT_TEST_TRANSFORMS= -n \
     "-e '/Running/p' " \
     "-e '/Summary/p' " \
     "-e '/\# of/p' "

--- a/components/developer/gcc-14/Makefile
+++ b/components/developer/gcc-14/Makefile
@@ -17,7 +17,7 @@ BOOTSTRAP_COMPONENT= no
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_VERSION= 14.3.0
-COMPONENT_REVISION= 1
+COMPONENT_REVISION= 2
 COMPONENT_SRC= gcc-releases-gcc-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE= $(COMPONENT_NAME)-$(COMPONENT_VERSION).tar.gz
 COMPONENT_ARCHIVE_URL= https://github.com/gcc-mirror/gcc/archive/releases/$(COMPONENT_ARCHIVE)
@@ -84,7 +84,7 @@ CONFIGURE_OPTIONS += enable_frame_pointer=yes
 
 COMPONENT_TEST_ENV += LC_ALL=C.UTF-8
 
-COMPONEMT_TEST_TRANSFORMS= -n \
+COMPONENT_TEST_TRANSFORMS= -n \
 	"-e '/Running/p' " \
 	"-e '/Summary/p' " \
 	"-e '/\# of/p' "


### PR DESCRIPTION
Variable was misspelled which broke test result reduction.  Does not affect package contents; patching it so the typo doesn't get copied again.