### PR TITLE
add zoxide 0.10.0

### DIFF
--- a/components/sysutils/zoxide/Makefile
+++ b/components/sysutils/zoxide/Makefile
@@ -1,0 +1,38 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"). You may
+# only use this file in accordance with the terms of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Benjamin S. Osenbach
+#
+
+BUILD_BITS=64 # for binaries or 32_and_64 for libraries
+BUILD_STYLE=cargo
+include ../../../make-rules/shared-macros.mk
+
+COMPONENT_NAME=zoxide
+COMPONENT_VERSION=0.10.0
+COMPONENT_SUMMARY= A smarter cd command. Supports all major shells
+COMPONENT_PROJECT_URL=https://github.com/ajeetdsouza/zoxide
+COMPONENT_FMRI=application/zoxide
+COMPONENT_CLASSIFICATION=Applications/System Utilities
+COMPONENT_SRC=		$(COMPONENT_NAME)-$(COMPONENT_VERSION)
+COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
+COMPONENT_ARCHIVE_URL=https://github.com/ajeetdsouza/zoxide/archive/refs/tags/v$(COMPONENT_VERSION).tar.gz
+COMPONENT_ARCHIVE_HASH=sha256:4fcd4272b013a10b637dbcc299c58a9924b94470a9042677ca1a204cc2e9150e
+COMPONENT_LICENSE=MIT
+COMPONENT_LICENSE_FILE=LICENSE
+TEST_TARGET=$(NO_TESTS) # if no testsuite enabled
+include $(WS_MAKE_RULES)/common.mk
+
+# Build dependencies
+# Auto-generated dependencies
+REQUIRED_PACKAGES += $(GCC_RUNTIME_PKG)
+REQUIRED_PACKAGES += system/library
+REQUIRED_PACKAGES += system/library/math

--- a/components/sysutils/zoxide/manifests/sample-manifest.p5m
+++ b/components/sysutils/zoxide/manifests/sample-manifest.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 <contributor>
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/zoxide

--- a/components/sysutils/zoxide/pkg5
+++ b/components/sysutils/zoxide/pkg5
@@ -1,0 +1,11 @@
+{
+    "dependencies": [
+        "system/library",
+        "system/library/gcc-14-runtime",
+        "system/library/math"
+    ],
+    "fmris": [
+        "application/zoxide"
+    ],
+    "name": "zoxide"
+}

--- a/components/sysutils/zoxide/zoxide.p5m
+++ b/components/sysutils/zoxide/zoxide.p5m
@@ -1,0 +1,26 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Benjamin S. Osenbach
+#
+
+set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)
+set name=pkg.human-version value=$(HUMAN_VERSION)
+set name=pkg.summary value="$(COMPONENT_SUMMARY)"
+set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
+set name=info.upstream-url value=$(COMPONENT_PROJECT_URL)
+set name=info.source-url value=$(COMPONENT_ARCHIVE_URL)
+set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
+
+license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
+
+file path=usr/bin/zoxide


### PR DESCRIPTION
[Zoxide](https://github.com/ajeetdsouza/zoxide) (commonly called as `z`) is a rust-y drop-in replacement or complement to `cd`. It remembers partial paths and can handle mitsakes in tpying, making it a tool I use every day on Linux. Figured it would be valuable to have it on OpenIndiana as well