### PR TITLE
fix(desktop-startup): preserve language preferences

### DIFF
--- a/components/openindiana/desktop-startup/Makefile
+++ b/components/openindiana/desktop-startup/Makefile
@@ -16,7 +16,7 @@ include ../../../make-rules/shared-macros.mk
 
 COMPONENT_NAME=		desktop-startup
 COMPONENT_VERSION=	0.5.11
-COMPONENT_REVISION=	2
+COMPONENT_REVISION=	3
 COMPONENT_PROJECT_URL=	http://openindiana.org/
 COMPONENT_SUMMARY=	Desktop startup scripts in xinitrc.d
 COMPONENT_FMRI=		system/display-manager/desktop-startup
@@ -41,3 +41,4 @@ clean:
 # Auto-generated dependencies
 REQUIRED_PACKAGES += SUNWcs
 REQUIRED_PACKAGES += shell/bash
+REQUIRED_PACKAGES += shell/ksh93

--- a/components/openindiana/desktop-startup/files/0020.pre-localization
+++ b/components/openindiana/desktop-startup/files/0020.pre-localization
@@ -26,15 +26,6 @@
 #
 
 
-if [ "x$LC_ALL" = x -a "x$LANG" = x -o "x$LANG" = xC ]; then
-  :
-else
-# Uncomment if you need 6757628
-# European locales have LC_MESSAGES=C in /etc/default/init
-#  LC_MESSAGES=$LANG; export LC_MESSAGES
-  :
-fi
-
 # To determine the character set used for filenames with
 # glib's g_filename_to/from_utf8() functions, we set the
 # environment variables G_FILENAME_ENCODING and G_BROKEN_FILENAMES.
@@ -64,8 +55,8 @@ zh*) VTE_CJK_WIDTH=1; export VTE_CJK_WIDTH;;
 *) ;;
 esac
 
-# Fixes 6555226
-if [ "x$LANG" = "xzh" ] ; then
+# Preserve explicit language preferences.
+if [ "x$LANG" = "xzh" -a "${LANGUAGE+x}" != x ] ; then
   LANGUAGE=zh:zh_CN.EUC
   export LANGUAGE
 fi


### PR DESCRIPTION
Preserve language preferences and remove redundant LC_MESSAGES handling. Declare the ksh93 dependency.

Native build and syntax checks passed. Live desktop testing is ongoing.

Related: OpenIndiana/sysding#9
