### PR TITLE
add nvidia-535 and nvidia-580 to xorg-video

### DIFF
--- a/components/meta-packages/xorg-video/Makefile
+++ b/components/meta-packages/xorg-video/Makefile
@@ -18,6 +18,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		xorg-video
 COMPONENT_VERSION=	1
+COMPONENT_REVISION= 2
 COMPONENT_SUMMARY=	Xorg server video drivers group
 COMPONENT_CLASSIFICATION=	System/X11
 COMPONENT_FMRI=			x11/server/xorg/driver/xorg-video

--- a/components/meta-packages/xorg-video/xorg-video.p5m
+++ b/components/meta-packages/xorg-video/xorg-video.p5m
@@ -19,7 +19,7 @@ set name=pkg.summary value="$(COMPONENT_SUMMARY)"
 set name=info.classification value="$(COMPONENT_CLASSIFICATION)"
 set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
-depend fmri=driver/graphics/nvidia fmri=driver/graphics/nvidia-340 fmri=driver/graphics/nvidia-390 fmri=driver/graphics/nvidia-470 type=require-any
+depend fmri=driver/graphics/nvidia fmri=driver/graphics/nvidia-340 fmri=driver/graphics/nvidia-390 fmri=driver/graphics/nvidia-470 fmri=driver/graphics/nvidia-535 fmri=driver/graphics/nvidia-580 type=require-any
 depend fmri=x11/server/xorg/driver/xorg-video-ast type=require
 depend fmri=x11/server/xorg/driver/xorg-video-ati type=require
 depend fmri=x11/server/xorg/driver/xorg-video-cirrus type=require


### PR DESCRIPTION
Add the missing driver/nvidia-535 and driver/nvidia-580 to the xorg-video meta-package.

I understand that this won't have any impact on standard hipster Live media, but it will make it easier to build custom Live images using distribution-constructor.