### PR TITLE
pari-native: update to 2.17.4, add optional dependency on pari

### DIFF
--- a/components/scientific/pari-native/Makefile
+++ b/components/scientific/pari-native/Makefile
@@ -9,7 +9,7 @@
 #
 
 #
-# Copyright (c) 2025 David Stes
+# Copyright (c) 2025,2026 David Stes
 
 #
 # IPS mediator "pari" mediator-implementation set to "native".
@@ -19,15 +19,16 @@
 # The manifest files hold no license and copyright info per explicit request from Bill Allombert from the PARI team.
 #
 
+USE_PARALLEL_BUILD= yes
 include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		pari-native
-COMPONENT_VERSION=	2.17.2
-COMPONENT_SUMMARY=	The PARI Computer Algebra System (Native Kernel)
+COMPONENT_VERSION=	2.17.4
+COMPONENT_SUMMARY=	PARI/GP (with Native Kernel) is a computer algebra system with the main aim of facilitating number theory computations
 COMPONENT_PROJECT_URL=	https://pari.math.u-bordeaux.fr
 COMPONENT_SRC=		pari-$(COMPONENT_VERSION)
 COMPONENT_ARCHIVE=	$(COMPONENT_SRC).tar.gz
-COMPONENT_ARCHIVE_HASH=	sha256:7d30578f5cf97b137a281f4548d131aafc0cde86bcfd10cc1e1bd72a81e65061
+COMPONENT_ARCHIVE_HASH=	sha256:02651d99c391007d384b3fadbc20abc6916b77036f9e496c99e9ce8688ca4b53
 COMPONENT_ARCHIVE_URL=	$(COMPONENT_PROJECT_URL)/pub/pari/unix/$(COMPONENT_ARCHIVE)
 COMPONENT_FMRI=		library/math/pari-native
 COMPONENT_CLASSIFICATION=	Development/Other Languages
@@ -76,6 +77,7 @@ TEST_REQUIRED_PACKAGES += library/math/pari-elldata
 
 # Auto-generated dependencies
 REQUIRED_PACKAGES += $(READLINE_PKG)
+REQUIRED_PACKAGES += library/math/pari
 REQUIRED_PACKAGES += system/library
 REQUIRED_PACKAGES += system/library/math
 REQUIRED_PACKAGES += x11/library/libx11

--- a/components/scientific/pari-native/manifests/sample-manifest.p5m
+++ b/components/scientific/pari-native/manifests/sample-manifest.p5m
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright 2025 <contributor>
+# Copyright 2026 <contributor>
 #
 
 set name=pkg.fmri value=pkg:/$(COMPONENT_FMRI)@$(IPS_COMPONENT_VERSION),$(BUILD_VERSION)

--- a/components/scientific/pari-native/pari-native.p5m
+++ b/components/scientific/pari-native/pari-native.p5m
@@ -18,3 +18,6 @@ link path=usr/lib/$(MACH64)/libpari-tls.so.9 \
 link path=usr/lib/$(MACH64)/libpari.so target=libpari-tls.so.$(HUMAN_VERSION) \
     mediator=pari mediator-implementation=native
 
+# if pari is installed (which is optional), then pari version should be same or higher
+depend type=optional fmri=pkg:/library/math/pari@$(IPS_COMPONENT_VERSION)
+


### PR DESCRIPTION

Update to 2.17.4 (pari package using GMP was already 2.17.4 )

USE_PARALLEL_BUILD= yes

Add an optional dependency on pari with gmp (both packages can be installed together and with a mediator either native or gmp executable can be used).

The optional dependency is because the include (header) files and manpage is in the pari with gmp package.

The dependency is optional because it is possible to use/install pari-native without pari with gmp.