### PR TITLE
slim_source: refresh packages for text installer virtualization support

### DIFF
--- a/components/openindiana/slim_source/Makefile
+++ b/components/openindiana/slim_source/Makefile
@@ -22,6 +22,8 @@ include ../../../make-rules/shared-macros.mk
 COMPONENT_NAME=	slim_source
 COMPONENT_SRC=	$(COMPONENT_NAME)
 
+# Source refresh: a69d9367103c32eccc6a8c3ec6b26366da358ce7 (revision 1130).
+# Includes VMware tools and VirtIO SCSI support in text installer images.
 COMPONENT_REVISION=$(shell cd $(COMPONENT_SRC); git rev-list HEAD --count)
 
 GIT=git


### PR DESCRIPTION
Trigger packaging after OpenIndiana/slim_source#101. Diff checked; native build not run.