### PR TITLE
openssh: update to 10.4p1

### DIFF
--- a/components/network/openssh/Makefile
+++ b/components/network/openssh/Makefile
@@ -29,15 +29,14 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=		openssh
 #   OpenSSH <x>.<y>p<n>     => IPS <x>.<y>.0.<n>
 #   OpenSSH <x>.<y>.<z>p<n> => IPS <x>.<y>.<z>.<n>
-COMPONENT_VERSION=	10.3.0.1
-COMPONENT_REVISION=	1
-HUMAN_VERSION=		10.3p1
+COMPONENT_VERSION=	10.4.0.1
+HUMAN_VERSION=		10.4p1
 COMPONENT_SUMMARY=	OpenSSH client and associated utilities
 # OpenSSH made a mistake when releasing openssh 10.0p1 which identifies itself as 10.0p2.
 COMPONENT_SRC=		$(COMPONENT_NAME)-$(HUMAN_VERSION)
 COMPONENT_PROJECT_URL=	https://www.openssh.org
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:56682a36bb92dcf4b4f016fd8ec8e74059b79a8de25c15d670d731e7d18e45f4
+COMPONENT_ARCHIVE_HASH=	sha256:ef6026dd2aea8d56059638d5d3262902c892ceba9f88395835e0d06d3fb63238
 COMPONENT_ARCHIVE_URL=	https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=	network/ssh
 COMPONENT_LICENSE=	BSD, BSD-like

--- a/components/network/openssh/patches/0001-Skip-config-check.patch
+++ b/components/network/openssh/patches/0001-Skip-config-check.patch
@@ -7,17 +7,18 @@ Subject: [PATCH 01/34] Skip config check
 # This change is to remove some misleading error messages when running
 # "gmake install". OpenSSH mixes the building and running together. Some
 # system setup checking for running the program needs to be removed, because
-# they are not suitable in a build system.  This is for Solaris only, so we
+# they are not suitable in a build system.  This is for illumos only, so we
 # will not contribute back this change to the upstream community.
 #
---- openssh-10.3p1/Makefile.in.orig
-+++ openssh-10.3p1/Makefile.in
-@@ -418,7 +418,16 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/Makefile.in a/Makefile.in
+--- a~/Makefile.in	1970-01-01 00:00:00
++++ a/Makefile.in	1970-01-01 00:00:00
+@@ -427,7 +427,16 @@ install-nokeys: $(CONFIGFILES) $(MANPAGE
  install-nosysconf: $(CONFIGFILES) $(MANPAGES) $(TARGETS) install-files
  
  check-config:
 -	-$(DESTDIR)$(sbindir)/sshd -t -f $(DESTDIR)$(sysconfdir)/sshd_config
-+# On Solaris, to workaround OpenSSH's unlucky mixing of 'building ssh' and
++# On illumos, to workaround OpenSSH's unlucky mixing of 'building ssh' and
 +# 'running ssh', on build machine the following requisites shouldn't be
 +# enforced:
 +#     1) existence of privsep user sshd
@@ -26,7 +27,7 @@ Subject: [PATCH 01/34] Skip config check
 +#
 +#	-$(DESTDIR)$(sbindir)/sshd -t -f $(DESTDIR)$(sysconfdir)/sshd_config
 +#
-+	@echo 'Oracle Solaris: skipping check-config'
++	@echo 'illumos: skipping check-config'
  
  install-files:
  	$(MKDIR_P) $(DESTDIR)$(bindir)

--- a/components/network/openssh/patches/0002-PAM-Support.patch
+++ b/components/network/openssh/patches/0002-PAM-Support.patch
@@ -4,36 +4,23 @@ Date: Mon, 3 Aug 2015 14:34:19 -0700
 Subject: [PATCH 02/34] PAM Support
 
 #
-# To comply to the Solaris PAM policy, the UsePAM option is changed to be
-# always on and not configurable on Solaris.  This is for Solaris only, so we
+# To comply to the illumos PAM policy, the UsePAM option is changed to be
+# always on and not configurable on illumos.  This is for illumos only, so we
 # will not contribute the changes to the upstream community.
 #
 
---- openssh-10.3p1/servconf.c.orig
-+++ openssh-10.3p1/servconf.c
-@@ -295,7 +295,12 @@
- 
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
+@@ -1172,8 +1172,16 @@ process_server_config_line_depth(ServerO
  	/* Portable-specific options */
- 	if (options->use_pam == -1)
-+#ifdef SET_USE_PAM
-+		/* use_pam should be always set to 1 on Solaris */
-+		options->use_pam = 1;
-+#else
- 		options->use_pam = 0;
-+#endif
- 	if (options->pam_service_name == NULL)
- 		options->pam_service_name = xstrdup(SSHD_PAM_SERVICE);
- 
-@@ -1390,8 +1395,17 @@
- 	switch (opcode) {
- 	/* Portable-specific options */
+ #ifdef USE_PAM
  	case sUsePAM:
 +#ifdef SET_USE_PAM
-+		/* UsePAM is always on and not configurable on Solaris */
++		/* UsePAM is always on and not configurable on illumos */
 +		logit("%s line %d: ignoring UsePAM option value."
 +		    " This option is always on.", filename, linenum);
-+		while (arg)
-+			arg = strdelim(&str);
++		argv_consume(&ac);
 +		break;
 +#else
  		intptr = &options->use_pam;
@@ -42,3 +29,15 @@ Subject: [PATCH 02/34] PAM Support
  	case sPAMServiceName:
  		charptr = &options->pam_service_name;
  		arg = argv_next(&ac, &av);
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.h a/servconf.h
+--- a~/servconf.h	1970-01-01 00:00:00
++++ a/servconf.h	1970-01-01 00:00:00
+@@ -272,7 +272,7 @@ SSHCONF_ALIAS(KeepAlive, TCPKeepAlive, S
+ 
+ #ifdef USE_PAM
+ #define SSHD_CONFIG_ENTRIES_PAM \
+-SSHCONF_INTFLAG(use_pam, UsePAM, SSHCFG_GLOBAL, 0, SSHCFG_COPY_NONE) \
++SSHCONF_INTFLAG(use_pam, UsePAM, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
+ SSHCONF_STRING(pam_service_name, PAMServiceName, SSHCFG_GLOBAL, SSHCFG_COPY_NONE)
+ #else
+ #define SSHD_CONFIG_ENTRIES_PAM \

--- a/components/network/openssh/patches/0003-lastlogin.patch
+++ b/components/network/openssh/patches/0003-lastlogin.patch
@@ -3,20 +3,21 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:34:41 -0700
 Subject: [PATCH 03/34] lastlogin
 
---- openssh-10.3p1/sshd_config.5.orig
-+++ openssh-10.3p1/sshd_config.5
-@@ -1710,8 +1710,8 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd_config.5 a/sshd_config.5
+--- a~/sshd_config.5	1970-01-01 00:00:00
++++ a/sshd_config.5	1970-01-01 00:00:00
+@@ -1718,8 +1718,8 @@ Specifies whether
  .Xr sshd 8
  should print the date and time of the last user login when a user logs
  in interactively.
 -The default is
 -.Cm yes .
-+On OmniOS this option is always ignored since pam_unix_session(7)
++On OpenIndiana this option is always ignored since pam_unix_session(7)
 +reports the last login time.
  .It Cm PrintMotd
  Specifies whether
  .Xr sshd 8
-@@ -2268,7 +2268,8 @@
+@@ -2276,7 +2276,8 @@ This file should be writable by root onl
  .El
  .Sh SEE ALSO
  .Xr sftp-server 8 ,

--- a/components/network/openssh/patches/0006-GSS-store-creds-for-Solaris.patch
+++ b/components/network/openssh/patches/0006-GSS-store-creds-for-Solaris.patch
@@ -1,23 +1,25 @@
 From 8952e72b9cf0f8a14d728feaeb2f5fe85ebbeae0 Mon Sep 17 00:00:00 2001
 From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:35:34 -0700
-Subject: [PATCH 06/34] GSS store creds for Solaris
+Subject: [PATCH 06/34] GSS store creds for illumos
 
---- openssh-10.3p1/configure.ac.orig
-+++ openssh-10.3p1/configure.ac
-@@ -1283,6 +1283,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -1283,6 +1283,9 @@ if (setsockopt(s, IPPROTO_IP, IP_TOS, &o
  		],
  	)
  	TEST_SHELL=$SHELL	# let configure find us a capable shell
-+	AC_DEFINE([USE_GSS_STORE_CRED], [1], [Use the Solaris-style GSS cred store])
++	AC_DEFINE([USE_GSS_STORE_CRED], [1], [Use the illumos-style GSS cred store])
 +	AC_DEFINE([GSSAPI_STORECREDS_NEEDS_RUID], [1], [GSSAPI storecreds needs ruid])
 +	AC_DEFINE([HAVE_PAM_AUSER], [1], [pam_auser])
  	;;
  *-*-sunos4*)
  	CPPFLAGS="$CPPFLAGS -DSUNOS4"
---- openssh-10.3p1/gss-serv-krb5.c.orig
-+++ openssh-10.3p1/gss-serv-krb5.c
-@@ -109,7 +109,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/gss-serv-krb5.c a/gss-serv-krb5.c
+--- a~/gss-serv-krb5.c	1970-01-01 00:00:00
++++ a/gss-serv-krb5.c	1970-01-01 00:00:00
+@@ -109,7 +109,7 @@ ssh_gssapi_krb5_userok(ssh_gssapi_client
  	return retval;
  }
  
@@ -26,7 +28,7 @@ Subject: [PATCH 06/34] GSS store creds for Solaris
  /* This writes out any forwarded credentials from the structure populated
   * during userauth. Called after we have setuid to the user */
  
-@@ -195,6 +195,7 @@
+@@ -195,6 +195,7 @@ ssh_gssapi_krb5_storecreds(ssh_gssapi_cl
  
  	return;
  }
@@ -34,7 +36,7 @@ Subject: [PATCH 06/34] GSS store creds for Solaris
  
  ssh_gssapi_mech gssapi_kerberos_mech = {
  	"toWM5Slw5Ew8Mqkay+al2g==",
-@@ -203,7 +204,11 @@
+@@ -203,7 +204,11 @@ ssh_gssapi_mech gssapi_kerberos_mech = {
  	NULL,
  	&ssh_gssapi_krb5_userok,
  	NULL,
@@ -46,8 +48,9 @@ Subject: [PATCH 06/34] GSS store creds for Solaris
  };
  
  #endif /* KRB5 */
---- openssh-10.3p1/gss-serv.c.orig
-+++ openssh-10.3p1/gss-serv.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/gss-serv.c a/gss-serv.c
+--- a~/gss-serv.c	1970-01-01 00:00:00
++++ a/gss-serv.c	1970-01-01 00:00:00
 @@ -46,6 +46,7 @@
  #include "session.h"
  #include "misc.h"
@@ -56,7 +59,7 @@ Subject: [PATCH 06/34] GSS store creds for Solaris
  
  #include "ssh-gss.h"
  
-@@ -321,18 +322,61 @@
+@@ -321,18 +322,61 @@ ssh_gssapi_getclient(Gssctxt *ctx, ssh_g
  void
  ssh_gssapi_cleanup_creds(void)
  {
@@ -118,7 +121,7 @@ Subject: [PATCH 06/34] GSS store creds for Solaris
  	if (options.gss_deleg_creds == 0) {
  		debug_f("delegate credential is disabled, doing nothing");
  		return;
-@@ -342,6 +386,7 @@
+@@ -342,6 +386,7 @@ ssh_gssapi_storecreds(void)
  		(*gssapi_client.mech->storecreds)(&gssapi_client);
  	} else
  		debug("ssh_gssapi_storecreds: Not a GSSAPI mechanism");
@@ -126,23 +129,58 @@ Subject: [PATCH 06/34] GSS store creds for Solaris
  }
  
  /* This allows GSSAPI methods to do things to the child's environment based
---- openssh-10.3p1/servconf.c.orig
-+++ openssh-10.3p1/servconf.c
-@@ -654,7 +654,11 @@
- 	{ "afstokenpassing", sUnsupported, SSHCFG_GLOBAL },
- #ifdef GSSAPI
- 	{ "gssapiauthentication", sGssAuthentication, SSHCFG_ALL },
-+#ifdef USE_GSS_STORE_CRED
-+	{ "gssapicleanupcredentials", sUnsupported, SSHCFG_GLOBAL },
-+#else /* USE_GSS_STORE_CRED */
- 	{ "gssapicleanupcredentials", sGssCleanupCreds, SSHCFG_GLOBAL },
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
+@@ -1445,9 +1445,11 @@ process_server_config_line_depth(ServerO
+ 		intptr = &options->gss_authentication;
+ 		goto parse_flag;
+ 
++#ifndef USE_GSS_STORE_CRED
+ 	case sGssCleanupCreds:
+ 		intptr = &options->gss_cleanup_creds;
+ 		goto parse_flag;
 +#endif /* USE_GSS_STORE_CRED */
- 	{ "gssapidelegatecredentials", sGssDelegateCreds, SSHCFG_GLOBAL },
- 	{ "gssapistrictacceptorcheck", sGssStrictAcceptor, SSHCFG_GLOBAL },
- #else
---- openssh-10.3p1/sshd-session.c.orig
-+++ openssh-10.3p1/sshd-session.c
-@@ -1269,9 +1269,23 @@
+ 
+ 	case sGssDelegateCreds:
+ 		intptr = &options->gss_deleg_creds;
+@@ -4224,7 +4226,9 @@ dump_config(ServerOptions *o)
+ #endif
+ #ifdef GSSAPI
+ 	dump_cfg_fmtint(sGssAuthentication, o->gss_authentication);
++#ifndef USE_GSS_STORE_CRED
+ 	dump_cfg_fmtint(sGssCleanupCreds, o->gss_cleanup_creds);
++#endif /* USE_GSS_STORE_CRED */
+ 	dump_cfg_fmtint(sGssDelegateCreds, o->gss_deleg_creds);
+ 	dump_cfg_fmtint(sGssStrictAcceptor, o->gss_strict_acceptor);
+ #endif
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.h a/servconf.h
+--- a~/servconf.h	1970-01-01 00:00:00
++++ a/servconf.h	1970-01-01 00:00:00
+@@ -313,11 +313,19 @@ SSHCONF_UNSUPPORTED_INT(kerberos_get_afs
+ #endif /* KRB5 */
+ 
+ #ifdef GSSAPI
++#ifdef USE_GSS_STORE_CRED
++#define SSHD_CONFIG_ENTRIES_GSS \
++SSHCONF_INTFLAG(gss_authentication, GssAuthentication, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH) \
++SSHCONF_UNSUPPORTED_INT(gss_cleanup_creds, GssCleanupCreds, SSHCFG_GLOBAL) \
++SSHCONF_INTFLAG(gss_deleg_creds, GssDelegateCreds, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
++SSHCONF_INTFLAG(gss_strict_acceptor, GssStrictAcceptor, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE)
++#else	/* USE_GSS_STORE_CRED */
+ #define SSHD_CONFIG_ENTRIES_GSS \
+ SSHCONF_INTFLAG(gss_authentication, GssAuthentication, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH) \
+ SSHCONF_INTFLAG(gss_cleanup_creds, GssCleanupCreds, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
+ SSHCONF_INTFLAG(gss_deleg_creds, GssDelegateCreds, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
+ SSHCONF_INTFLAG(gss_strict_acceptor, GssStrictAcceptor, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE)
++#endif	/* USE_GSS_STORE_CRED */
+ #else /* GSSAPI */
+ #define SSHD_CONFIG_ENTRIES_GSS \
+ SSHCONF_UNSUPPORTED_INT(gss_authentication, GssAuthentication, SSHCFG_ALL) \
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd-session.c a/sshd-session.c
+--- a~/sshd-session.c	1970-01-01 00:00:00
++++ a/sshd-session.c	1970-01-01 00:00:00
+@@ -1270,9 +1270,23 @@ main(int ac, char **av)
  
  #ifdef GSSAPI
  	if (options.gss_authentication) {

--- a/components/network/openssh/patches/0006a-Restore-keywords-lost-in-servconf-refactor.patch
+++ b/components/network/openssh/patches/0006a-Restore-keywords-lost-in-servconf-refactor.patch
@@ -1,0 +1,106 @@
+Restore configuration keywords lost in the 10.4 servconf refactor
+
+The upstream servconf refactor in 10.4 generates the sshd option keyword
+table from the SSHD_CONFIG_ENTRIES macros, and in the process the GSSAPI
+options were accidentally renamed (GSSAPIAuthentication became
+GssAuthentication, etc.), breaking existing configuration files.
+
+The GSSAPI portion of this is a backport of upstream
+commit c147093565634eae9f91e4df99e04a6b3513f9c6 (bz3974) and can be
+dropped when updating to a release that contains it.
+
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
+@@ -1441,21 +1441,21 @@ process_server_config_line_depth(ServerO
+ #endif /* KRB5 */
+ 
+ #ifdef GSSAPI
+-	case sGssAuthentication:
++	case sGSSAPIAuthentication:
+ 		intptr = &options->gss_authentication;
+ 		goto parse_flag;
+ 
+ #ifndef USE_GSS_STORE_CRED
+-	case sGssCleanupCreds:
++	case sGSSAPICleanupCredentials:
+ 		intptr = &options->gss_cleanup_creds;
+ 		goto parse_flag;
+ #endif /* USE_GSS_STORE_CRED */
+ 
+-	case sGssDelegateCreds:
++	case sGSSAPIDelegateCredentials:
+ 		intptr = &options->gss_deleg_creds;
+ 		goto parse_flag;
+ 
+-	case sGssStrictAcceptor:
++	case sGSSAPIStrictAcceptorCheck:
+ 		intptr = &options->gss_strict_acceptor;
+ 		goto parse_flag;
+ #endif /* GSSAPI */
+@@ -4225,12 +4225,12 @@ dump_config(ServerOptions *o)
+ # endif
+ #endif
+ #ifdef GSSAPI
+-	dump_cfg_fmtint(sGssAuthentication, o->gss_authentication);
++	dump_cfg_fmtint(sGSSAPIAuthentication, o->gss_authentication);
+ #ifndef USE_GSS_STORE_CRED
+-	dump_cfg_fmtint(sGssCleanupCreds, o->gss_cleanup_creds);
++	dump_cfg_fmtint(sGSSAPICleanupCredentials, o->gss_cleanup_creds);
+ #endif /* USE_GSS_STORE_CRED */
+-	dump_cfg_fmtint(sGssDelegateCreds, o->gss_deleg_creds);
+-	dump_cfg_fmtint(sGssStrictAcceptor, o->gss_strict_acceptor);
++	dump_cfg_fmtint(sGSSAPIDelegateCredentials, o->gss_deleg_creds);
++	dump_cfg_fmtint(sGSSAPIStrictAcceptorCheck, o->gss_strict_acceptor);
+ #endif
+ 	dump_cfg_fmtint(sPasswordAuthentication, o->password_authentication);
+ 	dump_cfg_fmtint(sKbdInteractiveAuthentication,
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.h a/servconf.h
+--- a~/servconf.h	1970-01-01 00:00:00
++++ a/servconf.h	1970-01-01 00:00:00
+@@ -251,7 +251,8 @@ SSHCONF_DEPRECATE(AuthorizedKeysFile2, S
+ SSHCONF_DEPRECATE(UsePrivilegeSeparation, SSHCFG_GLOBAL, SSHCONF_DEPRECATED) \
+ SSHCONF_DEPRECATE(KerberosTgtPassing, SSHCFG_GLOBAL, SSHCONF_DEPRECATED) \
+ SSHCONF_DEPRECATE(AFSTokenPassing, SSHCFG_GLOBAL, SSHCONF_DEPRECATED) \
+-SSHCONF_DEPRECATE(Protocol, SSHCFG_GLOBAL, SSHCONF_IGNORE)
++SSHCONF_DEPRECATE(Protocol, SSHCFG_GLOBAL, SSHCONF_IGNORE) \
++SSHCONF_DEPRECATE(PAMAuthenticationViaKbdInt, SSHCFG_GLOBAL, SSHCONF_DEPRECATED)
+ 
+ #define SSHD_CONFIG_ENTRIES_ALIASES \
+ SSHCONF_ALIAS(HostDSAKey, HostKey, SSHCFG_GLOBAL) \
+@@ -315,23 +316,23 @@ SSHCONF_UNSUPPORTED_INT(kerberos_get_afs
+ #ifdef GSSAPI
+ #ifdef USE_GSS_STORE_CRED
+ #define SSHD_CONFIG_ENTRIES_GSS \
+-SSHCONF_INTFLAG(gss_authentication, GssAuthentication, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH) \
+-SSHCONF_UNSUPPORTED_INT(gss_cleanup_creds, GssCleanupCreds, SSHCFG_GLOBAL) \
+-SSHCONF_INTFLAG(gss_deleg_creds, GssDelegateCreds, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
+-SSHCONF_INTFLAG(gss_strict_acceptor, GssStrictAcceptor, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE)
++SSHCONF_INTFLAG(gss_authentication, GSSAPIAuthentication, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH) \
++SSHCONF_UNSUPPORTED_INT(gss_cleanup_creds, GSSAPICleanupCredentials, SSHCFG_GLOBAL) \
++SSHCONF_INTFLAG(gss_deleg_creds, GSSAPIDelegateCredentials, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
++SSHCONF_INTFLAG(gss_strict_acceptor, GSSAPIStrictAcceptorCheck, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE)
+ #else	/* USE_GSS_STORE_CRED */
+ #define SSHD_CONFIG_ENTRIES_GSS \
+-SSHCONF_INTFLAG(gss_authentication, GssAuthentication, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH) \
+-SSHCONF_INTFLAG(gss_cleanup_creds, GssCleanupCreds, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
+-SSHCONF_INTFLAG(gss_deleg_creds, GssDelegateCreds, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
+-SSHCONF_INTFLAG(gss_strict_acceptor, GssStrictAcceptor, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE)
++SSHCONF_INTFLAG(gss_authentication, GSSAPIAuthentication, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH) \
++SSHCONF_INTFLAG(gss_cleanup_creds, GSSAPICleanupCredentials, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
++SSHCONF_INTFLAG(gss_deleg_creds, GSSAPIDelegateCredentials, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
++SSHCONF_INTFLAG(gss_strict_acceptor, GSSAPIStrictAcceptorCheck, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE)
+ #endif	/* USE_GSS_STORE_CRED */
+ #else /* GSSAPI */
+ #define SSHD_CONFIG_ENTRIES_GSS \
+-SSHCONF_UNSUPPORTED_INT(gss_authentication, GssAuthentication, SSHCFG_ALL) \
+-SSHCONF_UNSUPPORTED_INT(gss_cleanup_creds, GssCleanupCreds, SSHCFG_GLOBAL) \
+-SSHCONF_UNSUPPORTED_INT(gss_deleg_creds, GssDelegateCreds, SSHCFG_GLOBAL) \
+-SSHCONF_UNSUPPORTED_INT(gss_strict_acceptor, GssStrictAcceptor, SSHCFG_GLOBAL)
++SSHCONF_UNSUPPORTED_INT(gss_authentication, GSSAPIAuthentication, SSHCFG_ALL) \
++SSHCONF_UNSUPPORTED_INT(gss_cleanup_creds, GSSAPICleanupCredentials, SSHCFG_GLOBAL) \
++SSHCONF_UNSUPPORTED_INT(gss_deleg_creds, GSSAPIDelegateCredentials, SSHCFG_GLOBAL) \
++SSHCONF_UNSUPPORTED_INT(gss_strict_acceptor, GSSAPIStrictAcceptorCheck, SSHCFG_GLOBAL)
+ #endif /* GSSAPI */
+ 
+ #define SSHD_CONFIG_ENTRIES \

--- a/components/network/openssh/patches/0007-DTrace-support-for-SFTP.patch
+++ b/components/network/openssh/patches/0007-DTrace-support-for-SFTP.patch
@@ -3,9 +3,10 @@ From: oracle <solaris@oracle.com>
 Date: Mon, 3 Aug 2015 14:35:43 -0700
 Subject: [PATCH 07/34] DTrace support for SFTP
 
---- openssh-10.3p1/Makefile.in.orig
-+++ openssh-10.3p1/Makefile.in
-@@ -90,6 +90,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/Makefile.in a/Makefile.in
+--- a~/Makefile.in	1970-01-01 00:00:00
++++ a/Makefile.in	1970-01-01 00:00:00
+@@ -90,6 +90,7 @@ LIBOPENSSH_OBJS=\
  
  LIBSSH_OBJS=${LIBOPENSSH_OBJS} \
  	authfd.o authfile.o \
@@ -13,7 +14,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  	canohost.o channels.o cipher.o cipher-aes.o cipher-aesctr.o \
  	cleanup.o \
  	compat.o fatal.o hostfile.o \
-@@ -147,7 +148,7 @@
+@@ -148,7 +149,7 @@ SSHD_AUTH_OBJS=sshd-auth.o \
  	loginrec.o auth-pam.o auth-shadow.o auth-sia.o \
  	sandbox-null.o sandbox-rlimit.o sandbox-darwin.o \
  	sandbox-seccomp-filter.o sandbox-capsicum.o  sandbox-solaris.o \
@@ -22,7 +23,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  	uidswap.o $(P11OBJS) $(SKOBJS)
  
  SFTP_CLIENT_OBJS=sftp-common.o sftp-client.o sftp-glob.o ssherr-nolibcrypto.o
-@@ -170,6 +171,9 @@
+@@ -171,6 +172,9 @@ SSHKEYSCAN_OBJS=ssh-keyscan.o $(P11OBJS)
  
  SFTPSERVER_OBJS=sftp-common.o sftp-server.o sftp-server-main.o ssherr-nolibcrypto.o
  
@@ -32,7 +33,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  SFTP_OBJS=	sftp.o sftp-usergroup.o progressmeter.o $(SFTP_CLIENT_OBJS)
  
  MANPAGES	= moduli.5.out scp.1.out ssh-add.1.out ssh-agent.1.out ssh-keygen.1.out ssh-keyscan.1.out ssh.1.out sshd.8.out sftp-server.8.out sftp.1.out ssh-keysign.8.out ssh-pkcs11-helper.8.out ssh-sk-helper.8.out sshd_config.5.out ssh_config.5.out
-@@ -296,9 +300,22 @@
+@@ -297,9 +301,22 @@ $(CONFIGFILES): $(CONFIGFILES_IN) Makefi
  moduli:
  	echo
  
@@ -56,7 +57,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  	rm -f regress/check-perm$(EXEEXT)
  	rm -f regress/mkdtemp$(EXEEXT)
  	rm -f regress/unittests/test_helper/*.a
-@@ -466,6 +483,7 @@
+@@ -475,6 +492,7 @@ install-files:
  	$(INSTALL) -m 644 ssh-keysign.8.out $(DESTDIR)$(mandir)/$(mansubdir)8/ssh-keysign.8
  	$(INSTALL) -m 644 ssh-pkcs11-helper.8.out $(DESTDIR)$(mandir)/$(mansubdir)8/ssh-pkcs11-helper.8
  	$(INSTALL) -m 644 ssh-sk-helper.8.out $(DESTDIR)$(mandir)/$(mansubdir)8/ssh-sk-helper.8
@@ -64,8 +65,9 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  
  install-sysconf:
  	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
---- openssh-10.3p1/sftp-server.c.orig
-+++ openssh-10.3p1/sftp-server.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sftp-server.c a/sftp-server.c
+--- a~/sftp-server.c	1970-01-01 00:00:00
++++ a/sftp-server.c	1970-01-01 00:00:00
 @@ -48,6 +48,9 @@
  
  #include "sftp.h"
@@ -76,7 +78,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  
  char *sftp_realpath(const char *, char *); /* sftp-realpath.c */
  
-@@ -793,16 +796,19 @@
+@@ -793,16 +796,19 @@ process_read(uint32_t id)
  	static u_char *buf;
  	static size_t buflen;
  	uint32_t len;
@@ -98,7 +100,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  	if ((fd = handle_to_fd(handle)) == -1)
  		goto out;
  	if (len > SFTP_MAX_READ_LENGTH) {
-@@ -821,6 +827,9 @@
+@@ -821,6 +827,9 @@ process_read(uint32_t id)
  		    strerror(errno));
  		goto out;
  	}
@@ -108,7 +110,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  	if (len == 0) {
  		/* weird, but not strictly disallowed */
  		ret = 0;
-@@ -833,11 +842,18 @@
+@@ -833,11 +842,18 @@ process_read(uint32_t id)
  		status = SSH2_FX_EOF;
  		goto out;
  	}
@@ -127,7 +129,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  	if (status != SSH2_FX_OK)
  		send_status(id, status);
  }
-@@ -849,14 +865,17 @@
+@@ -849,14 +865,17 @@ process_write(uint32_t id)
  	size_t len;
  	int r, handle, fd, ret, status;
  	u_char *data;
@@ -146,7 +148,7 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  	fd = handle_to_fd(handle);
  
  	if (fd < 0)
-@@ -869,7 +888,13 @@
+@@ -869,7 +888,13 @@ process_write(uint32_t id)
  			    strerror(errno));
  		} else {
  /* XXX ATOMICIO ? */
@@ -160,8 +162,9 @@ Subject: [PATCH 07/34] DTrace support for SFTP
  			if (ret == -1) {
  				status = errno_to_portable(errno);
  				error_f("write \"%.100s\": %s",
---- /dev/null
-+++ openssh-10.3p1/sftp64.d
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sftp64.d a/sftp64.d
+--- a~/sftp64.d	1970-01-01 00:00:00
++++ a/sftp64.d	1970-01-01 00:00:00
 @@ -0,0 +1,56 @@
 +/*
 + * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
@@ -219,8 +222,9 @@ Subject: [PATCH 07/34] DTrace support for SFTP
 +	sfi_pathname = copyinstr((uintptr_t)*(uint64_t *)copyin(
 +	    (uintptr_t)&s->sftp_pathname, sizeof (uint64_t)));
 +};
---- /dev/null
-+++ openssh-10.3p1/sftp_provider.d
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sftp_provider.d a/sftp_provider.d
+--- a~/sftp_provider.d	1970-01-01 00:00:00
++++ a/sftp_provider.d	1970-01-01 00:00:00
 @@ -0,0 +1,61 @@
 +/*
 + * CDDL HEADER START
@@ -283,8 +287,9 @@ Subject: [PATCH 07/34] DTrace support for SFTP
 +#pragma D attributes Private/Private/Unknown provider sftp function
 +#pragma D attributes Private/Private/ISA provider sftp name
 +#pragma D attributes Evolving/Evolving/ISA provider sftp args
---- /dev/null
-+++ openssh-10.3p1/sftp_provider_impl.h
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sftp_provider_impl.h a/sftp_provider_impl.h
+--- a~/sftp_provider_impl.h	1970-01-01 00:00:00
++++ a/sftp_provider_impl.h	1970-01-01 00:00:00
 @@ -0,0 +1,73 @@
 +/*
 + * CDDL HEADER START

--- a/components/network/openssh/patches/0008-Add-DisableBanner-option.patch
+++ b/components/network/openssh/patches/0008-Add-DisableBanner-option.patch
@@ -1,6 +1,7 @@
---- openssh-10.3p1/readconf.c.orig
-+++ openssh-10.3p1/readconf.c
-@@ -154,6 +154,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/readconf.c a/readconf.c
+--- a~/readconf.c	1970-01-01 00:00:00
++++ a/readconf.c	1970-01-01 00:00:00
+@@ -154,6 +154,9 @@ typedef enum {
  	oServerAliveInterval, oServerAliveCountMax, oIdentitiesOnly,
  	oSendEnv, oSetEnv, oControlPath, oControlMaster, oControlPersist,
  	oHashKnownHosts,
@@ -10,7 +11,7 @@
  	oTunnel, oTunnelDevice,
  	oLocalCommand, oPermitLocalCommand, oRemoteCommand,
  	oVisualHostKey,
-@@ -282,6 +285,9 @@
+@@ -282,6 +285,9 @@ static struct {
  	{ "controlpersist", oControlPersist },
  	{ "hashknownhosts", oHashKnownHosts },
  	{ "include", oInclude },
@@ -20,7 +21,7 @@
  	{ "tunnel", oTunnel },
  	{ "tunneldevice", oTunnelDevice },
  	{ "localcommand", oLocalCommand },
-@@ -1116,6 +1122,17 @@
+@@ -1116,6 +1122,17 @@ parse_multistate_value(const char *arg,
  	return -1;
  }
  
@@ -38,7 +39,7 @@
  /*
   * Processes a single option line as used in the configuration files. This
   * only sets those values that have not already been set.
-@@ -2564,6 +2581,13 @@
+@@ -2564,6 +2581,13 @@ parse_pubkey_algos:
  		}
  		break;
  
@@ -52,7 +53,7 @@
  	case oDeprecated:
  		debug("%s line %d: Deprecated option \"%s\"",
  		    filename, linenum, keyword);
-@@ -2802,6 +2826,9 @@
+@@ -2802,6 +2826,9 @@ initialize_options(Options * options)
  	options->stdin_null = -1;
  	options->fork_after_authentication = -1;
  	options->proxy_use_fdpass = -1;
@@ -62,7 +63,7 @@
  	options->ignored_unknown = NULL;
  	options->num_canonical_domains = 0;
  	options->num_permitted_cnames = 0;
-@@ -3008,6 +3035,10 @@
+@@ -3008,6 +3035,10 @@ fill_default_options(Options * options)
  		options->canonicalize_fallback_local = 1;
  	if (options->canonicalize_hostname == -1)
  		options->canonicalize_hostname = SSH_CANONICALISE_NO;
@@ -73,9 +74,10 @@
  	if (options->fingerprint_hash == -1)
  		options->fingerprint_hash = SSH_FP_HASH_DEFAULT;
  #ifdef ENABLE_SK_INTERNAL
---- openssh-10.3p1/readconf.h.orig
-+++ openssh-10.3p1/readconf.h
-@@ -190,6 +190,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/readconf.h a/readconf.h
+--- a~/readconf.h	1970-01-01 00:00:00
++++ a/readconf.h	1970-01-01 00:00:00
+@@ -190,6 +190,9 @@ typedef struct {
  	char	*version_addendum;
  
  	char	*ignored_unknown; /* Pattern list of unknown tokens to ignore */
@@ -85,7 +87,7 @@
  }       Options;
  
  #define SSH_PUBKEY_AUTH_NO	0x00
-@@ -235,6 +238,12 @@
+@@ -235,6 +238,12 @@ typedef struct {
  #define SSH_KEYSTROKE_CHAFF_MIN_MS		1024
  #define SSH_KEYSTROKE_CHAFF_RNG_MS		2048
  
@@ -98,9 +100,10 @@
  const char *kex_default_pk_alg(void);
  char	*ssh_connection_hash(const char *thishost, const char *host,
      const char *portstr, const char *user, const char *jump_host);
---- openssh-10.3p1/ssh_config.5.orig
-+++ openssh-10.3p1/ssh_config.5
-@@ -748,6 +748,14 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/ssh_config.5 a/ssh_config.5
+--- a~/ssh_config.5	1970-01-01 00:00:00
++++ a/ssh_config.5	1970-01-01 00:00:00
+@@ -785,6 +785,14 @@ If set to a time in seconds, or a time i
  then the backgrounded master connection will automatically terminate
  after it has remained idle (with no client connections) for the
  specified time.
@@ -115,8 +118,9 @@
  .It Cm DynamicForward
  Specifies that a TCP port on the local machine be forwarded
  over the secure channel, and the application
---- openssh-10.3p1/sshconnect2.c.orig
-+++ openssh-10.3p1/sshconnect2.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshconnect2.c a/sshconnect2.c
+--- a~/sshconnect2.c	1970-01-01 00:00:00
++++ a/sshconnect2.c	1970-01-01 00:00:00
 @@ -78,6 +78,10 @@
  /* import */
  extern Options options;
@@ -128,7 +132,7 @@
  /*
   * SSH2 key exchange
   */
-@@ -577,8 +581,28 @@
+@@ -579,8 +583,28 @@ input_userauth_banner(int type, uint32_t
  	if ((r = sshpkt_get_cstring(ssh, &msg, &len)) != 0 ||
  	    (r = sshpkt_get_cstring(ssh, NULL, NULL)) != 0)
  		goto out;

--- a/components/network/openssh/patches/0010-PAM-enhancements-for-Solaris.patch
+++ b/components/network/openssh/patches/0010-PAM-enhancements-for-Solaris.patch
@@ -1,6 +1,7 @@
---- openssh-10.3p1/auth-pam.c.orig
-+++ openssh-10.3p1/auth-pam.c
-@@ -699,14 +699,83 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth-pam.c a/auth-pam.c
+--- a~/auth-pam.c	1970-01-01 00:00:00
++++ a/auth-pam.c	1970-01-01 00:00:00
+@@ -699,14 +699,83 @@ sshpam_cleanup(void)
  	sshpam_initial_user = NULL;
  }
  
@@ -84,7 +85,7 @@
  #if defined(PAM_SUN_CODEBASE) && defined(PAM_MAX_RESP_SIZE)
  	/* Protect buggy PAM implementations from excessively long usernames */
  	if (strlen(user) >= PAM_MAX_RESP_SIZE)
-@@ -716,15 +785,62 @@
+@@ -716,15 +785,62 @@ sshpam_init(struct ssh *ssh, Authctxt *a
  	if (sshpam_handle == NULL && ssh == NULL)
  		fatal("%s: called initially with no packet context", __func__);
  	if (sshpam_handle != NULL) {
@@ -147,9 +148,10 @@
  	sshpam_initial_user = xstrdup(user);
  	sshpam_authctxt = authctxt;
  
---- openssh-10.3p1/auth.h.orig
-+++ openssh-10.3p1/auth.h
-@@ -95,6 +95,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth.h a/auth.h
+--- a~/auth.h	1970-01-01 00:00:00
++++ a/auth.h	1970-01-01 00:00:00
+@@ -95,6 +95,9 @@ struct Authctxt {
  
  	/* Information exposed to session */
  	struct sshbuf	*session_info;	/* Auth info for environment */
@@ -159,9 +161,10 @@
  };
  
  /*
---- openssh-10.3p1/auth2.c.orig
-+++ openssh-10.3p1/auth2.c
-@@ -307,9 +307,17 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth2.c a/auth2.c
+--- a~/auth2.c	1970-01-01 00:00:00
++++ a/auth2.c	1970-01-01 00:00:00
+@@ -313,9 +313,17 @@ input_userauth_request(int type, uint32_
  #endif
  		}
  #ifdef USE_PAM
@@ -180,7 +183,7 @@
  		ssh_packet_set_log_preamble(ssh, "%suser %s",
  		    authctxt->valid ? "authenticating " : "invalid ", user);
  		setproctitle("%s [net]", authctxt->valid ? user : "unknown");
-@@ -342,6 +350,17 @@
+@@ -348,6 +356,17 @@ input_userauth_request(int type, uint32_
  	/* try to authenticate user */
  	m = authmethod_lookup(authctxt, method);
  	if (m != NULL && authctxt->failures < options.max_authtries) {
@@ -198,7 +201,7 @@
  		debug2("input_userauth_request: try method %s", method);
  		authenticated =	m->userauth(ssh, method);
  	}
-@@ -367,6 +386,10 @@
+@@ -373,6 +392,10 @@ userauth_finish(struct ssh *ssh, int aut
  	char *methods;
  	int r, partial = 0;
  
@@ -209,7 +212,7 @@
  	if (authenticated) {
  		if (!authctxt->valid) {
  			fatal("INTERNAL ERROR: authenticated invalid user %s",
-@@ -390,6 +413,31 @@
+@@ -396,6 +419,31 @@ userauth_finish(struct ssh *ssh, int aut
  	}
  
  	if (authenticated && options.num_auth_methods != 0) {
@@ -241,7 +244,7 @@
  		if (!auth2_update_methods_lists(authctxt, method, submethod)) {
  			authenticated = 0;
  			partial = 1;
-@@ -407,7 +455,19 @@
+@@ -413,7 +461,19 @@ userauth_finish(struct ssh *ssh, int aut
  		return;
  
  #ifdef USE_PAM
@@ -261,9 +264,10 @@
  		int r, success = mm_do_pam_account();
  
  		/* If PAM returned a message, send it to the user. */
---- openssh-10.3p1/monitor.c.orig
-+++ openssh-10.3p1/monitor.c
-@@ -111,6 +111,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/monitor.c a/monitor.c
+--- a~/monitor.c	1970-01-01 00:00:00
++++ a/monitor.c	1970-01-01 00:00:00
+@@ -111,6 +111,9 @@ int mm_answer_sign(struct ssh *, int, st
  int mm_answer_pwnamallow(struct ssh *, int, struct sshbuf *);
  int mm_answer_auth2_read_banner(struct ssh *, int, struct sshbuf *);
  int mm_answer_authserv(struct ssh *, int, struct sshbuf *);
@@ -273,7 +277,7 @@
  int mm_answer_authpassword(struct ssh *, int, struct sshbuf *);
  int mm_answer_bsdauthquery(struct ssh *, int, struct sshbuf *);
  int mm_answer_bsdauthrespond(struct ssh *, int, struct sshbuf *);
-@@ -188,10 +191,17 @@
+@@ -188,10 +191,17 @@ struct mon_table mon_dispatch_proto20[]
      {MONITOR_REQ_SIGN, MON_ONCE, mm_answer_sign},
      {MONITOR_REQ_PWNAM, MON_ONCE, mm_answer_pwnamallow},
      {MONITOR_REQ_AUTHSERV, MON_ONCE, mm_answer_authserv},
@@ -291,7 +295,7 @@
      {MONITOR_REQ_PAM_ACCOUNT, 0, mm_answer_pam_account},
      {MONITOR_REQ_PAM_INIT_CTX, MON_ONCE, mm_answer_pam_init_ctx},
      {MONITOR_REQ_PAM_QUERY, 0, mm_answer_pam_query},
-@@ -305,6 +315,23 @@
+@@ -305,6 +315,23 @@ monitor_child_preauth(struct ssh *ssh, s
  
  		/* Special handling for multiple required authentications */
  		if (options.num_auth_methods != 0) {
@@ -315,7 +319,7 @@
  			if (authenticated &&
  			    !auth2_update_methods_lists(authctxt,
  			    auth_method, auth_submethod)) {
-@@ -322,8 +349,21 @@
+@@ -322,8 +349,21 @@ monitor_child_preauth(struct ssh *ssh, s
  			    !auth_root_allowed(ssh, auth_method))
  				authenticated = 0;
  #ifdef USE_PAM
@@ -337,7 +341,7 @@
  				struct sshbuf *m;
  
  				if ((m = sshbuf_new()) == NULL)
-@@ -947,6 +987,10 @@
+@@ -921,6 +961,10 @@ mm_answer_pwnamallow(struct ssh *ssh, in
  	/* Allow service/style information on the auth context */
  	monitor_permit(mon_dispatch, MONITOR_REQ_AUTHSERV, 1);
  	monitor_permit(mon_dispatch, MONITOR_REQ_AUTH2_READ_BANNER, 1);
@@ -348,7 +352,7 @@
  
  #ifdef USE_PAM
  	if (options.use_pam)
-@@ -971,6 +1015,27 @@
+@@ -945,6 +989,27 @@ int mm_answer_auth2_read_banner(struct s
  	return (0);
  }
  
@@ -376,9 +380,10 @@
  int
  mm_answer_authserv(struct ssh *ssh, int sock, struct sshbuf *m)
  {
---- openssh-10.3p1/monitor.h.orig
-+++ openssh-10.3p1/monitor.h
-@@ -64,6 +64,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/monitor.h a/monitor.h
+--- a~/monitor.h	1970-01-01 00:00:00
++++ a/monitor.h	1970-01-01 00:00:00
+@@ -64,6 +64,9 @@ enum monitor_reqtype {
  	MONITOR_REQ_PAM_RESPOND = 108, MONITOR_ANS_PAM_RESPOND = 109,
  	MONITOR_REQ_PAM_FREE_CTX = 110, MONITOR_ANS_PAM_FREE_CTX = 111,
  	MONITOR_REQ_AUDIT_EVENT = 112, MONITOR_REQ_AUDIT_COMMAND = 113,
@@ -388,9 +393,10 @@
  
  };
  
---- openssh-10.3p1/monitor_wrap.c.orig
-+++ openssh-10.3p1/monitor_wrap.c
-@@ -473,6 +473,24 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/monitor_wrap.c a/monitor_wrap.c
+--- a~/monitor_wrap.c	1970-01-01 00:00:00
++++ a/monitor_wrap.c	1970-01-01 00:00:00
+@@ -438,6 +438,24 @@ mm_inform_authserv(char *service, char *
  	sshbuf_free(m);
  }
  
@@ -415,72 +421,51 @@
  /* Do the password authentication */
  int
  mm_auth_password(struct ssh *ssh, char *password)
---- openssh-10.3p1/servconf.c.orig
-+++ openssh-10.3p1/servconf.c
-@@ -87,6 +87,17 @@
- 	/* Portable-specific options */
- 	options->use_pam = -1;
- 	options->pam_service_name = NULL;
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
+@@ -161,6 +161,15 @@ initialize_server_options(ServerOptions
+ 	options->subsystem_args = NULL;
+ #define init_timingsecret(options) \
+ 	options->timing_secret = 0;
 +#ifdef PAM_ENHANCEMENT
-+	options->pam_service_prefix = NULL;
-+
-+	/*
-+	 * Each user method will have its own PAM service by default.
-+	 * However, if PAMServiceName is specified
-+	 * then there will be only one PAM service for the
-+	 * entire user authentication.
-+	 */
++/*
++ * Each userauth method will have its own PAM service by default. However,
++ * if PAMServiceName is specified then there will be only one PAM service
++ * for the entire user authentication.
++ */
++#define init_pamserviceperauthmethod(options) \
 +	options->pam_service_per_authmethod = 1;
 +#endif
  
- 	/* Standard Options */
- 	options->num_ports = 0;
-@@ -301,8 +312,13 @@
- #else
- 		options->use_pam = 0;
- #endif
+ 	SSHD_CONFIG_ENTRIES
+ 
+@@ -180,6 +189,9 @@ initialize_server_options(ServerOptions
+ #undef init_rekeylimit
+ #undef init_subsystem
+ #undef init_timingsecret
++#ifdef PAM_ENHANCEMENT
++#undef init_pamserviceperauthmethod
++#endif
+ #undef SSHCONF_INT
+ #undef SSHCONF_INTFLAG
+ #undef SSHCONF_STRING
+@@ -305,9 +317,14 @@ fill_default_server_options(ServerOption
+ #undef SSHCONF_ALIAS
+ 
+ #ifdef USE_PAM
 +#ifdef PAM_ENHANCEMENT
 +	if (options->pam_service_prefix == NULL)
 +		options->pam_service_prefix = xstrdup(SSHD_PAM_SERVICE);
 +#else
  	if (options->pam_service_name == NULL)
  		options->pam_service_name = xstrdup(SSHD_PAM_SERVICE);
+ #endif
 +#endif
  
- 	/* Standard Options */
  	if (options->num_host_key_files == 0) {
-@@ -550,6 +566,9 @@
- 	sBadOption,		/* == unknown option */
- 	/* Portable-specific options */
- 	sUsePAM, sPAMServiceName,
-+#ifdef PAM_ENHANCEMENT
-+	sPAMServicePrefix,
-+#endif
- 	/* Standard Options */
- 	sPort, sHostKeyFile, sLoginGraceTime,
- 	sPermitRootLogin, sLogFacility, sLogLevel, sLogVerbose,
-@@ -602,10 +621,20 @@
- 	/* Portable-specific options */
- #ifdef USE_PAM
- 	{ "usepam", sUsePAM, SSHCFG_GLOBAL },
-+#ifdef PAM_ENHANCEMENT
-+	{ "pamserviceprefix", sPAMServicePrefix, SSHCFG_GLOBAL },
-+	{ "pamservicename", sPAMServiceName, SSHCFG_GLOBAL },
-+#else
- 	{ "pamservicename", sPAMServiceName, SSHCFG_ALL },
-+#endif /* PAM_ENHANCEMENT */
- #else
- 	{ "usepam", sUnsupported, SSHCFG_GLOBAL },
-+#ifdef PAM_ENHANCEMENT
-+	{ "pamserviceprefix", sUnsupported, SSHCFG_GLOBAL },
-+	{ "pamservicename", sUnsupported, SSHCFG_GLOBAL },
-+#else
- 	{ "pamservicename", sUnsupported, SSHCFG_ALL },
-+#endif /* PAM_ENHANCEMENT */
- #endif
- 	{ "pamauthenticationviakbdint", sDeprecated, SSHCFG_GLOBAL },
- 	/* Standard Options */
-@@ -1410,6 +1439,21 @@
+ 		/* fill default hostkeys */
+@@ -1182,6 +1199,21 @@ process_server_config_line_depth(ServerO
  		intptr = &options->use_pam;
  		goto parse_flag;
  #endif
@@ -502,7 +487,7 @@
  	case sPAMServiceName:
  		charptr = &options->pam_service_name;
  		arg = argv_next(&ac, &av);
-@@ -1417,8 +1461,20 @@
+@@ -1189,8 +1221,20 @@ process_server_config_line_depth(ServerO
  			fatal("%s line %d: missing argument.",
  			    filename, linenum);
  		}
@@ -521,24 +506,129 @@
 +		options->pam_service_per_authmethod = 0;
 +#endif
  		break;
+ #endif
  
- 	/* Standard Options */
---- openssh-10.3p1/servconf.h.orig
-+++ openssh-10.3p1/servconf.h
-@@ -214,6 +214,10 @@
+@@ -3074,6 +3118,22 @@ serialise_timingsecret(const ServerOptio
+ 	return 0;
+ }
  
- 	int	use_pam;		/* Enable auth via PAM */
- 	char   *pam_service_name;
 +#ifdef PAM_ENHANCEMENT
-+	char   *pam_service_prefix;
-+	int     pam_service_per_authmethod;
++static int
++serialise_pamserviceperauthmethod(const ServerOptions *options,
++    struct sshbuf *buf)
++{
++	int r;
++
++	if ((r = serialise_s32(buf,
++	    options->pam_service_per_authmethod)) != 0) {
++		error_fr(r, "serialise");
++		return r;
++	}
++	return 0;
++}
++#endif /* PAM_ENHANCEMENT */
++
+ 
+ int
+ serialise_server_options(const ServerOptions *options, struct sshbuf **bufp)
+@@ -3608,6 +3668,22 @@ deserialise_timingsecret(ServerOptions *
+ 	return 0;
+ }
+ 
++#ifdef PAM_ENHANCEMENT
++static int
++deserialise_pamserviceperauthmethod(ServerOptions *options,
++    struct sshbuf *buf)
++{
++	int r;
++
++	if ((r = deserialise_s32(buf,
++	    &options->pam_service_per_authmethod)) != 0) {
++		error_fr(r, "deserialise");
++		return r;
++	}
++	return 0;
++}
++#endif /* PAM_ENHANCEMENT */
++
+ int
+ deserialise_server_options(struct sshbuf *buf, ServerOptions *options)
+ {
+@@ -3771,6 +3847,9 @@ free_server_options(ServerOptions *optio
+ #define free_persourcepenalties(options)
+ #define free_rekeylimit(options)
+ #define free_timingsecret(options)
++#ifdef PAM_ENHANCEMENT
++#define free_pamserviceperauthmethod(options)
 +#endif
  
- 	int	permit_tun;
+ 	SSHD_CONFIG_ENTRIES
  
---- openssh-10.3p1/sshd.8.orig
-+++ openssh-10.3p1/sshd.8
-@@ -1018,6 +1018,31 @@
+@@ -3786,6 +3865,9 @@ free_server_options(ServerOptions *optio
+ #undef free_persourcepenalties
+ #undef free_rekeylimit
+ #undef free_timingsecret
++#ifdef PAM_ENHANCEMENT
++#undef free_pamserviceperauthmethod
++#endif
+ 
+ #undef SSHCONF_INT
+ #undef SSHCONF_INTFLAG
+@@ -4197,6 +4279,9 @@ dump_config(ServerOptions *o)
+ #ifdef USE_PAM
+ 	dump_cfg_fmtint(sUsePAM, o->use_pam);
+ 	dump_cfg_string(sPAMServiceName, o->pam_service_name);
++#ifdef PAM_ENHANCEMENT
++	dump_cfg_string(sPAMServicePrefix, o->pam_service_prefix);
++#endif
+ #endif
+ 	dump_cfg_int(sLoginGraceTime, o->login_grace_time);
+ 	dump_cfg_int(sX11DisplayOffset, o->x11_display_offset);
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.h a/servconf.h
+--- a~/servconf.h	1970-01-01 00:00:00
++++ a/servconf.h	1970-01-01 00:00:00
+@@ -272,14 +272,23 @@ SSHCONF_ALIAS(KeepAlive, TCPKeepAlive, S
+ 	SSHD_CONFIG_ENTRIES_LASTLOG
+ 
+ #ifdef USE_PAM
++#ifdef PAM_ENHANCEMENT
++#define SSHD_CONFIG_ENTRIES_PAM \
++SSHCONF_INTFLAG(use_pam, UsePAM, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
++SSHCONF_STRING(pam_service_name, PAMServiceName, SSHCFG_GLOBAL, SSHCFG_COPY_NONE) \
++SSHCONF_STRING(pam_service_prefix, PAMServicePrefix, SSHCFG_GLOBAL, SSHCFG_COPY_NONE) \
++SSHCONF_NONCONF(pamserviceperauthmethod)
++#else	/* PAM_ENHANCEMENT */
+ #define SSHD_CONFIG_ENTRIES_PAM \
+ SSHCONF_INTFLAG(use_pam, UsePAM, SSHCFG_GLOBAL, 1, SSHCFG_COPY_NONE) \
+ SSHCONF_STRING(pam_service_name, PAMServiceName, SSHCFG_GLOBAL, SSHCFG_COPY_NONE)
+-#else
++#endif	/* PAM_ENHANCEMENT */
++#else	/* USE_PAM */
+ #define SSHD_CONFIG_ENTRIES_PAM \
+ SSHCONF_UNSUPPORTED_INT(use_pam, UsePAM, SSHCFG_GLOBAL) \
+-SSHCONF_UNSUPPORTED_STRING(pam_service_name, PAMServiceName, SSHCFG_GLOBAL)
+-#endif
++SSHCONF_UNSUPPORTED_STRING(pam_service_name, PAMServiceName, SSHCFG_GLOBAL) \
++SSHCONF_UNSUPPORTED_STRING(pam_service_prefix, PAMServicePrefix, SSHCFG_GLOBAL)
++#endif	/* USE_PAM */
+ 
+ #ifdef DISABLE_LASTLOG
+ #define SSHD_CONFIG_ENTRIES_LASTLOG \
+@@ -400,6 +409,10 @@ typedef struct ServerOptions {
+ 	int	rekey_interval;
+ 	/* Passed by config but not keyword for this */
+ 	uint64_t timing_secret;
++#ifdef PAM_ENHANCEMENT
++	/* Set as a side-effect of PAMServiceName */
++	int	pam_service_per_authmethod;
++#endif
+ }       ServerOptions;
+ #undef SSHCONF_INT
+ #undef SSHCONF_INTFLAG
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd.8 a/sshd.8
+--- a~/sshd.8	1970-01-01 00:00:00
++++ a/sshd.8	1970-01-01 00:00:00
+@@ -1018,6 +1018,31 @@ concurrently for different ports, this c
  started last).
  The content of this file is not sensitive; it can be world-readable.
  .El
@@ -570,9 +660,10 @@
  .Sh SEE ALSO
  .Xr scp 1 ,
  .Xr sftp 1 ,
---- openssh-10.3p1/sshd_config.5.orig
-+++ openssh-10.3p1/sshd_config.5
-@@ -1339,6 +1339,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd_config.5 a/sshd_config.5
+--- a~/sshd_config.5	1970-01-01 00:00:00
++++ a/sshd_config.5	1970-01-01 00:00:00
+@@ -1347,6 +1347,7 @@ Available keywords are
  .Cm MaxAuthTries ,
  .Cm MaxSessions ,
  .Cm PAMServiceName ,
@@ -580,7 +671,7 @@
  .Cm PasswordAuthentication ,
  .Cm PermitEmptyPasswords ,
  .Cm PermitListen ,
-@@ -1407,12 +1408,34 @@
+@@ -1415,12 +1416,34 @@ key exchange methods.
  The default is
  .Pa /etc/moduli .
  .It Cm PAMServiceName
@@ -621,13 +712,13 @@
  .It Cm PasswordAuthentication
  Specifies whether password authentication is allowed.
  The default is
-@@ -2077,8 +2100,7 @@
+@@ -2085,8 +2108,7 @@ If
  is enabled, you will not be able to run
  .Xr sshd 8
  as a non-root user.
 -The default is
 -.Cm no .
-+On OmniOS, the option is always enabled.
++On OpenIndiana, the option is always enabled.
  .It Cm VersionAddendum
  Optionally specifies additional text to append to the SSH protocol banner
  sent by the server upon connection.

--- a/components/network/openssh/patches/0013-Solaris-Auditing-support.patch
+++ b/components/network/openssh/patches/0013-Solaris-Auditing-support.patch
@@ -1,6 +1,7 @@
---- openssh-10.3p1/INSTALL.orig
-+++ openssh-10.3p1/INSTALL
-@@ -108,9 +108,13 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/INSTALL a/INSTALL
+--- a~/INSTALL	1970-01-01 00:00:00
++++ a/INSTALL	1970-01-01 00:00:00
+@@ -108,9 +108,13 @@ http://www.gnu.org/software/automake/
  
  Basic Security Module (BSM):
  
@@ -17,7 +18,7 @@
  
  makedepend:
  
-@@ -176,8 +180,9 @@
+@@ -176,8 +180,9 @@ name).
  There are a few other options to the configure script:
  
  --with-audit=[module] enable additional auditing via the specified module.
@@ -29,9 +30,10 @@
  
  --with-pam enables PAM support. If PAM support is compiled in, it must
  also be enabled in sshd_config (refer to the UsePAM directive).
---- openssh-10.3p1/Makefile.in.orig
-+++ openssh-10.3p1/Makefile.in
-@@ -124,7 +124,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/Makefile.in a/Makefile.in
+--- a~/Makefile.in	1970-01-01 00:00:00
++++ a/Makefile.in	1970-01-01 00:00:00
+@@ -125,7 +125,7 @@ SSHDOBJS=sshd.o \
  	$(P11OBJS) $(SKOBJS)
  
  SSHD_SESSION_OBJS=sshd-session.o auth-rhosts.o auth-passwd.o \
@@ -40,7 +42,7 @@
  	sshpty.o sshlogin.o servconf.o serverloop.o \
  	auth.o auth2.o auth2-methods.o auth-options.o session.o \
  	auth2-chall.o groupaccess.o \
-@@ -144,7 +144,7 @@
+@@ -145,7 +145,7 @@ SSHD_AUTH_OBJS=sshd-auth.o \
  	auth2-none.o auth2-passwd.o auth2-pubkey.o auth2-pubkeyfile.o \
  	auth2-gss.o gss-serv.o gss-serv-krb5.o \
  	monitor_wrap.o auth-krb5.o \
@@ -49,9 +51,10 @@
  	loginrec.o auth-pam.o auth-shadow.o auth-sia.o \
  	sandbox-null.o sandbox-rlimit.o sandbox-darwin.o \
  	sandbox-seccomp-filter.o sandbox-capsicum.o  sandbox-solaris.o \
---- openssh-10.3p1/README.platform.orig
-+++ openssh-10.3p1/README.platform
-@@ -72,10 +72,10 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/README.platform a/README.platform
+--- a~/README.platform	1970-01-01 00:00:00
++++ a/README.platform	1970-01-01 00:00:00
+@@ -72,10 +72,10 @@ zlib-devel and pam-devel, on Debian base
  libssl-dev, libz-dev and libpam-dev.
  
  
@@ -66,7 +69,7 @@
  added to /etc/security/audit_event:
  
  	32800:AUE_openssh:OpenSSH login:lo
-@@ -86,6 +86,9 @@
+@@ -86,6 +86,9 @@ There is no official registry of 3rd par
  number is already in use on your system, you may change it at build time
  by configure'ing --with-cflags=-DAUE_openssh=32801 then rebuilding.
  
@@ -76,9 +79,10 @@
  
  Platforms using PAM
  -------------------
---- openssh-10.3p1/audit-bsm.c.orig
-+++ openssh-10.3p1/audit-bsm.c
-@@ -348,7 +348,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/audit-bsm.c a/audit-bsm.c
+--- a~/audit-bsm.c	1970-01-01 00:00:00
++++ a/audit-bsm.c	1970-01-01 00:00:00
+@@ -348,7 +348,7 @@ bsm_audit_bad_login(const char *what)
  /* Below is the sshd audit API code */
  
  void
@@ -87,9 +91,10 @@
  {
  	AuditInfoTermID *tid = &ssh_bsm_tid;
  	char buf[1024];
---- openssh-10.3p1/audit-linux.c.orig
-+++ openssh-10.3p1/audit-linux.c
-@@ -73,7 +73,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/audit-linux.c a/audit-linux.c
+--- a~/audit-linux.c	1970-01-01 00:00:00
++++ a/audit-linux.c	1970-01-01 00:00:00
+@@ -73,7 +73,7 @@ linux_audit_record_event(int uid, const
  /* Below is the sshd audit API code */
  
  void
@@ -98,8 +103,9 @@
  {
  	/* not implemented */
  }
---- /dev/null
-+++ openssh-10.3p1/audit-solaris.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/audit-solaris.c a/audit-solaris.c
+--- a~/audit-solaris.c	1970-01-01 00:00:00
++++ a/audit-solaris.c	1970-01-01 00:00:00
 @@ -0,0 +1,574 @@
 +/*
 + * CDDL HEADER START
@@ -266,7 +272,7 @@
 +static void audit_logout(void);
 +static void audit_fail(int);
 +
-+/* Below is the sshd audit API Solaris adt interpretation */
++/* Below is the sshd audit API illumos adt interpretation */
 +
 +/*
 + * Called after a connection has been accepted but before any authentication
@@ -353,7 +359,7 @@
 +		tid = NULL;
 +		return;
 +
-+	/* Translate fail events to Solaris PAM errors */
++	/* Translate fail events to illumos PAM errors */
 +
 +	/* auth2.c: userauth_finish as audit_event(SSH_LOGIN_EXCEED_MAXTRIES) */
 +	/* auth1.c:do_authloop audit_event(SSH_LOGIN_EXCEED_MAXTRIES) */
@@ -374,7 +380,7 @@
 +		fail = PAM_USER_UNKNOWN;
 +		break;
 +
-+	/* seems unused, but translate to the Solaris PAM error */
++	/* seems unused, but translate to the illumos PAM error */
 +	case SSH_NOLOGIN:
 +		fail = PAM_ACCT_EXPIRED;
 +		break;
@@ -590,7 +596,7 @@
 + *		tid = connection audit TID set by audit_connect_from();
 + *
 + *	N.B.	pam_strerror() prototype takes a pam handle and error number.
-+ *		At least on Solaris, pam_strerror never uses the pam handle.
++ *		At least on illumos, pam_strerror never uses the pam handle.
 + *		Since there doesn't seem to be a pam handle available, this
 + *		code just uses NULL.
 + */
@@ -675,9 +681,10 @@
 +	(void) adt_end_session(ah);
 +}
 +#endif	/* USE_SOLARIS_AUDIT */
---- openssh-10.3p1/audit.c.orig
-+++ openssh-10.3p1/audit.c
-@@ -120,7 +120,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/audit.c a/audit.c
+--- a~/audit.c	1970-01-01 00:00:00
++++ a/audit.c	1970-01-01 00:00:00
+@@ -120,7 +120,7 @@ audit_event_lookup(ssh_audit_event_t ev)
   * has been attempted.
   */
  void
@@ -686,9 +693,10 @@
  {
  	debug("audit connection from %s port %d euid %d", host, port,
  	    (int)geteuid());
---- openssh-10.3p1/audit.h.orig
-+++ openssh-10.3p1/audit.h
-@@ -47,7 +47,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/audit.h a/audit.h
+--- a~/audit.h	1970-01-01 00:00:00
++++ a/audit.h	1970-01-01 00:00:00
+@@ -47,7 +47,7 @@ enum ssh_audit_event_type {
  };
  typedef enum ssh_audit_event_type ssh_audit_event_t;
  
@@ -697,9 +705,10 @@
  void	audit_event(struct ssh *, ssh_audit_event_t);
  void	audit_session_open(struct logininfo *);
  void	audit_session_close(struct logininfo *);
---- openssh-10.3p1/configure.ac.orig
-+++ openssh-10.3p1/configure.ac
-@@ -1983,7 +1983,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -1983,7 +1983,7 @@ AC_ARG_WITH([wtmpdb],
  
  AUDIT_MODULE=none
  AC_ARG_WITH([audit],
@@ -708,7 +717,7 @@
  	[
  	  AC_MSG_CHECKING([for supported audit module])
  	  case "$withval" in
-@@ -2020,6 +2020,13 @@
+@@ -2020,6 +2020,13 @@ AC_ARG_WITH([audit],
  		SSHDLIBS="$SSHDLIBS -laudit"
  		AC_DEFINE([USE_LINUX_AUDIT], [1], [Use Linux audit module])
  		;;
@@ -717,14 +726,15 @@
 +        AUDIT_MODULE=solaris
 +        AC_CHECK_HEADERS([bsm/adt.h])
 +        SSHDLIBS="$SSHDLIBS -lbsm"
-+        AC_DEFINE([USE_SOLARIS_AUDIT], [1], [Use Solaris audit module])
++        AC_DEFINE([USE_SOLARIS_AUDIT], [1], [Use illumos audit module])
 +        ;;
  	  debug)
  		AUDIT_MODULE=debug
  		AC_MSG_RESULT([debug])
---- openssh-10.3p1/defines.h.orig
-+++ openssh-10.3p1/defines.h
-@@ -770,6 +770,11 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/defines.h a/defines.h
+--- a~/defines.h	1970-01-01 00:00:00
++++ a/defines.h	1970-01-01 00:00:00
+@@ -777,6 +777,11 @@ struct winsize {
  # define CUSTOM_SSH_AUDIT_EVENTS
  #endif
  
@@ -736,9 +746,10 @@
  #if !defined(HAVE___func__) && defined(HAVE___FUNCTION__)
  #  define __func__ __FUNCTION__
  #elif !defined(HAVE___func__)
---- openssh-10.3p1/sshd-session.c.orig
-+++ openssh-10.3p1/sshd-session.c
-@@ -1185,7 +1185,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd-session.c a/sshd-session.c
+--- a~/sshd-session.c	1970-01-01 00:00:00
++++ a/sshd-session.c	1970-01-01 00:00:00
+@@ -1186,7 +1186,7 @@ main(int ac, char **av)
  	remote_ip = ssh_remote_ipaddr(ssh);
  
  #ifdef SSH_AUDIT_EVENTS
@@ -747,7 +758,7 @@
  #endif
  
  	rdomain = ssh_packet_rdomain_in(ssh);
-@@ -1264,8 +1264,10 @@
+@@ -1265,8 +1265,10 @@ main(int ac, char **av)
  		set_process_rdomain(ssh, options.routing_domain);
  
  #ifdef SSH_AUDIT_EVENTS
@@ -758,7 +769,7 @@
  
  #ifdef GSSAPI
  	if (options.gss_authentication) {
-@@ -1295,6 +1297,11 @@
+@@ -1296,6 +1298,11 @@ main(int ac, char **av)
  	}
  #endif
  

--- a/components/network/openssh/patches/0015-Enable-login-to-a-role-if-PAM-is-ok-with-it.patch
+++ b/components/network/openssh/patches/0015-Enable-login-to-a-role-if-PAM-is-ok-with-it.patch
@@ -1,6 +1,7 @@
---- openssh-10.3p1/auth-pam.c.orig
-+++ openssh-10.3p1/auth-pam.c
-@@ -1203,6 +1203,20 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth-pam.c a/auth-pam.c
+--- a~/auth-pam.c	1970-01-01 00:00:00
++++ a/auth-pam.c	1970-01-01 00:00:00
+@@ -1203,6 +1203,20 @@ do_pam_account(void)
  	return (sshpam_account_status);
  }
  
@@ -21,9 +22,10 @@
  void
  do_pam_setcred(void)
  {
---- openssh-10.3p1/auth-pam.h.orig
-+++ openssh-10.3p1/auth-pam.h
-@@ -44,4 +44,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth-pam.h a/auth-pam.h
+--- a~/auth-pam.h	1970-01-01 00:00:00
++++ a/auth-pam.h	1970-01-01 00:00:00
+@@ -44,4 +44,9 @@ void sshpam_set_maxtries_reached(int);
  int is_pam_session_open(void);
  int sshpam_priv_kbdint_authdone(void *ctxtp);
  
@@ -33,9 +35,10 @@
 +void do_pam_set_tty(const char *);
 +
  #endif /* USE_PAM */
---- openssh-10.3p1/auth.h.orig
-+++ openssh-10.3p1/auth.h
-@@ -98,6 +98,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth.h a/auth.h
+--- a~/auth.h	1970-01-01 00:00:00
++++ a/auth.h	1970-01-01 00:00:00
+@@ -98,6 +98,9 @@ struct Authctxt {
  #ifdef PAM_ENHANCEMENT
  	char		*authmethod_name;
  #endif
@@ -45,9 +48,10 @@
  };
  
  /*
---- openssh-10.3p1/auth2-hostbased.c.orig
-+++ openssh-10.3p1/auth2-hostbased.c
-@@ -81,6 +81,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth2-hostbased.c a/auth2-hostbased.c
+--- a~/auth2-hostbased.c	1970-01-01 00:00:00
++++ a/auth2-hostbased.c	1970-01-01 00:00:00
+@@ -81,6 +81,9 @@ userauth_hostbased(struct ssh *ssh, cons
  	debug("signature:");
  	sshbuf_dump_data(sig, slen, stderr);
  #endif
@@ -57,7 +61,7 @@
  	pktype = sshkey_type_from_name(pkalg);
  	if (pktype == KEY_UNSPEC) {
  		/* this is perfectly legal */
-@@ -153,6 +156,13 @@
+@@ -153,6 +156,13 @@ userauth_hostbased(struct ssh *ssh, cons
  	    sshbuf_ptr(b), sshbuf_len(b), pkalg, ssh->compat, NULL) == 0)
  		authenticated = 1;
  
@@ -71,9 +75,10 @@
  	auth2_record_key(authctxt, authenticated, key);
  	sshbuf_free(b);
  done:
---- openssh-10.3p1/monitor.c.orig
-+++ openssh-10.3p1/monitor.c
-@@ -394,6 +394,12 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/monitor.c a/monitor.c
+--- a~/monitor.c	1970-01-01 00:00:00
++++ a/monitor.c	1970-01-01 00:00:00
+@@ -394,6 +394,12 @@ monitor_child_preauth(struct ssh *ssh, s
  		}
  	}
  
@@ -86,7 +91,7 @@
  	if (!authctxt->valid)
  		fatal_f("authenticated invalid user");
  	if (strcmp(auth_method, "unknown") == 0)
-@@ -618,14 +624,16 @@
+@@ -618,14 +624,16 @@ monitor_reset_key_state(void)
  {
  	/* reset state */
  	free(key_blob);
@@ -104,7 +109,7 @@
  	hostbased_chost = NULL;
  }
  
-@@ -1216,6 +1224,11 @@
+@@ -1190,6 +1198,11 @@ mm_answer_pam_account(struct ssh *ssh, i
  	if (!options.use_pam)
  		fatal_f("PAM not enabled");
  

--- a/components/network/openssh/patches/0017-Don-t-call-do_pam_setcred-twice.patch
+++ b/components/network/openssh/patches/0017-Don-t-call-do_pam_setcred-twice.patch
@@ -23,11 +23,12 @@ Subject: [PATCH 17/34] Don't call do_pam_setcred twice
 # performs access control based on group membership.
 #
 # In short, this additional call to do_pam_setcred() is Linux-specific and
-# shouldn't be called on Solaris.
+# shouldn't be called on illumos.
 #
---- openssh-10.3p1/platform.c.orig
-+++ openssh-10.3p1/platform.c
-@@ -101,7 +101,7 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/platform.c a/platform.c
+--- a~/platform.c	1970-01-01 00:00:00
++++ a/platform.c	1970-01-01 00:00:00
+@@ -101,7 +101,7 @@ platform_setusercontext(struct passwd *p
  void
  platform_setusercontext_post_groups(struct passwd *pw)
  {

--- a/components/network/openssh/patches/0018-Per-session-xauthfile.patch
+++ b/components/network/openssh/patches/0018-Per-session-xauthfile.patch
@@ -11,8 +11,9 @@ more information, see https://bugzilla.mindrot.org/show_bug.cgi?id=2440
 In the future, if this fix is accepted by the upsteam in a later release, we
 will remove this patch when we upgrade to that release.
 
---- openssh-10.3p1/session.c.orig
-+++ openssh-10.3p1/session.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/session.c a/session.c
+--- a~/session.c	1970-01-01 00:00:00
++++ a/session.c	1970-01-01 00:00:00
 @@ -59,6 +59,10 @@
  #include <unistd.h>
  #include <limits.h>
@@ -24,7 +25,7 @@ will remove this patch when we upgrade to that release.
  #include "xmalloc.h"
  #include "ssh.h"
  #include "ssh2.h"
-@@ -135,6 +139,11 @@
+@@ -135,6 +139,11 @@ static void do_authenticated2(struct ssh
  
  static int session_pty_req(struct ssh *, Session *);
  
@@ -36,7 +37,7 @@ will remove this patch when we upgrade to that release.
  /* import */
  extern ServerOptions options;
  extern char *__progname;
-@@ -1056,6 +1065,11 @@
+@@ -1056,6 +1065,11 @@ do_setup_env(struct ssh *ssh, Session *s
  		    auth_sock_name);
  
  
@@ -48,7 +49,7 @@ will remove this patch when we upgrade to that release.
  	/* Set custom environment options from pubkey authentication. */
  	if (options.permit_user_env) {
  		for (n = 0 ; n < auth_opts->nenv; n++) {
-@@ -1953,6 +1967,11 @@
+@@ -1957,6 +1971,11 @@ session_x11_req(struct ssh *ssh, Session
  	int r, success;
  	u_char single_connection = 0;
  
@@ -60,7 +61,7 @@ will remove this patch when we upgrade to that release.
  	if (s->auth_proto != NULL || s->auth_data != NULL) {
  		error("session_x11_req: session %d: "
  		    "x11 forwarding already active", s->self);
-@@ -1967,19 +1986,78 @@
+@@ -1971,19 +1990,78 @@ session_x11_req(struct ssh *ssh, Session
  
  	s->single_connection = single_connection;
  
@@ -73,7 +74,7 @@ will remove this patch when we upgrade to that release.
  		success = 0;
  		error("Invalid X11 forwarding data");
 +		goto out;
- 	}
++	}
 +
 +#ifdef PER_SESSION_XAUTHFILE
 +	/*
@@ -91,7 +92,7 @@ will remove this patch when we upgrade to that release.
 +			    "for the buffer allocated");
 +			success = 0;
 +			goto out;
-+	}
+ 	}
 +		/*
 +		 * we don't want that "creating new authority file" message to
 +		 * be printed by xauth(1) so we must create that file
@@ -143,7 +144,7 @@ will remove this patch when we upgrade to that release.
  	return success;
  }
  
-@@ -2257,6 +2335,51 @@
+@@ -2261,6 +2339,51 @@ session_pty_cleanup(Session *s)
  	mm_session_pty_cleanup2(s);
  }
  
@@ -195,7 +196,7 @@ will remove this patch when we upgrade to that release.
  static char *
  sig2name(int sig)
  {
-@@ -2404,6 +2527,9 @@
+@@ -2408,6 +2531,9 @@ session_close(struct ssh *ssh, Session *
  	free(s->auth_display);
  	free(s->auth_data);
  	free(s->auth_proto);
@@ -205,7 +206,7 @@ will remove this patch when we upgrade to that release.
  	free(s->subsys);
  	if (s->env != NULL) {
  		for (i = 0; i < s->num_env; i++) {
-@@ -2659,6 +2785,10 @@
+@@ -2663,6 +2789,10 @@ do_cleanup(struct ssh *ssh, Authctxt *au
  		auth_info_file = NULL;
  	}
  
@@ -216,9 +217,10 @@ will remove this patch when we upgrade to that release.
  	/*
  	 * Cleanup ptys/utmp only if privsep is disabled,
  	 * or if running in monitor.
---- openssh-10.3p1/session.h.orig
-+++ openssh-10.3p1/session.h
-@@ -50,6 +50,9 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/session.h a/session.h
+--- a~/session.h	1970-01-01 00:00:00
++++ a/session.h	1970-01-01 00:00:00
+@@ -50,6 +50,9 @@ struct Session {
  	char	*auth_display;
  	char	*auth_proto;
  	char	*auth_data;

--- a/components/network/openssh/patches/0019-PubKeyPlugin-support.patch
+++ b/components/network/openssh/patches/0019-PubKeyPlugin-support.patch
@@ -7,8 +7,9 @@ This adds the PubKeyPlugin directive and associated code from
 SunSSH, allowing an in-process shared library to be called
 into to check public keys for authentication.
 
---- openssh-10.3p1/auth2-pubkey.c.orig
-+++ openssh-10.3p1/auth2-pubkey.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/auth2-pubkey.c a/auth2-pubkey.c
+--- a~/auth2-pubkey.c	1970-01-01 00:00:00
++++ a/auth2-pubkey.c	1970-01-01 00:00:00
 @@ -23,6 +23,11 @@
   * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
   * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -35,7 +36,7 @@ into to check public keys for authentication.
  #include "kex.h"
  #include "sshbuf.h"
  #include "log.h"
-@@ -84,6 +91,15 @@
+@@ -84,6 +91,15 @@ format_key(const struct sshkey *key)
  	return ret;
  }
  
@@ -51,7 +52,7 @@ into to check public keys for authentication.
  static int
  userauth_pubkey(struct ssh *ssh, const char *method)
  {
-@@ -783,6 +799,135 @@
+@@ -783,6 +799,135 @@ user_key_command_allowed2(struct passwd
  	return found_key;
  }
  
@@ -187,7 +188,7 @@ into to check public keys for authentication.
  /*
   * Check whether key authenticates and authorises the user.
   */
-@@ -857,6 +1002,10 @@
+@@ -857,6 +1002,10 @@ user_key_allowed(struct ssh *ssh, struct
  	sshauthopt_free(opts);
  	opts = NULL;
  
@@ -198,33 +199,10 @@ into to check public keys for authentication.
  	if ((success = user_key_command_allowed2(pw, key, remote_ip,
  	    remote_host, conn_id, rdomain, &opts)) != 0)
  		goto out;
---- openssh-10.3p1/servconf.c.orig
-+++ openssh-10.3p1/servconf.c
-@@ -224,6 +224,7 @@
- 	options->sshd_session_path = NULL;
- 	options->sshd_auth_path = NULL;
- 	options->refuse_connection = -1;
-+	options->pubkey_plugin = NULL;
- }
- 
- /* Returns 1 if a string option is unset or set to "none" or 0 otherwise. */
-@@ -596,6 +597,7 @@
- 	sRevokedKeys, sTrustedUserCAKeys, sAuthorizedPrincipalsFile,
- 	sAuthorizedPrincipalsCommand, sAuthorizedPrincipalsCommandUser,
- 	sKexAlgorithms, sCASignatureAlgorithms, sIPQoS, sVersionAddendum,
-+	sPubKeyPlugin,
- 	sAuthorizedKeysCommand, sAuthorizedKeysCommandUser,
- 	sAuthenticationMethods, sHostKeyAgent, sPermitUserRC,
- 	sStreamLocalBindMask, sStreamLocalBindUnlink,
-@@ -781,6 +783,7 @@
- 	{ "exposeauthinfo", sExposeAuthInfo, SSHCFG_ALL },
- 	{ "rdomain", sRDomain, SSHCFG_ALL },
- 	{ "casignaturealgorithms", sCASignatureAlgorithms, SSHCFG_ALL },
-+	{ "pubkeyplugin", sPubKeyPlugin, SSHCFG_ALL },
- 	{ "securitykeyprovider", sSecurityKeyProvider, SSHCFG_GLOBAL },
- 	{ "requiredrsasize", sRequiredRSASize, SSHCFG_ALL },
- 	{ "channeltimeout", sChannelTimeout, SSHCFG_ALL },
-@@ -2838,6 +2841,18 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
+@@ -2608,6 +2608,20 @@ process_server_config_line_depth(ServerO
  		multistate_ptr = multistate_flag;
  		goto parse_multistate;
  
@@ -233,23 +211,36 @@ into to check public keys for authentication.
 +		 * Can't use parse_filename, as we need to support plain
 +		 * names which dlopen will find on our lib path.
 +		 */
-+		arg = strdelim(&str);
++		charptr = &options->pubkey_plugin;
++		arg = argv_next(&ac, &av);
 +		if (!arg || *arg == '\0')
 +			fatal("%s line %d: missing file name.",
 +			    filename, linenum);
-+		options->pubkey_plugin = xstrdup(arg);
++		if (*activep && *charptr == NULL)
++			*charptr = xstrdup(arg);
 +		break;
 +
  	case sDeprecated:
  	case sIgnore:
  	case sUnsupported:
---- openssh-10.3p1/servconf.h.orig
-+++ openssh-10.3p1/servconf.h
-@@ -246,6 +246,7 @@
+@@ -4365,6 +4379,7 @@ dump_config(ServerOptions *o)
+ 	dump_cfg_string(sHostKeyAgent, o->host_key_agent);
+ 	dump_cfg_string(sKexAlgorithms, o->kex_algorithms);
+ 	dump_cfg_string(sCASignatureAlgorithms, o->ca_sign_algorithms);
++	dump_cfg_string(sPubKeyPlugin, o->pubkey_plugin);
+ 	dump_cfg_string(sHostbasedAcceptedAlgorithms, o->hostbased_accepted_algos);
+ 	dump_cfg_string(sHostKeyAlgorithms, o->hostkeyalgorithms);
+ 	dump_cfg_string(sPubkeyAcceptedAlgorithms, o->pubkey_accepted_algos);
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.h a/servconf.h
+--- a~/servconf.h	1970-01-01 00:00:00
++++ a/servconf.h	1970-01-01 00:00:00
+@@ -235,7 +235,8 @@ SSHCONF_STRARRAY(channel_timeouts, num_c
+ SSHCONF_INT(unused_connection_timeout, UnusedConnectionTimeout, SSHCFG_ALL, NULL, 0, SSHCFG_COPY_MATCH) \
+ SSHCONF_STRING(sshd_session_path, SshdSessionPath, SSHCFG_GLOBAL, SSHCFG_COPY_NONE) \
+ SSHCONF_STRING(sshd_auth_path, SshdAuthPath, SSHCFG_GLOBAL, SSHCFG_COPY_NONE) \
+-SSHCONF_INTFLAG(refuse_connection, RefuseConnection, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH)
++SSHCONF_INTFLAG(refuse_connection, RefuseConnection, SSHCFG_ALL, 0, SSHCFG_COPY_MATCH) \
++SSHCONF_STRING(pubkey_plugin, PubKeyPlugin, SSHCFG_ALL, SSHCFG_COPY_MATCH)
  
- 	int	fingerprint_hash;
- 	int	expose_userauth_info;
-+	char	*pubkey_plugin;
- 	uint64_t timing_secret;
- 	char   *sk_provider;
- 	int	required_rsa_size;	/* minimum size of RSA keys */
+ #define SSHD_CONFIG_ENTRIES_LEGACY \
+ SSHCONF_DEPRECATE(ServerKeyBits, SSHCFG_GLOBAL, SSHCONF_DEPRECATED) \

--- a/components/network/openssh/patches/0026-Don-t-use-krb5-config-to-check-for-GSSAPI-on-illumos.patch
+++ b/components/network/openssh/patches/0026-Don-t-use-krb5-config-to-check-for-GSSAPI-on-illumos.patch
@@ -3,9 +3,10 @@ From: Alex Wilson <alex.wilson@joyent.com>
 Date: Fri, 21 Aug 2015 18:47:46 -0700
 Subject: [PATCH 26/34] Don't use krb5-config to check for GSSAPI on illumos
 
---- openssh-10.3p1/configure.ac.orig
-+++ openssh-10.3p1/configure.ac
-@@ -5027,6 +5027,11 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/configure.ac a/configure.ac
+--- a~/configure.ac	1970-01-01 00:00:00
++++ a/configure.ac	1970-01-01 00:00:00
+@@ -5018,6 +5018,11 @@ AC_ARG_WITH([kerberos5],
  			AC_PATH_TOOL([KRB5CONF], [krb5-config],
  				     [$KRB5ROOT/bin/krb5-config],
  				     [$KRB5ROOT/bin:$PATH])
@@ -17,7 +18,7 @@ Subject: [PATCH 26/34] Don't use krb5-config to check for GSSAPI on illumos
  			if test -x $KRB5CONF ; then
  				K5CFLAGS="`$KRB5CONF --cflags`"
  				K5LIBS="`$KRB5CONF --libs`"
-@@ -5068,7 +5073,7 @@
+@@ -5059,7 +5064,7 @@ AC_ARG_WITH([kerberos5],
  						 AC_CHECK_LIB([des], [des_cbc_encrypt],
  						   [K5LIBS="$K5LIBS -ldes"])
  					       ], [ AC_MSG_RESULT([no])

--- a/components/network/openssh/patches/0027-Set-default-sshd-options-based-on-etc-default-login.patch
+++ b/components/network/openssh/patches/0027-Set-default-sshd-options-based-on-etc-default-login.patch
@@ -3,18 +3,20 @@ From: Alex Wilson <alex.wilson@joyent.com>
 Date: Mon, 24 Aug 2015 18:57:27 -0700
 Subject: [PATCH 27/34] Set default sshd options based on /etc/default/login
 
---- openssh-10.3p1/pathnames.h.orig
-+++ openssh-10.3p1/pathnames.h
-@@ -40,6 +40,7 @@
- #define _PATH_HOST_RSA_KEY_FILE		SSHDIR "/ssh_host_rsa_key"
+diff -wpruN --no-dereference '--exclude=*.orig' a~/pathnames.h a/pathnames.h
+--- a~/pathnames.h	1970-01-01 00:00:00
++++ a/pathnames.h	1970-01-01 00:00:00
+@@ -41,6 +41,7 @@
  #define _PATH_HOST_ED25519_KEY_FILE	SSHDIR "/ssh_host_ed25519_key"
+ #define _PATH_HOST_MLDSA44_ED25519_KEY_FILE SSHDIR "/ssh_host_mldsa44_ed25519_key"
  #define _PATH_DH_MODULI			SSHDIR "/moduli"
 +#define _PATH_DEFAULT_LOGIN		ETCDIR "/default/login"
  
  #ifndef _PATH_SSH_PROGRAM
  #define _PATH_SSH_PROGRAM		"/usr/bin/ssh"
---- openssh-10.3p1/servconf.c.orig
-+++ openssh-10.3p1/servconf.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
 @@ -37,6 +37,7 @@
  #include <unistd.h>
  #include <limits.h>
@@ -23,7 +25,7 @@ Subject: [PATCH 27/34] Set default sshd options based on /etc/default/login
  #include <errno.h>
  #include <util.h>
  
-@@ -234,6 +235,64 @@
+@@ -211,6 +212,64 @@ option_clear_or_none(const char *o)
  	return o == NULL || strcasecmp(o, "none") == 0;
  }
  
@@ -88,18 +90,19 @@ Subject: [PATCH 27/34] Set default sshd options based on /etc/default/login
  static void
  assemble_algorithms(ServerOptions *o)
  {
-@@ -321,6 +380,8 @@
- 		options->pam_service_name = xstrdup(SSHD_PAM_SERVICE);
+@@ -1238,6 +1297,8 @@ process_server_config_line_depth(ServerO
+ 		break;
  #endif
  
 +	deflt_fill_default_server_options(options);
 +
  	/* Standard Options */
- 	if (options->num_host_key_files == 0) {
- 		/* fill default hostkeys for protocols */
---- openssh-10.3p1/sshd_config.5.orig
-+++ openssh-10.3p1/sshd_config.5
-@@ -1369,7 +1369,14 @@
+ 	case sBadOption:
+ 		goto out;
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd_config.5 a/sshd_config.5
+--- a~/sshd_config.5	1970-01-01 00:00:00
++++ a/sshd_config.5	1970-01-01 00:00:00
+@@ -1377,7 +1377,14 @@ Specifies the maximum number of authenti
  connection.
  Once the number of failures reaches half this value,
  additional failures are logged.
@@ -115,7 +118,7 @@ Subject: [PATCH 27/34] Set default sshd options based on /etc/default/login
  .It Cm MaxSessions
  Specifies the maximum number of open shell, login or subsystem (e.g. sftp)
  sessions permitted per network connection.
-@@ -1444,7 +1451,14 @@
+@@ -1452,7 +1459,14 @@ The default is
  When password authentication is allowed, it specifies whether the
  server allows login to accounts with empty password strings.
  The default is

--- a/components/network/openssh/patches/0029-Accept-LANG-and-LC_-environment-variables-from-clien.patch
+++ b/components/network/openssh/patches/0029-Accept-LANG-and-LC_-environment-variables-from-clien.patch
@@ -7,20 +7,30 @@ Subject: [PATCH 29/34] Accept LANG and LC_* environment variables from clients
 This preserves most of the old SunSSH locale negotiation
 behaviour (at least the parts that are most commonly used).
 
---- openssh-10.3p1/servconf.c.orig
-+++ openssh-10.3p1/servconf.c
-@@ -197,6 +197,7 @@
- 	options->client_alive_count_max = -1;
- 	options->num_authkeys_files = 0;
- 	options->num_accept_env = 0;
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.c a/servconf.c
+--- a~/servconf.c	1970-01-01 00:00:00
++++ a/servconf.c	1970-01-01 00:00:00
+@@ -162,6 +162,8 @@ initialize_server_options(ServerOptions
+ 	options->subsystem_args = NULL;
+ #define init_timingsecret(options) \
+ 	options->timing_secret = 0;
++#define init_defaultacceptenv(options) \
 +	options->default_accept_env = 1;
- 	options->num_setenv = 0;
- 	options->permit_tun = -1;
- 	options->permitted_opens = NULL;
-@@ -534,6 +535,32 @@
- 		options->max_sessions = DEFAULT_SESSIONS_MAX;
- 	if (options->use_dns == -1)
- 		options->use_dns = 0;
+ #ifdef PAM_ENHANCEMENT
+ /*
+  * Each userauth method will have its own PAM service by default. However,
+@@ -190,6 +192,7 @@ initialize_server_options(ServerOptions
+ #undef init_rekeylimit
+ #undef init_subsystem
+ #undef init_timingsecret
++#undef init_defaultacceptenv
+ #ifdef PAM_ENHANCEMENT
+ #undef init_pamserviceperauthmethod
+ #endif
+@@ -469,6 +472,32 @@ fill_default_server_options(ServerOption
+ 		    &options->num_authkeys_files,
+ 		    _PATH_SSH_USER_PERMITTED_KEYS2);
+ 	}
 +	if (options->default_accept_env == 1) {
 +		opt_array_append("[default]", 0, "AcceptEnv",
 +		    &options->accept_env, &options->num_accept_env,
@@ -47,10 +57,10 @@ behaviour (at least the parts that are most commonly used).
 +		    &options->accept_env, &options->num_accept_env,
 +		    "LC_MESSAGES");
 +	}
- 	if (options->client_alive_interval == -1)
- 		options->client_alive_interval = 0;
- 	if (options->client_alive_count_max == -1)
-@@ -2395,9 +2422,12 @@
+ 	if (options->ip_qos_interactive == -1)
+ 		options->ip_qos_interactive = IPTOS_DSCP_EF;
+ 	if (options->ip_qos_bulk == -1)
+@@ -2162,9 +2191,12 @@ process_server_config_line_depth(ServerO
  			if (*arg == '\0' || strchr(arg, '=') != NULL)
  				fatal("%s line %d: Invalid environment name.",
  				    filename, linenum);
@@ -63,19 +73,84 @@ behaviour (at least the parts that are most commonly used).
  			opt_array_append(filename, linenum, keyword,
  			    &options->accept_env, &options->num_accept_env,
  			    arg);
---- openssh-10.3p1/servconf.h.orig
-+++ openssh-10.3p1/servconf.h
-@@ -181,6 +181,7 @@
- 	char   **subsystem_args;
+@@ -3193,6 +3225,18 @@ serialise_timingsecret(const ServerOptio
+ 	return 0;
+ }
  
- 	u_int num_accept_env;
-+	int    default_accept_env;
- 	char   **accept_env;
- 	u_int num_setenv;
- 	char   **setenv;
---- openssh-10.3p1/session.c.orig
-+++ openssh-10.3p1/session.c
-@@ -794,6 +794,18 @@
++static int
++serialise_defaultacceptenv(const ServerOptions *options, struct sshbuf *buf)
++{
++	int r;
++
++	if ((r = serialise_s32(buf, options->default_accept_env)) != 0) {
++		error_fr(r, "serialise");
++		return r;
++	}
++	return 0;
++}
++
+ #ifdef PAM_ENHANCEMENT
+ static int
+ serialise_pamserviceperauthmethod(const ServerOptions *options,
+@@ -3743,6 +3787,18 @@ deserialise_timingsecret(ServerOptions *
+ 	return 0;
+ }
+ 
++static int
++deserialise_defaultacceptenv(ServerOptions *options, struct sshbuf *buf)
++{
++	int r;
++
++	if ((r = deserialise_s32(buf, &options->default_accept_env)) != 0) {
++		error_fr(r, "deserialise");
++		return r;
++	}
++	return 0;
++}
++
+ #ifdef PAM_ENHANCEMENT
+ static int
+ deserialise_pamserviceperauthmethod(ServerOptions *options,
+@@ -3922,6 +3978,7 @@ free_server_options(ServerOptions *optio
+ #define free_persourcepenalties(options)
+ #define free_rekeylimit(options)
+ #define free_timingsecret(options)
++#define free_defaultacceptenv(options)
+ #ifdef PAM_ENHANCEMENT
+ #define free_pamserviceperauthmethod(options)
+ #endif
+@@ -3940,6 +3997,7 @@ free_server_options(ServerOptions *optio
+ #undef free_persourcepenalties
+ #undef free_rekeylimit
+ #undef free_timingsecret
++#undef free_defaultacceptenv
+ #ifdef PAM_ENHANCEMENT
+ #undef free_pamserviceperauthmethod
+ #endif
+diff -wpruN --no-dereference '--exclude=*.orig' a~/servconf.h a/servconf.h
+--- a~/servconf.h	1970-01-01 00:00:00
++++ a/servconf.h	1970-01-01 00:00:00
+@@ -203,6 +203,7 @@ SSHCONF_STRARRAY(deny_users, num_deny_us
+ SSHCONF_STRARRAY(allow_groups, num_allow_groups, AllowGroups, SSHCFG_ALL, SSHCFG_COPY_MATCH) \
+ SSHCONF_STRARRAY(deny_groups, num_deny_groups, DenyGroups, SSHCFG_ALL, SSHCFG_COPY_MATCH) \
+ SSHCONF_STRARRAY(accept_env, num_accept_env, AcceptEnv, SSHCFG_ALL, SSHCFG_COPY_MATCH) \
++SSHCONF_NONCONF(defaultacceptenv) \
+ SSHCONF_STRARRAY(setenv, num_setenv, SetEnv, SSHCFG_ALL, SSHCFG_COPY_MATCH) \
+ SSHCONF_INT(per_source_max_startups, PerSourceMaxStartups, SSHCFG_GLOBAL, NULL, INT_MAX, SSHCFG_COPY_NONE) \
+ SSHCONF_STRING(per_source_penalty_exempt, PerSourcePenaltyExemptList, SSHCFG_GLOBAL, SSHCFG_COPY_NONE) \
+@@ -410,6 +411,8 @@ typedef struct ServerOptions {
+ 	int	rekey_interval;
+ 	/* Passed by config but not keyword for this */
+ 	uint64_t timing_secret;
++	/* Cleared as a side-effect of AcceptEnv */
++	int	default_accept_env;
+ #ifdef PAM_ENHANCEMENT
+ 	/* Set as a side-effect of PAMServiceName */
+ 	int	pam_service_per_authmethod;
+diff -wpruN --no-dereference '--exclude=*.orig' a~/session.c a/session.c
+--- a~/session.c	1970-01-01 00:00:00
++++ a/session.c	1970-01-01 00:00:00
+@@ -794,6 +794,18 @@ check_quietlogin(Session *s, const char
  }
  
  /*
@@ -94,7 +169,7 @@ behaviour (at least the parts that are most commonly used).
   * Reads environment variables from the given file and adds/overrides them
   * into the environment.  If the file does not exist, this does nothing.
   * Otherwise, it must consist of empty lines, comments (line starts with '#')
-@@ -977,6 +989,16 @@
+@@ -977,6 +989,16 @@ do_setup_env(struct ssh *ssh, Session *s
  	ssh_gssapi_do_child(&env, &envsize);
  #endif
  
@@ -111,7 +186,7 @@ behaviour (at least the parts that are most commonly used).
  	/* Set basic environment. */
  	for (i = 0; i < s->num_env; i++)
  		child_set_env(&env, &envsize, s->env[i].name, s->env[i].val);
-@@ -1020,8 +1042,7 @@
+@@ -1020,8 +1042,7 @@ do_setup_env(struct ssh *ssh, Session *s
  	/* Normal systems set SHELL by default. */
  	child_set_env(&env, &envsize, "SHELL", shell);
  
@@ -121,8 +196,9 @@ behaviour (at least the parts that are most commonly used).
  #ifdef HAVE_LOGIN_CAP
  	if (getenv("XDG_RUNTIME_DIR")) {
  		child_set_env(&env, &envsize, "XDG_RUNTIME_DIR",
---- openssh-10.3p1/sshd_config.orig
-+++ openssh-10.3p1/sshd_config
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd_config a/sshd_config
+--- a~/sshd_config	1970-01-01 00:00:00
++++ a/sshd_config	1970-01-01 00:00:00
 @@ -26,6 +26,10 @@
  #SyslogFacility AUTH
  #LogLevel INFO
@@ -134,9 +210,10 @@ behaviour (at least the parts that are most commonly used).
  # Authentication:
  
  #LoginGraceTime 2m
---- openssh-10.3p1/sshd_config.5.orig
-+++ openssh-10.3p1/sshd_config.5
-@@ -86,7 +86,20 @@
+diff -wpruN --no-dereference '--exclude=*.orig' a~/sshd_config.5 a/sshd_config.5
+--- a~/sshd_config.5	1970-01-01 00:00:00
++++ a/sshd_config.5	1970-01-01 00:00:00
+@@ -86,7 +86,20 @@ directives.
  Be warned that some environment variables could be used to bypass restricted
  user environments.
  For this reason, care should be taken in the use of this directive.


### PR DESCRIPTION
Used omnios patches.  Renamed patch 0032 to 00006a to make sure it would be used in the correct order in oi-userland