### PR TITLE
fix(illumos-gate): resolve gettext locale fallbacks

### DIFF
--- a/components/openindiana/illumos-gate/patches/0011-gettext-locale-fallback.patch
+++ b/components/openindiana/illumos-gate/patches/0011-gettext-locale-fallback.patch
@@ -1,0 +1,155 @@
+fix(libc): resolve gettext catalogue fallbacks
+
+--- a/usr/src/lib/libc/port/i18n/gettext_real.c
++++ b/usr/src/lib/libc/port/i18n/gettext_real.c
+@@ -263,24 +263,98 @@
+ 		mp->status = 0;
+ 	}
+
+-	/*
+-	 * Finally, handle a single binding
+-	 */
+-#ifdef GETTEXT_DEBUG
+-	*mp->msgfile = '\0';
+-#endif
+-	if (mk_msgfile(mp) == NULL) {
+-		DFLTMSG(result, msgid1, msgid2, n, plural);
+-		return (result);
+-	}
+-
+-	result = handle_mo(mp);
++	result = handle_locale(mp);
+ 	if (result) {
+ 		return (result);
+ 	}
+ 	DFLTMSG(result, msgid1, msgid2, n, plural);
+ 	return (result);
+ } /* _real_gettext_u */
++
++/* Search catalogue names from most to least specific. */
++char *
++handle_locale(struct msg_pack *mp)
++{
++	const char *saved = mp->locale;
++	char name[MAXPATHLEN], normalized[MAXPATHLEN], path[MAXPATHLEN];
++	char *territory, *codeset, *modifier, *p, *out, *result;
++	unsigned int parts = 0;
++	int mask, length;
++	int digits = 1;
++
++	if (mk_msgfile(mp) == NULL)
++		return (NULL);
++	result = handle_mo(mp);
++	if ((mp->status & (ST_GNU_MSG_FOUND | ST_SUN_MO_FOUND)) != 0)
++		return (result);
++	if (strlen(saved) >= sizeof (name) || strchr(saved, '/') != NULL)
++		return (result);
++	(void) strcpy(name, saved);
++
++	modifier = strchr(name, '@');
++	if (modifier != NULL) {
++		*modifier++ = '\0';
++		parts |= 8;
++	}
++	codeset = strchr(name, '.');
++	if (codeset != NULL) {
++		*codeset++ = '\0';
++		parts |= 2;
++	}
++	territory = strchr(name, '_');
++	if (territory != NULL) {
++		*territory++ = '\0';
++		parts |= 4;
++	}
++	if (strcmp(name, "C") == 0 || strcmp(name, "POSIX") == 0)
++		return (result);
++
++	/* Normalize codesets without depending on the current locale. */
++	out = normalized;
++	if (codeset != NULL) {
++		for (p = codeset; *p != '\0'; p++) {
++			if (*p >= '0' && *p <= '9') {
++				*out++ = *p;
++			} else if ((*p >= 'A' && *p <= 'Z') ||
++			    (*p >= 'a' && *p <= 'z')) {
++				*out++ = (*p >= 'A' && *p <= 'Z') ?
++				    *p + ('a' - 'A') : *p;
++				digits = 0;
++			}
++		}
++	}
++	*out = '\0';
++	if (out != normalized) {
++		if (digits && strlen(normalized) + 4 <= sizeof (normalized)) {
++			(void) memmove(normalized + 3, normalized,
++			    strlen(normalized) + 1);
++			(void) memcpy(normalized, "iso", 3);
++		}
++		if (strcmp(normalized, codeset) != 0)
++			parts |= 1;
++	}
++
++	for (mask = parts; mask >= 0; mask--) {
++		if ((mask & ~parts) != 0 || (mask & 3) == 3)
++			continue;
++		length = snprintf(path, sizeof (path), "%s%s%s%s%s%s%s",
++		    name, (mask & 4) ? "_" : "", (mask & 4) ? territory : "",
++		    (mask & 3) ? "." : "",
++		    (mask & 2) ? codeset : ((mask & 1) ? normalized : ""),
++		    (mask & 8) ? "@" : "", (mask & 8) ? modifier : "");
++		if (length < 0 || (size_t)length >= sizeof (path) ||
++		    strcmp(path, saved) == 0)
++			continue;
++		mp->locale = path;
++		if (mk_msgfile(mp) == NULL)
++			continue;
++		result = handle_mo(mp);
++		if ((mp->status & (ST_GNU_MSG_FOUND | ST_SUN_MO_FOUND)) != 0)
++			break;
++	}
++	mp->locale = saved;
++	return (result);
++}
+
+ #define	ALLFREE	\
+ 	free_all(nlstmp, nnp, pathname, ppaths, lang)
+--- a/usr/src/lib/libc/port/i18n/gettext_gnu.c
++++ b/usr/src/lib/libc/port/i18n/gettext_gnu.c
+@@ -319,12 +319,7 @@
+ #ifdef GETTEXT_DEBUG
+ 		*mp->msgfile = '\0';
+ #endif
+-		if (mk_msgfile(mp) == NULL) {
+-			/* illegal locale name */
+-			continue;
+-		}
+-
+-		result = handle_mo(mp);
++		result = handle_locale(mp);
+ 		if (mp->status & ST_GNU_MSG_FOUND)
+ 			return (result);
+
+--- a/usr/src/lib/libc/port/i18n/gettext.h
++++ b/usr/src/lib/libc/port/i18n/gettext.h
+@@ -191,6 +191,7 @@
+ extern char	*_real_bindtextdomain_u(const char *, const char *, int);
+ extern char	*_real_gettext_u(const char *, const char *,
+     const char *, unsigned long int, int, int, locale_t);
++extern char	*handle_locale(struct msg_pack *);
+ extern char	*handle_mo(struct msg_pack *);
+
+ extern int	gnu_setmsg(Msg_node *, char *, size_t);
+--- a/usr/src/man/man3c/gettext.3c
++++ b/usr/src/man/man3c/gettext.3c
+@@ -128,6 +128,11 @@
+ \fBdcngettext()\fR.
+ .sp
+ .LP
++Catalogue lookup also tries less specific locale names by removing the codeset,
++territory, and modifier, in that order. Normalized codeset names are tried before
++removing the codeset. Each message domain is searched independently.
++.sp
++.LP
+ For \fBgettext()\fR and \fBngettext()\fR, the domain used is set by the last
+ valid call to \fBtextdomain()\fR. If a valid call to \fBtextdomain()\fR has not
+ been made, the default domain  (called \fBmessages\fR) is used.

--- a/components/openindiana/illumos-gate/test/README.md
+++ b/components/openindiana/illumos-gate/test/README.md
@@ -1,0 +1,9 @@
+Run on illumos against patched source:
+
+```sh
+python3 test/gettext-fallback.py illumos-gate/usr/src/lib/libc/port/i18n/gettext_real.c
+```
+
+The harness extracts the lookup function and uses native gettext to decode fixture
+catalogues. It checks fallback ordering, normalization and per-domain selection.
+A full libc build and public-API regression run are still required before release.

--- a/components/openindiana/illumos-gate/test/gettext-fallback.c
+++ b/components/openindiana/illumos-gate/test/gettext-fallback.c
@@ -1,0 +1,65 @@
+#include <assert.h>
+#include <libintl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <unistd.h>
+
+#define ST_GNU_MSG_FOUND 1
+#define ST_GNU_MO_FOUND 2
+#define ST_SUN_MO_FOUND 4
+
+struct msg_pack {
+	const char *locale, *domain, *binding, *msgid1;
+	char msgfile[MAXPATHLEN];
+	int status;
+};
+
+static char *
+mk_msgfile(struct msg_pack *mp)
+{
+	int n = snprintf(mp->msgfile, sizeof (mp->msgfile),
+	    "%s/%s/LC_MESSAGES/%s.mo", mp->binding, mp->locale, mp->domain);
+	return (n < 0 || (size_t)n >= sizeof (mp->msgfile) ? NULL : mp->msgfile);
+}
+
+/* Use native gettext to decode each candidate catalogue. */
+static char *
+handle_mo(struct msg_pack *mp)
+{
+	char *result;
+	if (access(mp->msgfile, R_OK) != 0)
+		return (NULL);
+	assert(setenv("NLSPATH", mp->msgfile, 1) == 0);
+	mp->status |= ST_GNU_MO_FOUND;
+	result = dgettext(mp->domain, mp->msgid1);
+	if (strcmp(result, mp->msgid1) != 0)
+		mp->status |= ST_GNU_MSG_FOUND;
+	return (result);
+}
+
+#include "handle_locale.c"
+
+int
+main(int argc, char **argv)
+{
+	struct msg_pack mp = { 0 };
+	char *result;
+	assert(argc == 5);
+	assert(unsetenv("LANGUAGE") == 0);
+	mp.binding = argv[1];
+	mp.locale = argv[2];
+	mp.domain = argv[3];
+	mp.msgid1 = "probe";
+	result = handle_locale(&mp);
+	assert(mp.locale == argv[2]);
+	if (result == NULL)
+		result = "probe";
+	if (strcmp(result, argv[4]) != 0) {
+		(void) fprintf(stderr, "%s: expected %s, got %s\n",
+		    mp.locale, argv[4], result);
+		return (1);
+	}
+	return (0);
+}

--- a/components/openindiana/illumos-gate/test/gettext-fallback.py
+++ b/components/openindiana/illumos-gate/test/gettext-fallback.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import pathlib
+import struct
+import subprocess
+import sys
+import tempfile
+
+
+def catalogue(path, text):
+    entries = {b'': b'Content-Type: text/plain; charset=UTF-8\n', b'probe': text.encode()}
+    if text == 'missing':
+        del entries[b'probe']
+    keys = sorted(entries)
+    offset = 28 + 16 * len(keys)
+    ids, values, data = [], [], bytearray()
+    for key in keys:
+        ids.append((len(key), offset + len(data)))
+        data.extend(key + b'\0')
+    for key in keys:
+        value = entries[key]
+        values.append((len(value), offset + len(data)))
+        data.extend(value + b'\0')
+    header = struct.pack('<7I', 0x950412de, 0, len(keys), 28, 28 + 8 * len(keys), 0, 0)
+    tables = b''.join(struct.pack('<2I', *entry) for entry in ids + values)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(header + tables + data)
+
+
+source = pathlib.Path(sys.argv[1]).read_text()
+start = source.index('char *\nhandle_locale(')
+end = source.index('\n#define\tALLFREE', start)
+cases = [
+    ('de_DE.UTF-8', {'de': 'base'}, 'base'),
+    ('de_DE.UTF-8', {'de_DE.UTF-8': 'exact', 'de': 'base'}, 'exact'),
+    ('de_DE.UTF-8', {'de_DE.UTF-8': 'missing', 'de': 'base'}, 'base'),
+    ('de_DE.UTF-8', {'de_DE.utf8': 'normalized', 'de_DE': 'region'}, 'normalized'),
+    ('de_DE.UTF-8', {'de_DE': 'region', 'de': 'base'}, 'region'),
+    ('sr_RS.UTF-8@latin', {'sr@latin': 'modifier', 'sr_RS': 'region'}, 'modifier'),
+    ('sr_RS.UTF-8@latin', {'sr_RS': 'region', 'sr': 'base'}, 'region'),
+    ('zh_TW.UTF-8', {'zh_TW': 'traditional', 'zh_CN': 'simplified'}, 'traditional'),
+    ('zh_TW.UTF-8', {'zh': 'base'}, 'base'),
+    ('fr_CA.UTF-8', {'fr_FR': 'other-region'}, 'probe'),
+    ('de_DE.8859-1', {'de_DE.iso88591': 'numeric'}, 'numeric'),
+    ('C.UTF-8', {'C': 'ignored'}, 'probe'),
+    ('POSIX.UTF-8', {'POSIX': 'ignored'}, 'probe'),
+    ('de', {'de': 'base'}, 'base'),
+    ('de_DE.UTF-8', {}, 'probe'),
+]
+with tempfile.TemporaryDirectory(prefix='gettext-fallback-') as tmp:
+    root = pathlib.Path(tmp)
+    (root / 'handle_locale.c').write_text(source[start:end])
+    test = pathlib.Path(__file__).with_suffix('.c')
+    binary = root / 'test'
+    subprocess.run(['gcc', '-m64', '-Wall', '-Wextra', '-Werror', '-I', str(root),
+                    str(test), '-o', str(binary)], check=True)
+    for i, (locale, catalogues, expected) in enumerate(cases):
+        domain = 'test' + str(i)
+        for name, text in catalogues.items():
+            catalogue(root / name / 'LC_MESSAGES' / (domain + '.mo'), text)
+        subprocess.run([str(binary), str(root), locale, domain, expected], check=True)
+print('PASS: 15 catalogue fallback cases')


### PR DESCRIPTION
Resolve gettext locale and per-message fallbacks without locale symlinks or generated LANGUAGE lists.

Native libc builds and 44 public API checks passed. Live desktop testing is ongoing.

Related: OpenIndiana/sysding#9
