### PR TITLE
tools/perl-version-convert: add special handling for Sereal-Decoder

### DIFF
--- a/tools/perl-version-convert
+++ b/tools/perl-version-convert
@@ -111,6 +111,7 @@ function convert_version
 	[[ "$PKG" == "pkgconfig" && "${VERSION:4:3}" == "026" ]] && ((${#VERSION} == 7)) && VER[1]=$((1${VERSION:2:2} - 100)) && VERSION=${VERSION:0:1}
 	[[ "$PKG" == "proc-processtable" && "${VERSION:0:2}" == "0." ]] && ((${#VERSION} == 5)) && VER[2]=$((1${VERSION:4:1} - 10)) && VERSION=${VERSION:0:4}
 	[[ "$PKG" == "regexp-common" ]] && ((${#VERSION} == 10)) && VER[1]=$((1${VERSION:4:2} - 100)) && VER[2]=$((1${VERSION:6:2} - 100)) && VER[3]=$((1${VERSION:8:2} - 100)) && VERSION=${VERSION:0:4}
+	[[ "$PKG" == "sereal-decoder" ]] && ((${VERSION%%.*} > 2)) && [[ -z "${VERSION/*.*}" ]] && while [[ "${VERSION/*.???}" == "$VERSION" ]] do VERSION=${VERSION}0 ; done
 	[[ "$PKG" == "test-regexp" ]] && ((${#VERSION} == 10)) && VER[1]=$((1${VERSION:4:2} - 100)) && VER[2]=$((1${VERSION:6:2} - 100)) && VER[3]=$((1${VERSION:8:2} - 100)) && VERSION=${VERSION:0:4}
 	[[ "$PKG" == "yaml-libyaml" && "${VERSION:0:4}" == "0.90" && "${VERSION:5:1}" == "." ]] && ((${#VERSION} == 7)) && VER[2]=$((1${VERSION:4:1} - 10)) && VER[3]=$((1${VERSION:6:1} - 10)) && VERSION=${VERSION:0:4}
 


### PR DESCRIPTION
This is needed because of https://github.com/Sereal/Sereal/issues/317.