### PR TITLE
ant: add symlink to p5m

### DIFF
--- a/components/developer/ant/Makefile
+++ b/components/developer/ant/Makefile
@@ -29,6 +29,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		ant
 COMPONENT_VERSION=	1.10.17
+COMPONENT_REVISION=	1
 COMPONENT_SUMMARY=	Apache Ant is a Java-based build tool
 COMPONENT_PROJECT_URL=	https://ant.apache.org/
 COMPONENT_SRC_NAME=	apache-ant

--- a/components/developer/ant/ant.p5m
+++ b/components/developer/ant/ant.p5m
@@ -23,6 +23,9 @@ set name=org.opensolaris.consolidation value=$(CONSOLIDATION)
 
 license $(COMPONENT_LICENSE_FILE) license='$(COMPONENT_LICENSE)'
 
+# Needed by at least openjdk8
+link path=usr/share/lib/ant target=../java/ant
+
 file path=etc/ant.conf
 link path=usr/bin/ant target=../share/ant/bin/ant
 file path=usr/share/ant/bin/ant


### PR DESCRIPTION
openjdk-8 is looking for .jar files in a different directory than what the ant archive provides.  Add a directory symlink so openjdk-8 can find the .jar files. Attemps were made to patch openjdk-8, but without success.  In case anything else is assuming the same directory path as openjdk-8, the ant package will now support multiple paths to provide .jar files.

This needs to be published before building openjdk-8-8u492